### PR TITLE
fix: Disable HTTP body logging in release builds

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/internet/GarageNetworkService.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/internet/GarageNetworkService.kt
@@ -18,6 +18,7 @@
 package com.chriscartland.garage.internet
 
 import androidx.annotation.Keep
+import com.chriscartland.garage.BuildConfig
 import com.chriscartland.garage.config.APP_CONFIG
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
@@ -159,7 +160,12 @@ object RetrofitModule {
                 .build()
         val logging =
             HttpLoggingInterceptor().apply {
-                level = HttpLoggingInterceptor.Level.BODY
+                level =
+                    if (BuildConfig.DEBUG) {
+                        HttpLoggingInterceptor.Level.BODY
+                    } else {
+                        HttpLoggingInterceptor.Level.NONE
+                    }
             }
         val client: OkHttpClient =
             OkHttpClient


### PR DESCRIPTION
## Summary
Gate `HttpLoggingInterceptor` level on `BuildConfig.DEBUG`:
- **Debug**: `Level.BODY` (full request/response logging for development)
- **Release**: `Level.NONE` (prevents auth tokens from leaking to Logcat)

Previously, `Level.BODY` was unconditional — release builds logged full HTTP bodies including `X-AuthTokenGoogle` headers.

Phase 5.2 from [TESTING.md](AndroidGarage/docs/TESTING.md).

## Test plan
- [x] Compiles and tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)