### PR TITLE
fix: Add missing failure listener to Firebase token refresh

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthRepository.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthRepository.kt
@@ -109,17 +109,22 @@ class AuthRepositoryImpl
                 val currentUser = Firebase.auth.currentUser ?: return AuthState.Unauthenticated.commit()
                 val idToken: FirebaseIdToken? =
                     suspendCancellableCoroutine { continuation ->
-                        currentUser.getIdToken(true).addOnSuccessListener { result ->
-                            Log.d(TAG, "Firebase ID Token: ${result.token}")
-                            continuation.resume(
-                                result.token?.let {
-                                    FirebaseIdToken(
-                                        idToken = it,
-                                        exp = result.expirationTimestamp,
-                                    )
-                                },
-                            )
-                        }
+                        currentUser
+                            .getIdToken(true)
+                            .addOnSuccessListener { result ->
+                                Log.d(TAG, "Firebase ID Token: ${result.token}")
+                                continuation.resume(
+                                    result.token?.let {
+                                        FirebaseIdToken(
+                                            idToken = it,
+                                            exp = result.expirationTimestamp,
+                                        )
+                                    },
+                                )
+                            }.addOnFailureListener { exception ->
+                                Log.e(TAG, "Failed to get Firebase ID Token", exception)
+                                continuation.resume(null)
+                            }
                     }
                 if (idToken == null) {
                     return AuthState.Unauthenticated.commit()


### PR DESCRIPTION
## Summary
- `refreshFirebaseAuthState()` used `suspendCancellableCoroutine` with `addOnSuccessListener` but **no `addOnFailureListener`**
- If Firebase token fetch failed, the coroutine hung forever, blocking the ViewModel
- Now resumes with `null` on failure, triggering the existing `Unauthenticated` fallback

This was identified in TESTING.md Phase 3.1 as a known bug.

## Test plan
- [x] `./scripts/validate.sh` passes
- [x] Existing auth tests pass (the fallback path is already tested in `EnsureFreshIdTokenUseCaseTest`)
- [x] Minimal change — only adds `.addOnFailureListener` to existing chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)