### PR TITLE
ci: Add shell loop warning hook for Claude Code

### DIFF
--- a/.claude/hooks/warn-shell-loops.sh
+++ b/.claude/hooks/warn-shell-loops.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Warn when using shell loops (for/while). These require user permission
+# approval which is slower than running each command individually.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+[ -z "$COMMAND" ] && exit 0
+
+# Strip quoted strings to avoid false positives on string content.
+STRIPPED=$(echo "$COMMAND" | sed -E "s/'[^']*'//g; s/\"[^\"]*\"//g" | sed '/<<.*EOF/,/^EOF/d')
+
+if echo "$STRIPPED" | grep -qE '\b(for|while|until)\b'; then
+  echo '{"systemMessage":"Shell loops (for/while) require user permission which is slower than running each command separately. Consider using multiple Bash tool calls instead."}'
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,10 @@
           {
             "type": "command",
             "command": ".claude/hooks/git-guardrails.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/warn-shell-loops.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary
Add `warn-shell-loops.sh` hook that warns when Claude uses `for`/`while`/`until` loops. These require user permission approval which is slower than separate Bash tool calls.

Warning only, does not block.

## Test plan
- [x] Hook pipe-tested
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)