### PR TITLE
fix: Share Activity-scoped AuthViewModel to fix sign-in

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/MainActivity.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/MainActivity.kt
@@ -24,6 +24,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.ui.util.trace
+import com.chriscartland.garage.auth.AuthViewModelImpl
 import com.chriscartland.garage.auth.RC_ONE_TAP_SIGN_IN
 import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.ui.GarageApp
@@ -31,13 +32,32 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    /**
+     * Activity-scoped AuthViewModel shared between Compose and onActivityResult.
+     *
+     * Must be the same instance because signInWithGoogle() stores the SignInClient,
+     * and processGoogleSignInResult() reads it back.
+     */
+    private val authViewModel: AuthViewModelImpl by lazy {
+        val component = (application as GarageApplication).component
+        androidx.lifecycle.ViewModelProvider(
+            this,
+            object : androidx.lifecycle.ViewModelProvider.Factory {
+                override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
+                    @Suppress("UNCHECKED_CAST")
+                    return component.authViewModel as T
+                }
+            },
+        )[AuthViewModelImpl::class.java]
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge() // Edge-to-edge required on Android 15+ (target SDK 35).
         val component = (application as GarageApplication).component
         trace("MainActivity.setContent") {
             setContent {
-                GarageApp()
+                GarageApp(authViewModel = authViewModel)
             }
         }
         Log.d(TAG, "onCreate: Try to subscribe to FCM topic")
@@ -64,16 +84,6 @@ class MainActivity : ComponentActivity() {
                     Log.e("MainActivity", "onActivityResult: data is null")
                     return
                 }
-                val component = (application as GarageApplication).component
-                val authViewModel = androidx.lifecycle.ViewModelProvider(
-                    this,
-                    object : androidx.lifecycle.ViewModelProvider.Factory {
-                        override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
-                            @Suppress("UNCHECKED_CAST")
-                            return component.authViewModel as T
-                        }
-                    },
-                )[com.chriscartland.garage.auth.AuthViewModelImpl::class.java]
                 authViewModel.processGoogleSignInResult(data)
             }
         }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -63,16 +63,19 @@ import java.time.Instant
 
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
-fun HomeContent(modifier: Modifier = Modifier) {
+fun HomeContent(
+    modifier: Modifier = Modifier,
+    authViewModel: AuthViewModel? = null,
+) {
     val component = rememberAppComponent()
+    val resolvedAuthViewModel = authViewModel ?: viewModel { component.authViewModel }
     val doorViewModel: DoorViewModel = viewModel { component.doorViewModel }
-    val authViewModel: AuthViewModel = viewModel { component.authViewModel }
     val buttonViewModel: RemoteButtonViewModel = viewModel { component.remoteButtonViewModel }
     val appLoggerViewModel: AppLoggerViewModel = viewModel { component.appLoggerViewModel }
     val activity = LocalActivity.current
     val currentDoorEvent by doorViewModel.currentDoorEvent.collectAsState()
     val buttonRequestStatus by buttonViewModel.requestStatus.collectAsState()
-    val authState by authViewModel.authState.collectAsState()
+    val authState by resolvedAuthViewModel.authState.collectAsState()
     HomeContent(
         currentDoorEvent = currentDoorEvent,
         remoteRequestStatus = buttonRequestStatus,
@@ -89,12 +92,12 @@ fun HomeContent(modifier: Modifier = Modifier) {
                         "Remote button clicked. " +
                             "AuthViewModel authState $authState",
                     )
-                    buttonViewModel.pushRemoteButton(authViewModel.authRepository)
+                    buttonViewModel.pushRemoteButton(resolvedAuthViewModel.authRepository)
                 }
 
                 AuthState.Unauthenticated -> {
                     if (activity != null) {
-                        authViewModel.signInWithGoogle(activity)
+                        resolvedAuthViewModel.signInWithGoogle(activity)
                     } else {
                         Log.e(TAG, "Activity is null, cannot sign in with Google")
                     }
@@ -102,7 +105,7 @@ fun HomeContent(modifier: Modifier = Modifier) {
 
                 AuthState.Unknown -> {
                     if (activity != null) {
-                        authViewModel.signInWithGoogle(activity)
+                        resolvedAuthViewModel.signInWithGoogle(activity)
                     } else {
                         Log.e(TAG, "Activity is null, cannot sign in with Google")
                     }
@@ -113,7 +116,7 @@ fun HomeContent(modifier: Modifier = Modifier) {
         authState = authState,
         onSignIn = {
             if (activity != null) {
-                authViewModel.signInWithGoogle(activity)
+                resolvedAuthViewModel.signInWithGoogle(activity)
             } else {
                 Log.e(TAG, "Activity is null, cannot sign in with Google")
             }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -62,9 +62,9 @@ import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
 import java.time.Instant
 
 @Composable
-fun GarageApp() {
+fun GarageApp(authViewModel: AuthViewModel) {
     AppTheme {
-        AppNavigation()
+        AppNavigation(authViewModel = authViewModel)
     }
 }
 
@@ -82,10 +82,9 @@ sealed class Screen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AppNavigation() {
+fun AppNavigation(authViewModel: AuthViewModel) {
     val component = rememberAppComponent()
     val doorViewModel: DoorViewModel = viewModel { component.doorViewModel }
-    val authViewModel: AuthViewModel = viewModel { component.authViewModel }
     val buttonViewModel: RemoteButtonViewModel = viewModel { component.remoteButtonViewModel }
     val appLoggerViewModel: AppLoggerViewModel = viewModel { component.appLoggerViewModel }
     var isOld by remember { mutableStateOf(false) }
@@ -148,6 +147,7 @@ fun AppNavigation() {
         ) {
             composable(Screen.Home.route) {
                 HomeContent(
+                    authViewModel = authViewModel,
                     modifier = Modifier
                         .padding(horizontal = 16.dp)
                         .fillMaxWidth(),
@@ -162,6 +162,7 @@ fun AppNavigation() {
             }
             composable(Screen.Profile.route) {
                 ProfileContent(
+                    authViewModel = authViewModel,
                     modifier = Modifier
                         .padding(horizontal = 16.dp)
                         .fillMaxWidth(),

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
@@ -53,12 +53,15 @@ import java.time.Duration
 
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
-fun ProfileContent(modifier: Modifier = Modifier) {
+fun ProfileContent(
+    modifier: Modifier = Modifier,
+    authViewModel: AuthViewModel? = null,
+) {
     val component = rememberAppComponent()
-    val authViewModel: AuthViewModel = viewModel { component.authViewModel }
+    val resolvedAuthViewModel = authViewModel ?: viewModel { component.authViewModel }
     val buttonViewModel: RemoteButtonViewModel = viewModel { component.remoteButtonViewModel }
     val activity = LocalActivity.current
-    val authState by authViewModel.authState.collectAsState()
+    val authState by resolvedAuthViewModel.authState.collectAsState()
     val snoozeRequestStatus by buttonViewModel.snoozeRequestStatus.collectAsState()
     val snoozeEndTimeSeconds by buttonViewModel.snoozeEndTimeSeconds.collectAsState()
 
@@ -77,17 +80,17 @@ fun ProfileContent(modifier: Modifier = Modifier) {
         modifier = modifier,
         signIn = {
             if (activity != null) {
-                authViewModel.signInWithGoogle(activity)
+                resolvedAuthViewModel.signInWithGoogle(activity)
             } else {
                 Log.e(TAG, "Activity is null, cannot sign in with Google")
             }
         },
-        signOut = { authViewModel.signOut() },
+        signOut = { resolvedAuthViewModel.signOut() },
         snoozeEndTimeSeconds = snoozeEndTimeSeconds,
         snoozeRequestStatus = snoozeRequestStatus,
         onSnooze = {
             buttonViewModel.snoozeOpenDoorsNotifications(
-                authViewModel.authRepository,
+                resolvedAuthViewModel.authRepository,
                 it,
             )
         },


### PR DESCRIPTION
## Summary
Sign-in broke because `signInWithGoogle()` stores the `SignInClient` in one ViewModel instance, but `processGoogleSignInResult()` in `onActivityResult` accessed a different instance. The `SignInClient` was null, so credential parsing failed.

**Root cause:** `component.authViewModel` creates a new instance each time. Compose's `viewModel {}` and `ViewModelProvider` use different `ViewModelStoreOwner`s.

**Fix:** Create AuthViewModel once in MainActivity's `ViewModelProvider` (Activity-scoped), pass it to Compose. Both `signInWithGoogle` and `processGoogleSignInResult` use the same instance.

## Test plan
- [x] `./scripts/validate.sh` passes (all 9 checks)
- [ ] **Manual test required:** sign in with Google on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)