### PR TITLE
refactor: Consolidate AuthRepository and DoorRepository to domain interfaces

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthRepository.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthRepository.kt
@@ -26,6 +26,7 @@ import com.chriscartland.garage.domain.model.Email
 import com.chriscartland.garage.domain.model.FirebaseIdToken
 import com.chriscartland.garage.domain.model.GoogleIdToken
 import com.chriscartland.garage.domain.model.User
+import com.chriscartland.garage.domain.repository.AuthRepository
 import com.google.firebase.Firebase
 import com.google.firebase.auth.GoogleAuthProvider
 import com.google.firebase.auth.auth
@@ -45,16 +46,6 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
 const val RC_ONE_TAP_SIGN_IN = 1
-
-interface AuthRepository {
-    val authState: StateFlow<AuthState>
-
-    suspend fun signInWithGoogle(idToken: GoogleIdToken): AuthState
-
-    suspend fun refreshFirebaseAuthState(): AuthState
-
-    suspend fun signOut()
-}
 
 class AuthRepositoryImpl
     @Inject

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthViewModel.kt
@@ -30,6 +30,7 @@ import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.GoogleIdToken
+import com.chriscartland.garage.domain.repository.AuthRepository
 import com.google.android.gms.auth.api.identity.BeginSignInRequest
 import com.google.android.gms.auth.api.identity.Identity
 import com.google.android.gms.auth.api.identity.SignInClient

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorRepository.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorRepository.kt
@@ -23,6 +23,7 @@ import com.chriscartland.garage.config.ServerConfigRepository
 import com.chriscartland.garage.db.LocalDoorDataSource
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
+import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.internet.GarageNetworkService
 import dagger.Binds
 import dagger.Module
@@ -32,23 +33,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
-
-interface DoorRepository {
-    // Only exposes the door position.
-    val currentDoorPosition: Flow<DoorPosition>
-
-    // Exposes the event, including last updated timestamps.
-    val currentDoorEvent: Flow<DoorEvent>
-    val recentDoorEvents: Flow<List<DoorEvent>>
-
-    suspend fun fetchBuildTimestampCached(): String?
-
-    fun insertDoorEvent(doorEvent: DoorEvent)
-
-    suspend fun fetchCurrentDoorEvent()
-
-    suspend fun fetchRecentDoorEvents()
-}
 
 class DoorRepositoryImpl
     @Inject

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorViewModel.kt
@@ -30,6 +30,7 @@ import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorFcmState
 import com.chriscartland.garage.domain.model.FcmRegistrationStatus
 import com.chriscartland.garage.domain.model.LoadingResult
+import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.fcm.DoorFcmRepository
 import com.chriscartland.garage.fcm.toFcmTopic
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
@@ -21,7 +21,7 @@ import android.util.Log
 import com.chriscartland.garage.applogger.AppLoggerRepository
 import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.domain.model.DoorEvent
-import com.chriscartland.garage.door.DoorRepository
+import com.chriscartland.garage.domain.repository.DoorRepository
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import dagger.hilt.android.AndroidEntryPoint

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
@@ -20,14 +20,14 @@ package com.chriscartland.garage.remotebutton
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.chriscartland.garage.auth.AuthRepository
 import com.chriscartland.garage.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.PushStatus
 import com.chriscartland.garage.domain.model.RequestStatus
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
-import com.chriscartland.garage.door.DoorRepository
+import com.chriscartland.garage.domain.repository.AuthRepository
+import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.internet.IdToken
 import com.chriscartland.garage.internet.SnoozeEventTimestampParameter
 import com.chriscartland.garage.snoozenotifications.SnoozeDurationUIOption

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/EnsureFreshIdTokenUseCase.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/EnsureFreshIdTokenUseCase.kt
@@ -17,9 +17,9 @@
 
 package com.chriscartland.garage.usecase
 
-import com.chriscartland.garage.auth.AuthRepository
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.FirebaseIdToken
+import com.chriscartland.garage.domain.repository.AuthRepository
 import javax.inject.Inject
 
 /**

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/door/DoorViewModelTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/door/DoorViewModelTest.kt
@@ -26,6 +26,7 @@ import com.chriscartland.garage.domain.model.DoorFcmTopic
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.model.FcmRegistrationStatus
 import com.chriscartland.garage.domain.model.LoadingResult
+import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.fcm.DoorFcmRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModelTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModelTest.kt
@@ -17,7 +17,6 @@
 
 package com.chriscartland.garage.remotebutton
 
-import com.chriscartland.garage.auth.AuthRepository
 import com.chriscartland.garage.coroutines.TestDispatcherProvider
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.DoorEvent
@@ -25,7 +24,8 @@ import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.model.PushStatus
 import com.chriscartland.garage.domain.model.RequestStatus
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
-import com.chriscartland.garage.door.DoorRepository
+import com.chriscartland.garage.domain.repository.AuthRepository
+import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.usecase.EnsureFreshIdTokenUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakeAuthRepository.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakeAuthRepository.kt
@@ -17,9 +17,9 @@
 
 package com.chriscartland.garage.testcommon
 
-import com.chriscartland.garage.auth.AuthRepository
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.GoogleIdToken
+import com.chriscartland.garage.domain.repository.AuthRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakeDoorRepository.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakeDoorRepository.kt
@@ -19,7 +19,7 @@ package com.chriscartland.garage.testcommon
 
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
-import com.chriscartland.garage.door.DoorRepository
+import com.chriscartland.garage.domain.repository.DoorRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 


### PR DESCRIPTION
## Summary
- Delete duplicate interface definitions from androidApp (AuthRepository, DoorRepository)
- Both had identical signatures in androidApp and domain module — now one source of truth in `domain/repository/`
- Update all imports across 11 files (source + tests + fakes)
- **Unblocks UseCase extraction** — UseCases can now depend on domain interfaces

## Test plan
- [x] All 125 tests pass
- [x] `./scripts/validate.sh` passes (all 9 checks)
- [x] No behavior change — same interfaces, just moved

🤖 Generated with [Claude Code](https://claude.com/claude-code)