### PR TITLE
docs: Consolidate session progress across all docs

### DIFF
--- a/AndroidGarage/docs/ARCHITECTURE.md
+++ b/AndroidGarage/docs/ARCHITECTURE.md
@@ -34,23 +34,35 @@ Firebase Server
 
 ## Package Structure
 
+### Domain Module (`domain/`)
+
+Pure Kotlin module (no Android dependencies). Single source of truth for shared types:
+
+| Package | Contents |
+|---------|----------|
+| `domain/model/` | `DoorEvent`, `DoorPosition`, `LoadingResult<T>`, `AuthState` (sealed), `User`, `FirebaseIdToken`, `GoogleIdToken`, `DoorFcmState` (sealed), `DoorFcmTopic`, `FcmRegistrationStatus`, `RequestStatus`, `PushStatus`, `SnoozeRequestStatus`, `ServerConfig` |
+| `domain/repository/` | `DoorRepository`, `AuthRepository`, `PushRepository`, `ServerConfigRepository` (interfaces — signatures pending alignment with androidApp) |
+
+### Android App (`androidApp/`)
+
 All packages under `androidApp/src/main/java/com/chriscartland/garage/`:
 
 | Package | Purpose | Key Classes |
 |---------|---------|-------------|
 | `applogger/` | Event logging to Room DB, CSV export | `AppLoggerRepository`, `AppLoggerViewModel` |
-| `auth/` | Google Sign-In, Firebase Auth | `AuthRepository`, `AuthViewModel`, `AuthState` (sealed) |
-| `config/` | App configuration, server config caching | `APP_CONFIG`, `ServerConfigRepository` |
+| `auth/` | Google Sign-In, Firebase Auth | `AuthRepositoryImpl`, `AuthViewModelImpl` |
+| `config/` | App configuration, server config caching | `APP_CONFIG`, `ServerConfigRepositoryImpl` |
 | `coroutines/` | Testable dispatcher injection | `DispatcherProvider`, `DefaultDispatcherProvider` |
-| `db/` | Room database, DAOs, schema | `AppDatabase` (v11), `DoorEventDao`, `AppLoggerDao` |
-| `door/` | Core domain: door events, status | `DoorRepository`, `DoorViewModel`, `DoorEvent`, `DoorPosition`, `LoadingResult<T>` |
-| `fcm/` | FCM registration, push handling | `FCMService`, `DoorFcmRepository`, `DoorFcmState` (sealed) |
+| `db/` | Room database, DAOs, entity mapping | `AppDatabase` (v11), `DoorEventEntity` ↔ domain `DoorEvent`, `DoorEventDao` |
+| `door/` | Door repository and ViewModel | `DoorRepositoryImpl`, `DoorViewModelImpl` |
+| `fcm/` | FCM registration, push handling | `FCMService`, `FcmPayloadParser`, `DoorFcmRepositoryImpl` |
 | `internet/` | Retrofit service, response DTOs | `GarageNetworkService`, value classes for type-safe params |
 | `permissions/` | Notification permission (API 33+) | Accompanist-based permission request |
-| `remotebutton/` | Remote button with state machine | `RemoteButtonViewModel`, `PushRepository`, `RequestStatus` |
+| `remotebutton/` | Remote button with state machine | `RemoteButtonViewModelImpl`, `PushRepositoryImpl` |
 | `settings/` | SharedPreferences wrapper | `AppSettings`, type-safe `Setting` classes |
 | `snoozenotifications/` | Snooze duration options | `SnoozeDurationUIOption`, server conversion |
 | `ui/` | Compose screens and components | Screens, DoorStatusCard, AnimatableGarageDoor, theme |
+| `usecase/` | Extracted business logic | `EnsureFreshIdTokenUseCase` |
 | `version/` | App version info | `AppVersion` |
 
 Root files: `GarageApplication.kt` (@HiltAndroidApp), `MainActivity.kt` (Compose entry point).

--- a/AndroidGarage/docs/MIGRATION.md
+++ b/AndroidGarage/docs/MIGRATION.md
@@ -155,7 +155,7 @@ Target: Align with [battery-butler](https://github.com/cartland/battery-butler) 
 | Phase | Effort | Prerequisite | Status |
 |-------|--------|-------------|--------|
 | 1. Testing | Medium | None | **COMPLETE** |
-| 2. Clean Architecture | Large | Phase 1 | Not started |
+| 2. Clean Architecture | Large | Phase 1 | **IN PROGRESS** (2.1 done, 2.2 started) |
 | 3. DI Migration | Medium | Phase 2 | Not started |
 | 4. Network Migration | Medium | Phase 3 | Not started |
 | 5. KMP | Large | Phases 3 + 4 | Not started |

--- a/AndroidGarage/docs/TESTING.md
+++ b/AndroidGarage/docs/TESTING.md
@@ -13,10 +13,12 @@
 
 ## Current State
 
-- **~90 unit tests** across ViewModels, Repositories, pure functions, and JSON parsing
-- **CI checks:** unit tests (3 build variants), Spotless formatting, Android Lint, debug APK build, release AAB build
-- **Completed:** Phase 1 (CI hardening), Phase 2 (network error tests), Phase 3.2 (token expiry via UseCase), Phase 4 (state machine completeness), Phase 5.2-5.3 (release safety)
-- **Remaining:** Phase 3.1 (auth token refresh — needs Firebase wrapper refactor), Phase 5.1 (ProGuard smoke test), Phase 6 (Firebase server)
+- **~125 unit tests** across 17 test files (15 androidApp + 2 domain module)
+- **CI checks:** unit tests (3 build variants), Spotless formatting (all modules), Detekt, Android Lint, debug APK build, release AAB build
+- **Local validation:** `./scripts/validate.sh` mirrors CI + Room schema drift check + domain tests
+- **Safety guardrails:** git hooks warn on Room entity changes, block push to main, enforce squash merge
+- **Completed:** Phase 1 (CI hardening), Phase 2 (network error tests), Phase 3 (auth token fix + UseCase tests), Phase 4 (state machine completeness), Phase 5.2-5.3 (release safety)
+- **Remaining:** Phase 5.1 (ProGuard smoke test), Phase 6 (Firebase server)
 
 ---
 


### PR DESCRIPTION
## Summary
Update all documentation to reflect current state after 12+ PRs this session:

- **MIGRATION.md** — Fix stale summary table (Phase 2 is IN PROGRESS, not "Not started")
- **TESTING.md** — Update test count to ~125, mark Phase 3 complete, document safety guardrails
- **ARCHITECTURE.md** — Add domain module section, update package inventory for DoorEventEntity, FcmPayloadParser, UseCase layer

## Test plan
- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)