### PR TITLE
fix: Clean up untracked files and commit detekt baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ out/
 .directory
 .Trash-*
 .nfs*
+.claude/worktrees/

--- a/AndroidGarage/androidApp/detekt-baseline.xml
+++ b/AndroidGarage/androidApp/detekt-baseline.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <CurrentIssues>
+    <ID>ConstructorParameterNaming:AuthViewModel.kt$AuthViewModelImpl$private val _authRepository: AuthRepository</ID>
+    <ID>ConstructorParameterNaming:ServerConfigResponse.kt$ServerConfigResponse.Body$@Json(name = "remoteButtonBuildTimestamp") val _remoteButtonBuildTimestamp: String?</ID>
+    <ID>ImplicitDefaultLocale:TimeFormats.kt$String.format( "%d day%s, %dh %dm %ds", days, if (days &gt; 1) "s" else "", hours, minutes, seconds, )</ID>
+    <ID>ImplicitDefaultLocale:TimeFormats.kt$String.format("%dh %dm %ds", hours, minutes, seconds)</ID>
+    <ID>ImplicitDefaultLocale:TimeFormats.kt$String.format("%dm %ds", minutes, seconds)</ID>
+    <ID>ImplicitDefaultLocale:TimeFormats.kt$String.format("%ds", seconds)</ID>
+    <ID>MatchingDeclarationName:Parallelogram.kt$ParallelogramShape : Shape</ID>
+    <ID>MatchingDeclarationName:VersionModel.kt$AppVersion</ID>
+    <ID>SwallowedException:AuthRepository.kt$AuthRepositoryImpl$e: Exception</ID>
+    <ID>SwallowedException:FCMService.kt$e: IllegalArgumentException</ID>
+    <ID>UnusedPrivateMember:RemoteButtonContent.kt$private fun ButtonColors.selectContainer(enabled: Boolean)</ID>
+    <ID>UnusedPrivateMember:RemoteButtonContent.kt$private fun ButtonColors.selectContent(enabled: Boolean)</ID>
+    <ID>UnusedPrivateProperty:AppSettings.kt$private const val TAG = "AppSettings"</ID>
+    <ID>UnusedPrivateProperty:DoorRepository.kt$private const val DIRECT_CURRENT = "com.chriscartland.garage.repository.DIRECT_CURRENT_DOOR_UPDATE"</ID>
+    <ID>UnusedPrivateProperty:DoorRepository.kt$private const val DIRECT_RECENT = "com.chriscartland.garage.repository.DIRECT_RECENT_DOOR_UPDATE"</ID>
+    <ID>UnusedPrivateProperty:DoorRepository.kt$private const val NETWORK_CURRENT = "com.chriscartland.garage.repository.NETWORK_CURRENT_DOOR_UPDATE"</ID>
+    <ID>UnusedPrivateProperty:DoorRepository.kt$private const val NETWORK_RECENT = "com.chriscartland.garage.repository.NETWORK_RECENT_DOOR_UPDATE"</ID>
+    <ID>UnusedPrivateProperty:PushRepository.kt$private const val TAG = "PushRepository"</ID>
+    <ID>UnusedPrivateProperty:PushRepositoryTest.kt$PushRepositoryTest$private val validServerConfig = ServerConfig( buildTimestamp = "2024-01-15T00:00:00Z", remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z", remoteButtonPushKey = "test-push-key", )</ID>
+  </CurrentIssues>
+</SmellBaseline>


### PR DESCRIPTION
## Summary
- Delete 5 untracked workflow files from a different project (web hosting, not SmartGarageDoor)
- Delete `cartland-dev-reference/` directory (different project)
- Commit `detekt-baseline.xml` (should be tracked)
- Add `.claude/worktrees/` to `.gitignore`

After this, `release-android.sh --check` reports zero warnings.

## Test plan
- [x] Zero untracked files after cleanup
- [x] detekt baseline committed for reproducible builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)