### PR TITLE
ci: Add Stop hooks for PR backlog check and dev mode

### DIFF
--- a/.claude/hooks/check-pr-backlog.sh
+++ b/.claude/hooks/check-pr-backlog.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Stop hook: Check open PR count and guide next action.
+# If 5+ PRs open, nudge Claude to focus on merging.
+# Otherwise, suggest continuing with next task.
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+[ -z "$REPO_ROOT" ] && exit 0
+
+cd "$REPO_ROOT" || exit 0
+
+# Count open PRs authored by any user (not dependabot)
+OPEN_PRS=$(gh pr list --state open --json number,author --jq '[.[] | select(.author.login != "dependabot[bot]" and .author.login != "dependabot")] | length' 2>/dev/null)
+[ -z "$OPEN_PRS" ] && exit 0
+
+if [ "$OPEN_PRS" -ge 5 ]; then
+  PR_LIST=$(gh pr list --state open --json number,title --jq '.[] | "#\(.number) \(.title)"' 2>/dev/null | head -10)
+  jq -n --arg count "$OPEN_PRS" --arg prs "$PR_LIST" '{
+    "decision": "block",
+    "reason": ("There are " + $count + " open PRs. Focus on merging existing PRs before creating new ones:\n" + $prs)
+  }'
+elif [ "$OPEN_PRS" -ge 1 ]; then
+  PR_LIST=$(gh pr list --state open --json number,title --jq '.[] | "#\(.number) \(.title)"' 2>/dev/null | head -10)
+  jq -n --arg count "$OPEN_PRS" --arg prs "$PR_LIST" '{
+    "systemMessage": ($count + " open PR(s). Check if any are ready to merge:\n" + $prs)
+  }'
+fi
+
+exit 0

--- a/.claude/hooks/dev-mode.sh
+++ b/.claude/hooks/dev-mode.sh
@@ -17,5 +17,5 @@ STOP_REASON=$(echo "$INPUT" | jq -r '.stop_reason // "end_turn"')
 
 jq -n '{
   "decision": "block",
-  "reason": "Dev mode is active (.claude/.dev-mode). Continue making progress:\n\n1. Check open PRs — if any passed CI, merge them (--squash --delete-branch)\n2. Read docs/TESTING.md and docs/MIGRATION.md for next action items\n3. Pick the highest-priority item not yet done\n4. Create PRs on separate branches that do not conflict with each other\n5. Do not wait for CI — create the next PR on a new branch while CI runs\n6. Run ./scripts/validate.sh before pushing code changes\n7. Keep PRs small and focused (one concern per PR)\n\nTo stop: tell the user to run `rm .claude/.dev-mode`"
+  "reason": "Dev mode is active (.claude/.dev-mode). Continue making progress:\n\n1. Check open PRs — merge any that have passed CI\n2. Read docs/TESTING.md and docs/MIGRATION.md for next action items\n3. Pick the highest-priority item not yet done and create a PR for it\n4. Run ./scripts/validate.sh before pushing\n5. Keep PRs small and focused (one concern per PR)\n\nTo stop: tell the user to run `rm .claude/.dev-mode`"
 }'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,22 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/check-pr-backlog.sh",
+            "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/dev-mode.sh",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Claude Code
 .claude/.validation-passed
+.claude/.dev-mode
 
 # macOS
 .DS_Store


### PR DESCRIPTION
## Summary
- **check-pr-backlog**: Stop hook that blocks Claude when 5+ PRs are open, forcing focus on merging. Shows reminder at 1-4 PRs.
- **dev-mode**: Stop hook toggled by `touch .claude/.dev-mode`. Keeps Claude creating PRs aligned with docs/TESTING.md and docs/MIGRATION.md until disabled with `rm .claude/.dev-mode`.

## Test plan
- [x] Both hooks pipe-tested with synthetic payloads
- [x] Dev mode toggle (marker file) works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)