### PR TITLE
feat: Migrate AppSettingsViewModel to kotlin-inject (Phase 3.2)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -18,17 +18,26 @@
 package com.chriscartland.garage.di
 
 import android.app.Application
+import com.chriscartland.garage.settings.AppSettings
+import com.chriscartland.garage.settings.AppSettingsImpl
+import com.chriscartland.garage.settings.AppSettingsViewModelImpl
 import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.Provides
 
 /**
  * Root kotlin-inject component.
  *
- * Dependencies will be added here as ViewModels and Repositories
+ * Dependencies are added here as ViewModels and Repositories
  * are migrated from Hilt. See docs/DI-MIGRATION.md for the plan.
  */
 @Component
 @Singleton
 abstract class AppComponent(
     @get:Provides val application: Application,
-)
+) {
+    abstract val appSettingsViewModel: AppSettingsViewModelImpl
+
+    @Provides
+    @Singleton
+    fun provideAppSettings(): AppSettings = AppSettingsImpl(application)
+}

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/ComponentProvider.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/ComponentProvider.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.di
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import com.chriscartland.garage.GarageApplication
+
+/**
+ * Remember the kotlin-inject [AppComponent] in a Composable.
+ *
+ * Must be called in a @Composable context, then the result can be
+ * used in non-composable lambdas like viewModel { }.
+ */
+@Composable
+fun rememberAppComponent(): AppComponent {
+    val context = LocalContext.current
+    return remember { (context.applicationContext as GarageApplication).component }
+}

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/settings/AppSettingsViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/settings/AppSettingsViewModel.kt
@@ -18,10 +18,9 @@
 package com.chriscartland.garage.settings
 
 import androidx.lifecycle.ViewModel
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import javax.inject.Inject
+import me.tatarka.inject.annotations.Inject
 
 interface AppSettingsViewModel {
     val fcmDoorTopic: StateFlow<String>
@@ -38,42 +37,40 @@ interface AppSettingsViewModel {
     fun setProfileAppCardExpanded(expanded: Boolean)
 }
 
-@HiltViewModel
-class AppSettingsViewModelImpl
-    @Inject
-    constructor(
-        private val settings: AppSettings,
-    ) : ViewModel(),
-        AppSettingsViewModel {
-        private val _fcmDoorTopic = MutableStateFlow(settings.fcmDoorTopic.get())
-        override val fcmDoorTopic: StateFlow<String> = _fcmDoorTopic
+@Inject
+class AppSettingsViewModelImpl(
+    private val settings: AppSettings,
+) : ViewModel(),
+    AppSettingsViewModel {
+    private val _fcmDoorTopic = MutableStateFlow(settings.fcmDoorTopic.get())
+    override val fcmDoorTopic: StateFlow<String> = _fcmDoorTopic
 
-        override fun setFcmDoorTopic(topic: String) {
-            _fcmDoorTopic.value = topic
-            settings.fcmDoorTopic.set(topic)
-        }
-
-        private val _profileUserCardExpanded = MutableStateFlow(settings.profileUserCardExpanded.get())
-        override val profileUserCardExpanded: StateFlow<Boolean> = _profileUserCardExpanded
-
-        override fun setProfileUserCardExpanded(expanded: Boolean) {
-            _profileUserCardExpanded.value = expanded
-            settings.profileUserCardExpanded.set(expanded)
-        }
-
-        private val _profileLogCardExpanded = MutableStateFlow(settings.profileLogCardExpanded.get())
-        override val profileLogCardExpanded: StateFlow<Boolean> = _profileLogCardExpanded
-
-        override fun setProfileLogCardExpanded(expanded: Boolean) {
-            _profileLogCardExpanded.value = expanded
-            settings.profileLogCardExpanded.set(expanded)
-        }
-
-        private val _profileAppCardExpanded = MutableStateFlow(settings.profileAppCardExpanded.get())
-        override val profileAppCardExpanded: StateFlow<Boolean> = _profileAppCardExpanded
-
-        override fun setProfileAppCardExpanded(expanded: Boolean) {
-            _profileAppCardExpanded.value = expanded
-            settings.profileAppCardExpanded.set(expanded)
-        }
+    override fun setFcmDoorTopic(topic: String) {
+        _fcmDoorTopic.value = topic
+        settings.fcmDoorTopic.set(topic)
     }
+
+    private val _profileUserCardExpanded = MutableStateFlow(settings.profileUserCardExpanded.get())
+    override val profileUserCardExpanded: StateFlow<Boolean> = _profileUserCardExpanded
+
+    override fun setProfileUserCardExpanded(expanded: Boolean) {
+        _profileUserCardExpanded.value = expanded
+        settings.profileUserCardExpanded.set(expanded)
+    }
+
+    private val _profileLogCardExpanded = MutableStateFlow(settings.profileLogCardExpanded.get())
+    override val profileLogCardExpanded: StateFlow<Boolean> = _profileLogCardExpanded
+
+    override fun setProfileLogCardExpanded(expanded: Boolean) {
+        _profileLogCardExpanded.value = expanded
+        settings.profileLogCardExpanded.set(expanded)
+    }
+
+    private val _profileAppCardExpanded = MutableStateFlow(settings.profileAppCardExpanded.get())
+    override val profileAppCardExpanded: StateFlow<Boolean> = _profileAppCardExpanded
+
+    override fun setProfileAppCardExpanded(expanded: Boolean) {
+        _profileAppCardExpanded.value = expanded
+        settings.profileAppCardExpanded.set(expanded)
+    }
+}

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/AndroidAppInfoCard.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/AndroidAppInfoCard.kt
@@ -37,9 +37,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.settings.AppSettingsViewModel
-import com.chriscartland.garage.settings.AppSettingsViewModelImpl
 import com.chriscartland.garage.version.AppVersion
 
 const val PRIVACY_POLICY_URL: String = "https://chriscart.land/garage-privacy-policy"
@@ -47,9 +47,10 @@ const val PRIVACY_POLICY_URL: String = "https://chriscart.land/garage-privacy-po
 @Composable
 fun AndroidAppInfoCard(
     modifier: Modifier = Modifier,
-    settingsViewModel: AppSettingsViewModel = hiltViewModel<AppSettingsViewModelImpl>(),
     colors: CardColors = CardDefaults.cardColors(),
 ) {
+    val component = rememberAppComponent()
+    val settingsViewModel: AppSettingsViewModel = viewModel { component.appSettingsViewModel }
     val startAndroidAppInfoCardExpanded by settingsViewModel.profileAppCardExpanded.collectAsState()
     AndroidAppInfoCard(
         appVersion = LocalContext.current.AppVersion(),

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/LogSummaryCard.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/LogSummaryCard.kt
@@ -43,10 +43,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.chriscartland.garage.applogger.AppLoggerViewModel
 import com.chriscartland.garage.applogger.AppLoggerViewModelImpl
+import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.settings.AppSettingsViewModel
-import com.chriscartland.garage.settings.AppSettingsViewModelImpl
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -58,9 +59,10 @@ import java.time.format.DateTimeFormatter
 fun LogSummaryCard(
     modifier: Modifier = Modifier,
     appLoggerViewModel: AppLoggerViewModel = hiltViewModel<AppLoggerViewModelImpl>(),
-    settingsViewModel: AppSettingsViewModel = hiltViewModel<AppSettingsViewModelImpl>(),
     colors: CardColors = CardDefaults.cardColors(),
 ) {
+    val component = rememberAppComponent()
+    val settingsViewModel: AppSettingsViewModel = viewModel { component.appSettingsViewModel }
     val startLogSummaryCardExpanded by settingsViewModel.profileLogCardExpanded.collectAsState()
     val initCurrent by appLoggerViewModel.initCurrentDoorCount.collectAsState()
     val initRecent by appLoggerViewModel.initRecentDoorCount.collectAsState()

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/UserInfoCard.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/UserInfoCard.kt
@@ -32,13 +32,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.DisplayName
 import com.chriscartland.garage.domain.model.Email
 import com.chriscartland.garage.domain.model.FirebaseIdToken
 import com.chriscartland.garage.domain.model.User
 import com.chriscartland.garage.settings.AppSettingsViewModel
-import com.chriscartland.garage.settings.AppSettingsViewModelImpl
 
 @Composable
 fun UserInfoCard(
@@ -46,9 +46,10 @@ fun UserInfoCard(
     modifier: Modifier = Modifier,
     signIn: () -> Unit = {},
     signOut: () -> Unit = {},
-    settingsViewModel: AppSettingsViewModel = hiltViewModel<AppSettingsViewModelImpl>(),
     colors: CardColors = CardDefaults.cardColors(),
 ) {
+    val component = rememberAppComponent()
+    val settingsViewModel: AppSettingsViewModel = viewModel { component.appSettingsViewModel }
     val startUserCardExpanded by settingsViewModel.profileUserCardExpanded.collectAsState()
     UserInfoCard(
         user = user,


### PR DESCRIPTION
## Summary
First ViewModel migrated from Hilt to kotlin-inject (proof of concept):

**Before:** `@HiltViewModel` + `hiltViewModel<AppSettingsViewModelImpl>()`
**After:** `@Inject` + `viewModel { component.appSettingsViewModel }`

- `rememberAppComponent()` composable helper for accessing the component
- `AppComponent` now provides `AppSettings` and `AppSettingsViewModelImpl`
- Hilt remains for all other ViewModels — both systems coexist

## Test plan
- [x] All tests pass
- [x] `./scripts/validate.sh` passes (all 9 checks)
- [x] Both DI systems compile together

🤖 Generated with [Claude Code](https://claude.com/claude-code)