### PR TITLE
feat: Add instrumented tests with Gradle Managed Device (Phase 7.1-7.3)

### DIFF
--- a/.github/workflows/instrumented-tests.yml
+++ b/.github/workflows/instrumented-tests.yml
@@ -1,0 +1,59 @@
+name: Instrumented Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'AndroidGarage/**'
+
+# Cancel previous runs on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      android: ${{ steps.filter.outputs.android }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            android:
+              - 'AndroidGarage/**'
+
+  instrumented-tests:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.android == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Decrypt secrets
+        env:
+          ENCRYPT_KEY: ${{ secrets.ENCRYPT_KEY }}
+        run: release/decrypt-secrets.sh
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run instrumented tests
+        working-directory: AndroidGarage
+        run: ./gradlew pixel6Api34DebugAndroidTest
+
+      - name: Clean secrets
+        if: always()
+        run: release/clean-secrets.sh

--- a/AndroidGarage/androidApp/build.gradle.kts
+++ b/AndroidGarage/androidApp/build.gradle.kts
@@ -145,6 +145,15 @@ android {
 
     testOptions {
         unitTests.isReturnDefaultValues = true
+        managedDevices {
+            localDevices {
+                create("pixel6Api34") {
+                    device = "Pixel 6"
+                    apiLevel = 34
+                    systemImageSource = "aosp-atd"
+                }
+            }
+        }
     }
 
     compileOptions {

--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ExampleInstrumentedTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ExampleInstrumentedTest.kt
@@ -34,6 +34,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("com.chriscartland.garage", appContext.packageName)
+        assertEquals("com.chriscartland.garage.debug", appContext.packageName)
     }
 }

--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/db/DatabaseSanityTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/db/DatabaseSanityTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.db
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.chriscartland.garage.applogger.model.AppEvent
+import com.chriscartland.garage.domain.model.DoorPosition
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies the Room database works at runtime.
+ *
+ * These tests catch failures that unit tests miss:
+ * - R8 stripping Room type converters or entity definitions
+ * - Room schema mismatches between code and compiled schema
+ * - DAO query compilation errors that only surface on device
+ */
+@RunWith(AndroidJUnit4::class)
+class DatabaseSanityTest {
+    private lateinit var db: AppDatabase
+
+    @Before
+    fun createDb() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+    }
+
+    @After
+    fun closeDb() {
+        db.close()
+    }
+
+    @Test
+    fun databaseCreates() {
+        assertNotNull("Database should create successfully", db)
+    }
+
+    @Test
+    fun doorEventDaoAccessible() {
+        assertNotNull("DoorEventDao should be accessible", db.doorEventDao())
+    }
+
+    @Test
+    fun appLoggerDaoAccessible() {
+        assertNotNull("AppLoggerDao should be accessible", db.appLoggerDao())
+    }
+
+    @Test
+    fun insertAndReadDoorEvent() {
+        val entity = DoorEventEntity(
+            doorPosition = DoorPosition.CLOSED,
+            message = "The door is closed.",
+            lastCheckInTimeSeconds = 1000L,
+            lastChangeTimeSeconds = 900L,
+        )
+        db.doorEventDao().insert(entity)
+
+        val result = runBlocking { db.doorEventDao().recentDoorEvents().first() }
+        assertEquals("Should have 1 door event", 1, result.size)
+        assertEquals(DoorPosition.CLOSED, result[0].doorPosition)
+        assertEquals("The door is closed.", result[0].message)
+        assertEquals(1000L, result[0].lastCheckInTimeSeconds)
+        assertEquals(900L, result[0].lastChangeTimeSeconds)
+    }
+
+    @Test
+    fun insertAndReadAppEvent() {
+        val event = AppEvent(
+            eventKey = "test_key",
+            timestamp = 12345L,
+        )
+        db.appLoggerDao().insert(event)
+
+        val result = runBlocking { db.appLoggerDao().getAll().first() }
+        assertEquals("Should have 1 app event", 1, result.size)
+        assertEquals("test_key", result[0].eventKey)
+    }
+
+    @Test
+    fun doorEventReplaceAll() {
+        val events = listOf(
+            DoorEventEntity(
+                doorPosition = DoorPosition.OPEN,
+                message = "Open",
+                lastChangeTimeSeconds = 100L,
+            ),
+            DoorEventEntity(
+                doorPosition = DoorPosition.CLOSED,
+                message = "Closed",
+                lastChangeTimeSeconds = 200L,
+            ),
+        )
+        db.doorEventDao().replaceAll(events)
+
+        val result = runBlocking { db.doorEventDao().recentDoorEvents().first() }
+        assertEquals("Should have 2 door events", 2, result.size)
+    }
+}

--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/di/ComponentGraphTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/di/ComponentGraphTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.di
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.chriscartland.garage.GarageApplication
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies the full kotlin-inject dependency graph resolves at runtime.
+ *
+ * This catches missing @Provides methods, constructor wiring errors, or
+ * R8 stripping that only surface on a real device. If AppComponent can
+ * create all ViewModels, the entire DI graph is valid.
+ */
+@RunWith(AndroidJUnit4::class)
+class ComponentGraphTest {
+    private val component: AppComponent
+        get() {
+            val app = InstrumentationRegistry
+                .getInstrumentation()
+                .targetContext.applicationContext as GarageApplication
+            return app.component
+        }
+
+    @Test
+    fun componentCreates() {
+        assertNotNull("AppComponent should create", component)
+    }
+
+    @Test
+    fun doorViewModelResolves() {
+        assertNotNull("DoorViewModel should resolve", component.doorViewModel)
+    }
+
+    @Test
+    fun authViewModelResolves() {
+        assertNotNull("AuthViewModel should resolve", component.authViewModel)
+    }
+
+    @Test
+    fun remoteButtonViewModelResolves() {
+        assertNotNull("RemoteButtonViewModel should resolve", component.remoteButtonViewModel)
+    }
+
+    @Test
+    fun appSettingsViewModelResolves() {
+        assertNotNull("AppSettingsViewModel should resolve", component.appSettingsViewModel)
+    }
+
+    @Test
+    fun appLoggerViewModelResolves() {
+        assertNotNull("AppLoggerViewModel should resolve", component.appLoggerViewModel)
+    }
+}


### PR DESCRIPTION
## Summary
- **Phase 7.1**: Configure Gradle Managed Device (Pixel 6, API 34, aosp-atd) + CI workflow
- **Phase 7.2**: `DatabaseSanityTest` — Room DB creates, DAOs accessible, insert/read DoorEvent + AppEvent (6 tests)
- **Phase 7.3**: `ComponentGraphTest` — kotlin-inject AppComponent resolves all 5 ViewModels (6 tests)
- Fix `ExampleInstrumentedTest` package name for `.debug` suffix

### CI workflow
- Triggers: push to `main` only (not PRs)
- Runs: `./gradlew pixel6Api34DebugAndroidTest`
- Uses KVM acceleration on GitHub Actions Linux runners
- Non-blocking: won't affect PR merges

### What these tests catch
- R8 stripping Room type converters or entity definitions
- Room schema mismatches between code and compiled schema
- Missing `@Provides` methods in kotlin-inject component
- Constructor wiring errors that only surface on device

## Test plan
- [x] `./scripts/validate.sh` passes
- [ ] Instrumented tests pass on device/emulator (CI will run post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)