### PR TITLE
test: Add shared fake implementations for repositories

### DIFF
--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakeAuthRepository.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakeAuthRepository.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.testcommon
+
+import com.chriscartland.garage.auth.AuthRepository
+import com.chriscartland.garage.auth.AuthState
+import com.chriscartland.garage.auth.GoogleIdToken
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class FakeAuthRepository : AuthRepository {
+    private val _authState = MutableStateFlow<AuthState>(AuthState.Unknown)
+    override val authState: StateFlow<AuthState> = _authState
+
+    var signInCount = 0
+        private set
+    var signOutCount = 0
+        private set
+    var refreshCount = 0
+        private set
+
+    fun setAuthState(state: AuthState) {
+        _authState.value = state
+    }
+
+    override suspend fun signInWithGoogle(idToken: GoogleIdToken): AuthState {
+        signInCount++
+        return _authState.value
+    }
+
+    override suspend fun refreshFirebaseAuthState(): AuthState {
+        refreshCount++
+        return _authState.value
+    }
+
+    override suspend fun signOut() {
+        signOutCount++
+        _authState.value = AuthState.Unauthenticated
+    }
+}

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakeDoorRepository.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakeDoorRepository.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.testcommon
+
+import com.chriscartland.garage.door.DoorEvent
+import com.chriscartland.garage.door.DoorPosition
+import com.chriscartland.garage.door.DoorRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeDoorRepository : DoorRepository {
+    private val _currentDoorEvent = MutableStateFlow(DoorEvent())
+    private val _recentDoorEvents = MutableStateFlow<List<DoorEvent>>(emptyList())
+    private val _currentDoorPosition = MutableStateFlow(DoorPosition.UNKNOWN)
+
+    override val currentDoorPosition: Flow<DoorPosition> = _currentDoorPosition
+    override val currentDoorEvent: Flow<DoorEvent> = _currentDoorEvent
+    override val recentDoorEvents: Flow<List<DoorEvent>> = _recentDoorEvents
+
+    var fetchCurrentDoorEventCount = 0
+        private set
+    var fetchRecentDoorEventsCount = 0
+        private set
+    var buildTimestamp: String? = "2024-01-15T00:00:00Z"
+
+    fun setCurrentDoorEvent(event: DoorEvent) {
+        _currentDoorEvent.value = event
+        _currentDoorPosition.value = event.doorPosition ?: DoorPosition.UNKNOWN
+    }
+
+    fun setRecentDoorEvents(events: List<DoorEvent>) {
+        _recentDoorEvents.value = events
+    }
+
+    override suspend fun fetchBuildTimestampCached(): String? = buildTimestamp
+
+    override fun insertDoorEvent(doorEvent: DoorEvent) {
+        _currentDoorEvent.value = doorEvent
+        _currentDoorPosition.value = doorEvent.doorPosition ?: DoorPosition.UNKNOWN
+    }
+
+    override suspend fun fetchCurrentDoorEvent() {
+        fetchCurrentDoorEventCount++
+    }
+
+    override suspend fun fetchRecentDoorEvents() {
+        fetchRecentDoorEventsCount++
+    }
+}

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakePushRepository.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakePushRepository.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.testcommon
+
+import com.chriscartland.garage.internet.IdToken
+import com.chriscartland.garage.internet.SnoozeEventTimestampParameter
+import com.chriscartland.garage.remotebutton.PushRepository
+import com.chriscartland.garage.remotebutton.PushStatus
+import com.chriscartland.garage.remotebutton.SnoozeRequestStatus
+import com.chriscartland.garage.snoozenotifications.SnoozeDurationUIOption
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class FakePushRepository : PushRepository {
+    private val _pushButtonStatus = MutableStateFlow(PushStatus.IDLE)
+    override val pushButtonStatus: StateFlow<PushStatus> = _pushButtonStatus
+
+    private val _snoozeRequestStatus = MutableStateFlow(SnoozeRequestStatus.IDLE)
+    override val snoozeRequestStatus: StateFlow<SnoozeRequestStatus> = _snoozeRequestStatus
+
+    private val _snoozeEndTimeSeconds = MutableStateFlow(0L)
+    override val snoozeEndTimeSeconds: StateFlow<Long> = _snoozeEndTimeSeconds
+
+    var pushCount = 0
+        private set
+    var lastIdToken: IdToken? = null
+        private set
+    var snoozeCount = 0
+        private set
+
+    fun setPushStatus(status: PushStatus) {
+        _pushButtonStatus.value = status
+    }
+
+    fun setSnoozeStatus(status: SnoozeRequestStatus) {
+        _snoozeRequestStatus.value = status
+    }
+
+    fun setSnoozeEndTime(seconds: Long) {
+        _snoozeEndTimeSeconds.value = seconds
+    }
+
+    override suspend fun push(
+        idToken: IdToken,
+        buttonAckToken: String,
+    ) {
+        pushCount++
+        lastIdToken = idToken
+        _pushButtonStatus.value = PushStatus.SENDING
+        _pushButtonStatus.value = PushStatus.IDLE
+    }
+
+    override suspend fun fetchSnoozeEndTimeSeconds() {
+        // No-op in fake
+    }
+
+    override suspend fun snoozeOpenDoorsNotifications(
+        snoozeDuration: SnoozeDurationUIOption,
+        idToken: IdToken,
+        snoozeEventTimestamp: SnoozeEventTimestampParameter,
+    ) {
+        snoozeCount++
+        _snoozeRequestStatus.value = SnoozeRequestStatus.SENDING
+        _snoozeRequestStatus.value = SnoozeRequestStatus.IDLE
+    }
+}


### PR DESCRIPTION
## Summary
Add reusable fake implementations in `testcommon/` package:
- **FakeDoorRepository**: MutableStateFlows for door events, tracks fetch call counts
- **FakePushRepository**: Tracks push/snooze calls, controllable status flows
- **FakeAuthRepository**: Controllable auth state, tracks sign-in/out/refresh counts

These replace Mockito mocks with more readable, KMP-compatible fakes (ADR-003). Phase 1.3 from [MIGRATION.md](AndroidGarage/docs/MIGRATION.md).

## Test plan
- [x] Compiles and all tests pass
- [x] Spotless passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)