### PR TITLE
ci: Add persistent permissions and block cd/git -C in guardrails

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,36 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(git *)",
+      "Bash(gh *)",
+      "Bash(./gradlew *)",
+      "Bash(AndroidGarage/gradlew *)",
+      "Bash(./scripts/*)",
+      "Bash(ls *)",
+      "Bash(ls)",
+      "Bash(pwd)",
+      "Bash(mkdir *)",
+      "Bash(chmod *)",
+      "Bash(find *)",
+      "Bash(wc *)",
+      "Bash(rm *)",
+      "Bash(touch *)",
+      "Bash(echo *)",
+      "Bash(cat *)",
+      "Bash(head *)",
+      "Bash(tail *)",
+      "Bash(grep *)",
+      "Bash(jq *)",
+      "Bash(npm *)",
+      "Bash(bd *)",
+      "Read(**/*)",
+      "Edit(**/*)",
+      "Write(**/*)",
+      "Glob(**/*)",
+      "Grep(**/*)",
+      "WebSearch"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
## Summary
- Add `permissions.allow` to `.claude/settings.json` — pre-approves git, gh, gradlew, scripts, file ops, npm, bd across sessions
- Block `cd` and `git -C` in guardrails hook (hard deny, not just warning)
- Fix regex false positive on branch names containing "cd"

## Test plan
- [x] Hook pipe-tested (cd blocked, git -C blocked, branch names pass)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)