### PR TITLE
fix: Dev mode hook warns Claude about conflicting PRs

### DIFF
--- a/.claude/hooks/dev-mode.sh
+++ b/.claude/hooks/dev-mode.sh
@@ -36,12 +36,23 @@ if [ "$OPEN_PRS" -ge 10 ]; then
   fi
 fi
 
-# Before blocking, enable auto-merge on any open PRs so they merge while idle.
-for PR_NUM in $(gh pr list --state open --json number,author --jq '.[] | select(.author.login != "dependabot[bot]" and .author.login != "dependabot") | .number' 2>/dev/null); do
+# Before blocking, check for conflicting PRs and enable auto-merge.
+DIRTY_PRS=""
+for PR_JSON in $(gh pr list --state open --json number,author,mergeStateStatus --jq '.[] | select(.author.login != "dependabot[bot]" and .author.login != "dependabot") | @json' 2>/dev/null); do
+  PR_NUM=$(echo "$PR_JSON" | jq -r '.number')
+  PR_STATUS=$(echo "$PR_JSON" | jq -r '.mergeStateStatus')
+  if [ "$PR_STATUS" = "DIRTY" ]; then
+    DIRTY_PRS="${DIRTY_PRS}#${PR_NUM} "
+  fi
   gh pr merge "$PR_NUM" --auto --squash --delete-branch 2>/dev/null
 done
 
-jq -n '{
+CONFLICT_MSG=""
+if [ -n "$DIRTY_PRS" ]; then
+  CONFLICT_MSG="\n\n⚠️ CONFLICTING PRs: ${DIRTY_PRS}\nRebase these on origin/main, resolve conflicts, force-push, then enable auto-merge before stopping."
+fi
+
+jq -n --arg conflict "$CONFLICT_MSG" '{
   "decision": "block",
-  "reason": "Dev mode is active (.claude/.dev-mode). Continue making progress:\n\n1. Check open PRs — if any passed CI, merge them (--squash --delete-branch)\n2. Read docs/TESTING.md and docs/MIGRATION.md for next action items\n3. Pick the highest-priority item not yet done\n4. Create PRs on separate branches that do not conflict with each other\n5. Do not wait for CI — create the next PR on a new branch while CI runs\n6. Run ./scripts/validate.sh before pushing code changes\n7. Keep PRs small and focused (one concern per PR)\n\nTo stop: tell the user to run `rm .claude/.dev-mode`"
+  "reason": ("Dev mode is active (.claude/.dev-mode). Continue making progress:\n\n1. Check open PRs — if any passed CI, merge them (--squash --delete-branch)\n2. Read docs/TESTING.md and docs/MIGRATION.md for next action items\n3. Pick the highest-priority item not yet done\n4. Create PRs on separate branches that do not conflict with each other\n5. Do not wait for CI — create the next PR on a new branch while CI runs\n6. Run ./scripts/validate.sh before pushing code changes\n7. Keep PRs small and focused (one concern per PR)" + $conflict + "\n\nTo stop: tell the user to run `rm .claude/.dev-mode`")
 }'


### PR DESCRIPTION
## Summary
Dev mode stop hook now detects DIRTY (conflicting) PRs and tells Claude to rebase them before stopping. This ensures auto-merge can succeed after CI passes.

## Test plan
- [x] Hook config only

🤖 Generated with [Claude Code](https://claude.com/claude-code)