### PR TITLE
feat: Add kotlin-inject alongside Hilt (Phase 3.1)

### DIFF
--- a/AndroidGarage/androidApp/build.gradle.kts
+++ b/AndroidGarage/androidApp/build.gradle.kts
@@ -261,10 +261,13 @@ dependencies {
     implementation(libs.squareup.retrofit.moshi.converter)
     implementation(libs.okhttpLoggingInterceptor)
     ksp(libs.squareup.moshi.kotlin.codegen)
-    // Hilt
+    // Hilt (being migrated to kotlin-inject — see docs/DI-MIGRATION.md)
     implementation(libs.hilt.android)
     implementation(libs.hilt.navigation.compose)
     ksp(libs.hilt.compiler)
+    // kotlin-inject
+    implementation(libs.kotlin.inject.runtime)
+    ksp(libs.kotlin.inject.compiler)
     // Room
     implementation(libs.androidx.room.common)
     implementation(libs.androidx.room.ktx)

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -15,17 +15,20 @@
  *
  */
 
-package com.chriscartland.garage
+package com.chriscartland.garage.di
 
 import android.app.Application
-import com.chriscartland.garage.di.AppComponent
-import com.chriscartland.garage.di.create
-import dagger.hilt.android.HiltAndroidApp
+import me.tatarka.inject.annotations.Component
+import me.tatarka.inject.annotations.Provides
 
-@HiltAndroidApp
-class GarageApplication : Application() {
-    /** kotlin-inject component — used by migrated ViewModels. */
-    val component: AppComponent by lazy {
-        AppComponent::class.create(this)
-    }
-}
+/**
+ * Root kotlin-inject component.
+ *
+ * Dependencies will be added here as ViewModels and Repositories
+ * are migrated from Hilt. See docs/DI-MIGRATION.md for the plan.
+ */
+@Component
+@Singleton
+abstract class AppComponent(
+    @get:Provides val application: Application,
+)

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/Singleton.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/Singleton.kt
@@ -15,17 +15,14 @@
  *
  */
 
-package com.chriscartland.garage
+package com.chriscartland.garage.di
 
-import android.app.Application
-import com.chriscartland.garage.di.AppComponent
-import com.chriscartland.garage.di.create
-import dagger.hilt.android.HiltAndroidApp
+import me.tatarka.inject.annotations.Scope
 
-@HiltAndroidApp
-class GarageApplication : Application() {
-    /** kotlin-inject component — used by migrated ViewModels. */
-    val component: AppComponent by lazy {
-        AppComponent::class.create(this)
-    }
-}
+/**
+ * kotlin-inject scope for singleton instances.
+ * Equivalent to Hilt's SingletonComponent / javax.inject.Singleton.
+ */
+@Scope
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER)
+annotation class Singleton

--- a/AndroidGarage/gradle/libs.versions.toml
+++ b/AndroidGarage/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ firebase-bom = "33.15.0"
 gms = "4.4.2"
 hilt = "2.56.2"
 hiltNavigation = "1.2.0"
+kotlinInject = "0.9.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 kotlin = "2.1.20"
@@ -84,6 +85,8 @@ firebase-auth-ktx = { group = "com.google.firebase", name = "firebase-auth-ktx" 
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigation" }
+kotlin-inject-runtime = { module = "me.tatarka.inject:kotlin-inject-runtime", version.ref = "kotlinInject" }
+kotlin-inject-compiler = { module = "me.tatarka.inject:kotlin-inject-compiler-ksp", version.ref = "kotlinInject" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }


### PR DESCRIPTION
## Summary
Step 1 of the Hilt → kotlin-inject migration (see `docs/DI-MIGRATION.md`).

Both DI systems coexist with no behavior change:
- Added kotlin-inject 0.9.0 (runtime + KSP compiler)
- Created `@Singleton` scope and empty `AppComponent`
- `GarageApplication` lazily creates the kotlin-inject component
- Hilt remains fully functional

Next: migrate `AppSettingsViewModel` as proof of concept (Step 2).

## Test plan
- [x] Both DI systems compile together
- [x] `./scripts/validate.sh` passes (all 9 checks)
- [x] No behavior change — Hilt still wires everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)