### PR TITLE
fix: Share Activity-scoped ViewModels to prevent instance mismatch

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/MainActivity.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/MainActivity.kt
@@ -24,45 +24,42 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.ui.util.trace
-import com.chriscartland.garage.auth.AuthViewModelImpl
 import com.chriscartland.garage.auth.RC_ONE_TAP_SIGN_IN
 import com.chriscartland.garage.config.AppLoggerKeys
+import com.chriscartland.garage.di.activityViewModel
 import com.chriscartland.garage.ui.GarageApp
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     /**
-     * Activity-scoped AuthViewModel shared between Compose and onActivityResult.
+     * Activity-scoped ViewModels shared between Compose and Activity callbacks.
      *
-     * Must be the same instance because signInWithGoogle() stores the SignInClient,
-     * and processGoogleSignInResult() reads it back.
+     * Created via [activityViewModel] to ensure the same instance is stored in the
+     * Activity's ViewModelStore. Compose receives these as parameters and uses the
+     * same instances. This prevents bugs where instance state (like SignInClient)
+     * exists on one ViewModel but is accessed from a different instance.
      */
-    private val authViewModel: AuthViewModelImpl by lazy {
-        val component = (application as GarageApplication).component
-        androidx.lifecycle.ViewModelProvider(
-            this,
-            object : androidx.lifecycle.ViewModelProvider.Factory {
-                override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
-                    @Suppress("UNCHECKED_CAST")
-                    return component.authViewModel as T
-                }
-            },
-        )[AuthViewModelImpl::class.java]
-    }
+    private val component by lazy { (application as GarageApplication).component }
+    private val authViewModel by lazy { activityViewModel(this) { component.authViewModel } }
+    private val doorViewModel by lazy { activityViewModel(this) { component.doorViewModel } }
+    private val appLoggerViewModel by lazy { activityViewModel(this) { component.appLoggerViewModel } }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge() // Edge-to-edge required on Android 15+ (target SDK 35).
-        val component = (application as GarageApplication).component
         trace("MainActivity.setContent") {
             setContent {
-                GarageApp(authViewModel = authViewModel)
+                GarageApp(
+                    authViewModel = authViewModel,
+                    doorViewModel = doorViewModel,
+                    appLoggerViewModel = appLoggerViewModel,
+                )
             }
         }
         Log.d(TAG, "onCreate: Try to subscribe to FCM topic")
-        component.doorViewModel.registerFcm(this)
-        component.appLoggerViewModel.log(AppLoggerKeys.ON_CREATE_FCM_SUBSCRIBE_TOPIC)
+        doorViewModel.registerFcm(this)
+        appLoggerViewModel.log(AppLoggerKeys.ON_CREATE_FCM_SUBSCRIBE_TOPIC)
     }
 
     // TODO: Migrate away from onActivityResult with Activity Result API and ActivityResultContract.

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/ActivityViewModels.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/ActivityViewModels.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.di
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStoreOwner
+
+/**
+ * Create a ViewModel scoped to the given [ViewModelStoreOwner] (typically an Activity),
+ * using the kotlin-inject component as a factory.
+ *
+ * This ensures the same ViewModel instance is returned across multiple calls,
+ * which is critical for ViewModels with instance state (e.g., SignInClient in AuthViewModel).
+ */
+inline fun <reified T : ViewModel> activityViewModel(
+    owner: ViewModelStoreOwner,
+    crossinline factory: () -> T,
+): T =
+    ViewModelProvider(
+        owner,
+        object : ViewModelProvider.Factory {
+            override fun <V : ViewModel> create(modelClass: Class<V>): V {
+                @Suppress("UNCHECKED_CAST")
+                return factory() as V
+            }
+        },
+    )[T::class.java]

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
@@ -45,22 +45,26 @@ import com.chriscartland.garage.door.DoorViewModel
 import java.time.Instant
 
 @Composable
-fun DoorHistoryContent(modifier: Modifier = Modifier) {
+fun DoorHistoryContent(
+    modifier: Modifier = Modifier,
+    doorViewModel: DoorViewModel? = null,
+    appLoggerViewModel: AppLoggerViewModel? = null,
+) {
     val component = rememberAppComponent()
-    val doorViewModel: DoorViewModel = viewModel { component.doorViewModel }
-    val appLoggerViewModel: AppLoggerViewModel = viewModel { component.appLoggerViewModel }
+    val resolvedDoorViewModel = doorViewModel ?: viewModel { component.doorViewModel }
+    val resolvedAppLoggerViewModel = appLoggerViewModel ?: viewModel { component.appLoggerViewModel }
     val activity = LocalActivity.current
-    val recentDoorEvents by doorViewModel.recentDoorEvents.collectAsState()
+    val recentDoorEvents by resolvedDoorViewModel.recentDoorEvents.collectAsState()
     DoorHistoryContent(
         recentDoorEvents = recentDoorEvents,
         modifier = modifier,
         onFetchRecentDoorEvents = {
-            appLoggerViewModel.log(AppLoggerKeys.USER_FETCH_RECENT_DOOR)
-            doorViewModel.fetchRecentDoorEvents()
+            resolvedAppLoggerViewModel.log(AppLoggerKeys.USER_FETCH_RECENT_DOOR)
+            resolvedDoorViewModel.fetchRecentDoorEvents()
         },
         onResetFcm = {
             if (activity != null) {
-                doorViewModel.deregisterFcm(activity)
+                resolvedDoorViewModel.deregisterFcm(activity)
             } else {
                 Log.e(TAG, "Activity is null, cannot deregister FCM")
             }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -66,14 +66,16 @@ import java.time.Instant
 fun HomeContent(
     modifier: Modifier = Modifier,
     authViewModel: AuthViewModel? = null,
+    doorViewModel: DoorViewModel? = null,
+    appLoggerViewModel: AppLoggerViewModel? = null,
 ) {
     val component = rememberAppComponent()
     val resolvedAuthViewModel = authViewModel ?: viewModel { component.authViewModel }
-    val doorViewModel: DoorViewModel = viewModel { component.doorViewModel }
+    val resolvedDoorViewModel = doorViewModel ?: viewModel { component.doorViewModel }
     val buttonViewModel: RemoteButtonViewModel = viewModel { component.remoteButtonViewModel }
-    val appLoggerViewModel: AppLoggerViewModel = viewModel { component.appLoggerViewModel }
+    val resolvedAppLoggerViewModel = appLoggerViewModel ?: viewModel { component.appLoggerViewModel }
     val activity = LocalActivity.current
-    val currentDoorEvent by doorViewModel.currentDoorEvent.collectAsState()
+    val currentDoorEvent by resolvedDoorViewModel.currentDoorEvent.collectAsState()
     val buttonRequestStatus by buttonViewModel.requestStatus.collectAsState()
     val authState by resolvedAuthViewModel.authState.collectAsState()
     HomeContent(
@@ -81,8 +83,8 @@ fun HomeContent(
         remoteRequestStatus = buttonRequestStatus,
         modifier = modifier,
         onFetchCurrentDoorEvent = {
-            appLoggerViewModel.log(AppLoggerKeys.USER_FETCH_CURRENT_DOOR)
-            doorViewModel.fetchCurrentDoorEvent()
+            resolvedAppLoggerViewModel.log(AppLoggerKeys.USER_FETCH_CURRENT_DOOR)
+            resolvedDoorViewModel.fetchCurrentDoorEvent()
         },
         onRemoteButtonClick = {
             when (authState) {
@@ -123,13 +125,13 @@ fun HomeContent(
         },
         onResetFcm = {
             if (activity != null) {
-                doorViewModel.deregisterFcm(activity)
+                resolvedDoorViewModel.deregisterFcm(activity)
             } else {
                 Log.e(TAG, "Activity is null, cannot deregister FCM")
             }
         },
         onLogNotificationPermissionRequested = {
-            appLoggerViewModel.log(AppLoggerKeys.USER_REQUESTED_NOTIFICATION_PERMISSION)
+            resolvedAppLoggerViewModel.log(AppLoggerKeys.USER_REQUESTED_NOTIFICATION_PERMISSION)
         },
     )
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -62,9 +62,17 @@ import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
 import java.time.Instant
 
 @Composable
-fun GarageApp(authViewModel: AuthViewModel) {
+fun GarageApp(
+    authViewModel: AuthViewModel,
+    doorViewModel: DoorViewModel,
+    appLoggerViewModel: AppLoggerViewModel,
+) {
     AppTheme {
-        AppNavigation(authViewModel = authViewModel)
+        AppNavigation(
+            authViewModel = authViewModel,
+            doorViewModel = doorViewModel,
+            appLoggerViewModel = appLoggerViewModel,
+        )
     }
 }
 
@@ -82,11 +90,13 @@ sealed class Screen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AppNavigation(authViewModel: AuthViewModel) {
+fun AppNavigation(
+    authViewModel: AuthViewModel,
+    doorViewModel: DoorViewModel,
+    appLoggerViewModel: AppLoggerViewModel,
+) {
     val component = rememberAppComponent()
-    val doorViewModel: DoorViewModel = viewModel { component.doorViewModel }
     val buttonViewModel: RemoteButtonViewModel = viewModel { component.remoteButtonViewModel }
-    val appLoggerViewModel: AppLoggerViewModel = viewModel { component.appLoggerViewModel }
     var isOld by remember { mutableStateOf(false) }
     val currentDoorEvent by doorViewModel.currentDoorEvent.collectAsState()
     val lastCheckInTime = currentDoorEvent.data?.lastCheckInTimeSeconds?.let {
@@ -148,6 +158,8 @@ fun AppNavigation(authViewModel: AuthViewModel) {
             composable(Screen.Home.route) {
                 HomeContent(
                     authViewModel = authViewModel,
+                    doorViewModel = doorViewModel,
+                    appLoggerViewModel = appLoggerViewModel,
                     modifier = Modifier
                         .padding(horizontal = 16.dp)
                         .fillMaxWidth(),
@@ -155,6 +167,8 @@ fun AppNavigation(authViewModel: AuthViewModel) {
             }
             composable(Screen.History.route) {
                 DoorHistoryContent(
+                    doorViewModel = doorViewModel,
+                    appLoggerViewModel = appLoggerViewModel,
                     modifier = Modifier
                         .padding(horizontal = 16.dp)
                         .fillMaxWidth(),


### PR DESCRIPTION
## Summary
Extends the auth sign-in fix (PR #93) to all ViewModels used in both MainActivity and Compose:

- **DoorViewModel**: `registerFcm()` in `onCreate` + UI state in Compose → same instance
- **AppLoggerViewModel**: `log()` in `onCreate` + counter display in Compose → same instance
- **AuthViewModel**: already fixed, now uses shared `activityViewModel()` helper

Created `activityViewModel()` utility that wraps `ViewModelProvider` with a kotlin-inject factory. Composables accept nullable params with component fallback for Previews.

## Test plan
- [x] `./scripts/validate.sh` passes (all 9 checks)
- [ ] **Manual test:** FCM registration, log counts, sign-in all work on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)