### PR TITLE
feat: Extract SnoozeNotificationsUseCase (Phase 2.2)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
@@ -31,8 +31,8 @@ import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.domain.repository.PushRepository
 import com.chriscartland.garage.snoozenotifications.SnoozeDurationUIOption
 import com.chriscartland.garage.snoozenotifications.toServer
-import com.chriscartland.garage.usecase.EnsureFreshIdTokenUseCase
 import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
+import com.chriscartland.garage.usecase.SnoozeNotificationsUseCase
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -74,8 +74,8 @@ class RemoteButtonViewModelImpl
         // Watch the door status, because we consider the request delivered when the door moves.
         private val doorRepository: DoorRepository,
         private val dispatchers: DispatcherProvider,
-        private val ensureFreshIdToken: EnsureFreshIdTokenUseCase,
         private val pushRemoteButtonUseCase: PushRemoteButtonUseCase,
+        private val snoozeNotificationsUseCase: SnoozeNotificationsUseCase,
     ) : ViewModel(),
         RemoteButtonViewModel {
         // Listen to network events and door status updates.
@@ -306,24 +306,15 @@ class RemoteButtonViewModelImpl
         ) {
             Log.d(TAG, "snoozeOpenDoorsNotifications")
             viewModelScope.launch(dispatchers.io) {
-                val authState = authRepository.authState.value
-                if (authState !is AuthState.Authenticated) {
-                    Log.e(TAG, "Not authenticated: $authState")
-                    return@launch
-                }
-                val idToken = ensureFreshIdToken(authRepository, authState)
-                Log.d(TAG, "snoozeOpenDoorsNotifications: Snoozing: $snoozeDuration")
-
-                val lastChangeTimeSeconds = currentDoorEvent.value?.lastChangeTimeSeconds
-                if (lastChangeTimeSeconds == null) {
-                    Log.e(TAG, "lastChangeTimeSeconds is null -- cannot snooze")
-                    return@launch
-                }
-                pushRepository.snoozeOpenDoorsNotifications(
+                val result = snoozeNotificationsUseCase(
+                    authRepository = authRepository,
+                    pushRepository = pushRepository,
                     snoozeDurationHours = snoozeDuration.toServer().duration,
-                    idToken = idToken.asString(),
-                    snoozeEventTimestampSeconds = lastChangeTimeSeconds,
+                    lastChangeTimeSeconds = currentDoorEvent.value?.lastChangeTimeSeconds,
                 )
+                if (!result) {
+                    Log.e(TAG, "Snooze failed — not authenticated or no door event")
+                }
             }
         }
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/SnoozeNotificationsUseCase.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/SnoozeNotificationsUseCase.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.repository.AuthRepository
+import com.chriscartland.garage.domain.repository.PushRepository
+import javax.inject.Inject
+
+/**
+ * Snoozes open-door notifications for a specified duration.
+ *
+ * Handles:
+ * - Verifying the user is authenticated
+ * - Ensuring the auth token is fresh
+ * - Delegating to PushRepository
+ *
+ * @return true if the snooze was initiated, false if not authenticated
+ *   or if lastChangeTimeSeconds is null
+ */
+class SnoozeNotificationsUseCase
+    @Inject
+    constructor(
+        private val ensureFreshIdToken: EnsureFreshIdTokenUseCase,
+    ) {
+        suspend operator fun invoke(
+            authRepository: AuthRepository,
+            pushRepository: PushRepository,
+            snoozeDurationHours: String,
+            lastChangeTimeSeconds: Long?,
+        ): Boolean {
+            val authState = authRepository.authState.value
+            if (authState !is AuthState.Authenticated) {
+                return false
+            }
+            if (lastChangeTimeSeconds == null) {
+                return false
+            }
+            val idToken = ensureFreshIdToken(authRepository, authState)
+            pushRepository.snoozeOpenDoorsNotifications(
+                snoozeDurationHours = snoozeDurationHours,
+                idToken = idToken.asString(),
+                snoozeEventTimestampSeconds = lastChangeTimeSeconds,
+            )
+            return true
+        }
+    }

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModelTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModelTest.kt
@@ -29,6 +29,7 @@ import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.domain.repository.PushRepository
 import com.chriscartland.garage.usecase.EnsureFreshIdTokenUseCase
 import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
+import com.chriscartland.garage.usecase.SnoozeNotificationsUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -89,8 +90,8 @@ class RemoteButtonViewModelTest {
             pushRepository,
             doorRepository,
             TestDispatcherProvider(testDispatcher),
-            ensureFreshIdToken,
             PushRemoteButtonUseCase(ensureFreshIdToken),
+            SnoozeNotificationsUseCase(ensureFreshIdToken),
         )
         testDispatcher.scheduler.runCurrent()
         return vm

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/SnoozeNotificationsUseCaseTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/SnoozeNotificationsUseCaseTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.DisplayName
+import com.chriscartland.garage.domain.model.Email
+import com.chriscartland.garage.domain.model.FirebaseIdToken
+import com.chriscartland.garage.domain.model.User
+import com.chriscartland.garage.testcommon.FakeAuthRepository
+import com.chriscartland.garage.testcommon.FakePushRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class SnoozeNotificationsUseCaseTest {
+    private lateinit var useCase: SnoozeNotificationsUseCase
+    private lateinit var fakeAuth: FakeAuthRepository
+    private lateinit var fakePush: FakePushRepository
+
+    @Before
+    fun setup() {
+        useCase = SnoozeNotificationsUseCase(EnsureFreshIdTokenUseCase())
+        fakeAuth = FakeAuthRepository()
+        fakePush = FakePushRepository()
+    }
+
+    private fun authenticateUser(
+        token: String = "token",
+        exp: Long = Long.MAX_VALUE,
+    ) {
+        fakeAuth.setAuthState(
+            AuthState.Authenticated(
+                user = User(
+                    name = DisplayName("Test"),
+                    email = Email("test@test.com"),
+                    idToken = FirebaseIdToken(idToken = token, exp = exp),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun snoozeSucceedsWhenAuthenticatedWithTimestamp() =
+        runTest {
+            authenticateUser()
+            val result = useCase(fakeAuth, fakePush, "1h", 1000L)
+            assertTrue(result)
+            assertEquals(1, fakePush.snoozeCount)
+        }
+
+    @Test
+    fun snoozeFailsWhenUnauthenticated() =
+        runTest {
+            fakeAuth.setAuthState(AuthState.Unauthenticated)
+            val result = useCase(fakeAuth, fakePush, "1h", 1000L)
+            assertFalse(result)
+            assertEquals(0, fakePush.snoozeCount)
+        }
+
+    @Test
+    fun snoozeFailsWhenAuthUnknown() =
+        runTest {
+            val result = useCase(fakeAuth, fakePush, "1h", 1000L)
+            assertFalse(result)
+            assertEquals(0, fakePush.snoozeCount)
+        }
+
+    @Test
+    fun snoozeFailsWhenTimestampIsNull() =
+        runTest {
+            authenticateUser()
+            val result = useCase(fakeAuth, fakePush, "1h", null)
+            assertFalse(result)
+            assertEquals(0, fakePush.snoozeCount)
+        }
+
+    @Test
+    fun snoozeDoesNotRefreshTokenWhenTimestampNull() =
+        runTest {
+            authenticateUser(exp = 1000L)
+            useCase(fakeAuth, fakePush, "1h", null)
+            assertEquals(0, fakeAuth.refreshCount)
+        }
+
+    @Test
+    fun snoozeRefreshesExpiredToken() =
+        runTest {
+            authenticateUser(token = "old", exp = 1000L)
+            fakeAuth.refreshResult = AuthState.Authenticated(
+                user = User(
+                    name = DisplayName("Test"),
+                    email = Email("test@test.com"),
+                    idToken = FirebaseIdToken(idToken = "fresh", exp = Long.MAX_VALUE),
+                ),
+            )
+            useCase(fakeAuth, fakePush, "4h", 2000L)
+            assertEquals(1, fakeAuth.refreshCount)
+        }
+}


### PR DESCRIPTION
## Summary
Third UseCase extraction for Phase 2.2:
- Extracts snooze logic from RemoteButtonViewModel
- 6 new tests: auth check, null timestamp guard, token refresh
- Removes `EnsureFreshIdTokenUseCase` from ViewModel constructor (both UseCases inject it themselves)

Phase 2.2 progress: 3 of 5 UseCases done.

## Test plan
- [x] 6 new SnoozeNotificationsUseCaseTest tests pass
- [x] All existing tests pass
- [x] `./scripts/validate.sh` passes (all 9 checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)