### PR TITLE
ci: Add build warnings for missing BuildConfig secrets

### DIFF
--- a/AndroidGarage/androidApp/build.gradle.kts
+++ b/AndroidGarage/androidApp/build.gradle.kts
@@ -73,15 +73,21 @@ android {
         val googleWebClientId = "GOOGLE_WEB_CLIENT_ID".let {
             localProperties.getProperty(it) ?: project.findProperty(it) as? String
         }
+        if (serverConfigKey.isNullOrBlank()) {
+            logger.warn("WARNING: SERVER_CONFIG_KEY is not set. The app will not be able to fetch server config.")
+        }
+        if (googleWebClientId.isNullOrBlank()) {
+            logger.warn("WARNING: GOOGLE_WEB_CLIENT_ID is not set. Google Sign-In will not work.")
+        }
         buildConfigField(
             "String",
             "SERVER_CONFIG_KEY",
-            "\"${serverConfigKey}\"",
+            "\"${serverConfigKey ?: ""}\"",
         )
         buildConfigField(
             "String",
             "GOOGLE_WEB_CLIENT_ID",
-            "\"${googleWebClientId}\"",
+            "\"${googleWebClientId ?: ""}\"",
         )
     }
 


### PR DESCRIPTION
## Summary
- Warn at build time if `SERVER_CONFIG_KEY` or `GOOGLE_WEB_CLIENT_ID` are missing
- Fix null values becoming literal string `"null"` in BuildConfig — defaults to empty string
- Uses `logger.warn` (not error) so builds succeed without secrets (CI, open-source)

Phase 5.3 from [TESTING.md](AndroidGarage/docs/TESTING.md).

## Test plan
- [x] Tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)