### PR TITLE
feat: Migrate AuthViewModel to kotlin-inject (Phase 3.2)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/MainActivity.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/MainActivity.kt
@@ -27,7 +27,6 @@ import androidx.activity.viewModels
 import androidx.compose.ui.util.trace
 import com.chriscartland.garage.applogger.AppLoggerViewModel
 import com.chriscartland.garage.applogger.AppLoggerViewModelImpl
-import com.chriscartland.garage.auth.AuthViewModelImpl
 import com.chriscartland.garage.auth.RC_ONE_TAP_SIGN_IN
 import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.door.DoorViewModel
@@ -74,7 +73,16 @@ class MainActivity : ComponentActivity() {
                     Log.e("MainActivity", "onActivityResult: data is null")
                     return
                 }
-                val authViewModel: AuthViewModelImpl by viewModels()
+                val component = (application as GarageApplication).component
+                val authViewModel = androidx.lifecycle.ViewModelProvider(
+                    this,
+                    object : androidx.lifecycle.ViewModelProvider.Factory {
+                        override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
+                            @Suppress("UNCHECKED_CAST")
+                            return component.authViewModel as T
+                        }
+                    },
+                )[com.chriscartland.garage.auth.AuthViewModelImpl::class.java]
                 authViewModel.processGoogleSignInResult(data)
             }
         }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthViewModel.kt
@@ -36,10 +36,9 @@ import com.google.android.gms.auth.api.identity.Identity
 import com.google.android.gms.auth.api.identity.SignInClient
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.common.api.CommonStatusCodes
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import javax.inject.Inject
+import me.tatarka.inject.annotations.Inject
 
 interface AuthViewModel {
     val authState: StateFlow<AuthState>
@@ -52,140 +51,138 @@ interface AuthViewModel {
     fun processGoogleSignInResult(data: Intent)
 }
 
-@HiltViewModel
-class AuthViewModelImpl
-    @Inject
-    constructor(
-        private val _authRepository: AuthRepository,
-        private val appLoggerRepository: AppLoggerRepository,
-        private val dispatchers: DispatcherProvider,
-    ) : ViewModel(),
-        AuthViewModel {
-        override val authRepository: AuthRepository = _authRepository
+@Inject
+class AuthViewModelImpl(
+    private val _authRepository: AuthRepository,
+    private val appLoggerRepository: AppLoggerRepository,
+    private val dispatchers: DispatcherProvider,
+) : ViewModel(),
+    AuthViewModel {
+    override val authRepository: AuthRepository = _authRepository
 
-        override val authState: StateFlow<AuthState> = _authRepository.authState
+    override val authState: StateFlow<AuthState> = _authRepository.authState
 
-        override fun signInWithGoogle(activity: Activity) {
-            viewModelScope.launch(dispatchers.io) {
-                appLoggerRepository.log(AppLoggerKeys.BEGIN_GOOGLE_SIGN_IN)
-                checkSignInConfiguration()
-                Log.d(TAG, "beginSignIn")
-                // Dialog Sign-In configuration.
-                val dialogSignInRequest = BeginSignInRequest
-                    .builder()
-                    .setGoogleIdTokenRequestOptions(
-                        BeginSignInRequest.GoogleIdTokenRequestOptions
-                            .builder()
-                            .setSupported(true)
-                            .setServerClientId(BuildConfig.GOOGLE_WEB_CLIENT_ID)
-                            .setFilterByAuthorizedAccounts(false)
-                            .build(),
-                    ).setAutoSelectEnabled(false) // Let user choose the account.
-                    .build()
-                createSignInClient(activity)
-                    .beginSignIn(dialogSignInRequest)
-                    .addOnSuccessListener(activity) { result ->
-                        try {
-                            activity.startIntentSenderForResult(
-                                result.pendingIntent.intentSender,
-                                RC_ONE_TAP_SIGN_IN,
-                                null,
-                                0,
-                                0,
-                                0,
-                                null,
-                            )
-                        } catch (e: IntentSender.SendIntentException) {
-                            Log.e(TAG, "Couldn't start One Tap UI: ${e.localizedMessage}")
-                        }
-                    }.addOnFailureListener(activity) { e ->
-                        // No saved credentials found. Launch the One Tap sign-up flow, or
-                        // do nothing and continue presenting the signed-out UI.
-                        Log.d(TAG, e.localizedMessage ?: "")
-                    }
-            }
-        }
-
-        override fun signOut() {
-            viewModelScope.launch(dispatchers.io) {
-                _authRepository.signOut()
-            }
-        }
-
-        override fun processGoogleSignInResult(data: Intent) {
-            viewModelScope.launch(dispatchers.io) {
-                val googleIdToken = googleIdTokenFromIntent(data)
-                if (googleIdToken == null) {
-                    Log.e(TAG, "Google sign-in failed")
-                    return@launch
-                }
-                _authRepository.signInWithGoogle(googleIdToken)
-            }
-        }
-
-        /**
-         * Extract the Google ID Token from the Intent.
-         */
-        private fun googleIdTokenFromIntent(data: Intent): GoogleIdToken? {
-            Log.d(TAG, "googleIdTokenFromIntent")
-            val client = signInClient
-            if (client == null) {
-                Log.e(TAG, "Cannot sign in without a Google client")
-                return null
-            }
-            try {
-                val credential = client.getSignInCredentialFromIntent(data)
-                return credential.googleIdToken?.let { GoogleIdToken(it) }
-            } catch (e: ApiException) {
-                Log.e(TAG, "ApiException: handleOneTapSignIn ${e.message}")
-                when (e.statusCode) {
-                    CommonStatusCodes.CANCELED -> {
-                        Log.d(TAG, "One-tap dialog was closed.")
-                    }
-                    CommonStatusCodes.NETWORK_ERROR -> {
-                        Log.d(TAG, "One-tap encountered a network error.")
-                    }
-                    else -> {
-                        Log.d(
-                            TAG,
-                            "Couldn't get credential from result." +
-                                " ApiException.statusCode: ${e.statusCode}" +
-                                " (${e.localizedMessage})",
+    override fun signInWithGoogle(activity: Activity) {
+        viewModelScope.launch(dispatchers.io) {
+            appLoggerRepository.log(AppLoggerKeys.BEGIN_GOOGLE_SIGN_IN)
+            checkSignInConfiguration()
+            Log.d(TAG, "beginSignIn")
+            // Dialog Sign-In configuration.
+            val dialogSignInRequest = BeginSignInRequest
+                .builder()
+                .setGoogleIdTokenRequestOptions(
+                    BeginSignInRequest.GoogleIdTokenRequestOptions
+                        .builder()
+                        .setSupported(true)
+                        .setServerClientId(BuildConfig.GOOGLE_WEB_CLIENT_ID)
+                        .setFilterByAuthorizedAccounts(false)
+                        .build(),
+                ).setAutoSelectEnabled(false) // Let user choose the account.
+                .build()
+            createSignInClient(activity)
+                .beginSignIn(dialogSignInRequest)
+                .addOnSuccessListener(activity) { result ->
+                    try {
+                        activity.startIntentSenderForResult(
+                            result.pendingIntent.intentSender,
+                            RC_ONE_TAP_SIGN_IN,
+                            null,
+                            0,
+                            0,
+                            0,
+                            null,
                         )
+                    } catch (e: IntentSender.SendIntentException) {
+                        Log.e(TAG, "Couldn't start One Tap UI: ${e.localizedMessage}")
                     }
+                }.addOnFailureListener(activity) { e ->
+                    // No saved credentials found. Launch the One Tap sign-up flow, or
+                    // do nothing and continue presenting the signed-out UI.
+                    Log.d(TAG, e.localizedMessage ?: "")
                 }
-            }
-            return null
-        }
-
-        private var signInClient: SignInClient? = null
-
-        // Google API for identity.
-        private fun createSignInClient(context: Context) = Identity.getSignInClient(context).also { signInClient = it }
-
-        /**
-         * Check to make sure we've updated the client ID.
-         */
-        private val incorrectWebClientId =
-            "123456789012-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.apps.googleusercontent.com"
-
-        /**
-         * Log a warning if the sign-in configuration is not correct.
-         */
-        private fun checkSignInConfiguration() {
-            val googleClientIdForWeb = BuildConfig.GOOGLE_WEB_CLIENT_ID
-            if (googleClientIdForWeb == incorrectWebClientId) {
-                Log.e(
-                    "checkSignInConfiguration",
-                    "The web client ID matches the INCORRECT_WEB_CLIENT_ID. " +
-                        "One Tap Sign-In with Google will not work. " +
-                        "Update the web client ID to be used with setServerClientId(). " +
-                        "https://developers.google.com/identity/one-tap/android/get-saved-credentials " +
-                        "Create a web client ID in this Google Cloud Console " +
-                        "https://console.cloud.google.com/apis/credentials",
-                )
-            }
         }
     }
+
+    override fun signOut() {
+        viewModelScope.launch(dispatchers.io) {
+            _authRepository.signOut()
+        }
+    }
+
+    override fun processGoogleSignInResult(data: Intent) {
+        viewModelScope.launch(dispatchers.io) {
+            val googleIdToken = googleIdTokenFromIntent(data)
+            if (googleIdToken == null) {
+                Log.e(TAG, "Google sign-in failed")
+                return@launch
+            }
+            _authRepository.signInWithGoogle(googleIdToken)
+        }
+    }
+
+    /**
+     * Extract the Google ID Token from the Intent.
+     */
+    private fun googleIdTokenFromIntent(data: Intent): GoogleIdToken? {
+        Log.d(TAG, "googleIdTokenFromIntent")
+        val client = signInClient
+        if (client == null) {
+            Log.e(TAG, "Cannot sign in without a Google client")
+            return null
+        }
+        try {
+            val credential = client.getSignInCredentialFromIntent(data)
+            return credential.googleIdToken?.let { GoogleIdToken(it) }
+        } catch (e: ApiException) {
+            Log.e(TAG, "ApiException: handleOneTapSignIn ${e.message}")
+            when (e.statusCode) {
+                CommonStatusCodes.CANCELED -> {
+                    Log.d(TAG, "One-tap dialog was closed.")
+                }
+                CommonStatusCodes.NETWORK_ERROR -> {
+                    Log.d(TAG, "One-tap encountered a network error.")
+                }
+                else -> {
+                    Log.d(
+                        TAG,
+                        "Couldn't get credential from result." +
+                            " ApiException.statusCode: ${e.statusCode}" +
+                            " (${e.localizedMessage})",
+                    )
+                }
+            }
+        }
+        return null
+    }
+
+    private var signInClient: SignInClient? = null
+
+    // Google API for identity.
+    private fun createSignInClient(context: Context) = Identity.getSignInClient(context).also { signInClient = it }
+
+    /**
+     * Check to make sure we've updated the client ID.
+     */
+    private val incorrectWebClientId =
+        "123456789012-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.apps.googleusercontent.com"
+
+    /**
+     * Log a warning if the sign-in configuration is not correct.
+     */
+    private fun checkSignInConfiguration() {
+        val googleClientIdForWeb = BuildConfig.GOOGLE_WEB_CLIENT_ID
+        if (googleClientIdForWeb == incorrectWebClientId) {
+            Log.e(
+                "checkSignInConfiguration",
+                "The web client ID matches the INCORRECT_WEB_CLIENT_ID. " +
+                    "One Tap Sign-In with Google will not work. " +
+                    "Update the web client ID to be used with setServerClientId(). " +
+                    "https://developers.google.com/identity/one-tap/android/get-saved-credentials " +
+                    "Create a web client ID in this Google Cloud Console " +
+                    "https://console.cloud.google.com/apis/credentials",
+            )
+        }
+    }
+}
 
 private const val TAG = "AuthViewModel"

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -18,6 +18,14 @@
 package com.chriscartland.garage.di
 
 import android.app.Application
+import com.chriscartland.garage.applogger.AppLoggerRepository
+import com.chriscartland.garage.applogger.AppLoggerRepositoryImpl
+import com.chriscartland.garage.auth.AuthRepositoryImpl
+import com.chriscartland.garage.auth.AuthViewModelImpl
+import com.chriscartland.garage.coroutines.DefaultDispatcherProvider
+import com.chriscartland.garage.coroutines.DispatcherProvider
+import com.chriscartland.garage.db.AppDatabase
+import com.chriscartland.garage.domain.repository.AuthRepository
 import com.chriscartland.garage.settings.AppSettings
 import com.chriscartland.garage.settings.AppSettingsImpl
 import com.chriscartland.garage.settings.AppSettingsViewModelImpl
@@ -35,9 +43,31 @@ import me.tatarka.inject.annotations.Provides
 abstract class AppComponent(
     @get:Provides val application: Application,
 ) {
+    // ViewModels
     abstract val appSettingsViewModel: AppSettingsViewModelImpl
+    abstract val authViewModel: AuthViewModelImpl
 
+    // Settings
     @Provides
     @Singleton
     fun provideAppSettings(): AppSettings = AppSettingsImpl(application)
+
+    // Database
+    @Provides
+    @Singleton
+    fun provideAppDatabase(): AppDatabase = AppDatabase.getDatabase(application)
+
+    // Repositories
+    @Provides
+    @Singleton
+    fun provideAuthRepository(): AuthRepository = AuthRepositoryImpl(provideAppLoggerRepository())
+
+    @Provides
+    @Singleton
+    fun provideAppLoggerRepository(): AppLoggerRepository = AppLoggerRepositoryImpl(application.applicationContext, provideAppDatabase())
+
+    // Coroutines
+    @Provides
+    @Singleton
+    fun provideDispatcherProvider(): DispatcherProvider = DefaultDispatcherProvider()
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -43,11 +43,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.chriscartland.garage.applogger.AppLoggerViewModel
 import com.chriscartland.garage.applogger.AppLoggerViewModelImpl
 import com.chriscartland.garage.auth.AuthViewModel
-import com.chriscartland.garage.auth.AuthViewModelImpl
 import com.chriscartland.garage.config.AppLoggerKeys
+import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.LoadingResult
@@ -69,10 +70,11 @@ import java.time.Instant
 fun HomeContent(
     modifier: Modifier = Modifier,
     viewModel: DoorViewModel = hiltViewModel<DoorViewModelImpl>(),
-    authViewModel: AuthViewModel = hiltViewModel<AuthViewModelImpl>(),
     buttonViewModel: RemoteButtonViewModel = hiltViewModel<RemoteButtonViewModelImpl>(),
     appLoggerViewModel: AppLoggerViewModel = hiltViewModel<AppLoggerViewModelImpl>(),
 ) {
+    val component = rememberAppComponent()
+    val authViewModel: AuthViewModel = viewModel { component.authViewModel }
     val activity = LocalActivity.current
     val currentDoorEvent by viewModel.currentDoorEvent.collectAsState()
     val buttonRequestStatus by buttonViewModel.requestStatus.collectAsState()

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.trace
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
@@ -53,8 +54,8 @@ import androidx.navigation.compose.rememberNavController
 import com.chriscartland.garage.applogger.AppLoggerViewModel
 import com.chriscartland.garage.applogger.AppLoggerViewModelImpl
 import com.chriscartland.garage.auth.AuthViewModel
-import com.chriscartland.garage.auth.AuthViewModelImpl
 import com.chriscartland.garage.config.AppLoggerKeys
+import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.door.DoorViewModel
 import com.chriscartland.garage.door.DoorViewModelImpl
 import com.chriscartland.garage.fcm.FCMRegistration
@@ -93,10 +94,11 @@ sealed class Screen(
 @Composable
 fun AppNavigation(
     doorViewModel: DoorViewModel = hiltViewModel<DoorViewModelImpl>(),
-    authViewModel: AuthViewModel = hiltViewModel<AuthViewModelImpl>(),
     buttonViewModel: RemoteButtonViewModel = hiltViewModel<RemoteButtonViewModelImpl>(),
     appLoggerViewModel: AppLoggerViewModel = hiltViewModel<AppLoggerViewModelImpl>(),
 ) {
+    val component = rememberAppComponent()
+    val authViewModel: AuthViewModel = viewModel { component.authViewModel }
     var isOld by remember { mutableStateOf(false) }
     val currentDoorEvent by doorViewModel.currentDoorEvent.collectAsState()
     val lastCheckInTime = currentDoorEvent.data?.lastCheckInTimeSeconds?.let {
@@ -158,7 +160,6 @@ fun AppNavigation(
             composable(Screen.Home.route) {
                 HomeContent(
                     viewModel = doorViewModel,
-                    authViewModel = authViewModel,
                     buttonViewModel = buttonViewModel,
                     modifier = Modifier
                         .padding(horizontal = 16.dp)
@@ -175,7 +176,6 @@ fun AppNavigation(
             }
             composable(Screen.Profile.route) {
                 ProfileContent(
-                    authViewModel = authViewModel,
                     modifier = Modifier
                         .padding(horizontal = 16.dp)
                         .fillMaxWidth(),

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
@@ -36,9 +36,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.chriscartland.garage.auth.AuthViewModel
-import com.chriscartland.garage.auth.AuthViewModelImpl
 import com.chriscartland.garage.config.APP_CONFIG
+import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
 import com.chriscartland.garage.domain.model.User
@@ -56,9 +57,10 @@ import java.time.Duration
 @Composable
 fun ProfileContent(
     modifier: Modifier = Modifier,
-    authViewModel: AuthViewModel = hiltViewModel<AuthViewModelImpl>(),
     buttonViewModel: RemoteButtonViewModel = hiltViewModel<RemoteButtonViewModelImpl>(),
 ) {
+    val component = rememberAppComponent()
+    val authViewModel: AuthViewModel = viewModel { component.authViewModel }
     val activity = LocalActivity.current
     val authState by authViewModel.authState.collectAsState()
     val snoozeRequestStatus by buttonViewModel.snoozeRequestStatus.collectAsState()


### PR DESCRIPTION
## Summary
Second ViewModel migrated from Hilt to kotlin-inject.

AppComponent now provides AuthRepository (+ dependencies: AppLoggerRepository, AppDatabase, DispatcherProvider). AuthViewModelImpl uses `me.tatarka.inject.annotations.Inject`.

4 composables updated to use `rememberAppComponent()` + `viewModel {}`.

## Test plan
- [x] All tests pass
- [x] `./scripts/validate.sh` passes (all 9 checks)
- [x] Hilt still active for remaining 2 ViewModels

🤖 Generated with [Claude Code](https://claude.com/claude-code)