### PR TITLE
feat: Add Android release script with tag safety guardrails

### DIFF
--- a/.claude/hooks/git-guardrails.sh
+++ b/.claude/hooks/git-guardrails.sh
@@ -71,6 +71,13 @@ if echo "$STRIPPED" | grep -qE '\bgit\s+push\b'; then
   fi
 fi
 
+# --- Block tag creation (use ./scripts/release-android.sh instead) ---
+if echo "$STRIPPED" | grep -qE '\bgit\s+tag\b'; then
+  if ! echo "$STRIPPED" | grep -qE '\bgit\s+tag\b.*(-l\b|--list\b)'; then
+    deny "BLOCKED: Never create or push tags directly. Use ./scripts/release-android.sh for releases. Use git tag -l to list tags."
+  fi
+fi
+
 # --- Enforce squash merge ---
 if echo "$STRIPPED" | grep -qE '\bgh\s+pr\s+merge\b'; then
   if ! echo "$STRIPPED" | grep -qF -- '--squash'; then

--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -1,0 +1,33 @@
+name: Setup Android Build Environment
+description: Shared setup for Android CI and release workflows
+
+inputs:
+  encrypt-key:
+    description: Key for decrypting release secrets
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permissions
+      working-directory: AndroidGarage
+      shell: bash
+      run: |
+        chmod +x gradlew
+        chmod +x release/*.sh
+
+    - name: Decrypt secrets
+      if: inputs.encrypt-key != ''
+      working-directory: AndroidGarage
+      shell: bash
+      run: ./release/decrypt-secrets.sh
+      env:
+        ENCRYPT_KEY: ${{ inputs.encrypt-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,31 +5,17 @@ on:
   pull_request:
     branches: [ "main" ]
   push:
-    branches: [ "main", "internal", "release" ]
+    branches: [ "main" ]
 
 jobs:
-  test:
-    name: Run Unit Tests & Formatting Checks
+  formatting:
+    name: Formatting & Static Analysis
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: set up JDK 17
-        uses: actions/setup-java@v4
+      - uses: ./.github/actions/setup-android
         with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: gradle
-      - name: Grant execute permission for release scripts
-        working-directory: AndroidGarage
-        run: chmod +x release/*.sh
-      - name: Decrypt secrets
-        working-directory: AndroidGarage
-        run: ./release/decrypt-secrets.sh
-        env:
-          ENCRYPT_KEY: ${{ secrets.ENCRYPT_KEY }}
-      - name: Grant execute permission for gradlew
-        working-directory: AndroidGarage
-        run: chmod +x gradlew
+          encrypt-key: ${{ secrets.ENCRYPT_KEY }}
       - name: Run Spotless Check
         working-directory: AndroidGarage
         run: ./gradlew spotlessCheck
@@ -39,6 +25,19 @@ jobs:
       - name: Run Android Lint
         working-directory: AndroidGarage
         run: ./gradlew :androidApp:lint
+      - name: Clean secrets
+        if: always()
+        working-directory: AndroidGarage
+        run: ./release/clean-secrets.sh
+
+  unit_tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-android
+        with:
+          encrypt-key: ${{ secrets.ENCRYPT_KEY }}
       - name: Run Unit Tests
         working-directory: AndroidGarage
         env:
@@ -55,28 +54,15 @@ jobs:
         with:
           name: test-reports
           path: AndroidGarage/androidApp/build/reports/tests/
+
   build_debug:
     name: Build Debug APK
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: set up JDK 17
-        uses: actions/setup-java@v4
+      - uses: ./.github/actions/setup-android
         with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: gradle
-      - name: Grant execute permission for release scripts
-        working-directory: AndroidGarage
-        run: chmod +x release/*.sh
-      - name: Decrypt secrets
-        working-directory: AndroidGarage
-        run: ./release/decrypt-secrets.sh
-        env:
-          ENCRYPT_KEY: ${{ secrets.ENCRYPT_KEY }}
-      - name: Grant execute permission for gradlew
-        working-directory: AndroidGarage
-        run: chmod +x gradlew
+          encrypt-key: ${{ secrets.ENCRYPT_KEY }}
       - name: Build Debug
         working-directory: AndroidGarage
         env:
@@ -93,28 +79,15 @@ jobs:
         with:
           name: debug-apk
           path: AndroidGarage/androidApp/build/outputs/apk/debug/
+
   build_release:
     name: Build Release AAB
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: set up JDK 17
-        uses: actions/setup-java@v4
+      - uses: ./.github/actions/setup-android
         with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: gradle
-      - name: Grant execute permission for release scripts
-        working-directory: AndroidGarage
-        run: chmod +x release/*.sh
-      - name: Decrypt secrets
-        working-directory: AndroidGarage
-        run: ./release/decrypt-secrets.sh
-        env:
-          ENCRYPT_KEY: ${{ secrets.ENCRYPT_KEY }}
-      - name: Grant execute permission for gradlew
-        working-directory: AndroidGarage
-        run: chmod +x gradlew
+          encrypt-key: ${{ secrets.ENCRYPT_KEY }}
       - name: Build Release AAB
         working-directory: AndroidGarage
         env:
@@ -132,23 +105,4 @@ jobs:
         with:
           name: release-aab
           path: AndroidGarage/androidApp/build/outputs/bundle/release/
-  deploy_internal:
-    name: Deploy to Internal Track
-    runs-on: ubuntu-latest
-    needs: build_release
-    if: github.event_name == 'push' && github.ref == 'refs/heads/internal'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download release AAB
-        uses: actions/download-artifact@v4
-        with:
-          name: release-aab
-          path: release-aab
-      - name: Deploy to Google Play
-        uses: r0adkll/upload-google-play@v1.1.3
-        with:
-          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
-          packageName: com.chriscartland.garage
-          releaseFiles: release-aab/*.aab
-          track: internal
-          whatsNewDirectory: AndroidGarage/distribution/whatsnew
+  # Deployment: .github/workflows/release-android.yml (triggered by android/N tags)

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -1,0 +1,131 @@
+name: Release Android to Play Store (Internal)
+
+# Triggered by android/N tags pushed by scripts/release-android.sh
+# Deploys to internal track only — never production.
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'android/[0-9]*'
+
+permissions:
+  contents: read
+
+jobs:
+  verify-ci:
+    name: Verify CI Passed
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/android/')
+    timeout-minutes: 5
+    steps:
+      - name: Get tagged commit SHA
+        id: get-sha
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          SHA=$(gh api repos/${{ github.repository }}/git/ref/tags/${TAG} --jq '.object.sha' 2>/dev/null || echo "")
+          if [ -z "$SHA" ]; then
+            SHA="${GITHUB_SHA}"
+          fi
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
+          echo "Tagged commit: $SHA"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Verify CI passed on tagged commit
+        run: |
+          TAG_SHA="${{ steps.get-sha.outputs.sha }}"
+          echo "Checking CI status for commit $TAG_SHA..."
+
+          TESTS_CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA/check-runs" \
+            --jq '[.check_runs[] | select(.name == "Unit Tests")] | last | .conclusion')
+          FORMAT_CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA/check-runs" \
+            --jq '[.check_runs[] | select(.name == "Formatting & Static Analysis")] | last | .conclusion')
+          BUILD_CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA/check-runs" \
+            --jq '[.check_runs[] | select(.name == "Build Debug APK")] | last | .conclusion')
+
+          echo "Tests: $TESTS_CONCLUSION"
+          echo "Formatting: $FORMAT_CONCLUSION"
+          echo "Build: $BUILD_CONCLUSION"
+
+          FAILED=false
+          if [ "$TESTS_CONCLUSION" != "success" ]; then
+            echo "::error::Unit Tests concluded '$TESTS_CONCLUSION', expected 'success'"
+            FAILED=true
+          fi
+          if [ "$FORMAT_CONCLUSION" != "success" ]; then
+            echo "::error::Formatting concluded '$FORMAT_CONCLUSION', expected 'success'"
+            FAILED=true
+          fi
+          if [ "$BUILD_CONCLUSION" != "success" ]; then
+            echo "::error::Build concluded '$BUILD_CONCLUSION', expected 'success'"
+            FAILED=true
+          fi
+          if [ "$FAILED" = true ]; then
+            exit 1
+          fi
+
+          echo "All CI checks passed on commit $TAG_SHA"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  release:
+    name: Build and Deploy to Internal
+    needs: verify-ci
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Validate tag format
+        id: validate
+        run: |
+          REF="${GITHUB_REF}"
+          if [[ ! "$REF" =~ ^refs/tags/ ]]; then
+            echo "::error::This workflow must be run on a tag."
+            exit 1
+          fi
+
+          TAG="${REF#refs/tags/}"
+          if [[ ! "$TAG" =~ ^android/[0-9]+$ ]]; then
+            echo "::error::Tag must match 'android/N' pattern, got: $TAG"
+            exit 1
+          fi
+
+          VERSION="${TAG#android/}"
+          echo "version_code=$VERSION" >> $GITHUB_OUTPUT
+          echo "Validated: tag=$TAG, versionCode=$VERSION"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-android
+        with:
+          encrypt-key: ${{ secrets.ENCRYPT_KEY }}
+
+      - name: Build Release AAB
+        working-directory: AndroidGarage
+        env:
+          SERVER_CONFIG_KEY: ${{ secrets.SERVER_CONFIG_KEY }}
+          GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
+          GARAGE_RELEASE_KEYSTORE_PWD: ${{ secrets.GARAGE_RELEASE_KEYSTORE_PWD }}
+          GARAGE_RELEASE_KEY_PWD: ${{ secrets.GARAGE_RELEASE_KEY_PWD }}
+        run: ./gradlew :androidApp:bundleRelease -PVERSION_CODE=${{ steps.validate.outputs.version_code }} -PSERVER_CONFIG_KEY="$SERVER_CONFIG_KEY" -PGOOGLE_WEB_CLIENT_ID="$GOOGLE_WEB_CLIENT_ID" -PGARAGE_RELEASE_KEYSTORE_PWD="$GARAGE_RELEASE_KEYSTORE_PWD" -PGARAGE_RELEASE_KEY_PWD="$GARAGE_RELEASE_KEY_PWD"
+
+      - name: Clean secrets
+        if: always()
+        working-directory: AndroidGarage
+        run: ./release/clean-secrets.sh
+
+      - name: Upload release AAB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-aab
+          path: AndroidGarage/androidApp/build/outputs/bundle/release/
+          retention-days: 30
+
+      - name: Deploy to Google Play (Internal Track)
+        uses: r0adkll/upload-google-play@v1.1.3
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.chriscartland.garage
+          releaseFiles: AndroidGarage/androidApp/build/outputs/bundle/release/*.aab
+          track: internal
+          whatsNewDirectory: AndroidGarage/distribution/whatsnew

--- a/AndroidGarage/androidApp/build.gradle.kts
+++ b/AndroidGarage/androidApp/build.gradle.kts
@@ -58,7 +58,10 @@ android {
         applicationId = "com.chriscartland.garage"
         minSdk = 26
         targetSdk = 35
-        versionCode = 117
+        // versionCode comes from android/N tag via -PVERSION_CODE=N
+        // Falls back to 1 for local development builds
+        val tagVersionCode = (project.findProperty("VERSION_CODE") as? String)?.toIntOrNull()
+        versionCode = tagVersionCode ?: 1
         versionName = "2.2-" + generateVersionNameTimestamp()
         setProperty("archivesBaseName", "$applicationId-$versionName-$versionCode")
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,18 @@ The firmware runs multiple concurrent tasks:
 ### Local Validation
 Run `./scripts/validate.sh` before pushing. It mirrors CI: spotless, lint, unit tests (3 variants), debug build. Writes a validation marker so the git-guardrails hook can warn on stale pushes.
 
+### Releasing Android
+Use `./scripts/release-android.sh` — never create or push tags directly (hooks block `git tag`).
+
+```bash
+./scripts/release-android.sh              # Interactive (terminal only)
+./scripts/release-android.sh --check      # Print latest + next tag
+./scripts/release-android.sh --confirm-tag android/N  # Non-interactive
+./scripts/release-android.sh --dry-run    # Preview without releasing
+```
+
+The script computes the next tag as `android/<highest + 1>`. The `--confirm-tag` flag is a safety check — it must match the computed tag, it cannot override it.
+
 ### PR Workflow
 - Always create feature branches — never push to main
 - Always `--squash --delete-branch` when merging PRs

--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Release Android app by creating and pushing an android/N tag.
+# This triggers release-android.yml to build and deploy to Play Store INTERNAL track.
+#
+# IMPORTANT: We only publish to internal track, never production.
+# Users promote from internal to production manually in Play Console.
+#
+# Usage:
+#   ./scripts/release-android.sh              # Interactive mode (fails in CI/non-TTY)
+#   ./scripts/release-android.sh --check      # Print latest and next tag, exit
+#   ./scripts/release-android.sh --confirm-tag android/N  # Non-interactive release
+#   ./scripts/release-android.sh --dry-run    # Show what would happen
+#
+# Safety:
+#   - Only this script can push tags (Claude hooks block git tag commands)
+#   - --confirm-tag must exactly match the computed next tag (cannot override)
+#   - Requires clean working tree and CI passing on HEAD
+#   - Requires main branch (or --confirm-hash for non-main)
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+# Parse flags
+MODE="interactive"
+CONFIRM_TAG=""
+CONFIRM_HASH=""
+DRY_RUN=false
+
+show_help() {
+    echo "Usage: ./scripts/release-android.sh [OPTIONS]"
+    echo ""
+    echo "Modes:"
+    echo "  (no args)                  Interactive mode — prompts for confirmation"
+    echo "  --check                    Print latest tag and next tag, then exit"
+    echo "  --confirm-tag <tag>        Non-interactive release. Tag must match computed next tag."
+    echo "  --dry-run                  Show what would happen without creating tags"
+    echo ""
+    echo "Options:"
+    echo "  --confirm-hash <sha>       Required when releasing from non-main branch."
+    echo "                             Must match HEAD's full SHA. This is a safety check"
+    echo "                             to confirm you intend to release from this commit."
+    echo "  -h, --help                 Show this help"
+    echo ""
+    echo "Examples:"
+    echo "  ./scripts/release-android.sh --check"
+    echo "  ./scripts/release-android.sh --confirm-tag android/2"
+    echo "  ./scripts/release-android.sh --confirm-tag android/2 --confirm-hash \$(git rev-parse HEAD)"
+    echo "  ./scripts/release-android.sh --dry-run"
+    echo ""
+    echo "Multiple tags on the same commit are allowed — tag numbers always increment."
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --check)
+            MODE="check"
+            shift
+            ;;
+        --confirm-tag)
+            MODE="confirm"
+            CONFIRM_TAG="$2"
+            shift 2
+            ;;
+        --confirm-hash)
+            CONFIRM_HASH="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Error: Unknown option: $1${RESET}"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+# Fetch tags
+git fetch origin --tags --quiet
+
+# Compute latest and next tag
+HIGHEST_VERSION=$(git tag -l 'android/[0-9]*' | \
+    sed 's|android/||' | \
+    grep -E '^[0-9]+$' || true)
+HIGHEST_VERSION=$(echo "$HIGHEST_VERSION" | sort -n | tail -1)
+
+if [ -z "$HIGHEST_VERSION" ]; then
+    NEXT_VERSION=1
+    LATEST_TAG="(none)"
+else
+    NEXT_VERSION=$((HIGHEST_VERSION + 1))
+    LATEST_TAG="android/$HIGHEST_VERSION"
+fi
+
+NEW_TAG="android/$NEXT_VERSION"
+CURRENT_COMMIT=$(git rev-parse HEAD)
+CURRENT_COMMIT_SHORT=$(git rev-parse --short HEAD)
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "(detached)")
+
+# === --check mode ===
+if [ "$MODE" = "check" ]; then
+    echo "Latest tag: $LATEST_TAG"
+    echo "Next tag:   $NEW_TAG"
+    echo "Branch:     $CURRENT_BRANCH"
+    echo "Commit:     $CURRENT_COMMIT_SHORT"
+    exit 0
+fi
+
+# === Interactive mode guard ===
+if [ "$MODE" = "interactive" ]; then
+    if [ ! -t 0 ] || [ ! -t 1 ]; then
+        echo -e "${RED}Error: Interactive mode requires a TTY.${RESET}"
+        echo ""
+        echo "This script must be run interactively from a terminal."
+        echo "For CI or Claude, use:"
+        echo "  ./scripts/release-android.sh --check          # See next tag"
+        echo "  ./scripts/release-android.sh --confirm-tag $NEW_TAG  # Release"
+        exit 1
+    fi
+fi
+
+echo -e "${BOLD}=== Android Release ===${RESET}"
+echo ""
+
+# Check clean working tree
+if ! git diff-index --quiet HEAD --; then
+    echo -e "${RED}Error: Working tree has uncommitted changes.${RESET}"
+    echo "Commit or stash changes before releasing."
+    exit 1
+fi
+
+# Check CI status
+echo "Checking CI status on HEAD..."
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
+if [ -n "$REPO" ]; then
+    # Check the required CI checks
+    TESTS_STATUS=$(gh api "repos/${REPO}/commits/${CURRENT_COMMIT}/check-runs" \
+        --jq '[.check_runs[] | select(.name == "Run Unit Tests & Formatting Checks")] | last | .conclusion' 2>/dev/null || echo "")
+    BUILD_STATUS=$(gh api "repos/${REPO}/commits/${CURRENT_COMMIT}/check-runs" \
+        --jq '[.check_runs[] | select(.name == "Build Debug APK")] | last | .conclusion' 2>/dev/null || echo "")
+
+    if [ "$TESTS_STATUS" = "success" ] && [ "$BUILD_STATUS" = "success" ]; then
+        echo -e "${GREEN}CI passed on HEAD.${RESET}"
+    elif [ -z "$TESTS_STATUS" ] && [ -z "$BUILD_STATUS" ]; then
+        echo -e "${YELLOW}Warning: No CI results found for HEAD.${RESET}"
+        if [ "$MODE" = "interactive" ]; then
+            read -p "Continue anyway? (y/N) " -n 1 -r
+            echo ""
+            [[ $REPLY =~ ^[Yy]$ ]] || { echo "Aborted."; exit 1; }
+        else
+            echo -e "${RED}Error: CI has not run on HEAD. Cannot release without CI.${RESET}"
+            exit 1
+        fi
+    else
+        echo -e "${RED}Error: CI did not pass on HEAD.${RESET}"
+        echo "  Tests: $TESTS_STATUS"
+        echo "  Build: $BUILD_STATUS"
+        exit 1
+    fi
+fi
+echo ""
+
+# Branch safety
+if [ "$CURRENT_BRANCH" != "main" ]; then
+    if [ -z "$CONFIRM_HASH" ]; then
+        echo -e "${RED}Error: Not on main branch (on '$CURRENT_BRANCH').${RESET}"
+        echo ""
+        echo "Release from non-main requires --confirm-hash:"
+        echo "  ./scripts/release-android.sh --confirm-hash $(git rev-parse HEAD)"
+        exit 1
+    elif [ "$CONFIRM_HASH" != "$CURRENT_COMMIT" ]; then
+        echo -e "${RED}Error: --confirm-hash does not match HEAD.${RESET}"
+        echo "  Provided: $CONFIRM_HASH"
+        echo "  HEAD:     $CURRENT_COMMIT"
+        exit 1
+    fi
+    echo -e "${YELLOW}Warning: Releasing from non-main branch '$CURRENT_BRANCH'.${RESET}"
+    echo ""
+fi
+
+# Release details
+echo "=== Release Details ==="
+echo "  Branch:     $CURRENT_BRANCH"
+echo "  Latest tag: $LATEST_TAG"
+echo "  New tag:    $NEW_TAG"
+echo "  Commit:     $CURRENT_COMMIT_SHORT ($CURRENT_COMMIT)"
+echo ""
+
+# Note existing tags on this commit (not blocking — tag numbers always increment)
+EXISTING_TAGS=$(git tag --points-at HEAD | grep -E '^android/[0-9]+$' || true)
+if [ -n "$EXISTING_TAGS" ]; then
+    echo -e "${YELLOW}Note: This commit already has tag(s): $EXISTING_TAGS${RESET}"
+    echo "  New tag $NEW_TAG will be created with the next number."
+    echo ""
+fi
+
+# Confirmation
+if [ "$MODE" = "confirm" ]; then
+    if [ "$CONFIRM_TAG" != "$NEW_TAG" ]; then
+        echo -e "${RED}Error: --confirm-tag does not match computed next tag.${RESET}"
+        echo "  Provided: $CONFIRM_TAG"
+        echo "  Expected: $NEW_TAG"
+        echo ""
+        echo "--confirm-tag is a safety check, not an override."
+        echo "The next tag is always computed as highest existing + 1."
+        exit 1
+    fi
+    echo "--confirm-tag matches, proceeding..."
+elif [ "$MODE" = "interactive" ]; then
+    echo -e "${YELLOW}This will create tag '$NEW_TAG' and push it to origin.${RESET}"
+    read -p "Proceed with release? (y/N) " -n 1 -r
+    echo ""
+    [[ $REPLY =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
+fi
+
+# Dry run
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${YELLOW}=== Dry Run ===${RESET}"
+    echo "Would create tag $NEW_TAG on commit $CURRENT_COMMIT_SHORT"
+    echo "Would push tag to origin"
+    echo "No tags were created or pushed."
+    exit 0
+fi
+
+# Create and push tag
+echo ""
+echo "Creating tag $NEW_TAG..."
+git tag "$NEW_TAG"
+
+echo "Pushing tag to origin..."
+if git push origin "$NEW_TAG"; then
+    echo ""
+    echo -e "${GREEN}=== Release Initiated ===${RESET}"
+    echo ""
+    echo "Tag $NEW_TAG pushed to origin."
+    echo "Monitor: https://github.com/cartland/SmartGarageDoor/actions"
+else
+    echo -e "${RED}Error: Failed to push tag.${RESET}"
+    echo "Removing local tag..."
+    git tag -d "$NEW_TAG"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
Add `scripts/release-android.sh` for safe Android releases:

| Mode | Usage | Who |
|------|-------|-----|
| Interactive | `./scripts/release-android.sh` | Human in terminal |
| Check | `--check` | Claude, CI, anyone |
| Confirm | `--confirm-tag android/N` | Claude (with user approval) |
| Dry run | `--dry-run` | Preview |

Safety:
- Computes next tag as `android/<highest + 1>` — cannot be overridden
- `--confirm-tag` must match computed tag (safety check, not override)
- Requires clean tree, CI passing, main branch
- Interactive mode fails in non-TTY (CI, Claude)
- `git tag` blocked by guardrails hook (only `git tag -l` allowed)

## Test plan
- [x] `--check` returns correct latest/next tag
- [x] `--dry-run` shows plan without creating tags
- [x] Non-TTY rejects interactive mode with instructions
- [x] Dirty working tree rejected
- [x] `git tag` blocked by guardrails hook
- [x] `git tag -l` allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)