### PR TITLE
docs: Dump session context — Phases 2+3 complete

### DIFF
--- a/AndroidGarage/docs/DI-MIGRATION.md
+++ b/AndroidGarage/docs/DI-MIGRATION.md
@@ -125,8 +125,8 @@ class GarageApplication : Application() {
 
 ### Commit Reference
 
-<!-- Update with actual commit hash after implementation -->
-`_______` (#__) — Add kotlin-inject alongside Hilt
+<!-- Completed -->
+`65f89c8` (#86) — Add kotlin-inject alongside Hilt
 
 ---
 
@@ -173,7 +173,7 @@ val viewModel: AppSettingsViewModel = viewModel { component.appSettingsViewModel
 
 ### Commit Reference
 
-`_______` (#__) — Migrate AppSettingsViewModel to kotlin-inject
+`a7c2ade` (#87) — Migrate AppSettingsViewModel to kotlin-inject
 
 ---
 
@@ -199,10 +199,11 @@ val viewModel: AppSettingsViewModel = viewModel { component.appSettingsViewModel
 
 | ViewModel | Commit | PR |
 |-----------|--------|-----|
-| AppSettingsViewModel | `_______` | #__ |
-| AuthViewModel | `_______` | #__ |
-| DoorViewModel | `_______` | #__ |
-| RemoteButtonViewModel | `_______` | #__ |
+| AppSettingsViewModel | `a7c2ade` | #87 |
+| AuthViewModel | `953beb6` | #89 |
+| DoorViewModel | `9312b01` | #90 |
+| RemoteButtonViewModel | `9312b01` | #90 |
+| AppLoggerViewModel | `2185646` | #91 |
 
 ---
 
@@ -254,7 +255,7 @@ abstract class AppComponent(...) {
 
 ### Commit Reference
 
-`_______` (#__) — Migrate all bindings to AppComponent
+`c5d9d58` (#96) — Migrated alongside Hilt removal
 
 ---
 
@@ -289,7 +290,7 @@ class FCMService : FirebaseMessagingService() {
 
 ### Commit Reference
 
-`_______` (#__) — Migrate FCMService from @AndroidEntryPoint to manual injection
+`2185646` (#91) — Migrate FCMService to lazy component access
 
 ---
 
@@ -314,7 +315,7 @@ class FCMService : FirebaseMessagingService() {
 
 ### Commit Reference
 
-`_______` (#__) — Remove Hilt completely
+`c5d9d58` (#96) — Remove Hilt completely
 
 ---
 

--- a/AndroidGarage/docs/MIGRATION.md
+++ b/AndroidGarage/docs/MIGRATION.md
@@ -75,26 +75,34 @@ Target: Align with [battery-butler](https://github.com/cartland/battery-butler) 
 - Extract `data-network/` as separate Gradle module (Retrofit service, response DTOs, adapters)
 - These are structural — the abstraction boundary is already enforced by interfaces
 
-## Phase 3: DI Migration (Hilt to kotlin-inject)
-
-**Status:** Not started. Begin after Phase 2.
+## Phase 3: DI Migration (Hilt to kotlin-inject) — COMPLETE
 
 **Goal:** KMP-compatible dependency injection.
 
-### 3.1 Add kotlin-inject
-- Add `me.tatarka.inject` KSP plugin and runtime dependency
-- Create `AppComponent` with `@Component` annotation
-- Provide all singletons via `@Provides` methods
+See `docs/DI-MIGRATION.md` for the full migration guide with before/after code examples.
 
-### 3.2 Migrate ViewModels
-- Replace `@HiltViewModel` with `@Inject` constructor
-- Build ViewModel instances from component, not Hilt
-- Update Navigation to pass ViewModel factories
+### 3.1 Add kotlin-inject — `65f89c8` (#86)
+- Added `me.tatarka.inject:kotlin-inject-runtime` 0.9.0 + KSP compiler
+- Created `@Singleton` scope annotation and empty `AppComponent`
+- Both Hilt and kotlin-inject coexisted during migration
 
-### 3.3 Remove Hilt
-- Delete all `@Module`, `@InstallIn`, `@Binds` annotations
-- Remove Hilt Gradle plugin and dependencies
-- Remove `@HiltAndroidApp` from `GarageApplication`
+### 3.2 Migrate ViewModels — `a7c2ade` (#87), `953beb6` (#89), `9312b01` (#90)
+- AppSettingsViewModel (#87), AuthViewModel (#89), DoorViewModel + RemoteButtonViewModel (#90)
+- Pattern: `rememberAppComponent()` + `viewModel { component.xxxViewModel }`
+- Activity-scoped ViewModels via `activityViewModel()` helper for shared instances
+- AppLoggerViewModel + FCMService also migrated (#91)
+
+### 3.3 Remove Hilt — `c5d9d58` (#96)
+- Deleted all 15 `@Module` classes, `@HiltAndroidApp`, `@AndroidEntryPoint`
+- Removed Hilt Gradle plugin and all 3 dependencies
+- Zero `dagger`/`hilt` references remain in source code
+- Net -257 lines
+
+### 3.4 Fix ViewModel instance sharing — `0aebfb1` (#93), `28151ce` (#95)
+- **Bug:** `component.xxxViewModel` creates new instances. ViewModels with instance state
+  (SignInClient, FCM status, log counts) must share the same instance across Activity and Compose.
+- **Fix:** `activityViewModel()` helper creates ViewModels in Activity's ViewModelStore.
+  Compose receives them as nullable params with component fallback for Previews.
 
 ## Phase 4: Network Migration (Retrofit to Ktor HTTP)
 
@@ -167,7 +175,7 @@ Target: Align with [battery-butler](https://github.com/cartland/battery-butler) 
 |-------|--------|-------------|--------|
 | 1. Testing | Medium | None | **COMPLETE** |
 | 2. Clean Architecture | Large | Phase 1 | **COMPLETE** |
-| 3. DI Migration | Medium | Phase 2 | Not started |
+| 3. DI Migration | Medium | Phase 2 | **COMPLETE** |
 | 4. Network Migration | Medium | Phase 3 | Not started |
 | 5. KMP | Large | Phases 3 + 4 | Not started |
 | 6. Screenshot Tests | Medium | None | Not started |

--- a/AndroidGarage/docs/TESTING.md
+++ b/AndroidGarage/docs/TESTING.md
@@ -13,12 +13,14 @@
 
 ## Current State
 
-- **~125 unit tests** across 17 test files (15 androidApp + 2 domain module)
+- **~135 unit tests** across 17 test files (15 androidApp + 2 domain module)
 - **CI checks:** unit tests (3 build variants), Spotless formatting (all modules), Detekt, Android Lint, debug APK build, release AAB build
-- **Local validation:** `./scripts/validate.sh` mirrors CI + Room schema drift check + domain tests
-- **Safety guardrails:** git hooks warn on Room entity changes, block push to main, enforce squash merge
+- **CI path filtering:** Android CI skips for Firebase-only/docs-only changes, and vice versa
+- **Local validation:** `./scripts/validate.sh` mirrors CI + Room schema drift check + auto-discovered module tests
+- **Safety guardrails:** git hooks warn on Room entity changes, block push to main, enforce squash merge, warn on command substitution
+- **DI system:** kotlin-inject (Hilt fully removed as of Phase 3)
 - **Completed:** Phase 1 (CI hardening), Phase 2 (network error tests), Phase 3 (auth token fix + UseCase tests), Phase 4 (state machine completeness), Phase 5.2-5.3 (release safety)
-- **Remaining:** Phase 5.1 (ProGuard smoke test), Phase 6 (Firebase server)
+- **Remaining:** Phase 5.1 (covered by Phase 7 instrumented tests), Phase 6 (Firebase server), Phase 7 (instrumented tests)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ idf.py menuconfig      # Enable fake implementations for testing
 - **UseCases** (`androidApp/usecase/`): Business logic extracted from ViewModels
 - **ViewModels**: `DoorViewModel`, `AuthViewModel`, `RemoteButtonViewModel` — delegate to UseCases
 - **Repositories**: `DoorRepository`, `AuthRepository`, `PushRepository` — implement domain interfaces, depend on data interfaces
+- **DI**: kotlin-inject (`AppComponent`) — Hilt fully removed. See `docs/DI-MIGRATION.md`
 - **Local storage**: Room database with offline-first caching
 - **Network**: Retrofit + Moshi for API communication
 


### PR DESCRIPTION
## Summary
Capture all session knowledge into durable docs:
- MIGRATION.md: Phase 3 complete with commit hashes
- TESTING.md: Updated test count, CI features, DI system
- DI-MIGRATION.md: All steps filled with commits/PRs
- CLAUDE.md: kotlin-inject noted in architecture
- Memory files updated for future sessions

## Test plan
- [x] Docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)