### PR TITLE
test: Add PushRepository tests for state transitions and null config

### DIFF
--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/PushRepositoryTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/PushRepositoryTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.remotebutton
+
+import com.chriscartland.garage.config.ServerConfigRepository
+import com.chriscartland.garage.config.model.ServerConfig
+import com.chriscartland.garage.internet.IdToken
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class PushRepositoryTest {
+    private lateinit var serverConfigRepository: ServerConfigRepository
+    private lateinit var repo: PushRepositoryImpl
+
+    private val validServerConfig =
+        ServerConfig(
+            buildTimestamp = "2024-01-15T00:00:00Z",
+            remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+            remoteButtonPushKey = "test-push-key",
+        )
+
+    @Before
+    fun setup() {
+        serverConfigRepository = mock(ServerConfigRepository::class.java)
+        // Network is mocked but push() uses value classes that don't work with any().
+        // We test state transitions and null-config handling without verifying network args.
+        repo = PushRepositoryImpl(mock(), serverConfigRepository)
+    }
+
+    @Test
+    fun initialPushStatusIsIdle() {
+        assertEquals(PushStatus.IDLE, repo.pushButtonStatus.value)
+    }
+
+    @Test
+    fun initialSnoozeRequestStatusIsIdle() {
+        assertEquals(SnoozeRequestStatus.IDLE, repo.snoozeRequestStatus.value)
+    }
+
+    @Test
+    fun initialSnoozeEndTimeIsZero() {
+        assertEquals(0L, repo.snoozeEndTimeSeconds.value)
+    }
+
+    @Test
+    fun pushResetsToIdleWhenServerConfigIsNull() =
+        runTest {
+            `when`(serverConfigRepository.getServerConfigCached()).thenReturn(null)
+
+            repo.push(IdToken("token"), "ack-token")
+
+            // Should reset to IDLE, not stay stuck in SENDING
+            assertEquals(PushStatus.IDLE, repo.pushButtonStatus.value)
+        }
+
+    @Test
+    fun snoozeResetsToIdleWhenServerConfigIsNull() =
+        runTest {
+            `when`(serverConfigRepository.getServerConfigCached()).thenReturn(null)
+
+            repo.snoozeOpenDoorsNotifications(
+                com.chriscartland.garage.snoozenotifications.SnoozeDurationUIOption.OneHour,
+                IdToken("token"),
+                com.chriscartland.garage.internet
+                    .SnoozeEventTimestampParameter(1000L),
+            )
+
+            // Should reset to IDLE, not stay stuck in SENDING
+            assertEquals(SnoozeRequestStatus.IDLE, repo.snoozeRequestStatus.value)
+        }
+}


### PR DESCRIPTION
## Summary
- 5 tests for `PushRepositoryImpl`: initial state values, push resets to IDLE on null config, snooze resets to IDLE on null config
- Catches silent failures where status gets stuck in SENDING when server config is unavailable

Phase 2.2 from [TESTING.md](AndroidGarage/docs/TESTING.md).

## Test plan
- [x] All tests pass locally
- [x] Spotless passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)