### PR TITLE
feat: Add empty domain module for Phase 2 clean architecture

### DIFF
--- a/AndroidGarage/domain/build.gradle.kts
+++ b/AndroidGarage/domain/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    kotlin("jvm")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+dependencies {
+    implementation(libs.kotlinx.coroutines.core)
+}

--- a/AndroidGarage/gradle/libs.versions.toml
+++ b/AndroidGarage/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ androidxCore = "1.16.0"
 androidxNavigation = "2.9.0"
 androidxDatastore = "1.1.7"
 composeBom = "2025.06.01"
+coroutines = "1.10.2"
 coroutinesTest = "1.10.2"
 credentials = "1.5.0"
 detekt = "1.23.7"
@@ -84,6 +85,7 @@ hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt"
 hilt-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigation" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }
 mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
 okhttpLoggingInterceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }

--- a/AndroidGarage/settings.gradle.kts
+++ b/AndroidGarage/settings.gradle.kts
@@ -38,5 +38,6 @@ dependencyResolutionManagement {
 
 rootProject.name = "AndroidGarage"
 include(":androidApp")
+include(":domain")
 include(":macrobenchmark")
 include(":shared")


### PR DESCRIPTION
## Summary
Create `domain/` Gradle module — pure Kotlin (no Android dependencies). Foundation for Phase 2 clean architecture migration.

- `kotlin("jvm")` plugin, JVM 17
- Only dependency: `kotlinx-coroutines-core` (for Flow in interfaces)
- Added to `settings.gradle.kts`
- Added `kotlinx-coroutines-core` to version catalog

No code moves in this PR. Subsequent PRs will migrate interfaces and models one at a time.

Phase 2.1 scaffolding from [MIGRATION.md](AndroidGarage/docs/MIGRATION.md).

## Test plan
- [x] `./gradlew :domain:build` passes
- [x] `./gradlew :androidApp:assembleDebug` still passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)