### PR TITLE
docs: Mark Phase 4 complete, update architecture for Ktor + kotlin-inject

### DIFF
--- a/AndroidGarage/docs/ARCHITECTURE.md
+++ b/AndroidGarage/docs/ARCHITECTURE.md
@@ -26,7 +26,7 @@ ViewModel (StateFlow, business coordination)
     ↓ suspend calls
 Repository (data abstraction, caching)
     ↓              ↓
-Retrofit         Room
+Ktor HTTP        Room
 (network)      (local DB)
     ↓
 Firebase Server
@@ -56,7 +56,7 @@ All packages under `androidApp/src/main/java/com/chriscartland/garage/`:
 | `db/` | Room database, DAOs, entity mapping | `AppDatabase` (v11), `DoorEventEntity` ↔ domain `DoorEvent`, `DoorEventDao` |
 | `door/` | Door repository and ViewModel | `DoorRepositoryImpl`, `DoorViewModelImpl` |
 | `fcm/` | FCM registration, push handling | `FCMService`, `FcmPayloadParser`, `DoorFcmRepositoryImpl` |
-| `internet/` | Retrofit service, response DTOs | `GarageNetworkService`, value classes for type-safe params |
+| `internet/` | Ktor HTTP client, data source implementations | `KtorNetworkDoorDataSource`, `KtorNetworkConfigDataSource`, `KtorNetworkButtonDataSource` |
 | `permissions/` | Notification permission (API 33+) | Accompanist-based permission request |
 | `remotebutton/` | Remote button with state machine | `RemoteButtonViewModelImpl`, `PushRepositoryImpl` |
 | `settings/` | SharedPreferences wrapper | `AppSettings`, type-safe `Setting` classes |
@@ -102,21 +102,25 @@ Root files: `GarageApplication.kt` (@HiltAndroidApp), `MainActivity.kt` (Compose
 4. `refreshFirebaseAuthState()` → `getIdToken(true)` → `AuthState.Authenticated`
 5. Token included as `X-AuthTokenGoogle` header in server requests
 
-## Dependency Injection (Hilt)
+## Dependency Injection (kotlin-inject)
 
-| Module | Provides | Scope |
-|--------|----------|-------|
-| `RetrofitModule` | `GarageNetworkService` | Singleton |
-| `AppDatabaseModule` | `AppDatabase` | Singleton |
-| `GarageRepositoryModule` | `DoorRepository` | Singleton |
-| `PushRepositoryModule` | `PushRepository` | Singleton |
-| `AuthRepositoryModule` | `AuthRepository` | Singleton |
-| `ServerConfigRepositoryModule` | `ServerConfigRepository` | Singleton |
-| `AppLoggerRepositoryModule` | `AppLoggerRepository` | Singleton |
-| `DoorFcmRepositoryModule` | `DoorFcmRepository` | Singleton |
-| `DispatcherModule` | `DispatcherProvider` | Singleton |
+All dependencies wired in `AppComponent` (see `docs/DI-MIGRATION.md`):
 
-ViewModels use `@HiltViewModel` and are scoped to the navigation graph.
+| Provider | Provides | Scope |
+|----------|----------|-------|
+| `provideHttpClient()` | `HttpClient` (Ktor) | Singleton |
+| `provideNetworkDoorDataSource()` | `NetworkDoorDataSource` | Singleton |
+| `provideNetworkConfigDataSource()` | `NetworkConfigDataSource` | Singleton |
+| `provideNetworkButtonDataSource()` | `NetworkButtonDataSource` | Singleton |
+| `provideAppDatabase()` | `AppDatabase` | Singleton |
+| `provideLocalDoorDataSource()` | `LocalDoorDataSource` | Singleton |
+| `provideDoorRepository()` | `DoorRepository` | Singleton |
+| `providePushRepository()` | `PushRepository` | Singleton |
+| `provideAuthRepository()` | `AuthRepository` | Singleton |
+| `provideServerConfigRepository()` | `ServerConfigRepository` | Singleton |
+| `provideDispatcherProvider()` | `DispatcherProvider` | Singleton |
+
+ViewModels are created via `activityViewModel()` helper for Activity-scoped sharing.
 
 ## State Management
 

--- a/AndroidGarage/docs/MIGRATION.md
+++ b/AndroidGarage/docs/MIGRATION.md
@@ -104,30 +104,30 @@ See `docs/DI-MIGRATION.md` for the full migration guide with before/after code e
 - **Fix:** `activityViewModel()` helper creates ViewModels in Activity's ViewModelStore.
   Compose receives them as nullable params with component fallback for Previews.
 
-## Phase 4: Network Migration (Retrofit to Ktor HTTP)
-
-**Status:** Not started. Begin after Phase 3.
+## Phase 4: Network Migration (Retrofit to Ktor HTTP) — COMPLETE
 
 **Goal:** KMP-compatible HTTP client.
 
-### 4.1 Add Ktor Client
-- Add `io.ktor:ktor-client-core`, `ktor-client-okhttp` (Android), `ktor-client-content-negotiation`
-- Add `io.ktor:ktor-serialization-kotlinx-json`
-- Configure base URL, logging, auth headers
+### 4.1 Add Ktor Client + Create Ktor Data Sources — `158c176` (#100)
+- Added Ktor 3.1.3 (client-core, client-okhttp, content-negotiation, logging)
+- Added kotlinx-serialization-json 1.8.1 + Gradle plugin
+- Created `KtorNetworkDoorDataSource`, `KtorNetworkConfigDataSource`, `KtorNetworkButtonDataSource`
+- Each uses `@Serializable` DTOs with `ignoreUnknownKeys` — only fields actually used
+- Ktor implementations bypass `GarageNetworkService` entirely — implement data source interfaces directly
+- Swapped DI wiring in `AppComponent` from Retrofit to Ktor
 
-### 4.2 Replace Retrofit Endpoints
-- Rewrite `GarageNetworkService` methods as Ktor `HttpClient` calls
-- Replace Moshi response DTOs with `@Serializable` data classes (kotlinx.serialization)
-- Migrate one endpoint at a time, keeping both active during transition
-
-### 4.3 Remove Retrofit
-- Delete Retrofit interface, annotations, Moshi adapters
-- Remove OkHttp logging interceptor (Ktor has its own)
-- Remove Retrofit/Moshi/OkHttp dependencies
+### 4.2 Remove Retrofit — `759443e` (#101)
+- Deleted `GarageNetworkService.kt` (Retrofit interface + inline value classes)
+- Deleted 3 Retrofit adapter implementations, 6 Moshi `@JsonClass` DTOs
+- Deleted `retrofit2.pro`, `moshi.pro` ProGuard rules
+- Removed 7 dependencies: retrofit2, moshi, moshi-kotlin, moshi-codegen, converter-moshi, okhttp3-logging-interceptor
+- Migrated `GarageNetworkServiceTest` and `RoomSchemaTest` from Moshi to kotlinx.serialization
+- Net -841 lines
+- Zero `retrofit2`/`moshi`/`okhttp3` imports remain in source code
 
 ## Phase 5: KMP Preparation
 
-**Status:** Not started. Begin after Phases 3 + 4.
+**Status:** Not started. Begin after Phase 4.
 
 **Goal:** Share code across platforms.
 
@@ -176,8 +176,8 @@ See `docs/DI-MIGRATION.md` for the full migration guide with before/after code e
 | 1. Testing | Medium | None | **COMPLETE** |
 | 2. Clean Architecture | Large | Phase 1 | **COMPLETE** |
 | 3. DI Migration | Medium | Phase 2 | **COMPLETE** |
-| 4. Network Migration | Medium | Phase 3 | Not started |
-| 5. KMP | Large | Phases 3 + 4 | Not started |
+| 4. Network Migration | Medium | Phase 3 | **COMPLETE** |
+| 5. KMP | Large | Phase 4 | Not started |
 | 6. Screenshot Tests | Medium | None | Not started |
 
 **Rule:** Finish each phase before starting the next. Update this document with commit hashes when items complete.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,13 +71,13 @@ idf.py menuconfig      # Enable fake implementations for testing
 
 ### Android Clean Architecture
 - **Domain module** (`domain/`): Pure Kotlin types and repository interfaces — no Android deps
-- **Data module** (`data/`): Pure Kotlin data source interfaces (`LocalDoorDataSource`, `NetworkDoorDataSource`, etc.) — abstracts Room/Retrofit
+- **Data module** (`data/`): Pure Kotlin data source interfaces (`LocalDoorDataSource`, `NetworkDoorDataSource`, etc.) — abstracts Room/Ktor
 - **UseCases** (`androidApp/usecase/`): Business logic extracted from ViewModels
 - **ViewModels**: `DoorViewModel`, `AuthViewModel`, `RemoteButtonViewModel` — delegate to UseCases
 - **Repositories**: `DoorRepository`, `AuthRepository`, `PushRepository` — implement domain interfaces, depend on data interfaces
 - **DI**: kotlin-inject (`AppComponent`) — Hilt fully removed. See `docs/DI-MIGRATION.md`
 - **Local storage**: Room database with offline-first caching
-- **Network**: Retrofit + Moshi for API communication
+- **Network**: Ktor HTTP client + kotlinx.serialization for API communication
 
 ### ESP32 Component Architecture
 ```


### PR DESCRIPTION
## Summary
- Mark Phase 4 (Retrofit → Ktor) as complete in MIGRATION.md with commit hashes
- Update ARCHITECTURE.md: DI section from Hilt to kotlin-inject, network from Retrofit to Ktor
- Update CLAUDE.md: network stack reference

## Test plan
- Docs only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)