### PR TITLE
refactor: Consolidate PushRepository to domain interface

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/PushRepository.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/PushRepository.kt
@@ -23,6 +23,7 @@ import com.chriscartland.garage.config.APP_CONFIG
 import com.chriscartland.garage.config.ServerConfigRepository
 import com.chriscartland.garage.domain.model.PushStatus
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
+import com.chriscartland.garage.domain.repository.PushRepository
 import com.chriscartland.garage.internet.BuildTimestamp
 import com.chriscartland.garage.internet.ButtonAckToken
 import com.chriscartland.garage.internet.GarageNetworkService
@@ -41,25 +42,6 @@ import kotlinx.coroutines.time.delay
 import java.time.Duration
 import java.util.Date
 import javax.inject.Inject
-
-interface PushRepository {
-    val pushButtonStatus: StateFlow<PushStatus>
-    val snoozeRequestStatus: StateFlow<SnoozeRequestStatus>
-    val snoozeEndTimeSeconds: StateFlow<Long>
-
-    suspend fun push(
-        idToken: String,
-        buttonAckToken: String,
-    )
-
-    suspend fun fetchSnoozeEndTimeSeconds()
-
-    suspend fun snoozeOpenDoorsNotifications(
-        snoozeDurationHours: String,
-        idToken: String,
-        snoozeEventTimestampSeconds: Long,
-    )
-}
 
 class PushRepositoryImpl
     @Inject

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
@@ -28,6 +28,7 @@ import com.chriscartland.garage.domain.model.RequestStatus
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
 import com.chriscartland.garage.domain.repository.AuthRepository
 import com.chriscartland.garage.domain.repository.DoorRepository
+import com.chriscartland.garage.domain.repository.PushRepository
 import com.chriscartland.garage.snoozenotifications.SnoozeDurationUIOption
 import com.chriscartland.garage.snoozenotifications.toServer
 import com.chriscartland.garage.usecase.EnsureFreshIdTokenUseCase

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModelTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModelTest.kt
@@ -26,6 +26,7 @@ import com.chriscartland.garage.domain.model.RequestStatus
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
 import com.chriscartland.garage.domain.repository.AuthRepository
 import com.chriscartland.garage.domain.repository.DoorRepository
+import com.chriscartland.garage.domain.repository.PushRepository
 import com.chriscartland.garage.usecase.EnsureFreshIdTokenUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakePushRepository.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakePushRepository.kt
@@ -19,7 +19,7 @@ package com.chriscartland.garage.testcommon
 
 import com.chriscartland.garage.domain.model.PushStatus
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
-import com.chriscartland.garage.remotebutton.PushRepository
+import com.chriscartland.garage.domain.repository.PushRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 


### PR DESCRIPTION
## Summary
Delete duplicate PushRepository interface from androidApp — now all three repository interfaces have a single source of truth in `domain/repository/`:

- AuthRepository — consolidated in PR #59
- DoorRepository — consolidated in PR #59
- **PushRepository — this PR**

This completes the repository interface alignment noted in MIGRATION.md Phase 2.1.

## Test plan
- [x] All 125 tests pass
- [x] `./scripts/validate.sh` passes (all 9 checks)
- [x] No behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)