### PR TITLE
docs: Update decisions from architecture interview

### DIFF
--- a/AndroidGarage/docs/DECISIONS.md
+++ b/AndroidGarage/docs/DECISIONS.md
@@ -6,7 +6,7 @@
 
 **Context:** The system has three clients (ESP32, Android app, potential future iOS/web). Business logic changes (door state interpretation, notification rules, error detection) should not require client updates.
 
-**Decision:** All critical business logic lives on the Firebase server. ESP32 reports raw sensor data. Android displays server-computed results. Neither client interprets sensor data.
+**Decision:** All critical business logic lives on the Firebase server. ESP32 reports raw sensor data. Android displays server-computed results. Neither client interprets sensor data. No offline business logic on clients — not even local door state interpretation.
 
 **Consequences:**
 - Feature updates deploy to one place (server), not three
@@ -14,6 +14,7 @@
 - ESP32 firmware updates (OTA) are risky and rare
 - Adds network dependency: if server is down, no door status interpretation
 - Increases server cost (every sensor reading hits Cloud Functions)
+- App shows stale data without network; this is an accepted tradeoff
 
 ## ADR-002: Current Tech Stack (Android)
 
@@ -66,15 +67,19 @@
 - **Testing:** Fakes over Mockito, Kotlin Test, StandardTestDispatcher
 - **Static analysis:** Detekt with zero tolerance
 
+**KMP targets:** Android + iOS (no desktop). Firebase Auth on both platforms via platform-specific implementations behind a shared interface (expect/actual).
+
 **Not adopted from battery-butler:**
-- gRPC/Wire (server uses REST endpoints, no proto definitions)
+- gRPC/Wire (server uses REST endpoints forever, no proto definitions)
 - Navigation3 (too experimental for this project's needs)
+- Desktop target (not needed for this project)
 
 **Consequences:**
 - Each migration phase is independent and can be a separate PR
 - DI migration (Hilt → kotlin-inject) is the most invasive change
 - Network migration (Retrofit → Ktor) requires new HTTP client setup
 - KMP preparation can happen incrementally after library migrations
+- REST endpoints are the permanent server protocol — no future protocol migration needed
 
 ## ADR-005: DispatcherProvider Pattern
 
@@ -107,14 +112,15 @@ viewmodel/       → state management (depends on usecase, domain)
 presentation/    → Compose UI (depends on viewmodel)
 ```
 
-ViewModels depend on UseCases, not Repositories directly. Each UseCase has a single `operator fun invoke()` method.
+ViewModels depend on UseCases, not Repositories directly. Each UseCase has a single `operator fun invoke()` method. **Every ViewModel operation goes through a UseCase, even simple pass-through ones** — consistency over pragmatism.
 
 **Consequences:**
 - Each layer testable in isolation with fakes
 - UseCases are reusable across ViewModels
-- More files and modules (overhead for a small project)
+- More files and modules (accepted overhead for consistency)
 - Convention tests can enforce structure (e.g., every UseCase has a test)
 - Migration is incremental: extract one UseCase at a time
+- Simple UseCases may feel like boilerplate but maintain uniform architecture
 
 ## ADR-007: Screenshot Tests for Gallery Generation
 
@@ -122,7 +128,7 @@ ViewModels depend on UseCases, not Repositories directly. Each UseCase has a sin
 
 **Context:** Need app screenshots for Play Store listings and development documentation. Manual screenshots are tedious and inconsistent.
 
-**Decision:** Use pure composable previews with screenshot tests (Paparazzi/Roborazzi) to generate gallery images. These are for asset generation, NOT CI blocking checks. Screenshots will not fail CI on pixel mismatch — they are regenerated on demand.
+**Decision:** Use Compose screenshot tests (same approach as battery-butler) to generate gallery images. This is its own migration phase. Screenshots are for asset generation, NOT CI blocking checks. Screenshots will not fail CI on pixel mismatch — they are regenerated on demand.
 
 **Requirements:**
 - All preview composables use deterministic data (fixed timestamps, no `Clock.System.now()`)

--- a/AndroidGarage/docs/MIGRATION.md
+++ b/AndroidGarage/docs/MIGRATION.md
@@ -99,7 +99,7 @@ Target: Align with [battery-butler](https://github.com/cartland/battery-butler) 
 
 ### 5.1 Configure Multiplatform
 - Add `org.jetbrains.kotlin.multiplatform` plugin
-- Define targets: `androidTarget()`, `iosArm64()`, `iosSimulatorArm64()`, `jvm()`
+- Define targets: `androidTarget()`, `iosArm64()`, `iosSimulatorArm64()`
 - Create `commonMain`, `androidMain`, `iosMain` source sets
 
 ### 5.2 Move Shared Code to Common
@@ -111,7 +111,27 @@ Target: Align with [battery-butler](https://github.com/cartland/battery-butler) 
 ### 5.3 Platform-Specific Implementations
 - `expect class DatabaseFactory` / `actual class DatabaseFactory` for Room
 - `expect class HttpClientFactory` / `actual class HttpClientFactory` for Ktor engine
+- `expect class AuthBridge` / `actual class AuthBridge` for Firebase Auth (Android SDK / iOS SDK)
 - Platform entry points create components with platform-specific dependencies
+
+## Phase 6: Screenshot Tests
+
+**Goal:** Automated app screenshot generation for Play Store and documentation.
+
+### 6.1 Set Up Compose Screenshot Testing
+- Add Compose screenshot test dependencies (same approach as battery-butler)
+- Create screenshot test module or source set
+
+### 6.2 Write Deterministic Previews
+- All previews use fixed `Instant.parse(...)` timestamps, not `Clock.System.now()`
+- Thread time parameters through composable chain
+- Create preview data fixtures for consistent test data
+
+### 6.3 Generate Gallery
+- Write screenshot tests for key screens: Home, Door History, Remote Button, Profile
+- Write screenshot tests for key components: DoorStatusCard, AnimatableGarageDoor
+- Generate reference PNGs, commit to repository
+- Screenshots do NOT block CI — regenerated on demand
 
 ## Phase Summary
 
@@ -121,4 +141,7 @@ Target: Align with [battery-butler](https://github.com/cartland/battery-butler) 
 | 2. Clean Architecture | Large | None | Testable layers, reusable logic |
 | 3. DI Migration | Medium | Phase 2 helps but not required | KMP-compatible DI |
 | 4. Network Migration | Medium | None | KMP-compatible networking |
-| 5. KMP | Large | Phases 3 + 4 | Cross-platform code sharing |
+| 5. KMP | Large | Phases 3 + 4 | Android + iOS code sharing |
+| 6. Screenshot Tests | Medium | None | Automated Play Store assets |
+
+**Recommended order:** Start with Phase 1 (testing infrastructure). It builds the safety net needed before making structural changes in later phases.


### PR DESCRIPTION
## Summary
Update DECISIONS.md and MIGRATION.md with confirmed architecture decisions:
- Server-only business logic, no offline interpretation
- REST forever, no protocol migration
- Always use UseCases (consistency over pragmatism)
- KMP targets: Android + iOS only
- Firebase Auth on both platforms via expect/actual
- Screenshot tests as Phase 6 (Compose screenshot testing)
- Phase 1 (testing infra) first

Replaces #15 (closed due to conflicts after CI fix merge).

## Test plan
- Documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)