### PR TITLE
feat: Extract FCM registration UseCases (Phase 2.2 complete)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorViewModel.kt
@@ -27,14 +27,14 @@ import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.config.FetchOnViewModelInit
 import com.chriscartland.garage.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.DoorEvent
-import com.chriscartland.garage.domain.model.DoorFcmState
 import com.chriscartland.garage.domain.model.FcmRegistrationStatus
 import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.domain.repository.DoorRepository
-import com.chriscartland.garage.fcm.DoorFcmRepository
-import com.chriscartland.garage.fcm.toFcmTopic
+import com.chriscartland.garage.usecase.DeregisterFcmUseCase
 import com.chriscartland.garage.usecase.FetchCurrentDoorEventUseCase
+import com.chriscartland.garage.usecase.FetchFcmStatusUseCase
 import com.chriscartland.garage.usecase.FetchRecentDoorEventsUseCase
+import com.chriscartland.garage.usecase.RegisterFcmUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -63,10 +63,12 @@ class DoorViewModelImpl
     constructor(
         private val appLoggerRepository: AppLoggerRepository,
         private val doorRepository: DoorRepository,
-        private val doorFcmRepository: DoorFcmRepository,
         private val dispatchers: DispatcherProvider,
         private val fetchCurrentDoorEventUseCase: FetchCurrentDoorEventUseCase,
         private val fetchRecentDoorEventsUseCase: FetchRecentDoorEventsUseCase,
+        private val fetchFcmStatusUseCase: FetchFcmStatusUseCase,
+        private val registerFcmUseCase: RegisterFcmUseCase,
+        private val deregisterFcmUseCase: DeregisterFcmUseCase,
     ) : ViewModel(),
         DoorViewModel {
         private val _fcmRegistrationStatus =
@@ -114,52 +116,25 @@ class DoorViewModelImpl
         override fun fetchFcmRegistrationStatus(activity: Activity) {
             Log.d(TAG, "fetchFcmRegistrationStatus")
             viewModelScope.launch(dispatchers.io) {
-                Log.d(TAG, "Fetching FCM registration status")
-                val status = doorFcmRepository.fetchStatus(activity)
-                Log.d(TAG, "Fetched FCM registration status: $status")
-                _fcmRegistrationStatus.value =
-                    when (status) {
-                        is DoorFcmState.Registered -> FcmRegistrationStatus.REGISTERED
-                        DoorFcmState.NotRegistered -> FcmRegistrationStatus.NOT_REGISTERED
-                        DoorFcmState.Unknown -> FcmRegistrationStatus.UNKNOWN
-                    }
+                _fcmRegistrationStatus.value = fetchFcmStatusUseCase(activity)
             }
         }
 
         override fun registerFcm(activity: Activity) {
             Log.d(TAG, "registerFcm")
             viewModelScope.launch(dispatchers.io) {
-                val buildTimestamp = doorRepository.fetchBuildTimestampCached()
-                if (buildTimestamp == null) {
-                    Log.e(TAG, "buildTimestamp is null, cannot register FCM")
-                    _fcmRegistrationStatus.value = FcmRegistrationStatus.NOT_REGISTERED
-                    return@launch
+                _fcmRegistrationStatus.value = registerFcmUseCase(activity).also {
+                    Log.d(TAG, "Updated FcmRegistrationStatus: $it")
                 }
-                Log.d(TAG, "Registering FCM for buildTimestamp: $buildTimestamp")
-                val result = doorFcmRepository.registerDoor(activity, buildTimestamp.toFcmTopic())
-                _fcmRegistrationStatus.value =
-                    when (result) {
-                        is DoorFcmState.Registered -> FcmRegistrationStatus.REGISTERED
-                        DoorFcmState.NotRegistered -> FcmRegistrationStatus.NOT_REGISTERED
-                        DoorFcmState.Unknown -> FcmRegistrationStatus.UNKNOWN
-                    }.also {
-                        Log.d(TAG, "Updated FcmRegistrationStatus: $it")
-                    }
             }
         }
 
         override fun deregisterFcm(activity: Activity) {
             Log.d(TAG, "deregisterFcm")
             viewModelScope.launch(dispatchers.io) {
-                val result = doorFcmRepository.deregisterDoor(activity)
-                _fcmRegistrationStatus.value =
-                    when (result) {
-                        is DoorFcmState.Registered -> FcmRegistrationStatus.REGISTERED
-                        DoorFcmState.NotRegistered -> FcmRegistrationStatus.NOT_REGISTERED
-                        DoorFcmState.Unknown -> FcmRegistrationStatus.UNKNOWN
-                    }.also {
-                        Log.d(TAG, "Updated FcmRegistrationStatus: $it")
-                    }
+                _fcmRegistrationStatus.value = deregisterFcmUseCase(activity).also {
+                    Log.d(TAG, "Updated FcmRegistrationStatus: $it")
+                }
             }
         }
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/RegisterFcmUseCase.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/RegisterFcmUseCase.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import android.app.Activity
+import com.chriscartland.garage.domain.model.DoorFcmState
+import com.chriscartland.garage.domain.model.FcmRegistrationStatus
+import com.chriscartland.garage.domain.repository.DoorRepository
+import com.chriscartland.garage.fcm.DoorFcmRepository
+import com.chriscartland.garage.fcm.toFcmTopic
+import javax.inject.Inject
+
+/**
+ * Maps [DoorFcmState] to the simpler [FcmRegistrationStatus] enum.
+ */
+fun DoorFcmState.toRegistrationStatus(): FcmRegistrationStatus =
+    when (this) {
+        is DoorFcmState.Registered -> FcmRegistrationStatus.REGISTERED
+        DoorFcmState.NotRegistered -> FcmRegistrationStatus.NOT_REGISTERED
+        DoorFcmState.Unknown -> FcmRegistrationStatus.UNKNOWN
+    }
+
+/**
+ * Fetches the current FCM registration status.
+ */
+class FetchFcmStatusUseCase
+    @Inject
+    constructor(
+        private val doorFcmRepository: DoorFcmRepository,
+    ) {
+        suspend operator fun invoke(activity: Activity): FcmRegistrationStatus =
+            doorFcmRepository.fetchStatus(activity).toRegistrationStatus()
+    }
+
+/**
+ * Registers for FCM door notifications.
+ *
+ * Fetches the build timestamp from server config, converts it to an FCM topic,
+ * and subscribes. Returns NOT_REGISTERED if build timestamp is unavailable.
+ */
+class RegisterFcmUseCase
+    @Inject
+    constructor(
+        private val doorRepository: DoorRepository,
+        private val doorFcmRepository: DoorFcmRepository,
+    ) {
+        suspend operator fun invoke(activity: Activity): FcmRegistrationStatus {
+            val buildTimestamp = doorRepository.fetchBuildTimestampCached()
+                ?: return FcmRegistrationStatus.NOT_REGISTERED
+            val result = doorFcmRepository.registerDoor(activity, buildTimestamp.toFcmTopic())
+            return result.toRegistrationStatus()
+        }
+    }
+
+/**
+ * Deregisters from FCM door notifications.
+ */
+class DeregisterFcmUseCase
+    @Inject
+    constructor(
+        private val doorFcmRepository: DoorFcmRepository,
+    ) {
+        suspend operator fun invoke(activity: Activity): FcmRegistrationStatus =
+            doorFcmRepository.deregisterDoor(activity).toRegistrationStatus()
+    }

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/door/DoorViewModelTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/door/DoorViewModelTest.kt
@@ -28,8 +28,11 @@ import com.chriscartland.garage.domain.model.FcmRegistrationStatus
 import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.fcm.DoorFcmRepository
+import com.chriscartland.garage.usecase.DeregisterFcmUseCase
 import com.chriscartland.garage.usecase.FetchCurrentDoorEventUseCase
+import com.chriscartland.garage.usecase.FetchFcmStatusUseCase
 import com.chriscartland.garage.usecase.FetchRecentDoorEventsUseCase
+import com.chriscartland.garage.usecase.RegisterFcmUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -92,10 +95,12 @@ class DoorViewModelTest {
         val vm = DoorViewModelImpl(
             appLoggerRepository,
             doorRepository,
-            doorFcmRepository,
             TestDispatcherProvider(testDispatcher),
             FetchCurrentDoorEventUseCase(doorRepository),
             FetchRecentDoorEventsUseCase(doorRepository),
+            FetchFcmStatusUseCase(doorFcmRepository),
+            RegisterFcmUseCase(doorRepository, doorFcmRepository),
+            DeregisterFcmUseCase(doorFcmRepository),
         )
         testDispatcher.scheduler.runCurrent()
         return vm

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/RegisterFcmUseCaseTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/RegisterFcmUseCaseTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import android.app.Activity
+import com.chriscartland.garage.domain.model.DoorFcmState
+import com.chriscartland.garage.domain.model.DoorFcmTopic
+import com.chriscartland.garage.domain.model.FcmRegistrationStatus
+import com.chriscartland.garage.fcm.DoorFcmRepository
+import com.chriscartland.garage.testcommon.FakeDoorRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+class FakeDoorFcmRepository : DoorFcmRepository {
+    var fetchStatusResult: DoorFcmState = DoorFcmState.Unknown
+    var registerResult: DoorFcmState = DoorFcmState.NotRegistered
+    var deregisterResult: DoorFcmState = DoorFcmState.NotRegistered
+    var registerCount = 0
+    var lastRegisteredTopic: DoorFcmTopic? = null
+
+    override suspend fun fetchStatus(activity: Activity): DoorFcmState = fetchStatusResult
+
+    override suspend fun registerDoor(
+        activity: Activity,
+        fcmTopic: DoorFcmTopic,
+    ): DoorFcmState {
+        registerCount++
+        lastRegisteredTopic = fcmTopic
+        return registerResult
+    }
+
+    override suspend fun deregisterDoor(activity: Activity): DoorFcmState = deregisterResult
+}
+
+class DoorFcmStateToRegistrationStatusTest {
+    @Test
+    fun registeredMapsToRegistered() {
+        val state = DoorFcmState.Registered(DoorFcmTopic("test"))
+        assertEquals(FcmRegistrationStatus.REGISTERED, state.toRegistrationStatus())
+    }
+
+    @Test
+    fun notRegisteredMapsToNotRegistered() {
+        assertEquals(
+            FcmRegistrationStatus.NOT_REGISTERED,
+            DoorFcmState.NotRegistered.toRegistrationStatus(),
+        )
+    }
+
+    @Test
+    fun unknownMapsToUnknown() {
+        assertEquals(FcmRegistrationStatus.UNKNOWN, DoorFcmState.Unknown.toRegistrationStatus())
+    }
+}
+
+class RegisterFcmUseCaseTest {
+    private lateinit var fakeDoor: FakeDoorRepository
+    private lateinit var fakeFcm: FakeDoorFcmRepository
+    private lateinit var useCase: RegisterFcmUseCase
+    private lateinit var mockActivity: Activity
+
+    @Before
+    fun setup() {
+        fakeDoor = FakeDoorRepository()
+        fakeFcm = FakeDoorFcmRepository()
+        useCase = RegisterFcmUseCase(fakeDoor, fakeFcm)
+        mockActivity = mock(Activity::class.java)
+    }
+
+    @Test
+    fun registerSucceedsWithBuildTimestamp() =
+        runTest {
+            fakeDoor.buildTimestamp = "Sat Mar 13 14:45:00 2021"
+            fakeFcm.registerResult =
+                DoorFcmState.Registered(DoorFcmTopic("door_open-Sat.Mar.13.14.45.00.2021"))
+
+            val result = useCase(mockActivity)
+
+            assertEquals(FcmRegistrationStatus.REGISTERED, result)
+            assertEquals(1, fakeFcm.registerCount)
+        }
+
+    @Test
+    fun registerFailsWithNullBuildTimestamp() =
+        runTest {
+            fakeDoor.buildTimestamp = null
+            val result = useCase(mockActivity)
+
+            assertEquals(FcmRegistrationStatus.NOT_REGISTERED, result)
+            assertEquals(0, fakeFcm.registerCount)
+        }
+
+    @Test
+    fun registerConvertsTimestampToTopic() =
+        runTest {
+            fakeDoor.buildTimestamp = "Sat Mar 13 14:45:00 2021"
+            fakeFcm.registerResult = DoorFcmState.Registered(DoorFcmTopic("test"))
+
+            useCase(mockActivity)
+
+            assertEquals("door_open-Sat.Mar.13.14.45.00.2021", fakeFcm.lastRegisteredTopic?.string)
+        }
+
+    @Test
+    fun registerReturnsNotRegisteredOnFailure() =
+        runTest {
+            fakeDoor.buildTimestamp = "timestamp"
+            fakeFcm.registerResult = DoorFcmState.NotRegistered
+
+            val result = useCase(mockActivity)
+
+            assertEquals(FcmRegistrationStatus.NOT_REGISTERED, result)
+        }
+}


### PR DESCRIPTION
## Summary
Final UseCase extraction — completes Phase 2.2:

- `FetchFcmStatusUseCase` — fetches FCM registration status
- `RegisterFcmUseCase` — build timestamp lookup → topic conversion → FCM registration
- `DeregisterFcmUseCase` — FCM deregistration
- `DoorFcmState.toRegistrationStatus()` — shared mapping (was duplicated 3x)

DoorViewModel no longer depends on DoorFcmRepository directly.

**Phase 2.2 complete:** All 8 UseCases extracted from ViewModels.

## Test plan
- [x] 7 new tests (state mapping, registration with/without timestamp, topic conversion)
- [x] All existing tests pass
- [x] `./scripts/validate.sh` passes (all 9 checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)