### PR TITLE
ci: Run release AAB build on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,6 @@ jobs:
   build_release:
     name: Build Release AAB
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/internal' || github.ref == 'refs/heads/release')
     steps:
       - uses: actions/checkout@v4
       - name: set up JDK 17


### PR DESCRIPTION
## Summary
Remove the push-only condition from `build_release` job so it also runs on PRs. Catches release-breaking changes before merge.

Previously, only `test` and `build_debug` ran on PRs — a PR could pass CI but break the release build.

Phase 1.2 from [TESTING.md](AndroidGarage/docs/TESTING.md).

## Test plan
- [ ] CI runs release build on this PR (proves the change works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)