### PR TITLE
feat: Extract PushRemoteButtonUseCase (Phase 2.2)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
@@ -32,6 +32,7 @@ import com.chriscartland.garage.domain.repository.PushRepository
 import com.chriscartland.garage.snoozenotifications.SnoozeDurationUIOption
 import com.chriscartland.garage.snoozenotifications.toServer
 import com.chriscartland.garage.usecase.EnsureFreshIdTokenUseCase
+import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -74,6 +75,7 @@ class RemoteButtonViewModelImpl
         private val doorRepository: DoorRepository,
         private val dispatchers: DispatcherProvider,
         private val ensureFreshIdToken: EnsureFreshIdTokenUseCase,
+        private val pushRemoteButtonUseCase: PushRemoteButtonUseCase,
     ) : ViewModel(),
         RemoteButtonViewModel {
         // Listen to network events and door status updates.
@@ -286,15 +288,13 @@ class RemoteButtonViewModelImpl
         override fun pushRemoteButton(authRepository: AuthRepository) {
             Log.d(TAG, "pushRemoteButton")
             viewModelScope.launch(dispatchers.io) {
-                val authState = authRepository.authState.value
-                if (authState !is AuthState.Authenticated) {
-                    Log.e(TAG, "Not authenticated: $authState")
+                if (authRepository.authState.value !is AuthState.Authenticated) {
+                    Log.e(TAG, "Not authenticated — push skipped")
                     return@launch
                 }
-                val idToken = ensureFreshIdToken(authRepository, authState)
-                Log.d(TAG, "pushRemoteButton: Pushing remote button: $idToken")
-                pushRepository.push(
-                    idToken = idToken.asString(),
+                pushRemoteButtonUseCase(
+                    authRepository = authRepository,
+                    pushRepository = pushRepository,
                     buttonAckToken = createButtonAckToken(Date()),
                 )
             }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/PushRemoteButtonUseCase.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/PushRemoteButtonUseCase.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.repository.AuthRepository
+import com.chriscartland.garage.domain.repository.PushRepository
+import javax.inject.Inject
+
+/**
+ * Pushes the remote garage button.
+ *
+ * Handles:
+ * - Verifying the user is authenticated
+ * - Ensuring the auth token is fresh
+ * - Delegating to PushRepository
+ *
+ * @return true if the push was initiated, false if not authenticated
+ */
+class PushRemoteButtonUseCase
+    @Inject
+    constructor(
+        private val ensureFreshIdToken: EnsureFreshIdTokenUseCase,
+    ) {
+        suspend operator fun invoke(
+            authRepository: AuthRepository,
+            pushRepository: PushRepository,
+            buttonAckToken: String,
+        ): Boolean {
+            val authState = authRepository.authState.value
+            if (authState !is AuthState.Authenticated) {
+                return false
+            }
+            val idToken = ensureFreshIdToken(authRepository, authState)
+            pushRepository.push(
+                idToken = idToken.asString(),
+                buttonAckToken = buttonAckToken,
+            )
+            return true
+        }
+    }

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModelTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModelTest.kt
@@ -28,6 +28,7 @@ import com.chriscartland.garage.domain.repository.AuthRepository
 import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.domain.repository.PushRepository
 import com.chriscartland.garage.usecase.EnsureFreshIdTokenUseCase
+import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -83,11 +84,13 @@ class RemoteButtonViewModelTest {
     }
 
     private fun createViewModel(): RemoteButtonViewModelImpl {
+        val ensureFreshIdToken = EnsureFreshIdTokenUseCase()
         val vm = RemoteButtonViewModelImpl(
             pushRepository,
             doorRepository,
             TestDispatcherProvider(testDispatcher),
-            EnsureFreshIdTokenUseCase(),
+            ensureFreshIdToken,
+            PushRemoteButtonUseCase(ensureFreshIdToken),
         )
         testDispatcher.scheduler.runCurrent()
         return vm

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/PushRemoteButtonUseCaseTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/PushRemoteButtonUseCaseTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.DisplayName
+import com.chriscartland.garage.domain.model.Email
+import com.chriscartland.garage.domain.model.FirebaseIdToken
+import com.chriscartland.garage.domain.model.User
+import com.chriscartland.garage.testcommon.FakeAuthRepository
+import com.chriscartland.garage.testcommon.FakePushRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class PushRemoteButtonUseCaseTest {
+    private lateinit var useCase: PushRemoteButtonUseCase
+    private lateinit var fakeAuth: FakeAuthRepository
+    private lateinit var fakePush: FakePushRepository
+
+    @Before
+    fun setup() {
+        useCase = PushRemoteButtonUseCase(EnsureFreshIdTokenUseCase())
+        fakeAuth = FakeAuthRepository()
+        fakePush = FakePushRepository()
+    }
+
+    private fun authenticateUser(
+        token: String = "token",
+        exp: Long = Long.MAX_VALUE,
+    ) {
+        fakeAuth.setAuthState(
+            AuthState.Authenticated(
+                user = User(
+                    name = DisplayName("Test"),
+                    email = Email("test@test.com"),
+                    idToken = FirebaseIdToken(idToken = token, exp = exp),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun pushSucceedsWhenAuthenticated() =
+        runTest {
+            authenticateUser()
+            val result = useCase(fakeAuth, fakePush, "ack-123")
+            assertTrue("Push should succeed when authenticated", result)
+            assertEquals(1, fakePush.pushCount)
+        }
+
+    @Test
+    fun pushFailsWhenUnauthenticated() =
+        runTest {
+            fakeAuth.setAuthState(AuthState.Unauthenticated)
+            val result = useCase(fakeAuth, fakePush, "ack-123")
+            assertFalse("Push should fail when unauthenticated", result)
+            assertEquals(0, fakePush.pushCount)
+        }
+
+    @Test
+    fun pushFailsWhenAuthUnknown() =
+        runTest {
+            val result = useCase(fakeAuth, fakePush, "ack-123")
+            assertFalse("Push should fail when auth unknown", result)
+            assertEquals(0, fakePush.pushCount)
+        }
+
+    @Test
+    fun pushPassesCorrectIdToken() =
+        runTest {
+            authenticateUser(token = "my-token-123")
+            useCase(fakeAuth, fakePush, "ack-456")
+            assertEquals("my-token-123", fakePush.lastIdToken)
+        }
+
+    @Test
+    fun pushPassesButtonAckToken() =
+        runTest {
+            authenticateUser()
+            useCase(fakeAuth, fakePush, "ack-unique-789")
+            assertEquals(1, fakePush.pushCount)
+        }
+
+    @Test
+    fun pushRefreshesExpiredToken() =
+        runTest {
+            authenticateUser(token = "old-token", exp = 1000L)
+            val refreshedAuth = AuthState.Authenticated(
+                user = User(
+                    name = DisplayName("Test"),
+                    email = Email("test@test.com"),
+                    idToken = FirebaseIdToken(idToken = "new-token", exp = Long.MAX_VALUE),
+                ),
+            )
+            fakeAuth.refreshResult = refreshedAuth
+
+            useCase(fakeAuth, fakePush, "ack-123")
+
+            assertEquals("new-token", fakePush.lastIdToken)
+            assertEquals(1, fakeAuth.refreshCount)
+        }
+}


### PR DESCRIPTION
## Summary
Second UseCase extraction for Phase 2.2 — extracts push button logic from RemoteButtonViewModel:

- Auth verification + token refresh + PushRepository delegation
- 6 new tests via FakeAuthRepository and FakePushRepository
- ViewModel retains early auth check to avoid Android API call when unauthenticated

## Test plan
- [x] 6 new PushRemoteButtonUseCaseTest tests pass
- [x] All existing tests pass
- [x] `./scripts/validate.sh` passes (all 9 checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)