### PR TITLE
feat: Define domain models and repository interfaces

### DIFF
--- a/AndroidGarage/domain/build.gradle.kts
+++ b/AndroidGarage/domain/build.gradle.kts
@@ -2,9 +2,8 @@ plugins {
     kotlin("jvm")
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+kotlin {
+    jvmToolchain(17)
 }
 
 dependencies {

--- a/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/model/AuthModel.kt
+++ b/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/model/AuthModel.kt
@@ -1,0 +1,45 @@
+package com.chriscartland.garage.domain.model
+
+@JvmInline
+value class Email(
+    private val s: String,
+) {
+    fun asString(): String = s
+}
+
+@JvmInline
+value class DisplayName(
+    private val s: String,
+) {
+    fun asString(): String = s
+}
+
+data class FirebaseIdToken(
+    val idToken: String,
+    val exp: Long,
+) {
+    fun asString(): String = idToken
+}
+
+@JvmInline
+value class GoogleIdToken(
+    private val s: String,
+) {
+    fun asString(): String = s
+}
+
+data class User(
+    val name: DisplayName,
+    val email: Email,
+    val idToken: FirebaseIdToken,
+)
+
+sealed class AuthState {
+    data object Unknown : AuthState()
+
+    data object Unauthenticated : AuthState()
+
+    data class Authenticated(
+        val user: User,
+    ) : AuthState()
+}

--- a/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/model/DoorEvent.kt
+++ b/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/model/DoorEvent.kt
@@ -1,0 +1,8 @@
+package com.chriscartland.garage.domain.model
+
+data class DoorEvent(
+    val doorPosition: DoorPosition? = null,
+    val message: String? = null,
+    val lastCheckInTimeSeconds: Long? = null,
+    val lastChangeTimeSeconds: Long? = null,
+)

--- a/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/model/DoorPosition.kt
+++ b/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/model/DoorPosition.kt
@@ -1,0 +1,14 @@
+package com.chriscartland.garage.domain.model
+
+// DO NOT CHANGE NAMES — must match server strings
+enum class DoorPosition {
+    UNKNOWN,
+    CLOSED,
+    OPENING,
+    OPENING_TOO_LONG,
+    OPEN,
+    OPEN_MISALIGNED,
+    CLOSING,
+    CLOSING_TOO_LONG,
+    ERROR_SENSOR_CONFLICT,
+}

--- a/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/model/FcmModel.kt
+++ b/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/model/FcmModel.kt
@@ -1,0 +1,22 @@
+package com.chriscartland.garage.domain.model
+
+sealed class DoorFcmState {
+    data object Unknown : DoorFcmState()
+
+    data object NotRegistered : DoorFcmState()
+
+    data class Registered(
+        val topic: DoorFcmTopic,
+    ) : DoorFcmState()
+}
+
+@JvmInline
+value class DoorFcmTopic(
+    val string: String,
+)
+
+enum class FcmRegistrationStatus {
+    UNKNOWN,
+    REGISTERED,
+    NOT_REGISTERED,
+}

--- a/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/model/LoadingResult.kt
+++ b/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/model/LoadingResult.kt
@@ -1,0 +1,23 @@
+package com.chriscartland.garage.domain.model
+
+sealed class LoadingResult<out T> {
+    data class Loading<out T>(
+        internal val d: T?,
+    ) : LoadingResult<T>()
+
+    data class Complete<out T>(
+        internal val d: T?,
+    ) : LoadingResult<T>()
+
+    data class Error(
+        val exception: Throwable,
+    ) : LoadingResult<Nothing>()
+
+    val data: T?
+        get() =
+            when (this) {
+                is Loading -> this.d
+                is Complete -> this.d
+                is Error -> null
+            }
+}

--- a/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/model/RemoteButtonModel.kt
+++ b/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/model/RemoteButtonModel.kt
@@ -1,0 +1,21 @@
+package com.chriscartland.garage.domain.model
+
+enum class RequestStatus {
+    NONE,
+    SENDING,
+    SENDING_TIMEOUT,
+    SENT,
+    SENT_TIMEOUT,
+    RECEIVED,
+}
+
+enum class PushStatus {
+    IDLE,
+    SENDING,
+}
+
+enum class SnoozeRequestStatus {
+    IDLE,
+    SENDING,
+    ERROR,
+}

--- a/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/model/ServerConfig.kt
+++ b/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/model/ServerConfig.kt
@@ -1,0 +1,7 @@
+package com.chriscartland.garage.domain.model
+
+data class ServerConfig(
+    val buildTimestamp: String,
+    val remoteButtonBuildTimestamp: String,
+    val remoteButtonPushKey: String,
+)

--- a/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/repository/AuthRepository.kt
+++ b/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/repository/AuthRepository.kt
@@ -1,0 +1,15 @@
+package com.chriscartland.garage.domain.repository
+
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.GoogleIdToken
+import kotlinx.coroutines.flow.StateFlow
+
+interface AuthRepository {
+    val authState: StateFlow<AuthState>
+
+    suspend fun signInWithGoogle(idToken: GoogleIdToken): AuthState
+
+    suspend fun refreshFirebaseAuthState(): AuthState
+
+    suspend fun signOut()
+}

--- a/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/repository/DoorRepository.kt
+++ b/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/repository/DoorRepository.kt
@@ -1,0 +1,19 @@
+package com.chriscartland.garage.domain.repository
+
+import com.chriscartland.garage.domain.model.DoorEvent
+import com.chriscartland.garage.domain.model.DoorPosition
+import kotlinx.coroutines.flow.Flow
+
+interface DoorRepository {
+    val currentDoorPosition: Flow<DoorPosition>
+    val currentDoorEvent: Flow<DoorEvent>
+    val recentDoorEvents: Flow<List<DoorEvent>>
+
+    suspend fun fetchBuildTimestampCached(): String?
+
+    fun insertDoorEvent(doorEvent: DoorEvent)
+
+    suspend fun fetchCurrentDoorEvent()
+
+    suspend fun fetchRecentDoorEvents()
+}

--- a/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/repository/PushRepository.kt
+++ b/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/repository/PushRepository.kt
@@ -1,0 +1,24 @@
+package com.chriscartland.garage.domain.repository
+
+import com.chriscartland.garage.domain.model.PushStatus
+import com.chriscartland.garage.domain.model.SnoozeRequestStatus
+import kotlinx.coroutines.flow.StateFlow
+
+interface PushRepository {
+    val pushButtonStatus: StateFlow<PushStatus>
+    val snoozeRequestStatus: StateFlow<SnoozeRequestStatus>
+    val snoozeEndTimeSeconds: StateFlow<Long>
+
+    suspend fun push(
+        idToken: String,
+        buttonAckToken: String,
+    )
+
+    suspend fun fetchSnoozeEndTimeSeconds()
+
+    suspend fun snoozeOpenDoorsNotifications(
+        snoozeDurationHours: String,
+        idToken: String,
+        snoozeEventTimestampSeconds: Long,
+    )
+}

--- a/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/repository/ServerConfigRepository.kt
+++ b/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/repository/ServerConfigRepository.kt
@@ -1,0 +1,9 @@
+package com.chriscartland.garage.domain.repository
+
+import com.chriscartland.garage.domain.model.ServerConfig
+
+interface ServerConfigRepository {
+    suspend fun getServerConfigCached(): ServerConfig?
+
+    suspend fun fetchServerConfig(): ServerConfig?
+}


### PR DESCRIPTION
## Summary
Add pure Kotlin domain types to `domain/` module (no Android dependencies):

**Models:** DoorPosition, DoorEvent, LoadingResult, AuthState, User, FirebaseIdToken, GoogleIdToken, DoorFcmState, FcmRegistrationStatus, RequestStatus, PushStatus, SnoozeRequestStatus, ServerConfig

**Repository interfaces:** DoorRepository, AuthRepository, PushRepository, ServerConfigRepository

This PR defines the domain layer only. Next PR: migrate androidApp to use these types (update imports, add type aliases or mappers where Room @Entity annotations are needed).

Phase 2.1 from [MIGRATION.md](AndroidGarage/docs/MIGRATION.md).

## Test plan
- [x] `./gradlew :domain:build` passes
- [x] Spotless passes
- [ ] CI passes
- androidApp unchanged — no import migration yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)