### PR TITLE
feat: Extract FetchDoorEvent UseCases (Phase 2.2)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorViewModel.kt
@@ -33,6 +33,8 @@ import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.fcm.DoorFcmRepository
 import com.chriscartland.garage.fcm.toFcmTopic
+import com.chriscartland.garage.usecase.FetchCurrentDoorEventUseCase
+import com.chriscartland.garage.usecase.FetchRecentDoorEventsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -63,6 +65,8 @@ class DoorViewModelImpl
         private val doorRepository: DoorRepository,
         private val doorFcmRepository: DoorFcmRepository,
         private val dispatchers: DispatcherProvider,
+        private val fetchCurrentDoorEventUseCase: FetchCurrentDoorEventUseCase,
+        private val fetchRecentDoorEventsUseCase: FetchRecentDoorEventsUseCase,
     ) : ViewModel(),
         DoorViewModel {
         private val _fcmRegistrationStatus =
@@ -163,7 +167,7 @@ class DoorViewModelImpl
             Log.d(TAG, "fetchCurrentDoorEvent")
             viewModelScope.launch(dispatchers.io) {
                 _currentDoorEvent.value = LoadingResult.Loading(_currentDoorEvent.value.data)
-                doorRepository.fetchCurrentDoorEvent()
+                fetchCurrentDoorEventUseCase()
             }
         }
 
@@ -171,7 +175,7 @@ class DoorViewModelImpl
             Log.d(TAG, "fetchRecentDoorEvents")
             viewModelScope.launch(dispatchers.io) {
                 _recentDoorEvents.value = LoadingResult.Loading(_recentDoorEvents.value.data)
-                doorRepository.fetchRecentDoorEvents()
+                fetchRecentDoorEventsUseCase()
             }
         }
     }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/FetchDoorEventsUseCase.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/FetchDoorEventsUseCase.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.repository.DoorRepository
+import javax.inject.Inject
+
+/**
+ * Fetches the current door event from the network.
+ *
+ * Delegates to [DoorRepository.fetchCurrentDoorEvent]. The repository handles
+ * server config lookup, network requests, and local database insertion.
+ */
+class FetchCurrentDoorEventUseCase
+    @Inject
+    constructor(
+        private val doorRepository: DoorRepository,
+    ) {
+        suspend operator fun invoke() {
+            doorRepository.fetchCurrentDoorEvent()
+        }
+    }
+
+/**
+ * Fetches recent door events from the network.
+ *
+ * Delegates to [DoorRepository.fetchRecentDoorEvents]. The repository handles
+ * server config lookup, network requests, and local database replacement.
+ */
+class FetchRecentDoorEventsUseCase
+    @Inject
+    constructor(
+        private val doorRepository: DoorRepository,
+    ) {
+        suspend operator fun invoke() {
+            doorRepository.fetchRecentDoorEvents()
+        }
+    }

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/door/DoorViewModelTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/door/DoorViewModelTest.kt
@@ -28,6 +28,8 @@ import com.chriscartland.garage.domain.model.FcmRegistrationStatus
 import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.fcm.DoorFcmRepository
+import com.chriscartland.garage.usecase.FetchCurrentDoorEventUseCase
+import com.chriscartland.garage.usecase.FetchRecentDoorEventsUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -87,7 +89,14 @@ class DoorViewModelTest {
     }
 
     private fun createViewModel(): DoorViewModelImpl {
-        val vm = DoorViewModelImpl(appLoggerRepository, doorRepository, doorFcmRepository, TestDispatcherProvider(testDispatcher))
+        val vm = DoorViewModelImpl(
+            appLoggerRepository,
+            doorRepository,
+            doorFcmRepository,
+            TestDispatcherProvider(testDispatcher),
+            FetchCurrentDoorEventUseCase(doorRepository),
+            FetchRecentDoorEventsUseCase(doorRepository),
+        )
         testDispatcher.scheduler.runCurrent()
         return vm
     }

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/FetchDoorEventsUseCaseTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/FetchDoorEventsUseCaseTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.testcommon.FakeDoorRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class FetchDoorEventsUseCaseTest {
+    private lateinit var fakeDoor: FakeDoorRepository
+    private lateinit var fetchCurrent: FetchCurrentDoorEventUseCase
+    private lateinit var fetchRecent: FetchRecentDoorEventsUseCase
+
+    @Before
+    fun setup() {
+        fakeDoor = FakeDoorRepository()
+        fetchCurrent = FetchCurrentDoorEventUseCase(fakeDoor)
+        fetchRecent = FetchRecentDoorEventsUseCase(fakeDoor)
+    }
+
+    @Test
+    fun fetchCurrentDelegatesToRepository() =
+        runTest {
+            fetchCurrent()
+            assertEquals(1, fakeDoor.fetchCurrentDoorEventCount)
+        }
+
+    @Test
+    fun fetchCurrentCanBeCalledMultipleTimes() =
+        runTest {
+            fetchCurrent()
+            fetchCurrent()
+            fetchCurrent()
+            assertEquals(3, fakeDoor.fetchCurrentDoorEventCount)
+        }
+
+    @Test
+    fun fetchRecentDelegatesToRepository() =
+        runTest {
+            fetchRecent()
+            assertEquals(1, fakeDoor.fetchRecentDoorEventsCount)
+        }
+
+    @Test
+    fun fetchCurrentAndRecentAreIndependent() =
+        runTest {
+            fetchCurrent()
+            fetchRecent()
+            assertEquals(1, fakeDoor.fetchCurrentDoorEventCount)
+            assertEquals(1, fakeDoor.fetchRecentDoorEventsCount)
+        }
+}


### PR DESCRIPTION
## Summary
Fourth and fifth UseCase extractions:
- `FetchCurrentDoorEventUseCase` — delegates to `DoorRepository.fetchCurrentDoorEvent()`
- `FetchRecentDoorEventsUseCase` — delegates to `DoorRepository.fetchRecentDoorEvents()`

Thin wrappers that establish the pattern: all data fetching goes through UseCases.

Phase 2.2 progress: 5 of 6 UseCases done (only RegisterFcmUseCase remains — blocked on Activity dependency).

## Test plan
- [x] 4 new tests verifying delegation and independence
- [x] All existing tests pass
- [x] `./scripts/validate.sh` passes (all 9 checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)