### PR TITLE
feat: Add path-based CI skipping with gate jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,51 @@ on:
     branches: [ "main" ]
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      android: ${{ steps.filter.outputs.android }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for Android changes
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "android=true" >> $GITHUB_OUTPUT
+            echo "workflow_dispatch: running all checks"
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "push" ]; then
+            BASE="${{ github.event.before }}"
+          else
+            BASE="origin/${{ github.base_ref }}"
+            git fetch --depth=1 origin "${{ github.base_ref }}" 2>/dev/null || true
+          fi
+
+          CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null || echo "UNKNOWN")
+
+          if [ "$CHANGED" = "UNKNOWN" ]; then
+            echo "android=true" >> $GITHUB_OUTPUT
+            echo "Could not determine changes, running all checks"
+            exit 0
+          fi
+
+          if echo "$CHANGED" | grep -qE '^(AndroidGarage/|\.github/workflows/ci\.yml|\.github/actions/)'; then
+            echo "android=true" >> $GITHUB_OUTPUT
+            echo "Android files changed:"
+            echo "$CHANGED" | grep -E '^(AndroidGarage/|\.github/workflows/ci\.yml|\.github/actions/)'
+          else
+            echo "android=false" >> $GITHUB_OUTPUT
+            echo "No Android files changed. Changed files:"
+            echo "$CHANGED"
+          fi
+
   formatting:
     name: Formatting & Static Analysis
+    needs: changes
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,6 +75,8 @@ jobs:
 
   unit_tests:
     name: Unit Tests
+    needs: changes
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -57,6 +102,8 @@ jobs:
 
   build_debug:
     name: Build Debug APK
+    needs: changes
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -82,6 +129,8 @@ jobs:
 
   build_release:
     name: Build Release AAB
+    needs: changes
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -105,4 +154,34 @@ jobs:
         with:
           name: release-aab
           path: AndroidGarage/androidApp/build/outputs/bundle/release/
+
+  # Gate job — the ONLY required status check in branch protection.
+  # Succeeds when all CI jobs pass OR when they're skipped (no Android changes).
+  ci-complete:
+    name: CI Complete
+    if: always()
+    needs: [formatting, unit_tests, build_debug, build_release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        run: |
+          echo "Formatting: ${{ needs.formatting.result }}"
+          echo "Unit Tests: ${{ needs.unit_tests.result }}"
+          echo "Build Debug: ${{ needs.build_debug.result }}"
+          echo "Build Release: ${{ needs.build_release.result }}"
+
+          # Fail if any job failed or was cancelled
+          if [[ "${{ needs.formatting.result }}" == "failure" || \
+                "${{ needs.unit_tests.result }}" == "failure" || \
+                "${{ needs.build_debug.result }}" == "failure" || \
+                "${{ needs.build_release.result }}" == "failure" || \
+                "${{ needs.formatting.result }}" == "cancelled" || \
+                "${{ needs.unit_tests.result }}" == "cancelled" || \
+                "${{ needs.build_debug.result }}" == "cancelled" || \
+                "${{ needs.build_release.result }}" == "cancelled" ]]; then
+            echo "::error::One or more CI jobs failed"
+            exit 1
+          fi
+
+          echo "All CI checks passed (or skipped — no Android changes)"
   # Deployment: .github/workflows/release-android.yml (triggered by android/N tags)

--- a/.github/workflows/firebase-ci.yml
+++ b/.github/workflows/firebase-ci.yml
@@ -4,22 +4,59 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [ "main" ]
-    paths:
-      - 'FirebaseServer/**'
-      - '.github/workflows/firebase-ci.yml'
   push:
     branches: [ "main" ]
-    paths:
-      - 'FirebaseServer/**'
-      - '.github/workflows/firebase-ci.yml'
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      firebase: ${{ steps.filter.outputs.firebase }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for Firebase changes
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "firebase=true" >> $GITHUB_OUTPUT
+            echo "workflow_dispatch: running all checks"
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "push" ]; then
+            BASE="${{ github.event.before }}"
+          else
+            BASE="origin/${{ github.base_ref }}"
+            git fetch --depth=1 origin "${{ github.base_ref }}" 2>/dev/null || true
+          fi
+
+          CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null || echo "UNKNOWN")
+
+          if [ "$CHANGED" = "UNKNOWN" ]; then
+            echo "firebase=true" >> $GITHUB_OUTPUT
+            echo "Could not determine changes, running all checks"
+            exit 0
+          fi
+
+          if echo "$CHANGED" | grep -qE '^(FirebaseServer/|\.github/workflows/firebase-ci\.yml)'; then
+            echo "firebase=true" >> $GITHUB_OUTPUT
+            echo "Firebase files changed:"
+            echo "$CHANGED" | grep -E '^(FirebaseServer/|\.github/workflows/firebase-ci\.yml)'
+          else
+            echo "firebase=false" >> $GITHUB_OUTPUT
+            echo "No Firebase files changed. Changed files:"
+            echo "$CHANGED"
+          fi
+
   test:
     name: Run Unit Tests
+    needs: changes
+    if: needs.changes.outputs.firebase == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: set up Node.js
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -29,3 +66,20 @@ jobs:
       - name: Run Unit Tests
         working-directory: FirebaseServer
         run: npm run tests
+
+  # Gate job — required status check for Firebase.
+  firebase-ci-complete:
+    name: Firebase CI Complete
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        run: |
+          echo "Tests: ${{ needs.test.result }}"
+          if [[ "${{ needs.test.result }}" == "failure" || \
+                "${{ needs.test.result }}" == "cancelled" ]]; then
+            echo "::error::Firebase CI failed"
+            exit 1
+          fi
+          echo "Firebase CI passed (or skipped — no Firebase changes)"


### PR DESCRIPTION
## Summary
Android CI and Firebase CI now skip irrelevant checks based on which files changed:

- **Docs-only PRs**: CI completes in ~30s (just the change detection + gate)
- **Firebase-only PRs**: Android CI skipped, Firebase CI runs
- **Android-only PRs**: Firebase CI skipped, Android CI runs
- **workflow_dispatch / unknown diffs**: always run everything (safe default)

### How it works
1. `changes` job diffs HEAD against base to detect relevant file paths
2. CI jobs run only `if: needs.changes.outputs.android == 'true'`
3. `CI Complete` gate job runs `if: always()` — fails on failure, succeeds on success or skip
4. **Branch protection uses only the gate job** as required check

### After merging
Update branch protection required status checks:
- Replace `Unit Tests`, `Formatting & Static Analysis`, `Build Debug APK`, `Build Release AAB` with → **`CI Complete`**
- Add → **`Firebase CI Complete`**

## Test plan
- [x] This PR touches `.github/workflows/ci.yml` so Android CI will run (self-test)
- [x] Gate job pattern is the standard GitHub Actions approach for conditional required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)