### PR TITLE
feat: Create data module with LocalDoorDataSource interface (Phase 2.3)

### DIFF
--- a/AndroidGarage/androidApp/build.gradle.kts
+++ b/AndroidGarage/androidApp/build.gradle.kts
@@ -225,6 +225,7 @@ room {
 
 dependencies {
     implementation(project(":domain"))
+    implementation(project(":data"))
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/db/LocalDoorDataSource.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/db/LocalDoorDataSource.kt
@@ -18,6 +18,7 @@
 package com.chriscartland.garage.db
 
 import android.util.Log
+import com.chriscartland.garage.data.LocalDoorDataSource
 import com.chriscartland.garage.domain.model.DoorEvent
 import dagger.Module
 import dagger.Provides
@@ -27,15 +28,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
-
-interface LocalDoorDataSource {
-    val currentDoorEvent: Flow<DoorEvent>
-    val recentDoorEvents: Flow<List<DoorEvent>>
-
-    fun insertDoorEvent(doorEvent: DoorEvent)
-
-    fun replaceDoorEvents(doorEvents: List<DoorEvent>)
-}
 
 class DatabaseLocalDoorDataSource
     @Inject

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorRepository.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorRepository.kt
@@ -20,7 +20,7 @@ package com.chriscartland.garage.door
 import android.util.Log
 import com.chriscartland.garage.config.APP_CONFIG
 import com.chriscartland.garage.config.ServerConfigRepository
-import com.chriscartland.garage.db.LocalDoorDataSource
+import com.chriscartland.garage.data.LocalDoorDataSource
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.repository.DoorRepository

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/door/DoorRepositoryTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/door/DoorRepositoryTest.kt
@@ -19,7 +19,7 @@ package com.chriscartland.garage.door
 
 import com.chriscartland.garage.config.ServerConfigRepository
 import com.chriscartland.garage.config.model.ServerConfig
-import com.chriscartland.garage.db.LocalDoorDataSource
+import com.chriscartland.garage.data.LocalDoorDataSource
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.internet.CurrentEventDataResponse

--- a/AndroidGarage/data/build.gradle.kts
+++ b/AndroidGarage/data/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    kotlin("jvm")
+}
+
+kotlin {
+    jvmToolchain(17)
+}
+
+dependencies {
+    implementation(project(":domain"))
+    implementation(libs.kotlinx.coroutines.core)
+    testImplementation(libs.junit)
+}

--- a/AndroidGarage/data/src/main/kotlin/com/chriscartland/garage/data/LocalDoorDataSource.kt
+++ b/AndroidGarage/data/src/main/kotlin/com/chriscartland/garage/data/LocalDoorDataSource.kt
@@ -1,0 +1,19 @@
+package com.chriscartland.garage.data
+
+import com.chriscartland.garage.domain.model.DoorEvent
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Pure data source interface for local door event storage.
+ *
+ * Implementations handle persistence (Room, in-memory, etc.)
+ * without leaking implementation details to the Repository layer.
+ */
+interface LocalDoorDataSource {
+    val currentDoorEvent: Flow<DoorEvent>
+    val recentDoorEvents: Flow<List<DoorEvent>>
+
+    fun insertDoorEvent(doorEvent: DoorEvent)
+
+    fun replaceDoorEvents(doorEvents: List<DoorEvent>)
+}

--- a/AndroidGarage/settings.gradle.kts
+++ b/AndroidGarage/settings.gradle.kts
@@ -38,6 +38,7 @@ dependencyResolutionManagement {
 
 rootProject.name = "AndroidGarage"
 include(":androidApp")
+include(":data")
 include(":domain")
 include(":macrobenchmark")
 include(":shared")


### PR DESCRIPTION
## Summary
First step of Phase 2.3 — create the `data` module as a pure Kotlin abstraction layer:

```
domain/     ← types + repository interfaces
data/       ← NEW: data source interfaces (LocalDoorDataSource)
androidApp/ ← implementations (Room, Retrofit) + DI wiring
```

- `data/` is pure Kotlin (no Android deps), depends only on `domain`
- `LocalDoorDataSource` interface moved from `androidApp/db/` to `data/`
- `DatabaseLocalDoorDataSource` (Room impl) stays in androidApp, implements data interface
- Repositories import from `data`, never from Room directly

Next steps: add `NetworkDoorService` interface to data, then extract `data-local` and `data-network` implementation modules.

## Test plan
- [x] All 125+ tests pass
- [x] `./scripts/validate.sh` passes (all 9 checks)
- [x] No behavior change — same interface, moved to own module

🤖 Generated with [Claude Code](https://claude.com/claude-code)