### PR TITLE
docs: Update Phase 2.2 and testing status

### DIFF
--- a/AndroidGarage/docs/MIGRATION.md
+++ b/AndroidGarage/docs/MIGRATION.md
@@ -45,13 +45,16 @@ Target: Align with [battery-butler](https://github.com/cartland/battery-butler) 
 - Domain module types: `DoorEvent`, `DoorPosition`, `LoadingResult`, `AuthState`, `User`, `FirebaseIdToken`, `GoogleIdToken`, `DoorFcmState`, `DoorFcmTopic`, `FcmRegistrationStatus`, `RequestStatus`, `PushStatus`, `SnoozeRequestStatus`, `ServerConfig`
 - Repository interfaces in domain (signatures pending alignment with androidApp)
 
-### 2.2 Extract UseCase Layer
-- Create `usecase/` module depending on domain
-- Extract business logic from ViewModels into single-purpose UseCases:
-  - `FetchDoorStatusUseCase`
-  - `PushRemoteButtonUseCase`
-  - `RegisterFcmUseCase`
-  - `RefreshAuthTokenUseCase`
+### 2.2 Extract UseCase Layer — IN PROGRESS
+- Created `usecase/` package in androidApp (will become separate module when repository interfaces align)
+- Extracted `EnsureFreshIdTokenUseCase` — `79d3a6b` (#48)
+  - Token refresh logic with 6 tests covering all branches
+  - Wired into `RemoteButtonViewModelImpl` via Hilt `@Inject`
+- Remaining UseCases:
+  - `PushRemoteButtonUseCase` — auth check + push (blocked on Android-specific types in repository interfaces)
+  - `SnoozeNotificationsUseCase` — same pattern as push
+  - `FetchDoorStatusUseCase` — wraps repository fetch
+  - `RegisterFcmUseCase` — FCM registration (tightly coupled to Firebase APIs)
 - Each UseCase has `operator fun invoke()` for clean call syntax
 - ViewModels depend on UseCases, not Repositories
 

--- a/AndroidGarage/docs/TESTING.md
+++ b/AndroidGarage/docs/TESTING.md
@@ -93,19 +93,11 @@ Already done (8 tests in PR #11). Covers caching, all null-validation branches, 
 
 ## Phase 3: Auth Token Lifecycle Tests
 
-`AuthRepository.refreshFirebaseAuthState()` uses `suspendCancellableCoroutine` with `addOnSuccessListener` but no `addOnFailureListener`. If the Firebase token fetch fails, the coroutine hangs forever.
+### 3.1 Auth Token Refresh Bug Fix — `9c469b8` (#53)
 
-### 3.1 Auth Token Refresh Tests
+`refreshFirebaseAuthState()` had `addOnSuccessListener` without `addOnFailureListener`. Fixed by adding failure listener that resumes with null (triggering existing Unauthenticated fallback).
 
-**Tests to write:**
-- Token refresh success → verify `AuthState.Authenticated` with fresh token
-- Token refresh failure (Firebase returns error) → verify fallback to `Unauthenticated` (not hang)
-- Token refresh with null `currentUser` → verify immediate `Unauthenticated`
-- Sign out → verify state transitions to `Unauthenticated`
-
-**Prerequisite:** Either mock `Firebase.auth` (difficult) or extract the Firebase calls behind an interface for testability. This may require a small refactor.
-
-**Files:** New `AuthRepositoryTest.kt`, possibly new `FirebaseAuthWrapper` interface
+**Remaining:** Full AuthRepository unit tests still need Firebase wrapper extraction. The fix was a one-line safety improvement, not a full test suite.
 
 ### 3.2 Token Expiry in RemoteButtonViewModel — COMPLETE (PR #48)
 


### PR DESCRIPTION
## Summary
- Mark Phase 2.2 as in progress, document EnsureFreshIdTokenUseCase completion
- Update Phase 3.1 to reflect auth token hang fix (#53)
- No code changes

## Test plan
- [x] Docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)