### PR TITLE
feat: Complete kotlin-inject migration — all ViewModels + FCMService

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/MainActivity.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/MainActivity.kt
@@ -23,10 +23,7 @@ import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.activity.viewModels
 import androidx.compose.ui.util.trace
-import com.chriscartland.garage.applogger.AppLoggerViewModel
-import com.chriscartland.garage.applogger.AppLoggerViewModelImpl
 import com.chriscartland.garage.auth.RC_ONE_TAP_SIGN_IN
 import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.ui.GarageApp
@@ -38,17 +35,14 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge() // Edge-to-edge required on Android 15+ (target SDK 35).
         val component = (application as GarageApplication).component
-        val appLoggerViewModel: AppLoggerViewModel by viewModels<AppLoggerViewModelImpl>()
         trace("MainActivity.setContent") {
             setContent {
-                GarageApp(
-                    appLoggerViewModel = appLoggerViewModel,
-                )
+                GarageApp()
             }
         }
         Log.d(TAG, "onCreate: Try to subscribe to FCM topic")
         component.doorViewModel.registerFcm(this)
-        appLoggerViewModel.log(AppLoggerKeys.ON_CREATE_FCM_SUBSCRIBE_TOPIC)
+        component.appLoggerViewModel.log(AppLoggerKeys.ON_CREATE_FCM_SUBSCRIBE_TOPIC)
     }
 
     // TODO: Migrate away from onActivityResult with Activity Result API and ActivityResultContract.

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/applogger/AppLoggerViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/applogger/AppLoggerViewModel.kt
@@ -23,11 +23,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.coroutines.DispatcherProvider
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import javax.inject.Inject
+import me.tatarka.inject.annotations.Inject
 
 interface AppLoggerViewModel {
     fun log(key: String)
@@ -47,93 +46,91 @@ interface AppLoggerViewModel {
     val timeWithoutFcmInExpectedRangeCount: StateFlow<Long>
 }
 
-@HiltViewModel
-class AppLoggerViewModelImpl
-    @Inject
-    constructor(
-        private val appLoggerRepository: AppLoggerRepository,
-        private val dispatchers: DispatcherProvider,
-    ) : ViewModel(),
-        AppLoggerViewModel {
-        private val _initCurrentDoorCount = MutableStateFlow<Long>(0L)
-        override val initCurrentDoorCount = _initCurrentDoorCount
+@Inject
+class AppLoggerViewModelImpl(
+    private val appLoggerRepository: AppLoggerRepository,
+    private val dispatchers: DispatcherProvider,
+) : ViewModel(),
+    AppLoggerViewModel {
+    private val _initCurrentDoorCount = MutableStateFlow<Long>(0L)
+    override val initCurrentDoorCount = _initCurrentDoorCount
 
-        private val _initRecentDoorCount = MutableStateFlow<Long>(0L)
-        override val initRecentDoorCount = _initRecentDoorCount
+    private val _initRecentDoorCount = MutableStateFlow<Long>(0L)
+    override val initRecentDoorCount = _initRecentDoorCount
 
-        private val _userFetchCurrentDoorCount = MutableStateFlow<Long>(0L)
-        override val userFetchCurrentDoorCount = _userFetchCurrentDoorCount
+    private val _userFetchCurrentDoorCount = MutableStateFlow<Long>(0L)
+    override val userFetchCurrentDoorCount = _userFetchCurrentDoorCount
 
-        private val _userFetchRecentDoorCount = MutableStateFlow<Long>(0L)
-        override val userFetchRecentDoorCount = _userFetchRecentDoorCount
+    private val _userFetchRecentDoorCount = MutableStateFlow<Long>(0L)
+    override val userFetchRecentDoorCount = _userFetchRecentDoorCount
 
-        private val _fcmReceivedDoorCount = MutableStateFlow<Long>(0L)
-        override val fcmReceivedDoorCount = _fcmReceivedDoorCount
+    private val _fcmReceivedDoorCount = MutableStateFlow<Long>(0L)
+    override val fcmReceivedDoorCount = _fcmReceivedDoorCount
 
-        private val _fcmSubscribeTopicCount = MutableStateFlow<Long>(0L)
-        override val fcmSubscribeTopicCount = _fcmSubscribeTopicCount
+    private val _fcmSubscribeTopicCount = MutableStateFlow<Long>(0L)
+    override val fcmSubscribeTopicCount = _fcmSubscribeTopicCount
 
-        private val _exceededExpectedTimeWithoutFcmCount = MutableStateFlow<Long>(0L)
-        override val exceededExpectedTimeWithoutFcmCount = _exceededExpectedTimeWithoutFcmCount
+    private val _exceededExpectedTimeWithoutFcmCount = MutableStateFlow<Long>(0L)
+    override val exceededExpectedTimeWithoutFcmCount = _exceededExpectedTimeWithoutFcmCount
 
-        private val _timeWithoutFcmInExpectedRangeCount = MutableStateFlow<Long>(0L)
-        override val timeWithoutFcmInExpectedRangeCount = _timeWithoutFcmInExpectedRangeCount
+    private val _timeWithoutFcmInExpectedRangeCount = MutableStateFlow<Long>(0L)
+    override val timeWithoutFcmInExpectedRangeCount = _timeWithoutFcmInExpectedRangeCount
 
-        init {
-            viewModelScope.launch(dispatchers.io) {
-                appLoggerRepository.countKey(AppLoggerKeys.INIT_CURRENT_DOOR).collect {
-                    _initCurrentDoorCount.value = it
-                }
-            }
-            viewModelScope.launch(dispatchers.io) {
-                appLoggerRepository.countKey(AppLoggerKeys.INIT_RECENT_DOOR).collect {
-                    _initRecentDoorCount.value = it
-                }
-            }
-            viewModelScope.launch(dispatchers.io) {
-                appLoggerRepository.countKey(AppLoggerKeys.USER_FETCH_CURRENT_DOOR).collect {
-                    _userFetchCurrentDoorCount.value = it
-                }
-            }
-            viewModelScope.launch(dispatchers.io) {
-                appLoggerRepository.countKey(AppLoggerKeys.USER_FETCH_RECENT_DOOR).collect {
-                    _userFetchRecentDoorCount.value = it
-                }
-            }
-            viewModelScope.launch(dispatchers.io) {
-                appLoggerRepository.countKey(AppLoggerKeys.FCM_DOOR_RECEIVED).collect {
-                    _fcmReceivedDoorCount.value = it
-                }
-            }
-            viewModelScope.launch(dispatchers.io) {
-                appLoggerRepository.countKey(AppLoggerKeys.FCM_SUBSCRIBE_TOPIC).collect {
-                    _fcmSubscribeTopicCount.value = it
-                }
-            }
-            viewModelScope.launch(dispatchers.io) {
-                appLoggerRepository.countKey(AppLoggerKeys.EXCEEDED_EXPECTED_TIME_WITHOUT_FCM).collect {
-                    _exceededExpectedTimeWithoutFcmCount.value = it
-                }
-            }
-            viewModelScope.launch(dispatchers.io) {
-                appLoggerRepository.countKey(AppLoggerKeys.TIME_WITHOUT_FCM_IN_EXPECTED_RANGE).collect {
-                    _timeWithoutFcmInExpectedRangeCount.value = it
-                }
+    init {
+        viewModelScope.launch(dispatchers.io) {
+            appLoggerRepository.countKey(AppLoggerKeys.INIT_CURRENT_DOOR).collect {
+                _initCurrentDoorCount.value = it
             }
         }
-
-        override fun log(key: String) {
-            viewModelScope.launch(dispatchers.io) {
-                appLoggerRepository.log(key)
+        viewModelScope.launch(dispatchers.io) {
+            appLoggerRepository.countKey(AppLoggerKeys.INIT_RECENT_DOOR).collect {
+                _initRecentDoorCount.value = it
             }
         }
-
-        override fun writeCsvToUri(
-            context: Context,
-            uri: Uri,
-        ) {
-            viewModelScope.launch(dispatchers.io) {
-                appLoggerRepository.writeCsvToUri(context, uri)
+        viewModelScope.launch(dispatchers.io) {
+            appLoggerRepository.countKey(AppLoggerKeys.USER_FETCH_CURRENT_DOOR).collect {
+                _userFetchCurrentDoorCount.value = it
+            }
+        }
+        viewModelScope.launch(dispatchers.io) {
+            appLoggerRepository.countKey(AppLoggerKeys.USER_FETCH_RECENT_DOOR).collect {
+                _userFetchRecentDoorCount.value = it
+            }
+        }
+        viewModelScope.launch(dispatchers.io) {
+            appLoggerRepository.countKey(AppLoggerKeys.FCM_DOOR_RECEIVED).collect {
+                _fcmReceivedDoorCount.value = it
+            }
+        }
+        viewModelScope.launch(dispatchers.io) {
+            appLoggerRepository.countKey(AppLoggerKeys.FCM_SUBSCRIBE_TOPIC).collect {
+                _fcmSubscribeTopicCount.value = it
+            }
+        }
+        viewModelScope.launch(dispatchers.io) {
+            appLoggerRepository.countKey(AppLoggerKeys.EXCEEDED_EXPECTED_TIME_WITHOUT_FCM).collect {
+                _exceededExpectedTimeWithoutFcmCount.value = it
+            }
+        }
+        viewModelScope.launch(dispatchers.io) {
+            appLoggerRepository.countKey(AppLoggerKeys.TIME_WITHOUT_FCM_IN_EXPECTED_RANGE).collect {
+                _timeWithoutFcmInExpectedRangeCount.value = it
             }
         }
     }
+
+    override fun log(key: String) {
+        viewModelScope.launch(dispatchers.io) {
+            appLoggerRepository.log(key)
+        }
+    }
+
+    override fun writeCsvToUri(
+        context: Context,
+        uri: Uri,
+    ) {
+        viewModelScope.launch(dispatchers.io) {
+            appLoggerRepository.writeCsvToUri(context, uri)
+        }
+    }
+}

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -20,6 +20,7 @@ package com.chriscartland.garage.di
 import android.app.Application
 import com.chriscartland.garage.applogger.AppLoggerRepository
 import com.chriscartland.garage.applogger.AppLoggerRepositoryImpl
+import com.chriscartland.garage.applogger.AppLoggerViewModelImpl
 import com.chriscartland.garage.auth.AuthRepositoryImpl
 import com.chriscartland.garage.auth.AuthViewModelImpl
 import com.chriscartland.garage.config.ServerConfigRepository
@@ -76,6 +77,7 @@ abstract class AppComponent(
     abstract val authViewModel: AuthViewModelImpl
     abstract val doorViewModel: DoorViewModelImpl
     abstract val remoteButtonViewModel: RemoteButtonViewModelImpl
+    abstract val appLoggerViewModel: AppLoggerViewModelImpl
 
     // Settings
     @Provides

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
@@ -18,26 +18,26 @@
 package com.chriscartland.garage.fcm
 
 import android.util.Log
+import com.chriscartland.garage.GarageApplication
 import com.chriscartland.garage.applogger.AppLoggerRepository
 import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.repository.DoorRepository
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
-import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@AndroidEntryPoint
 class FCMService : FirebaseMessagingService() {
-    @Inject
-    lateinit var doorRepository: DoorRepository
+    private val doorRepository: DoorRepository by lazy {
+        (application as GarageApplication).component.provideDoorRepository()
+    }
 
-    @Inject
-    lateinit var appLoggerRepository: AppLoggerRepository
+    private val appLoggerRepository: AppLoggerRepository by lazy {
+        (application as GarageApplication).component.provideAppLoggerRepository()
+    }
 
     // Create Job and CoroutineScope to schedule brief, concurrent work.
     private val supervisorJob = SupervisorJob()

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
@@ -35,10 +35,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.chriscartland.garage.applogger.AppLoggerViewModel
-import com.chriscartland.garage.applogger.AppLoggerViewModelImpl
 import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.DoorEvent
@@ -47,12 +45,10 @@ import com.chriscartland.garage.door.DoorViewModel
 import java.time.Instant
 
 @Composable
-fun DoorHistoryContent(
-    modifier: Modifier = Modifier,
-    appLoggerViewModel: AppLoggerViewModel = hiltViewModel<AppLoggerViewModelImpl>(),
-) {
+fun DoorHistoryContent(modifier: Modifier = Modifier) {
     val component = rememberAppComponent()
     val doorViewModel: DoorViewModel = viewModel { component.doorViewModel }
+    val appLoggerViewModel: AppLoggerViewModel = viewModel { component.appLoggerViewModel }
     val activity = LocalActivity.current
     val recentDoorEvents by doorViewModel.recentDoorEvents.collectAsState()
     DoorHistoryContent(

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -42,10 +42,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.chriscartland.garage.applogger.AppLoggerViewModel
-import com.chriscartland.garage.applogger.AppLoggerViewModelImpl
 import com.chriscartland.garage.auth.AuthViewModel
 import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.di.rememberAppComponent
@@ -65,14 +63,12 @@ import java.time.Instant
 
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
-fun HomeContent(
-    modifier: Modifier = Modifier,
-    appLoggerViewModel: AppLoggerViewModel = hiltViewModel<AppLoggerViewModelImpl>(),
-) {
+fun HomeContent(modifier: Modifier = Modifier) {
     val component = rememberAppComponent()
     val doorViewModel: DoorViewModel = viewModel { component.doorViewModel }
     val authViewModel: AuthViewModel = viewModel { component.authViewModel }
     val buttonViewModel: RemoteButtonViewModel = viewModel { component.remoteButtonViewModel }
+    val appLoggerViewModel: AppLoggerViewModel = viewModel { component.appLoggerViewModel }
     val activity = LocalActivity.current
     val currentDoorEvent by doorViewModel.currentDoorEvent.collectAsState()
     val buttonRequestStatus by buttonViewModel.requestStatus.collectAsState()

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/LogSummaryCard.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/LogSummaryCard.kt
@@ -42,10 +42,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.chriscartland.garage.applogger.AppLoggerViewModel
-import com.chriscartland.garage.applogger.AppLoggerViewModelImpl
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.settings.AppSettingsViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -58,10 +56,10 @@ import java.time.format.DateTimeFormatter
 @Composable
 fun LogSummaryCard(
     modifier: Modifier = Modifier,
-    appLoggerViewModel: AppLoggerViewModel = hiltViewModel<AppLoggerViewModelImpl>(),
     colors: CardColors = CardDefaults.cardColors(),
 ) {
     val component = rememberAppComponent()
+    val appLoggerViewModel: AppLoggerViewModel = viewModel { component.appLoggerViewModel }
     val settingsViewModel: AppSettingsViewModel = viewModel { component.appSettingsViewModel }
     val startLogSummaryCardExpanded by settingsViewModel.profileLogCardExpanded.collectAsState()
     val initCurrent by appLoggerViewModel.initCurrentDoorCount.collectAsState()

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.trace
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
@@ -52,7 +51,6 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.chriscartland.garage.applogger.AppLoggerViewModel
-import com.chriscartland.garage.applogger.AppLoggerViewModelImpl
 import com.chriscartland.garage.auth.AuthViewModel
 import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.di.rememberAppComponent
@@ -64,11 +62,9 @@ import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
 import java.time.Instant
 
 @Composable
-fun GarageApp(appLoggerViewModel: AppLoggerViewModel) {
+fun GarageApp() {
     AppTheme {
-        AppNavigation(
-            appLoggerViewModel = appLoggerViewModel,
-        )
+        AppNavigation()
     }
 }
 
@@ -86,11 +82,12 @@ sealed class Screen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AppNavigation(appLoggerViewModel: AppLoggerViewModel = hiltViewModel<AppLoggerViewModelImpl>()) {
+fun AppNavigation() {
     val component = rememberAppComponent()
     val doorViewModel: DoorViewModel = viewModel { component.doorViewModel }
     val authViewModel: AuthViewModel = viewModel { component.authViewModel }
     val buttonViewModel: RemoteButtonViewModel = viewModel { component.remoteButtonViewModel }
+    val appLoggerViewModel: AppLoggerViewModel = viewModel { component.appLoggerViewModel }
     var isOld by remember { mutableStateOf(false) }
     val currentDoorEvent by doorViewModel.currentDoorEvent.collectAsState()
     val lastCheckInTime = currentDoorEvent.data?.lastCheckInTimeSeconds?.let {


### PR DESCRIPTION
## Summary
Completes the kotlin-inject migration (Phase 3.2-3.5):

- **All 5 ViewModels** migrated: AppSettings, Auth, Door, RemoteButton, AppLogger
- **FCMService** migrated: `@AndroidEntryPoint` removed, uses lazy component access
- **No hiltViewModel<>()** calls remain in any composable
- **No javax.inject.Inject** on any ViewModel

Only `@AndroidEntryPoint` on MainActivity and `@HiltAndroidApp` on GarageApplication remain — the final Hilt removal PR will be pure deletion.

## Test plan
- [x] All tests pass
- [x] `./scripts/validate.sh` passes (all 9 checks)
- [x] No hiltViewModel or @HiltViewModel references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)