### PR TITLE
feat: Add network data source interfaces to data module (Phase 2.3)

### DIFF
--- a/AndroidGarage/data/src/main/kotlin/com/chriscartland/garage/data/NetworkButtonDataSource.kt
+++ b/AndroidGarage/data/src/main/kotlin/com/chriscartland/garage/data/NetworkButtonDataSource.kt
@@ -1,0 +1,41 @@
+package com.chriscartland.garage.data
+
+/**
+ * Pure data source interface for remote button and snooze operations.
+ *
+ * Implementations handle HTTP communication. The Repository layer
+ * never sees HTTP response codes or network DTOs.
+ */
+interface NetworkButtonDataSource {
+    /**
+     * Send a remote button push request.
+     *
+     * @return true if the server acknowledged the request
+     */
+    suspend fun pushButton(
+        remoteButtonBuildTimestamp: String,
+        buttonAckToken: String,
+        remoteButtonPushKey: String,
+        idToken: String,
+    ): Boolean
+
+    /**
+     * Request to snooze open-door notifications.
+     *
+     * @return true if the server acknowledged, false on error
+     */
+    suspend fun snoozeNotifications(
+        buildTimestamp: String,
+        remoteButtonPushKey: String,
+        idToken: String,
+        snoozeDurationHours: String,
+        snoozeEventTimestampSeconds: Long,
+    ): Boolean
+
+    /**
+     * Fetch the current snooze end time.
+     *
+     * @return Snooze end time in epoch seconds, or 0 if not snoozing
+     */
+    suspend fun fetchSnoozeEndTimeSeconds(buildTimestamp: String): Long
+}

--- a/AndroidGarage/data/src/main/kotlin/com/chriscartland/garage/data/NetworkConfigDataSource.kt
+++ b/AndroidGarage/data/src/main/kotlin/com/chriscartland/garage/data/NetworkConfigDataSource.kt
@@ -1,0 +1,19 @@
+package com.chriscartland.garage.data
+
+import com.chriscartland.garage.domain.model.ServerConfig
+
+/**
+ * Pure data source interface for fetching server configuration.
+ *
+ * Implementations handle HTTP communication and map responses
+ * to domain [ServerConfig] objects.
+ */
+interface NetworkConfigDataSource {
+    /**
+     * Fetch the server configuration.
+     *
+     * @param serverConfigKey API key for authentication
+     * @return The server config, or null if the request failed or config is invalid
+     */
+    suspend fun fetchServerConfig(serverConfigKey: String): ServerConfig?
+}

--- a/AndroidGarage/data/src/main/kotlin/com/chriscartland/garage/data/NetworkDoorDataSource.kt
+++ b/AndroidGarage/data/src/main/kotlin/com/chriscartland/garage/data/NetworkDoorDataSource.kt
@@ -1,0 +1,32 @@
+package com.chriscartland.garage.data
+
+import com.chriscartland.garage.domain.model.DoorEvent
+
+/**
+ * Pure data source interface for fetching door events from the network.
+ *
+ * Implementations handle HTTP communication (Retrofit, Ktor, etc.)
+ * and map network response DTOs to domain types. The Repository layer
+ * never sees HTTP response codes, network DTOs, or serialization details.
+ */
+interface NetworkDoorDataSource {
+    /**
+     * Fetch the current door event from the server.
+     *
+     * @param buildTimestamp Server build timestamp for the API request
+     * @return The current door event, or null if the request failed
+     */
+    suspend fun fetchCurrentDoorEvent(buildTimestamp: String): DoorEvent?
+
+    /**
+     * Fetch recent door events from the server.
+     *
+     * @param buildTimestamp Server build timestamp for the API request
+     * @param count Maximum number of events to return
+     * @return List of door events, or null if the request failed
+     */
+    suspend fun fetchRecentDoorEvents(
+        buildTimestamp: String,
+        count: Int,
+    ): List<DoorEvent>?
+}


### PR DESCRIPTION
## Summary
Define pure data source interfaces for all network operations in the `data` module:

- **NetworkDoorDataSource** — fetch current/recent door events (returns `DoorEvent`, not `Response<CurrentEventDataResponse>`)
- **NetworkConfigDataSource** — fetch server config (returns `ServerConfig`, not `Response<ServerConfigResponse>`)
- **NetworkButtonDataSource** — push button, snooze, fetch snooze time (returns `Boolean`/`Long`, not `Response<...>`)

All interfaces use plain types and domain objects — no Retrofit, Moshi, or HTTP types. This is the contract that Repositories depend on. Implementations (Retrofit today, Ktor later) live in the app or data-network module.

## Test plan
- [x] `./scripts/validate.sh` passes (all 9 checks)
- [x] Interface definitions only — no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)