### PR TITLE
fix: Fix Firebase server TypeScript build errors

### DIFF
--- a/FirebaseServer/package-lock.json
+++ b/FirebaseServer/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@types/chai": "^4.2.15",
         "@types/mocha": "^8.2.2",
-        "@types/node": "^14.14.36",
+        "@types/node": "^20.0.0",
         "@types/sinon": "^17.0.4",
         "chai": "^4.3.4",
         "copyfiles": "^2.4.1",
@@ -630,10 +630,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "license": "MIT"
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/qs": {
       "version": "6.14.0",

--- a/FirebaseServer/package.json
+++ b/FirebaseServer/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/chai": "^4.2.15",
     "@types/mocha": "^8.2.2",
-    "@types/node": "^14.14.36",
+    "@types/node": "^20.0.0",
     "@types/sinon": "^17.0.4",
     "chai": "^4.3.4",
     "copyfiles": "^2.4.1",

--- a/FirebaseServer/src/functions/firestore/Events.ts
+++ b/FirebaseServer/src/functions/firestore/Events.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as functions from 'firebase-functions';
+import * as functions from 'firebase-functions/v1';
 
 import { updateEvent } from '../../controller/EventUpdates';
 

--- a/FirebaseServer/src/functions/http/DeleteData.ts
+++ b/FirebaseServer/src/functions/http/DeleteData.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as functions from 'firebase-functions';
+import * as functions from 'firebase-functions/v1';
 
 import { Config } from '../../database/ServerConfigDatabase';
 import { deleteOldData } from '../../controller/DatabaseCleaner';

--- a/FirebaseServer/src/functions/http/Echo.ts
+++ b/FirebaseServer/src/functions/http/Echo.ts
@@ -16,7 +16,7 @@
 
 import { v4 as uuidv4 } from 'uuid';
 
-import * as functions from 'firebase-functions';
+import * as functions from 'firebase-functions/v1';
 
 import { TimeSeriesDatabase } from '../../database/TimeSeriesDatabase';
 

--- a/FirebaseServer/src/functions/http/Events.ts
+++ b/FirebaseServer/src/functions/http/Events.ts
@@ -16,7 +16,7 @@
 
 import { v4 as uuidv4 } from 'uuid';
 
-import * as functions from 'firebase-functions';
+import * as functions from 'firebase-functions/v1';
 
 import { DATABASE as SensorEventDatabase } from '../../database/SensorEventDatabase';
 

--- a/FirebaseServer/src/functions/http/OpenDoor.ts
+++ b/FirebaseServer/src/functions/http/OpenDoor.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as functions from 'firebase-functions';
+import * as functions from 'firebase-functions/v1';
 
 import { sendFCMForOldData } from '../../controller/fcm/OldDataFCM';
 import { TimeSeriesDatabase } from '../../database/TimeSeriesDatabase';

--- a/FirebaseServer/src/functions/http/RemoteButton.ts
+++ b/FirebaseServer/src/functions/http/RemoteButton.ts
@@ -17,7 +17,7 @@
 import { v4 as uuidv4 } from 'uuid';
 
 import * as firebase from 'firebase-admin';
-import * as functions from 'firebase-functions';
+import * as functions from 'firebase-functions/v1';
 
 import { TimeSeriesDatabase } from '../../database/TimeSeriesDatabase';
 

--- a/FirebaseServer/src/functions/http/ServerConfig.ts
+++ b/FirebaseServer/src/functions/http/ServerConfig.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as functions from 'firebase-functions';
+import * as functions from 'firebase-functions/v1';
 
 import { Config } from '../../database/ServerConfigDatabase';
 

--- a/FirebaseServer/src/functions/http/Snooze.ts
+++ b/FirebaseServer/src/functions/http/Snooze.ts
@@ -15,7 +15,7 @@
  */
 
 import * as firebase from 'firebase-admin';
-import * as functions from 'firebase-functions';
+import * as functions from 'firebase-functions/v1';
 
 import { Config } from '../../database/ServerConfigDatabase';
 import { isAuthorizedToPushRemoteButton } from '../../controller/Auth';

--- a/FirebaseServer/src/functions/pubsub/DataRetentionPolicy.ts
+++ b/FirebaseServer/src/functions/pubsub/DataRetentionPolicy.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as functions from 'firebase-functions';
+import * as functions from 'firebase-functions/v1';
 
 import { Config } from '../../database/ServerConfigDatabase';
 import { deleteOldData } from '../../controller/DatabaseCleaner';

--- a/FirebaseServer/src/functions/pubsub/DoorErrors.ts
+++ b/FirebaseServer/src/functions/pubsub/DoorErrors.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as functions from 'firebase-functions';
+import * as functions from 'firebase-functions/v1';
 
 import { updateEvent } from '../../controller/EventUpdates';
 

--- a/FirebaseServer/src/functions/pubsub/OpenDoor.ts
+++ b/FirebaseServer/src/functions/pubsub/OpenDoor.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as functions from 'firebase-functions';
+import * as functions from 'firebase-functions/v1';
 
 import { sendFCMForOldData } from '../../controller/fcm/OldDataFCM';
 import { TimeSeriesDatabase } from '../../database/TimeSeriesDatabase';

--- a/FirebaseServer/src/functions/pubsub/RemoteButton.ts
+++ b/FirebaseServer/src/functions/pubsub/RemoteButton.ts
@@ -15,7 +15,7 @@
  */
 
 import * as firebase from 'firebase-admin';
-import * as functions from 'firebase-functions';
+import * as functions from 'firebase-functions/v1';
 
 import { TimeSeriesDatabase } from '../../database/TimeSeriesDatabase';
 

--- a/FirebaseServer/tsconfig.json
+++ b/FirebaseServer/tsconfig.json
@@ -1,16 +1,17 @@
 {
   "compilerOptions": {
     "lib": [
-      "es6",
+      "es2020",
       "esnext.asynciterable"
     ],
     "module": "commonjs",
     "noImplicitReturns": true,
     "outDir": "lib",
     "sourceMap": true,
-    "target": "es6",
+    "target": "es2020",
     "resolveJsonModule": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "compileOnSave": true,
   "include": [


### PR DESCRIPTION
## Summary
The Firebase deploy workflow (`server/1`) failed because `npm run build` has TypeScript errors. The server code hasn't changed in 7 months but the dependencies have drifted.

**Root cause:** `firebase-functions@6.4.0` exports v2 APIs by default, but the code uses v1-style APIs (`functions.firestore.document()`, `functions.pubsub.schedule()`).

**Fix:**
- Import from `firebase-functions/v1` in all 12 source files (v1 compatibility layer, zero logic changes)
- Update `@types/node` from `^14` to `^20` (match Node 20 engine)
- Update `tsconfig.json`: `es6` → `es2020`, add `skipLibCheck` (standard practice)

## Test plan
- [x] `npm run build` succeeds (was failing)
- [x] All 68 tests pass
- [x] No business logic changes — only import paths and config

After merging, re-deploy with `./scripts/release-firebase.sh --confirm-tag server/2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)