### PR TITLE
feat: Add tag-based Firebase server deployment

### DIFF
--- a/.claude/hooks/git-guardrails.sh
+++ b/.claude/hooks/git-guardrails.sh
@@ -71,10 +71,10 @@ if echo "$STRIPPED" | grep -qE '\bgit\s+push\b'; then
   fi
 fi
 
-# --- Block tag creation (use ./scripts/release-android.sh instead) ---
+# --- Block tag creation (use release scripts instead) ---
 if echo "$STRIPPED" | grep -qE '\bgit\s+tag\b'; then
   if ! echo "$STRIPPED" | grep -qE '\bgit\s+tag\b.*(-l\b|--list\b)'; then
-    deny "BLOCKED: Never create or push tags directly. Use ./scripts/release-android.sh for releases. Use git tag -l to list tags."
+    deny "BLOCKED: Never create or push tags directly. Use ./scripts/release-android.sh or ./scripts/release-firebase.sh for releases. Use git tag -l to list tags."
   fi
 fi
 

--- a/.claude/skills/release-firebase/SKILL.md
+++ b/.claude/skills/release-firebase/SKILL.md
@@ -1,0 +1,59 @@
+---
+description: Release Firebase server functions via tag-based deployment.
+---
+
+# Release Firebase
+
+Cut a Firebase server release by creating a tag via `scripts/release-firebase.sh`. The tag triggers CI to deploy Cloud Functions.
+
+## Steps
+
+### 1. Pre-flight checks
+
+```bash
+# Must be on main with clean tree
+git checkout main && git pull
+git status  # Must be clean
+```
+
+Verify Firebase CI is green on latest main:
+```bash
+gh run list --branch main --workflow=firebase-ci.yml --limit 1 --json conclusion,headSha --jq '.[0]'
+```
+
+### 2. Check release state
+
+```bash
+scripts/release-firebase.sh --check
+```
+
+This prints the latest tag and the computed next tag (`server/<N+1>`).
+
+### 3. Cut the release
+
+```bash
+scripts/release-firebase.sh --confirm-tag server/N
+```
+
+Where `N` is the next tag number from step 2. The `--confirm-tag` is a safety check — it must match the computed tag exactly.
+
+The script will:
+- Verify clean git state
+- Verify on main branch
+- Verify Firebase CI passed on HEAD
+- Create and push the tag
+- The tag triggers `.github/workflows/firebase-deploy.yml`
+
+### 4. Verify deployment
+
+Watch the deploy workflow:
+```bash
+gh run list --workflow=firebase-deploy.yml --limit 1
+gh run watch <run-id>
+```
+
+### Rules
+
+- **Never push tags directly** — hooks block `git tag`. Only release scripts can create tags.
+- **Tag pattern:** `server/N` (e.g., server/1, server/2)
+- **Don't skip CI** — the script verifies Firebase CI passed before tagging.

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -1,15 +1,45 @@
 name: Deploy Firebase Server
 
+# Triggered by server/N tags only — never on push to main.
+# To deploy: push a tag like server/1, server/2, etc.
 on:
-  workflow_dispatch:
+  push:
+    tags:
+      - 'server/[0-9]*'
 
 jobs:
+  verify-ci:
+    name: Verify Firebase CI Passed
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify CI passed on tagged commit
+        run: |
+          TAG_SHA="${GITHUB_SHA}"
+          echo "Checking Firebase CI status for commit $TAG_SHA..."
+
+          TESTS_CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA/check-runs" \
+            --jq '[.check_runs[] | select(.name == "Run Unit Tests" and .app.slug == "github-actions")] | last | .conclusion')
+
+          echo "Firebase Tests: $TESTS_CONCLUSION"
+
+          if [ "$TESTS_CONCLUSION" != "success" ]; then
+            echo "::error::Firebase tests concluded '$TESTS_CONCLUSION', expected 'success'"
+            exit 1
+          fi
+
+          echo "Firebase CI passed on commit $TAG_SHA"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   deploy:
     name: Deploy to Firebase
+    needs: verify-ci
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - name: set up Node.js
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -24,8 +54,7 @@ jobs:
       - name: Authenticate with Google Cloud
         uses: 'google-github-actions/auth@v2'
         with:
-          credentials_json: '${{ secrets.FIRE"
-"BASE_SERVICE_ACCOUNT }}'
+          credentials_json: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
       - name: Deploy to Firebase
         run: firebase deploy --only functions --project "${{ secrets.FIREBASE_PROJECT_ID }}"
         working-directory: FirebaseServer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,18 @@ Use `./scripts/release-android.sh` — never create or push tags directly (hooks
 
 The script computes the next tag as `android/<highest + 1>`. The `--confirm-tag` flag is a safety check — it must match the computed tag, it cannot override it. Deploys to Play Store internal track only — never production.
 
+### Releasing Firebase Server
+Use `./scripts/release-firebase.sh` — same pattern as Android releases.
+
+```bash
+./scripts/release-firebase.sh              # Interactive (terminal only)
+./scripts/release-firebase.sh --check      # Print latest + next tag
+./scripts/release-firebase.sh --confirm-tag server/N  # Non-interactive
+./scripts/release-firebase.sh --dry-run    # Preview without releasing
+```
+
+The script computes the next tag as `server/<highest + 1>`. Deploys Cloud Functions only.
+
 ### Secret Management (Android)
 The app requires secrets in `local.properties` (decrypted from GPG at build time):
 - `SERVER_CONFIG_KEY`, `GOOGLE_WEB_CLIENT_ID` — required for all builds

--- a/scripts/release-firebase.sh
+++ b/scripts/release-firebase.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Firebase Server release script — mirrors scripts/release-android.sh.
+# Creates a server/N tag that triggers .github/workflows/firebase-deploy.yml.
+#
+# Usage:
+#   ./scripts/release-firebase.sh              # Interactive (terminal only)
+#   ./scripts/release-firebase.sh --check      # Print latest + next tag
+#   ./scripts/release-firebase.sh --confirm-tag server/N  # Non-interactive
+#   ./scripts/release-firebase.sh --dry-run    # Preview without releasing
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+# Find the latest server tag number.
+latest_tag_number() {
+    git tag -l 'server/*' \
+        | sed 's|server/||' \
+        | sort -n \
+        | tail -1
+}
+
+LATEST_NUM=$(latest_tag_number)
+LATEST_NUM=${LATEST_NUM:-0}
+NEXT_NUM=$((LATEST_NUM + 1))
+LATEST_TAG="server/$LATEST_NUM"
+NEXT_TAG="server/$NEXT_NUM"
+BRANCH=$(git branch --show-current)
+SHORT_SHA=$(git rev-parse --short HEAD)
+FULL_SHA=$(git rev-parse HEAD)
+
+# --- --check mode ---
+if [[ "${1:-}" == "--check" ]]; then
+    echo "Latest tag: $LATEST_TAG"
+    echo "Next tag:   $NEXT_TAG"
+    echo "Branch:     $BRANCH"
+    echo "Commit:     $SHORT_SHA"
+    exit 0
+fi
+
+# --- Validations ---
+echo -e "${BOLD}=== Firebase Server Release ===${RESET}"
+
+# Must be on main.
+if [[ "$BRANCH" != "main" ]]; then
+    echo -e "${RED}ERROR: Must be on 'main' branch (currently on '$BRANCH').${RESET}"
+    exit 1
+fi
+
+# Must have clean working tree (allow untracked files).
+if ! git diff --quiet HEAD 2>/dev/null; then
+    echo -e "${RED}ERROR: Working tree has uncommitted changes.${RESET}"
+    exit 1
+fi
+
+# Check Firebase CI passed on HEAD.
+echo "Checking CI status on HEAD..."
+FIREBASE_CI_CONCLUSION=$(gh api "repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/commits/$FULL_SHA/check-runs" \
+    --jq '[.check_runs[] | select(.name == "Run Unit Tests" and .check_suite.conclusion != null)] | last | .conclusion' 2>/dev/null || echo "")
+
+if [[ "$FIREBASE_CI_CONCLUSION" == "success" ]]; then
+    echo -e "${GREEN}CI passed on HEAD.${RESET}"
+elif [[ -z "$FIREBASE_CI_CONCLUSION" ]]; then
+    echo -e "WARNING: Could not verify Firebase CI status. Proceeding anyway (Firebase CI may not run on all commits)."
+else
+    echo -e "${RED}ERROR: Firebase CI concluded '$FIREBASE_CI_CONCLUSION'. Fix CI before releasing.${RESET}"
+    exit 1
+fi
+
+echo ""
+echo "=== Release Details ==="
+echo "  Branch:     $BRANCH"
+echo "  Latest tag: $LATEST_TAG"
+echo "  New tag:    $NEXT_TAG"
+echo "  Commit:     $SHORT_SHA ($FULL_SHA)"
+echo ""
+
+# --- --dry-run mode ---
+if [[ "${1:-}" == "--dry-run" ]]; then
+    echo "(Dry run — no tag created)"
+    exit 0
+fi
+
+# --- --confirm-tag mode ---
+if [[ "${1:-}" == "--confirm-tag" ]]; then
+    CONFIRM="${2:-}"
+    if [[ "$CONFIRM" != "$NEXT_TAG" ]]; then
+        echo -e "${RED}ERROR: --confirm-tag '$CONFIRM' does not match computed tag '$NEXT_TAG'.${RESET}"
+        echo "The tag number is computed as latest + 1. You cannot override it."
+        exit 1
+    fi
+    # Proceed to create tag below.
+elif [[ -t 0 ]]; then
+    # Interactive mode.
+    read -p "Create and push tag $NEXT_TAG? [y/N] " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Aborted."
+        exit 1
+    fi
+else
+    echo -e "${RED}ERROR: Non-interactive mode requires --confirm-tag $NEXT_TAG${RESET}"
+    exit 1
+fi
+
+# --- Create and push tag ---
+echo "Creating tag $NEXT_TAG..."
+git tag "$NEXT_TAG"
+
+echo "Pushing tag to origin..."
+git push origin "$NEXT_TAG"
+
+echo ""
+echo -e "${GREEN}=== Release Initiated ===${RESET}"
+echo ""
+echo "Tag $NEXT_TAG pushed to origin."
+echo "Monitor: https://github.com/$(gh repo view --json nameWithOwner -q .nameWithOwner)/actions"


### PR DESCRIPTION
## Summary
Mirror the Android release infrastructure for Firebase server:

- **firebase-deploy.yml** — trigger on `server/N` tags instead of `workflow_dispatch`. Verifies Firebase CI passed before deploying. Fixes broken `credentials_json` string.
- **scripts/release-firebase.sh** — same UX as `release-android.sh` (`--check`, `--confirm-tag`, `--dry-run`)
- **/release-firebase** Claude skill for guided releases
- Updated guardrails to mention both release scripts
- Documented in CLAUDE.md

## Test plan
- [x] `./scripts/validate.sh` passes
- [x] `./scripts/release-firebase.sh --check` works (prints server/1 as next tag)
- [x] Workflow trigger changed from `workflow_dispatch` to `push.tags`

🤖 Generated with [Claude Code](https://claude.com/claude-code)