### PR TITLE
feat: Extract EnsureFreshIdTokenUseCase (Phase 2.2)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
@@ -24,7 +24,6 @@ import com.chriscartland.garage.auth.AuthRepository
 import com.chriscartland.garage.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.DoorEvent
-import com.chriscartland.garage.domain.model.FirebaseIdToken
 import com.chriscartland.garage.domain.model.PushStatus
 import com.chriscartland.garage.domain.model.RequestStatus
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
@@ -32,6 +31,7 @@ import com.chriscartland.garage.door.DoorRepository
 import com.chriscartland.garage.internet.IdToken
 import com.chriscartland.garage.internet.SnoozeEventTimestampParameter
 import com.chriscartland.garage.snoozenotifications.SnoozeDurationUIOption
+import com.chriscartland.garage.usecase.EnsureFreshIdTokenUseCase
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -73,6 +73,7 @@ class RemoteButtonViewModelImpl
         // Watch the door status, because we consider the request delivered when the door moves.
         private val doorRepository: DoorRepository,
         private val dispatchers: DispatcherProvider,
+        private val ensureFreshIdToken: EnsureFreshIdTokenUseCase,
     ) : ViewModel(),
         RemoteButtonViewModel {
         // Listen to network events and door status updates.
@@ -323,29 +324,6 @@ class RemoteButtonViewModelImpl
                     idToken = IdToken(idToken.asString()),
                     snoozeEventTimestamp = SnoozeEventTimestampParameter(lastChangeTimeSeconds),
                 )
-            }
-        }
-
-        /**
-         * Ensure the ID token is fresh.
-         */
-        private suspend fun ensureFreshIdToken(
-            authRepository: AuthRepository,
-            authState: AuthState.Authenticated,
-        ): FirebaseIdToken {
-            Log.d(TAG, "refreshIdToken")
-            return if (authState.user.idToken.exp > System.currentTimeMillis()) {
-                Log.d(TAG, "freshIdToken: Using cached token")
-                authState.user.idToken
-            } else {
-                val newAuthState = authRepository.refreshFirebaseAuthState()
-                if (newAuthState !is AuthState.Authenticated) {
-                    Log.w(TAG, "freshIdToken: Not authenticated")
-                    authState.user.idToken
-                } else {
-                    Log.d(TAG, "freshIdToken: New token")
-                    newAuthState.user.idToken
-                }
             }
         }
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/EnsureFreshIdTokenUseCase.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/EnsureFreshIdTokenUseCase.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.auth.AuthRepository
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.FirebaseIdToken
+import javax.inject.Inject
+
+/**
+ * Ensures we have a fresh (non-expired) Firebase ID token for API calls.
+ *
+ * Logic:
+ * - If the cached token is still valid (exp > now), return it
+ * - Otherwise, refresh the auth state and return the new token
+ * - If refresh fails (user becomes unauthenticated), fall back to the cached token
+ */
+class EnsureFreshIdTokenUseCase
+    @Inject
+    constructor() {
+        suspend operator fun invoke(
+            authRepository: AuthRepository,
+            currentAuth: AuthState.Authenticated,
+            currentTimeMillis: Long = System.currentTimeMillis(),
+        ): FirebaseIdToken =
+            if (currentAuth.user.idToken.exp > currentTimeMillis) {
+                currentAuth.user.idToken
+            } else {
+                val refreshed = authRepository.refreshFirebaseAuthState()
+                if (refreshed is AuthState.Authenticated) {
+                    refreshed.user.idToken
+                } else {
+                    currentAuth.user.idToken
+                }
+            }
+    }

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModelTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModelTest.kt
@@ -26,6 +26,7 @@ import com.chriscartland.garage.domain.model.PushStatus
 import com.chriscartland.garage.domain.model.RequestStatus
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
 import com.chriscartland.garage.door.DoorRepository
+import com.chriscartland.garage.usecase.EnsureFreshIdTokenUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -81,7 +82,12 @@ class RemoteButtonViewModelTest {
     }
 
     private fun createViewModel(): RemoteButtonViewModelImpl {
-        val vm = RemoteButtonViewModelImpl(pushRepository, doorRepository, TestDispatcherProvider(testDispatcher))
+        val vm = RemoteButtonViewModelImpl(
+            pushRepository,
+            doorRepository,
+            TestDispatcherProvider(testDispatcher),
+            EnsureFreshIdTokenUseCase(),
+        )
         testDispatcher.scheduler.runCurrent()
         return vm
     }

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakeAuthRepository.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakeAuthRepository.kt
@@ -34,6 +34,8 @@ class FakeAuthRepository : AuthRepository {
     var refreshCount = 0
         private set
 
+    var refreshResult: AuthState? = null
+
     fun setAuthState(state: AuthState) {
         _authState.value = state
     }
@@ -45,7 +47,7 @@ class FakeAuthRepository : AuthRepository {
 
     override suspend fun refreshFirebaseAuthState(): AuthState {
         refreshCount++
-        return _authState.value
+        return refreshResult ?: _authState.value
     }
 
     override suspend fun signOut() {

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/EnsureFreshIdTokenUseCaseTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/EnsureFreshIdTokenUseCaseTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.DisplayName
+import com.chriscartland.garage.domain.model.Email
+import com.chriscartland.garage.domain.model.FirebaseIdToken
+import com.chriscartland.garage.domain.model.User
+import com.chriscartland.garage.testcommon.FakeAuthRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class EnsureFreshIdTokenUseCaseTest {
+    private lateinit var useCase: EnsureFreshIdTokenUseCase
+    private lateinit var fakeAuth: FakeAuthRepository
+
+    @Before
+    fun setup() {
+        useCase = EnsureFreshIdTokenUseCase()
+        fakeAuth = FakeAuthRepository()
+    }
+
+    private fun makeAuth(
+        token: String = "token",
+        exp: Long = 5000L,
+    ): AuthState.Authenticated =
+        AuthState.Authenticated(
+            user = User(
+                name = DisplayName("Test"),
+                email = Email("test@test.com"),
+                idToken = FirebaseIdToken(idToken = token, exp = exp),
+            ),
+        )
+
+    @Test
+    fun returnsCachedTokenWhenNotExpired() =
+        runTest {
+            val auth = makeAuth(token = "cached-token", exp = 5000L)
+            val result = useCase(fakeAuth, auth, currentTimeMillis = 4999L)
+
+            assertEquals("cached-token", result.asString())
+            assertEquals(0, fakeAuth.refreshCount)
+        }
+
+    @Test
+    fun refreshesTokenWhenExpired() =
+        runTest {
+            val auth = makeAuth(token = "old-token", exp = 1000L)
+            val refreshedAuth = makeAuth(token = "new-token", exp = 9000L)
+            fakeAuth.refreshResult = refreshedAuth
+
+            val result = useCase(fakeAuth, auth, currentTimeMillis = 2000L)
+
+            assertEquals("new-token", result.asString())
+            assertEquals(1, fakeAuth.refreshCount)
+        }
+
+    @Test
+    fun refreshesTokenWhenExactlyExpired() =
+        runTest {
+            val auth = makeAuth(token = "old-token", exp = 1000L)
+            val refreshedAuth = makeAuth(token = "new-token", exp = 9000L)
+            fakeAuth.refreshResult = refreshedAuth
+
+            val result = useCase(fakeAuth, auth, currentTimeMillis = 1000L)
+
+            assertEquals("new-token", result.asString())
+            assertEquals(1, fakeAuth.refreshCount)
+        }
+
+    @Test
+    fun fallsBackToCachedTokenWhenRefreshFailsWithUnauthenticated() =
+        runTest {
+            val auth = makeAuth(token = "old-token", exp = 1000L)
+            fakeAuth.refreshResult = AuthState.Unauthenticated
+
+            val result = useCase(fakeAuth, auth, currentTimeMillis = 2000L)
+
+            assertEquals("old-token", result.asString())
+            assertEquals(1, fakeAuth.refreshCount)
+        }
+
+    @Test
+    fun fallsBackToCachedTokenWhenRefreshFailsWithUnknown() =
+        runTest {
+            val auth = makeAuth(token = "old-token", exp = 1000L)
+            fakeAuth.refreshResult = AuthState.Unknown
+
+            val result = useCase(fakeAuth, auth, currentTimeMillis = 2000L)
+
+            assertEquals("old-token", result.asString())
+            assertEquals(1, fakeAuth.refreshCount)
+        }
+
+    @Test
+    fun doesNotRefreshWhenTokenHasLargeMargin() =
+        runTest {
+            val auth = makeAuth(token = "cached-token", exp = Long.MAX_VALUE)
+            val result = useCase(fakeAuth, auth, currentTimeMillis = System.currentTimeMillis())
+
+            assertEquals("cached-token", result.asString())
+            assertEquals(0, fakeAuth.refreshCount)
+        }
+}


### PR DESCRIPTION
## Summary
- First UseCase extraction for Phase 2.2 (Extract UseCase Layer)
- Extracts token refresh logic from `RemoteButtonViewModel` into `EnsureFreshIdTokenUseCase`
- UseCase is injectable via Hilt `@Inject constructor`
- 6 new tests covering all branches (cached token, expired/refresh, refresh failures)
- Enhanced `FakeAuthRepository` with configurable `refreshResult`

**Stacked on #45** — merge #45 first.

## Test plan
- [x] `EnsureFreshIdTokenUseCaseTest` — 6 tests covering all logic branches
- [x] Existing `RemoteButtonViewModelTest` passes with UseCase injected
- [x] All unit tests pass
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)