### PR TITLE
ci: Fix hook deadlock, update PR thresholds, add workflow docs

### DIFF
--- a/.claude/hooks/check-pr-backlog.sh
+++ b/.claude/hooks/check-pr-backlog.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Stop hook: Check open PR count and guide next action.
-# If 5+ PRs open, nudge Claude to focus on merging.
-# Otherwise, suggest continuing with next task.
+# - 10+ PRs: block — must focus on merging
+# - 5-9 PRs: warn — remind to merge, don't block
+# - <5 PRs: silent
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
 [ -z "$REPO_ROOT" ] && exit 0
@@ -12,16 +13,16 @@ cd "$REPO_ROOT" || exit 0
 OPEN_PRS=$(gh pr list --state open --json number,author --jq '[.[] | select(.author.login != "dependabot[bot]" and .author.login != "dependabot")] | length' 2>/dev/null)
 [ -z "$OPEN_PRS" ] && exit 0
 
-if [ "$OPEN_PRS" -ge 5 ]; then
-  PR_LIST=$(gh pr list --state open --json number,title --jq '.[] | "#\(.number) \(.title)"' 2>/dev/null | head -10)
+PR_LIST=$(gh pr list --state open --json number,title --jq '.[] | "#\(.number) \(.title)"' 2>/dev/null | head -10)
+
+if [ "$OPEN_PRS" -ge 10 ]; then
   jq -n --arg count "$OPEN_PRS" --arg prs "$PR_LIST" '{
     "decision": "block",
     "reason": ("There are " + $count + " open PRs. Focus on merging existing PRs before creating new ones:\n" + $prs)
   }'
-elif [ "$OPEN_PRS" -ge 1 ]; then
-  PR_LIST=$(gh pr list --state open --json number,title --jq '.[] | "#\(.number) \(.title)"' 2>/dev/null | head -10)
+elif [ "$OPEN_PRS" -ge 5 ]; then
   jq -n --arg count "$OPEN_PRS" --arg prs "$PR_LIST" '{
-    "systemMessage": ($count + " open PR(s). Check if any are ready to merge:\n" + $prs)
+    "systemMessage": ($count + " open PRs — consider merging some before creating more:\n" + $prs)
   }'
 fi
 

--- a/.claude/hooks/dev-mode.sh
+++ b/.claude/hooks/dev-mode.sh
@@ -3,6 +3,9 @@
 #
 # Toggle on:  touch .claude/.dev-mode
 # Toggle off: rm .claude/.dev-mode
+#
+# Yields when all open PRs are waiting on CI and backlog is full (5+).
+# In that case, there's nothing productive to do — let Claude stop.
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
 [ -z "$REPO_ROOT" ] && exit 0
@@ -15,7 +18,25 @@ INPUT=$(cat)
 STOP_REASON=$(echo "$INPUT" | jq -r '.stop_reason // "end_turn"')
 [ "$STOP_REASON" != "end_turn" ] && exit 0
 
+cd "$REPO_ROOT" || exit 0
+
+# Count open PRs (excluding dependabot)
+OPEN_PRS=$(gh pr list --state open --json number,author --jq '[.[] | select(.author.login != "dependabot[bot]" and .author.login != "dependabot")] | length' 2>/dev/null)
+OPEN_PRS="${OPEN_PRS:-0}"
+
+# If backlog is full, check if any PRs can be acted on
+if [ "$OPEN_PRS" -ge 10 ]; then
+  # Check if any PR has passed CI (mergeable and not blocked)
+  MERGEABLE=$(gh pr list --state open --json number,mergeStateStatus --jq '[.[] | select(.mergeStateStatus == "CLEAN" or .mergeStateStatus == "HAS_HOOKS" or .mergeStateStatus == "UNSTABLE")] | length' 2>/dev/null)
+  MERGEABLE="${MERGEABLE:-0}"
+  if [ "$MERGEABLE" -eq 0 ]; then
+    # All PRs waiting on CI, nothing to do — let Claude stop
+    echo '{"systemMessage":"Dev mode: 5+ PRs open, all waiting on CI. Pausing until PRs merge. Re-enable with `touch .claude/.dev-mode` when ready."}'
+    exit 0
+  fi
+fi
+
 jq -n '{
   "decision": "block",
-  "reason": "Dev mode is active (.claude/.dev-mode). Continue making progress:\n\n1. Check open PRs — merge any that have passed CI\n2. Read docs/TESTING.md and docs/MIGRATION.md for next action items\n3. Pick the highest-priority item not yet done and create a PR for it\n4. Run ./scripts/validate.sh before pushing\n5. Keep PRs small and focused (one concern per PR)\n\nTo stop: tell the user to run `rm .claude/.dev-mode`"
+  "reason": "Dev mode is active (.claude/.dev-mode). Continue making progress:\n\n1. Check open PRs — if any passed CI, merge them (--squash --delete-branch)\n2. Read docs/TESTING.md and docs/MIGRATION.md for next action items\n3. Pick the highest-priority item not yet done\n4. Create PRs on separate branches that do not conflict with each other\n5. Do not wait for CI — create the next PR on a new branch while CI runs\n6. Run ./scripts/validate.sh before pushing code changes\n7. Keep PRs small and focused (one concern per PR)\n\nTo stop: tell the user to run `rm .claude/.dev-mode`"
 }'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,35 @@ The firmware runs multiple concurrent tasks:
 - `push_button`: Execute button press via relay control
 - `log_hello`: Periodic heartbeat logging
 
+## Development Workflow
+
+### Local Validation
+Run `./scripts/validate.sh` before pushing. It mirrors CI: spotless, lint, unit tests (3 variants), debug build. Writes a validation marker so the git-guardrails hook can warn on stale pushes.
+
+### PR Workflow
+- Always create feature branches — never push to main
+- Always `--squash --delete-branch` when merging PRs
+- Never use `--admin` to bypass CI — enforce_admins is enabled
+- Keep PRs small and focused (one concern per PR)
+- Create multiple non-conflicting PRs in parallel — don't wait for CI on each one
+- Use `gh pr update-branch <number>` to keep queued PRs current with main
+
+### Dev Mode
+Toggle with `touch .claude/.dev-mode` / `rm .claude/.dev-mode`. When active, Claude keeps creating PRs aligned with docs/TESTING.md and docs/MIGRATION.md. Yields when 5+ PRs are open and all waiting on CI.
+
+### Claude Hooks (.claude/hooks/)
+- **block-admin-bypass.sh** — Denies `--admin` on PR merges
+- **git-guardrails.sh** — Blocks push to main, force push, destructive commands; enforces squash merge; warns on stale validation
+- **check-pr-backlog.sh** — Warns at 5+ open PRs, blocks at 10+
+- **dev-mode.sh** — Keeps Claude working when `.claude/.dev-mode` exists
+- **warn-shell-loops.sh** — Warns on `for`/`while` loops (prefer separate Bash calls)
+
+### Testing Philosophy
+- Tests must add value — no coverage for coverage's sake
+- Prefer fakes over Mockito mocks (aligns with KMP migration target)
+- CI is the deployment gate — if CI passes, the app is safe to ship
+- Reference: [battery-butler](https://github.com/cartland/battery-butler) for testing patterns
+
 ## Documentation
 
 Detailed project documentation lives in `AndroidGarage/docs/`:


### PR DESCRIPTION
## Summary
- **Fix dev-mode deadlock**: Yield when 10+ PRs open and none mergeable (all waiting CI). Previously both Stop hooks blocked simultaneously with no escape.
- **Update PR backlog thresholds**: Warn at 5+, block at 10+ (was: warn at 1+, block at 5+)
- **Add Development Workflow section to CLAUDE.md**: Local validation, PR rules, dev mode toggle, all 5 hook descriptions, testing philosophy

## Test plan
- [x] dev-mode hook yields correctly when no mergeable PRs
- [x] check-pr-backlog warns at 5+, blocks at 10+
- Documentation only for CLAUDE.md changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)