### PR TITLE
fix: Expand validation script to cover all modules

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -16,14 +16,17 @@ pass() { echo -e "${GREEN}PASS${RESET} $1"; }
 fail() { echo -e "${RED}FAIL${RESET} $1"; exit 1; }
 step() { echo -e "\n${BOLD}--- $1 ---${RESET}"; }
 
-step "Spotless (formatting)"
-$GRADLE :androidApp:spotlessCheck && pass "spotlessCheck" || fail "spotlessCheck"
+step "Spotless (formatting — all modules)"
+$GRADLE spotlessCheck && pass "spotlessCheck" || fail "spotlessCheck"
 
 step "Detekt (static analysis)"
 $GRADLE :androidApp:detekt && pass "detekt" || fail "detekt"
 
 step "Android Lint"
 $GRADLE :androidApp:lint && pass "lint" || fail "lint"
+
+step "Domain module tests"
+$GRADLE :domain:test && pass "domain:test" || fail "domain:test"
 
 step "Unit Tests (debug)"
 $GRADLE :androidApp:testDebugUnitTest && pass "testDebugUnitTest" || fail "testDebugUnitTest"


### PR DESCRIPTION
## Summary
Closes the gap between local validation and CI that caused PR #45 to pass locally but fail in CI.

- `spotlessCheck` now runs at root level (covers `:domain` module, not just `:androidApp`)
- Added `:domain:test` step to catch domain module test regressions

This is the direct fix for the concern about merging breaking changes — if local validation matches CI, we catch issues before push.

## Test plan
- [x] `./scripts/validate.sh` passes with expanded checks
- [x] Verified domain spotless and tests are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)