### PR TITLE
refactor: Extract FcmPayloadParser object (ADR-008)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
@@ -21,7 +21,6 @@ import android.util.Log
 import com.chriscartland.garage.applogger.AppLoggerRepository
 import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.domain.model.DoorEvent
-import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.door.DoorRepository
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
@@ -56,7 +55,7 @@ class FCMService : FirebaseMessagingService() {
         if (remoteMessage.data.isNotEmpty()) {
             Log.d(TAG, "Message data payload: ${remoteMessage.data}")
 
-            val doorEvent = remoteMessage.data.asDoorEvent()
+            val doorEvent = FcmPayloadParser.parseDoorEvent(remoteMessage.data)
             if (doorEvent == null) {
                 Log.e(TAG, "Unknown message type: ${remoteMessage.data.entries.joinToString()}")
                 return
@@ -105,35 +104,6 @@ class FCMService : FirebaseMessagingService() {
     override fun onDestroy() {
         super.onDestroy()
         supervisorJob.cancel()
-    }
-}
-
-/**
- * Extract DoorEvent from Firebase RemoteMessage data payload.
- */
-internal fun <K, V> Map<K, V>.asDoorEvent(): DoorEvent? {
-    try {
-        val currentEvent = this as? Map<*, *> ?: return null // Required
-        val type = currentEvent["type"] as? String ?: return null // Required
-        val position = try {
-            DoorPosition.valueOf(type)
-        } catch (e: IllegalArgumentException) {
-            DoorPosition.UNKNOWN
-        }
-        val message = currentEvent["message"] as? String ?: "" // Optional
-        val timestampSeconds = (currentEvent["timestampSeconds"] as? String)
-            ?.toLong() ?: return null // Required
-        val checkInTimestampSeconds = (currentEvent["checkInTimestampSeconds"] as? String)
-            ?.toLong() ?: return null // Required
-        return DoorEvent(
-            doorPosition = position,
-            message = message,
-            lastChangeTimeSeconds = timestampSeconds,
-            lastCheckInTimeSeconds = checkInTimestampSeconds,
-        )
-    } catch (e: Exception) {
-        Log.e("FCMService", "Error converting to DoorEvent: $e")
-        return null
     }
 }
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FcmPayloadParser.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FcmPayloadParser.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.fcm
+
+import android.util.Log
+import com.chriscartland.garage.domain.model.DoorEvent
+import com.chriscartland.garage.domain.model.DoorPosition
+
+/**
+ * Parses FCM data message payloads into domain objects.
+ *
+ * The server sends FCM data messages with string key/value pairs.
+ * This parser converts them into typed domain objects.
+ *
+ * Required keys: "type", "timestampSeconds", "checkInTimestampSeconds"
+ * Optional keys: "message" (defaults to "")
+ */
+object FcmPayloadParser {
+    /**
+     * Parse a door event from an FCM data payload.
+     *
+     * @param data The FCM data message payload (string key/value pairs)
+     * @return The parsed [DoorEvent], or null if required fields are missing or malformed
+     */
+    fun parseDoorEvent(data: Map<String, String>): DoorEvent? {
+        try {
+            val type = data["type"] ?: return null
+            val position = try {
+                DoorPosition.valueOf(type)
+            } catch (e: IllegalArgumentException) {
+                DoorPosition.UNKNOWN
+            }
+            val message = data["message"] ?: ""
+            val timestampSeconds = data["timestampSeconds"]?.toLongOrNull() ?: return null
+            val checkInTimestampSeconds = data["checkInTimestampSeconds"]?.toLongOrNull()
+                ?: return null
+            return DoorEvent(
+                doorPosition = position,
+                message = message,
+                lastChangeTimeSeconds = timestampSeconds,
+                lastCheckInTimeSeconds = checkInTimestampSeconds,
+            )
+        } catch (e: Exception) {
+            Log.e("FcmPayloadParser", "Error parsing DoorEvent: $e")
+            return null
+        }
+    }
+}

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/fcm/FcmPayloadParsingTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/fcm/FcmPayloadParsingTest.kt
@@ -47,7 +47,7 @@ class FcmPayloadParsingTest {
     @Test
     fun validPayloadParsesCorrectly() {
         val payload = makePayload()
-        val event = payload.asDoorEvent()
+        val event = FcmPayloadParser.parseDoorEvent(payload)
 
         assertNotNull("Valid payload should parse to DoorEvent", event)
         assertEquals(DoorPosition.CLOSED, event!!.doorPosition)
@@ -60,7 +60,7 @@ class FcmPayloadParsingTest {
     fun allDoorPositionsParse() {
         DoorPosition.entries.forEach { position ->
             val payload = makePayload(type = position.name)
-            val event = payload.asDoorEvent()
+            val event = FcmPayloadParser.parseDoorEvent(payload)
             assertNotNull("Position ${position.name} should parse", event)
             assertEquals(position, event!!.doorPosition)
         }
@@ -69,7 +69,7 @@ class FcmPayloadParsingTest {
     @Test
     fun unknownTypeParsesAsUnknown() {
         val payload = makePayload(type = "NEVER_SEEN_BEFORE")
-        val event = payload.asDoorEvent()
+        val event = FcmPayloadParser.parseDoorEvent(payload)
         assertNotNull("Unknown type should still parse", event)
         assertEquals(DoorPosition.UNKNOWN, event!!.doorPosition)
     }
@@ -77,25 +77,25 @@ class FcmPayloadParsingTest {
     @Test
     fun missingTypeReturnsNull() {
         val payload = makePayload(type = null)
-        assertNull("Missing 'type' key should return null", payload.asDoorEvent())
+        assertNull("Missing 'type' key should return null", FcmPayloadParser.parseDoorEvent(payload))
     }
 
     @Test
     fun missingTimestampReturnsNull() {
         val payload = makePayload(timestampSeconds = null)
-        assertNull("Missing 'timestampSeconds' should return null", payload.asDoorEvent())
+        assertNull("Missing 'timestampSeconds' should return null", FcmPayloadParser.parseDoorEvent(payload))
     }
 
     @Test
     fun missingCheckInTimestampReturnsNull() {
         val payload = makePayload(checkInTimestampSeconds = null)
-        assertNull("Missing 'checkInTimestampSeconds' should return null", payload.asDoorEvent())
+        assertNull("Missing 'checkInTimestampSeconds' should return null", FcmPayloadParser.parseDoorEvent(payload))
     }
 
     @Test
     fun missingMessageDefaultsToEmpty() {
         val payload = makePayload(message = null)
-        val event = payload.asDoorEvent()
+        val event = FcmPayloadParser.parseDoorEvent(payload)
         assertNotNull(event)
         assertEquals("", event!!.message)
     }
@@ -103,13 +103,13 @@ class FcmPayloadParsingTest {
     @Test
     fun nonNumericTimestampReturnsNull() {
         val payload = makePayload(timestampSeconds = "not-a-number")
-        assertNull("Non-numeric timestamp should return null", payload.asDoorEvent())
+        assertNull("Non-numeric timestamp should return null", FcmPayloadParser.parseDoorEvent(payload))
     }
 
     @Test
     fun emptyPayloadReturnsNull() {
         val payload = emptyMap<String, String>()
-        assertNull("Empty payload should return null", payload.asDoorEvent())
+        assertNull("Empty payload should return null", FcmPayloadParser.parseDoorEvent(payload))
     }
 
     @Test
@@ -122,7 +122,7 @@ class FcmPayloadParsingTest {
             "timestampSeconds" to "1710000000",
             "checkInTimestampSeconds" to "1710000060",
         )
-        val event = payload.asDoorEvent()
+        val event = FcmPayloadParser.parseDoorEvent(payload)
         assertNotNull("Real server payload must parse successfully", event)
         assertEquals(DoorPosition.OPEN, event!!.doorPosition)
         assertEquals("The door is open.", event.message)


### PR DESCRIPTION
## Summary
- Applies ADR-008: replace `Map<K, V>.asDoorEvent()` extension with `FcmPayloadParser.parseDoorEvent(Map<String, String>)`
- Parser object makes the parsing logic discoverable and input type explicit
- All 17 FCM contract tests pass unchanged (only call site updated)
- No behavior change — same parsing logic, better API

## Test plan
- [x] All 17 FCM contract tests pass
- [x] All existing tests pass
- [x] `./scripts/validate.sh` passes
- [x] No behavior change to push notification handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)