### PR TITLE
feat: Add Room schema safety checks

### DIFF
--- a/.claude/hooks/git-guardrails.sh
+++ b/.claude/hooks/git-guardrails.sh
@@ -85,6 +85,27 @@ if echo "$STRIPPED" | grep -qE '\bgh\s+pr\s+merge\b'; then
   fi
 fi
 
+# --- Warn on Room database changes ---
+if echo "$STRIPPED" | grep -qE '\bgit\s+(add|commit)\b'; then
+  # Check if any staged files are Room entities, DAOs, or the database class
+  STAGED=$(git diff --cached --name-only 2>/dev/null)
+  ROOM_CHANGED=false
+  for f in $STAGED; do
+    case "$f" in
+      *Entity.kt|*Dao.kt|*AppDatabase.kt|*Migration*.kt)
+        ROOM_CHANGED=true
+        break
+        ;;
+    esac
+  done
+  if [ "$ROOM_CHANGED" = "true" ]; then
+    echo "WARNING: Room database files are being committed." >&2
+    echo "  - If the schema changed, increment the version in @Database" >&2
+    echo "  - Run ./scripts/validate.sh (includes Room schema drift check)" >&2
+    echo "  - Commit the updated schema JSON from androidApp/schemas/" >&2
+  fi
+fi
+
 # --- Block destructive git commands ---
 if echo "$STRIPPED" | grep -qE '\bgit\s+reset\s+--hard\b'; then
   deny "BLOCKED: git reset --hard discards commits. Use git stash or a backup branch."

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/db/RoomSchemaTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/db/RoomSchemaTest.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.db
+
+import com.chriscartland.garage.domain.model.DoorPosition
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Verifies the Room database schema is consistent.
+ *
+ * Room schema changes break at runtime (not compile time). These tests
+ * catch schema drift before it reaches a device:
+ *
+ * - Schema file must exist for the declared version
+ * - Entity structure must match what the code defines
+ * - DoorPosition enum values must match the type converter expectations
+ *
+ * If a test fails, you likely need to increment the database version
+ * in AppDatabase.kt and commit the new schema JSON.
+ */
+class RoomSchemaTest {
+    @JsonClass(generateAdapter = false)
+    data class SchemaFile(
+        val database: SchemaDatabase,
+    )
+
+    @JsonClass(generateAdapter = false)
+    data class SchemaDatabase(
+        val version: Int,
+        val entities: List<SchemaEntity>,
+    )
+
+    @JsonClass(generateAdapter = false)
+    data class SchemaEntity(
+        val tableName: String,
+        val fields: List<SchemaField>,
+    )
+
+    @JsonClass(generateAdapter = false)
+    data class SchemaField(
+        val columnName: String,
+        val affinity: String,
+    )
+
+    private val schemaDir = File("schemas/com.chriscartland.garage.db.AppDatabase")
+
+    private val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+
+    private fun latestSchemaVersion(): Int {
+        val files = schemaDir.listFiles { f -> f.extension == "json" } ?: emptyArray()
+        return files.mapNotNull { it.nameWithoutExtension.toIntOrNull() }.maxOrNull() ?: -1
+    }
+
+    private fun readSchema(version: Int): SchemaFile {
+        val file = File(schemaDir, "$version.json")
+        assertTrue("Schema file $version.json must exist", file.exists())
+        val adapter = moshi.adapter(SchemaFile::class.java)
+        return adapter.fromJson(file.readText())!!
+    }
+
+    @Test
+    fun schemaFileExistsForLatestVersion() {
+        val version = latestSchemaVersion()
+        assertTrue("No schema files found in $schemaDir", version > 0)
+        val file = File(schemaDir, "$version.json")
+        assertTrue("Schema file ${file.name} must exist", file.exists())
+    }
+
+    @Test
+    fun doorEventEntityHasExpectedColumns() {
+        val schema = readSchema(latestSchemaVersion())
+        val doorEvent = schema.database.entities.find { it.tableName == "DoorEvent" }
+        assertNotNull("DoorEvent table must exist in schema", doorEvent)
+
+        val columnNames = doorEvent!!.fields.map { it.columnName }.toSet()
+
+        val expectedColumns = setOf(
+            "id",
+            "doorPosition",
+            "message",
+            "lastCheckInTimeSeconds",
+            "lastChangeTimeSeconds",
+        )
+        assertEquals(
+            "DoorEvent columns changed — increment database version in AppDatabase.kt",
+            expectedColumns,
+            columnNames,
+        )
+    }
+
+    @Test
+    fun doorPositionEnumValuesMatchSchemaExpectations() {
+        // Room stores DoorPosition as TEXT (enum name). If enum values change,
+        // existing database rows become unreadable. This test ensures we don't
+        // accidentally rename or remove values.
+        val expectedValues = setOf(
+            "UNKNOWN",
+            "CLOSED",
+            "OPENING",
+            "OPENING_TOO_LONG",
+            "OPEN",
+            "OPEN_MISALIGNED",
+            "CLOSING",
+            "CLOSING_TOO_LONG",
+            "ERROR_SENSOR_CONFLICT",
+        )
+        val actualValues = DoorPosition.entries.map { it.name }.toSet()
+        assertEquals(
+            "DoorPosition enum values changed — this breaks existing Room data. " +
+                "If intentional, increment database version.",
+            expectedValues,
+            actualValues,
+        )
+    }
+
+    @Test
+    fun appEventEntityExistsInSchema() {
+        val schema = readSchema(latestSchemaVersion())
+        val appEvent = schema.database.entities.find { it.tableName == "AppEvent" }
+        assertNotNull("AppEvent table must exist in schema", appEvent)
+    }
+
+    @Test
+    fun schemaVersionMatchesDatabaseAnnotation() {
+        val schema = readSchema(latestSchemaVersion())
+        val jsonVersion = schema.database.version
+        val latestFile = latestSchemaVersion()
+        assertEquals(
+            "Schema JSON filename ($latestFile.json) must match the version inside it ($jsonVersion). " +
+                "Rebuild to regenerate schema.",
+            latestFile,
+            jsonVersion,
+        )
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,22 @@ Firestore Functions: Event-driven processing on data changes
 ## Development Workflow
 
 ### Local Validation
-Run `./scripts/validate.sh` before pushing. It mirrors CI: spotless, lint, unit tests (3 variants), debug build. Writes a validation marker so the git-guardrails hook can warn on stale pushes.
+Run `./scripts/validate.sh` before pushing. It mirrors CI: spotless (all modules), lint, unit tests (3 variants), domain tests, debug build, and Room schema drift check. Writes a validation marker so the git-guardrails hook can warn on stale pushes.
+
+### Room Database Safety
+Room schema changes break at runtime (not compile time). The following safeguards are in place:
+
+1. **Schema drift check** in `validate.sh` — detects if compilation changed the exported schema JSON without it being committed
+2. **Guardrails hook** — warns when committing Room entity, DAO, or database files
+3. **Schema contract tests** (`RoomSchemaTest`) — verify column structure and enum values match expectations
+4. **Schema export** — `androidApp/schemas/` contains versioned JSON files tracked in git
+
+**When modifying Room entities or DAOs:**
+1. Make the change
+2. Increment `version` in `@Database` annotation (`AppDatabase.kt`)
+3. Run `./gradlew :androidApp:assembleDebug` to regenerate schema
+4. Commit the new schema JSON file alongside your code change
+5. `fallbackToDestructiveMigration` handles upgrades (users lose cached data, which is re-fetched from server)
 
 ### Releasing Android
 Use `./scripts/release-android.sh` — never create or push tags directly (hooks block `git tag`).

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -40,6 +40,31 @@ $GRADLE :androidApp:testBenchmarkUnitTest && pass "testBenchmarkUnitTest" || fai
 step "Build Debug APK"
 $GRADLE :androidApp:assembleDebug && pass "assembleDebug" || fail "assembleDebug"
 
+step "Room schema drift check"
+# After compilation, Room KSP generates schema JSON files.
+# If they differ from what's committed, the schema changed without being tracked.
+SCHEMA_DIR="$REPO_ROOT/AndroidGarage/androidApp/schemas"
+if git diff --quiet -- "$SCHEMA_DIR" 2>/dev/null && \
+   [ -z "$(git ls-files --others --exclude-standard -- "$SCHEMA_DIR" 2>/dev/null)" ]; then
+    pass "Room schema unchanged"
+else
+    echo -e "${RED}FAIL${RESET} Room schema files changed after compilation!"
+    echo ""
+    echo "This means a Room entity or database definition was modified."
+    echo "You MUST increment the database version in AppDatabase.kt."
+    echo ""
+    echo "Changed schema files:"
+    git diff --name-only -- "$SCHEMA_DIR" 2>/dev/null
+    git ls-files --others --exclude-standard -- "$SCHEMA_DIR" 2>/dev/null
+    echo ""
+    echo "Steps to fix:"
+    echo "  1. Increment 'version' in @Database annotation (AppDatabase.kt)"
+    echo "  2. Run ./gradlew :androidApp:assembleDebug to regenerate schema"
+    echo "  3. Commit the new schema JSON file"
+    echo ""
+    fail "Room schema drift detected"
+fi
+
 # Record successful validation so git-guardrails hook knows we validated.
 git rev-parse HEAD > "$REPO_ROOT/.claude/.validation-passed"
 


### PR DESCRIPTION
## Summary
Room schema changes break at runtime (not compile time). This adds three layers of protection so we **never** ship a schema mismatch:

**1. Validation script schema drift check**
After compilation, `validate.sh` compares the generated schema JSON against what's committed. If they differ, it fails with clear instructions to increment the database version.

**2. Git guardrails hook**
Warns when committing Room entity (`*Entity.kt`), DAO (`*Dao.kt`), or database (`*AppDatabase.kt`) files. Reminds to increment version and run validation.

**3. RoomSchemaTest (5 tests)**
- Schema file exists for declared version
- DoorEvent entity has expected columns (catches column additions/removals)
- DoorPosition enum values are stable (enum renames break stored TEXT data)
- AppEvent entity exists
- Schema version is self-consistent

Also documents the Room safety workflow in CLAUDE.md with step-by-step instructions.

## Test plan
- [x] 5 new RoomSchemaTest tests pass
- [x] Schema drift check passes in validate.sh
- [x] All existing tests pass
- [x] `./scripts/validate.sh` passes (all 9 checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)