### PR TITLE
refactor: Align PushRepository interface with plain types

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/PushRepository.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/PushRepository.kt
@@ -29,10 +29,8 @@ import com.chriscartland.garage.internet.GarageNetworkService
 import com.chriscartland.garage.internet.IdToken
 import com.chriscartland.garage.internet.RemoteButtonBuildTimestamp
 import com.chriscartland.garage.internet.RemoteButtonPushKey
+import com.chriscartland.garage.internet.SnoozeDurationParameter
 import com.chriscartland.garage.internet.SnoozeEventTimestampParameter
-import com.chriscartland.garage.snoozenotifications.SnoozeDurationUIOption
-import com.chriscartland.garage.snoozenotifications.toParam
-import com.chriscartland.garage.snoozenotifications.toServer
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -50,16 +48,16 @@ interface PushRepository {
     val snoozeEndTimeSeconds: StateFlow<Long>
 
     suspend fun push(
-        idToken: IdToken,
+        idToken: String,
         buttonAckToken: String,
     )
 
     suspend fun fetchSnoozeEndTimeSeconds()
 
     suspend fun snoozeOpenDoorsNotifications(
-        snoozeDuration: SnoozeDurationUIOption,
-        idToken: IdToken,
-        snoozeEventTimestamp: SnoozeEventTimestampParameter,
+        snoozeDurationHours: String,
+        idToken: String,
+        snoozeEventTimestampSeconds: Long,
     )
 }
 
@@ -82,7 +80,7 @@ class PushRepositoryImpl
          * Send a command to the server to push the remote button.
          */
         override suspend fun push(
-            idToken: IdToken,
+            idToken: String,
             buttonAckToken: String,
         ) {
             _pushButtonStatus.value = PushStatus.SENDING
@@ -110,7 +108,7 @@ class PushRepositoryImpl
                     remoteButtonPushKey = RemoteButtonPushKey(
                         serverConfig.remoteButtonPushKey,
                     ),
-                    idToken = idToken,
+                    idToken = IdToken(idToken),
                 )
                 Log.i(tag, "Response: ${response.code()}")
                 Log.i(tag, "Response body: ${response.body()}")
@@ -165,13 +163,13 @@ class PushRepositoryImpl
         }
 
         override suspend fun snoozeOpenDoorsNotifications(
-            snoozeDuration: SnoozeDurationUIOption,
-            idToken: IdToken,
-            snoozeEventTimestamp: SnoozeEventTimestampParameter,
+            snoozeDurationHours: String,
+            idToken: String,
+            snoozeEventTimestampSeconds: Long,
         ) {
             _snoozeRequestStatus.value = SnoozeRequestStatus.SENDING
             val tag = "snoozeOpenDoorsNotifications"
-            Log.d(tag, "Requesting to snooze door open notifications for $snoozeDuration")
+            Log.d(tag, "Requesting to snooze door open notifications for $snoozeDurationHours hours")
 
             val serverConfig = serverConfigRepository.getServerConfigCached()
             if (serverConfig == null) {
@@ -191,9 +189,9 @@ class PushRepositoryImpl
                     remoteButtonPushKey = RemoteButtonPushKey(
                         serverConfig.remoteButtonPushKey,
                     ),
-                    idToken = idToken,
-                    snoozeDuration = snoozeDuration.toServer().toParam(),
-                    snoozeEventTimestamp = snoozeEventTimestamp,
+                    idToken = IdToken(idToken),
+                    snoozeDuration = SnoozeDurationParameter(snoozeDurationHours),
+                    snoozeEventTimestamp = SnoozeEventTimestampParameter(snoozeEventTimestampSeconds),
                 )
                 Log.i(tag, "Response: ${response.code()}")
                 Log.i(tag, "Response body: ${response.body()}")

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
@@ -28,9 +28,8 @@ import com.chriscartland.garage.domain.model.RequestStatus
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
 import com.chriscartland.garage.domain.repository.AuthRepository
 import com.chriscartland.garage.domain.repository.DoorRepository
-import com.chriscartland.garage.internet.IdToken
-import com.chriscartland.garage.internet.SnoozeEventTimestampParameter
 import com.chriscartland.garage.snoozenotifications.SnoozeDurationUIOption
+import com.chriscartland.garage.snoozenotifications.toServer
 import com.chriscartland.garage.usecase.EnsureFreshIdTokenUseCase
 import dagger.Binds
 import dagger.Module
@@ -294,7 +293,7 @@ class RemoteButtonViewModelImpl
                 val idToken = ensureFreshIdToken(authRepository, authState)
                 Log.d(TAG, "pushRemoteButton: Pushing remote button: $idToken")
                 pushRepository.push(
-                    idToken = IdToken(idToken.asString()),
+                    idToken = idToken.asString(),
                     buttonAckToken = createButtonAckToken(Date()),
                 )
             }
@@ -320,9 +319,9 @@ class RemoteButtonViewModelImpl
                     return@launch
                 }
                 pushRepository.snoozeOpenDoorsNotifications(
-                    snoozeDuration = snoozeDuration,
-                    idToken = IdToken(idToken.asString()),
-                    snoozeEventTimestamp = SnoozeEventTimestampParameter(lastChangeTimeSeconds),
+                    snoozeDurationHours = snoozeDuration.toServer().duration,
+                    idToken = idToken.asString(),
+                    snoozeEventTimestampSeconds = lastChangeTimeSeconds,
                 )
             }
         }

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/PushRepositoryTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/PushRepositoryTest.kt
@@ -21,7 +21,6 @@ import com.chriscartland.garage.config.ServerConfigRepository
 import com.chriscartland.garage.config.model.ServerConfig
 import com.chriscartland.garage.domain.model.PushStatus
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
-import com.chriscartland.garage.internet.IdToken
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -68,7 +67,7 @@ class PushRepositoryTest {
         runTest {
             `when`(serverConfigRepository.getServerConfigCached()).thenReturn(null)
 
-            repo.push(IdToken("token"), "ack-token")
+            repo.push("token", "ack-token")
 
             // Should reset to IDLE, not stay stuck in SENDING
             assertEquals(PushStatus.IDLE, repo.pushButtonStatus.value)
@@ -80,10 +79,9 @@ class PushRepositoryTest {
             `when`(serverConfigRepository.getServerConfigCached()).thenReturn(null)
 
             repo.snoozeOpenDoorsNotifications(
-                com.chriscartland.garage.snoozenotifications.SnoozeDurationUIOption.OneHour,
-                IdToken("token"),
-                com.chriscartland.garage.internet
-                    .SnoozeEventTimestampParameter(1000L),
+                snoozeDurationHours = "1h",
+                idToken = "token",
+                snoozeEventTimestampSeconds = 1000L,
             )
 
             // Should reset to IDLE, not stay stuck in SENDING

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakePushRepository.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakePushRepository.kt
@@ -19,10 +19,7 @@ package com.chriscartland.garage.testcommon
 
 import com.chriscartland.garage.domain.model.PushStatus
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
-import com.chriscartland.garage.internet.IdToken
-import com.chriscartland.garage.internet.SnoozeEventTimestampParameter
 import com.chriscartland.garage.remotebutton.PushRepository
-import com.chriscartland.garage.snoozenotifications.SnoozeDurationUIOption
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -38,7 +35,7 @@ class FakePushRepository : PushRepository {
 
     var pushCount = 0
         private set
-    var lastIdToken: IdToken? = null
+    var lastIdToken: String? = null
         private set
     var snoozeCount = 0
         private set
@@ -56,7 +53,7 @@ class FakePushRepository : PushRepository {
     }
 
     override suspend fun push(
-        idToken: IdToken,
+        idToken: String,
         buttonAckToken: String,
     ) {
         pushCount++
@@ -70,9 +67,9 @@ class FakePushRepository : PushRepository {
     }
 
     override suspend fun snoozeOpenDoorsNotifications(
-        snoozeDuration: SnoozeDurationUIOption,
-        idToken: IdToken,
-        snoozeEventTimestamp: SnoozeEventTimestampParameter,
+        snoozeDurationHours: String,
+        idToken: String,
+        snoozeEventTimestampSeconds: Long,
     ) {
         snoozeCount++
         _snoozeRequestStatus.value = SnoozeRequestStatus.SENDING


### PR DESCRIPTION
## Summary
Last repository interface alignment — replaces Android-specific wrapper types with plain types in PushRepository:

- `push(idToken: IdToken)` → `push(idToken: String)`
- `snooze(SnoozeDurationUIOption, IdToken, SnoozeEventTimestampParameter)` → `snooze(snoozeDurationHours: String, idToken: String, snoozeEventTimestampSeconds: Long)`
- Wrapper conversion moves into PushRepositoryImpl (Retrofit layer)
- ViewModel converts `SnoozeDurationUIOption` → server string before calling repo

After this PR, all three repository interfaces (Auth, Door, Push) use domain-compatible types. PushRepository can then be consolidated with the domain interface.

## Test plan
- [x] All 125 tests pass
- [x] `./scripts/validate.sh` passes (all 9 checks)
- [x] No behavior change — same data flows, wrappers moved to impl

🤖 Generated with [Claude Code](https://claude.com/claude-code)