### PR TITLE
ci: Add validation script, Claude hooks, and fix CI path filtering

### DIFF
--- a/.claude/hooks/block-admin-bypass.sh
+++ b/.claude/hooks/block-admin-bypass.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Block gh commands that use --admin to bypass branch protection.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+[ -z "$COMMAND" ] && exit 0
+
+# Strip quoted strings so we don't match --admin inside PR body text.
+STRIPPED=$(echo "$COMMAND" | sed -E "s/'[^']*'//g; s/\"[^\"]*\"//g" | sed '/<<.*EOF/,/^EOF/d')
+
+if echo "$STRIPPED" | grep -qE '\bgh\b.*--admin'; then
+  jq -n '{
+    "hookSpecificOutput": {
+      "hookEventName": "PreToolUse",
+      "permissionDecision": "deny",
+      "permissionDecisionReason": "BLOCKED: --admin flag bypasses branch protection. Remove --admin and wait for CI to pass."
+    }
+  }'
+  exit 0
+fi
+
+exit 0

--- a/.claude/hooks/git-guardrails.sh
+++ b/.claude/hooks/git-guardrails.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Git workflow guardrails. Blocks dangerous operations and enforces conventions.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+[ -z "$COMMAND" ] && exit 0
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+deny() {
+  jq -n --arg reason "$1" '{
+    "hookSpecificOutput": {
+      "hookEventName": "PreToolUse",
+      "permissionDecision": "deny",
+      "permissionDecisionReason": $reason
+    }
+  }'
+  exit 0
+}
+
+# Strip heredoc bodies and quoted strings to avoid false positives on PR body text.
+STRIPPED=$(echo "$COMMAND" | sed '/<<.*EOF/,/^EOF/d' | sed -E "s/'[^']*'//g; s/\"[^\"]*\"//g")
+
+# --- Block push to main ---
+if echo "$STRIPPED" | grep -qE '\bgit\s+push\b'; then
+  if echo "$STRIPPED" | grep -qE '\bgit\s+push\b.*\b(main|master)\b'; then
+    deny "BLOCKED: Never push directly to main. Create a branch and open a PR."
+  fi
+  if [ -n "$REPO_ROOT" ]; then
+    CURRENT_BRANCH=$(git branch --show-current 2>/dev/null)
+    if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; then
+      deny "BLOCKED: You are on '$CURRENT_BRANCH'. Switch to a feature branch before pushing."
+    fi
+  fi
+
+  # Block --force, allow --force-with-lease on feature branches
+  if echo "$STRIPPED" | grep -qE '\bgit\s+push\b.*--force\b' && ! echo "$STRIPPED" | grep -qF -- '--force-with-lease'; then
+    deny "BLOCKED: Use --force-with-lease instead of --force for safety."
+  fi
+
+  # Warn if validate.sh hasn't been run
+  if [ -n "$REPO_ROOT" ]; then
+    MARKER="$REPO_ROOT/.claude/.validation-passed"
+    VALIDATED_HASH=$(cat "$MARKER" 2>/dev/null)
+    CURRENT_HEAD=$(git rev-parse HEAD 2>/dev/null)
+    if [ "$VALIDATED_HASH" != "$CURRENT_HEAD" ]; then
+      # Skip warning for docs-only changes
+      CHANGED_FILES=$(git diff --name-only origin/main...HEAD 2>/dev/null)
+      DOCS_ONLY=true
+      for f in $CHANGED_FILES; do
+        case "$f" in
+          *.md|.claude/*|.beads/*|.github/*) ;;
+          *) DOCS_ONLY=false; break ;;
+        esac
+      done
+      if [ "$DOCS_ONLY" = "false" ]; then
+        echo "WARNING: Consider running ./scripts/validate.sh before pushing." >&2
+      fi
+    fi
+  fi
+fi
+
+# --- Enforce squash merge ---
+if echo "$STRIPPED" | grep -qE '\bgh\s+pr\s+merge\b'; then
+  if ! echo "$STRIPPED" | grep -qF -- '--squash'; then
+    deny "BLOCKED: Always use --squash --delete-branch when merging PRs."
+  fi
+fi
+
+# --- Block destructive git commands ---
+if echo "$STRIPPED" | grep -qE '\bgit\s+reset\s+--hard\b'; then
+  deny "BLOCKED: git reset --hard discards commits. Use git stash or a backup branch."
+fi
+if echo "$STRIPPED" | grep -qE '\bgit\s+clean\b.*-[a-zA-Z]*f'; then
+  deny "BLOCKED: git clean -f permanently deletes untracked files."
+fi
+if echo "$STRIPPED" | grep -qE '\bgit\s+(checkout|restore)\s+\.\s*$'; then
+  deny "BLOCKED: Discarding all changes is destructive. Use git stash or target specific files."
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/block-admin-bypass.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/git-guardrails.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,8 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [ "main" ]
-    paths:
-      - 'AndroidGarage/**'
-      - '.github/workflows/ci.yml'
   push:
     branches: [ "main", "internal", "release" ]
-    paths:
-      - 'AndroidGarage/**'
-      - '.github/workflows/ci.yml'
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Claude Code
+.claude/.validation-passed
+
 # macOS
 .DS_Store
 .DS_Store?

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Local validation script — mirrors CI checks.
+# Run before pushing to catch issues early.
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GRADLE="$REPO_ROOT/AndroidGarage/gradlew -p $REPO_ROOT/AndroidGarage"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${RESET} $1"; }
+fail() { echo -e "${RED}FAIL${RESET} $1"; exit 1; }
+step() { echo -e "\n${BOLD}--- $1 ---${RESET}"; }
+
+step "Spotless (formatting)"
+$GRADLE :androidApp:spotlessCheck && pass "spotlessCheck" || fail "spotlessCheck"
+
+step "Unit Tests (debug)"
+$GRADLE :androidApp:testDebugUnitTest && pass "testDebugUnitTest" || fail "testDebugUnitTest"
+
+step "Unit Tests (release)"
+$GRADLE :androidApp:testReleaseUnitTest && pass "testReleaseUnitTest" || fail "testReleaseUnitTest"
+
+step "Unit Tests (benchmark)"
+$GRADLE :androidApp:testBenchmarkUnitTest && pass "testBenchmarkUnitTest" || fail "testBenchmarkUnitTest"
+
+step "Build Debug APK"
+$GRADLE :androidApp:assembleDebug && pass "assembleDebug" || fail "assembleDebug"
+
+# Record successful validation so git-guardrails hook knows we validated.
+git rev-parse HEAD > "$REPO_ROOT/.claude/.validation-passed"
+
+echo -e "\n${GREEN}${BOLD}All checks passed.${RESET}"


### PR DESCRIPTION
## Summary
- **scripts/validate.sh**: Local CI mirror — runs spotless, all 3 test variants, debug build. Writes validation marker so hooks can warn on stale pushes.
- **Claude hooks**: block-admin-bypass (denies `--admin` on PR merge), git-guardrails (blocks push to main, force push, destructive commands, enforces `--squash`, warns if validate.sh not run)
- **CI fix**: Remove `paths:` filter from ci.yml so required checks always report status. Fixes docs-only PRs being blocked by missing check status.

## Test plan
- [x] validate.sh passes locally
- [x] All hooks pipe-tested with synthetic payloads
- [ ] CI runs on this PR (verifies path filter removal works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)