### PR TITLE
feat: Warn when releasing on a commit that already has tags

### DIFF
--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -110,6 +110,25 @@ CURRENT_COMMIT=$(git rev-parse HEAD)
 CURRENT_COMMIT_SHORT=$(git rev-parse --short HEAD)
 CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "(detached)")
 
+# Check for existing tags on this commit.
+TAGS_ON_COMMIT=$(git tag -l 'android/[0-9]*' --points-at HEAD 2>/dev/null | sort -t/ -k2 -n)
+check_existing_tags() {
+    if [ -n "$TAGS_ON_COMMIT" ]; then
+        TAG_COUNT=$(echo "$TAGS_ON_COMMIT" | wc -l | tr -d ' ')
+        NEWEST_TAG_ON_COMMIT=$(echo "$TAGS_ON_COMMIT" | tail -1)
+        if [ "$NEWEST_TAG_ON_COMMIT" = "$LATEST_TAG" ]; then
+            # Latest tag is on this commit — releasing again on same code
+            echo -e "${YELLOW}WARNING: This commit already has $LATEST_TAG.${RESET}"
+            echo "  Creating $NEW_TAG on the same commit (version bump, no code change)."
+        else
+            # An older tag is on this commit — rollback/rollforward
+            echo -e "${YELLOW}WARNING: This commit was previously released as: $TAGS_ON_COMMIT${RESET}"
+            echo "  Latest tag $LATEST_TAG is on a different commit."
+            echo "  Creating $NEW_TAG here (rollback/rollforward)."
+        fi
+    fi
+}
+
 # === --check mode ===
 if [ "$MODE" = "check" ]; then
     echo "Latest tag: $LATEST_TAG"
@@ -124,6 +143,7 @@ if [ "$MODE" = "check" ]; then
         UNTRACKED_COUNT=$(echo "$UNTRACKED_CHECK" | wc -l | tr -d ' ')
         echo -e "${YELLOW}WARNING: $UNTRACKED_COUNT untracked file(s)${RESET}"
     fi
+    check_existing_tags
     exit 0
 fi
 
@@ -171,6 +191,9 @@ if [ -n "$UNTRACKED" ]; then
         echo -e "${YELLOW}Non-interactive: proceeding with untracked files.${RESET}"
     fi
 fi
+
+# Check for existing tags on this commit
+check_existing_tags
 
 # Check CI status
 echo "Checking CI status on HEAD..."

--- a/scripts/release-firebase.sh
+++ b/scripts/release-firebase.sh
@@ -38,6 +38,22 @@ BRANCH=$(git branch --show-current)
 SHORT_SHA=$(git rev-parse --short HEAD)
 FULL_SHA=$(git rev-parse HEAD)
 
+# Check for existing tags on this commit.
+TAGS_ON_COMMIT=$(git tag -l 'server/[0-9]*' --points-at HEAD 2>/dev/null | sort -t/ -k2 -n)
+check_existing_tags() {
+    if [[ -n "$TAGS_ON_COMMIT" ]]; then
+        NEWEST_TAG_ON_COMMIT=$(echo "$TAGS_ON_COMMIT" | tail -1)
+        if [[ "$NEWEST_TAG_ON_COMMIT" == "$LATEST_TAG" ]]; then
+            echo "WARNING: This commit already has $LATEST_TAG."
+            echo "  Creating $NEXT_TAG on the same commit (version bump, no code change)."
+        else
+            echo "WARNING: This commit was previously released as: $TAGS_ON_COMMIT"
+            echo "  Latest tag $LATEST_TAG is on a different commit."
+            echo "  Creating $NEXT_TAG here (rollback/rollforward)."
+        fi
+    fi
+}
+
 # --- --check mode ---
 if [[ "${1:-}" == "--check" ]]; then
     echo "Latest tag: $LATEST_TAG"
@@ -52,6 +68,7 @@ if [[ "${1:-}" == "--check" ]]; then
         UNTRACKED_COUNT=$(echo "$UNTRACKED_CHECK" | wc -l | tr -d ' ')
         echo "WARNING: $UNTRACKED_COUNT untracked file(s)"
     fi
+    check_existing_tags
     exit 0
 fi
 
@@ -91,6 +108,9 @@ if [[ -n "$UNTRACKED" ]]; then
         echo "Non-interactive: proceeding with untracked files."
     fi
 fi
+
+# Check for existing tags on this commit
+check_existing_tags
 
 # Check Firebase CI passed on HEAD.
 echo "Checking CI status on HEAD..."


### PR DESCRIPTION
## Summary
Both release scripts now detect and warn about existing tags on HEAD:

- **Latest tag on this commit**: "version bump, no code change"
- **Older tag on this commit**: "rollback/rollforward"
- **No tags**: no warning (normal release)

Shown in both `--check` and release mode.

## Test plan
- [x] Scripts only — no code changes
- [x] Verified: no warning when HEAD has no tags
- [x] Warning logic covers both scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)