### PR TITLE
feat: Add screenshot test infrastructure (Phase 6)

### DIFF
--- a/.claude/skills/update-android-screenshots/SKILL.md
+++ b/.claude/skills/update-android-screenshots/SKILL.md
@@ -1,0 +1,65 @@
+---
+description: Update Android reference screenshots for image tracking (not pixel-perfect verification).
+allowed-tools: Bash(*), Read, Glob, Grep
+user-invocable: true
+---
+
+# Update Android Screenshots
+
+Generate reference screenshots for tracking app appearance over time. These are for documentation and visual history — NOT pixel-perfect CI verification. Screenshots never block CI or PRs.
+
+## Purpose
+
+- Track how the app looks across releases
+- Generate Play Store assets and documentation images
+- Provide visual history of UI changes in git
+- Light/dark theme variants for all key screens and components
+
+## Steps
+
+### 1. Generate screenshots sequentially (avoids OOM)
+
+```bash
+./scripts/generate-android-screenshots.sh
+```
+
+This runs each test file in its own Gradle invocation, then auto-generates the gallery.
+
+### 2. Review the gallery
+
+Open `AndroidGarage/android-screenshot-tests/SCREENSHOT_GALLERY.md` to see all screenshots.
+
+### 3. Commit the references
+
+```bash
+git add AndroidGarage/android-screenshot-tests/src/screenshotTestDebug/reference/
+git add AndroidGarage/android-screenshot-tests/SCREENSHOT_GALLERY.md
+```
+
+## Adding New Screenshots
+
+1. Create or find a `@Preview` composable in the app code
+2. Add a screenshot test in `android-screenshot-tests/src/screenshotTest/kotlin/.../`:
+
+```kotlin
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(showBackground = true, name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun MyComponentPreviewTest() {
+    AppTheme {
+        MyComponentPreview()
+    }
+}
+```
+
+3. Run `./scripts/generate-android-screenshots.sh` to generate the reference PNGs
+
+## Notes
+
+- `updateDebugScreenshotTest` and `validateDebugScreenshotTest` can't run in the same Gradle invocation
+- To force single-invocation: `./gradlew :android-screenshot-tests:updateDebugScreenshotTest -PforceAllScreenshots`
+- Preview composables must be deterministic — use fixed `Instant.parse(...)` for timestamps, never `Clock.System.now()`
+- Reference PNGs are committed to git but are NOT validated in CI
+- The gallery markdown is auto-generated — do not edit it manually

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Run Android Lint
         working-directory: AndroidGarage
         run: ./gradlew :androidApp:lint
+      - name: Compile Screenshot Tests
+        working-directory: AndroidGarage
+        run: ./gradlew :android-screenshot-tests:compileDebugScreenshotTestKotlin
       - name: Clean secrets
         if: always()
         working-directory: AndroidGarage

--- a/AndroidGarage/android-screenshot-tests/build.gradle.kts
+++ b/AndroidGarage/android-screenshot-tests/build.gradle.kts
@@ -1,0 +1,99 @@
+plugins {
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.jetbrains.kotlin.android)
+    alias(libs.plugins.screenshot)
+}
+
+android {
+    namespace = "com.chriscartland.garage.screenshottests"
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 26
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+    buildFeatures {
+        compose = true
+    }
+    @Suppress("UnstableApiUsage")
+    experimentalProperties["android.experimental.enableScreenshotTest"] = true
+}
+
+dependencies {
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.ui)
+    implementation(libs.androidx.ui.graphics)
+    implementation(libs.androidx.ui.tooling.preview)
+    implementation(libs.androidx.material3)
+    debugImplementation(libs.androidx.ui.tooling)
+
+    screenshotTestImplementation(libs.screenshot.validation.api)
+    screenshotTestImplementation(libs.androidx.ui.test.junit4)
+    screenshotTestImplementation(libs.androidx.ui.test.manifest)
+
+    implementation(project(":androidApp"))
+    implementation(project(":domain"))
+}
+
+tasks.register("cleanReferenceScreenshots") {
+    group = "screenshot"
+    description = "Cleans the reference screenshots directory."
+    doLast {
+        val referenceDir = file("src/screenshotTestDebug/reference")
+        if (referenceDir.exists()) {
+            referenceDir.deleteRecursively()
+            println("Deleted reference screenshots: $referenceDir")
+        }
+    }
+}
+
+tasks.register<Exec>("generateScreenshotGallery") {
+    group = "screenshot"
+    description = "Generates a Markdown gallery of all reference screenshots."
+    workingDir = rootProject.projectDir
+    commandLine("./scripts/generate-android-screenshot-gallery.sh")
+}
+
+tasks.whenTaskAdded {
+    if (name == "updateDebugScreenshotTest") {
+        if (!project.hasProperty("retainedReferenceScreenshots")) {
+            dependsOn("cleanReferenceScreenshots")
+        }
+        finalizedBy("generateScreenshotGallery")
+    }
+    if (name in listOf("updateDebugScreenshotTest", "validateDebugScreenshotTest")) {
+        doFirst {
+            val isSequentialScript = project.hasProperty("retainedReferenceScreenshots")
+            val isForced = project.hasProperty("forceAllScreenshots")
+            if (!isSequentialScript && !isForced) {
+                error(
+                    """
+
+                    ===========================================================
+                    BLOCKED: Running all screenshot tests in a single Gradle
+                    invocation may cause OutOfMemoryError.
+                    ===========================================================
+
+                    Use the sequential script instead:
+                      ./scripts/generate-android-screenshots.sh
+
+                    To force a single-invocation run, add:
+                      -PforceAllScreenshots
+
+                    ===========================================================
+
+                    """.trimIndent(),
+                )
+            }
+        }
+    }
+}

--- a/AndroidGarage/android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/ComponentsScreenshotTest.kt
+++ b/AndroidGarage/android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/ComponentsScreenshotTest.kt
@@ -1,0 +1,126 @@
+package com.chriscartland.garage.screenshottests
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+import com.chriscartland.garage.ui.DoorStatusCardPreview
+import com.chriscartland.garage.ui.ErrorCardPreview
+import com.chriscartland.garage.ui.LogSummaryCardPreview
+import com.chriscartland.garage.ui.RecentDoorEventListItemPreview
+import com.chriscartland.garage.ui.RemoteButtonContentPreview
+import com.chriscartland.garage.ui.SnoozeNotificationCardPreview
+import com.chriscartland.garage.ui.UserInfoCardPreview
+import com.chriscartland.garage.ui.UserInfoNoUserPreview
+import com.chriscartland.garage.ui.theme.AppTheme
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun DoorStatusCardPreviewTest() {
+    AppTheme {
+        DoorStatusCardPreview()
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun RecentDoorEventListItemPreviewTest() {
+    AppTheme {
+        RecentDoorEventListItemPreview()
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun RemoteButtonContentPreviewTest() {
+    AppTheme {
+        RemoteButtonContentPreview()
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun ErrorCardPreviewTest() {
+    AppTheme {
+        ErrorCardPreview()
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun UserInfoCardPreviewTest() {
+    AppTheme {
+        UserInfoCardPreview()
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun UserInfoNoUserPreviewTest() {
+    AppTheme {
+        UserInfoNoUserPreview()
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun LogSummaryCardPreviewTest() {
+    AppTheme {
+        LogSummaryCardPreview()
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun SnoozeNotificationCardPreviewTest() {
+    AppTheme {
+        SnoozeNotificationCardPreview()
+    }
+}

--- a/AndroidGarage/android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/GarageDoorScreenshotTest.kt
+++ b/AndroidGarage/android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/GarageDoorScreenshotTest.kt
@@ -1,0 +1,96 @@
+package com.chriscartland.garage.screenshottests
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+import com.chriscartland.garage.ui.ClosedPreview
+import com.chriscartland.garage.ui.ClosingPreview
+import com.chriscartland.garage.ui.GarageIconPreview
+import com.chriscartland.garage.ui.MidwayPreview
+import com.chriscartland.garage.ui.OpenPreview
+import com.chriscartland.garage.ui.OpeningPreview
+import com.chriscartland.garage.ui.theme.AppTheme
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun GarageDoorClosedPreviewTest() {
+    AppTheme {
+        ClosedPreview()
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun GarageDoorOpenPreviewTest() {
+    AppTheme {
+        OpenPreview()
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun GarageDoorOpeningPreviewTest() {
+    AppTheme {
+        OpeningPreview()
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun GarageDoorClosingPreviewTest() {
+    AppTheme {
+        ClosingPreview()
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun GarageDoorMidwayPreviewTest() {
+    AppTheme {
+        MidwayPreview()
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun GarageIconPreviewTest() {
+    AppTheme {
+        GarageIconPreview()
+    }
+}

--- a/AndroidGarage/android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/ScreensScreenshotTest.kt
+++ b/AndroidGarage/android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/ScreensScreenshotTest.kt
@@ -1,0 +1,51 @@
+package com.chriscartland.garage.screenshottests
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+import com.chriscartland.garage.ui.DoorHistoryContentPreview
+import com.chriscartland.garage.ui.HomeContentPreview
+import com.chriscartland.garage.ui.ProfileContentPreview
+import com.chriscartland.garage.ui.theme.AppTheme
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun HomeScreenPreviewTest() {
+    AppTheme {
+        HomeContentPreview()
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun DoorHistoryScreenPreviewTest() {
+    AppTheme {
+        DoorHistoryContentPreview()
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun ProfileScreenPreviewTest() {
+    AppTheme {
+        ProfileContentPreview()
+    }
+}

--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -18,6 +18,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.screenshot) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
     alias(libs.plugins.google.devtools.ksp) apply false

--- a/AndroidGarage/gradle.properties
+++ b/AndroidGarage/gradle.properties
@@ -38,3 +38,5 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 org.gradle.configuration-cache=true
+# Screenshot tests (AGP Screenshot Plugin)
+android.experimental.enableScreenshotTest=true

--- a/AndroidGarage/gradle/libs.versions.toml
+++ b/AndroidGarage/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ lifecycle = "2.9.1"
 mockito = "5.14.2"
 playServicesAuth = "21.3.0"
 room = "2.7.2"
+screenshot = "0.0.1-alpha12"
 tracing = "1.3.0"
 spotless = "7.2.1"
 # Baseline Profiles
@@ -91,6 +92,7 @@ kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }
 mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
 play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version.ref = "playServicesAuth" }
+screenshot-validation-api = { group = "com.android.tools.screenshot", name = "screenshot-validation-api", version.ref = "screenshot" }
 androidx-credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }
 androidx-credentials-play-services-auth = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "credentials"}
 googleId = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "credentialsGoogleId" }
@@ -105,12 +107,14 @@ androidx-core = { group = "androidx.test", name = "core", version.ref = "core" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
+android-library = { id = "com.android.library", version.ref = "agp" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 gms = { id = "com.google.gms.google-services", version.ref = "gms" }
 google-devtools-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp"}
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 room = { id = "androidx.room", version.ref = "room" }
+screenshot = { id = "com.android.compose.screenshot", version.ref = "screenshot" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 # Baseline Profiles

--- a/AndroidGarage/settings.gradle.kts
+++ b/AndroidGarage/settings.gradle.kts
@@ -38,6 +38,7 @@ dependencyResolutionManagement {
 
 rootProject.name = "AndroidGarage"
 include(":androidApp")
+include(":android-screenshot-tests")
 include(":data")
 include(":domain")
 include(":macrobenchmark")

--- a/scripts/generate-android-screenshot-gallery.sh
+++ b/scripts/generate-android-screenshot-gallery.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Generate a Markdown gallery of all reference screenshots.
+
+OUTPUT_FILE="AndroidGarage/android-screenshot-tests/SCREENSHOT_GALLERY.md"
+REFERENCE_DIR="AndroidGarage/android-screenshot-tests/src/screenshotTestDebug/reference"
+
+echo "<!-- GENERATED FILE - DO NOT EDIT -->" > "$OUTPUT_FILE"
+echo "" >> "$OUTPUT_FILE"
+echo "# Screenshot Gallery" >> "$OUTPUT_FILE"
+echo "" >> "$OUTPUT_FILE"
+echo "Generated on $(date)" >> "$OUTPUT_FILE"
+echo "" >> "$OUTPUT_FILE"
+echo "## Table of Contents" >> "$OUTPUT_FILE"
+
+CONTENT_FILE=$(mktemp)
+current_class=""
+
+find "$REFERENCE_DIR" -name "*.png" 2>/dev/null | sort | while read -r filepath; do
+    relative_path="${filepath#AndroidGarage/android-screenshot-tests/}"
+    parent_dir=$(dirname "$filepath")
+    class_name=$(basename "$parent_dir")
+    filename=$(basename "$filepath")
+    test_name="${filename%.*}"
+
+    if [ "$class_name" != "$current_class" ]; then
+        current_class="$class_name"
+        echo "" >> "$CONTENT_FILE"
+        echo "## $class_name" >> "$CONTENT_FILE"
+        echo "- [$class_name](#$(echo "$class_name" | tr '[:upper:]' '[:lower:]'))" >> "$OUTPUT_FILE"
+    fi
+
+    echo "" >> "$CONTENT_FILE"
+    echo "### $test_name" >> "$CONTENT_FILE"
+    echo "<img src=\"$relative_path\" width=\"300\" />" >> "$CONTENT_FILE"
+done
+
+echo "" >> "$OUTPUT_FILE"
+cat "$CONTENT_FILE" >> "$OUTPUT_FILE"
+rm "$CONTENT_FILE"
+
+echo "Screenshot gallery generated at $OUTPUT_FILE"

--- a/scripts/generate-android-screenshots.sh
+++ b/scripts/generate-android-screenshots.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+# Generate Android reference screenshots sequentially to avoid OOM.
+# Each test file runs in its own Gradle invocation.
+
+echo "Cleaning reference screenshots..."
+AndroidGarage/gradlew -p AndroidGarage :android-screenshot-tests:cleanReferenceScreenshots
+
+for file in AndroidGarage/android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/*.kt; do
+    filename=$(basename "$file" .kt)
+    classname="com.chriscartland.garage.screenshottests.${filename}Kt"
+
+    echo "----------------------------------------------------------------"
+    echo "Running screenshot generation for $classname"
+    echo "----------------------------------------------------------------"
+
+    AndroidGarage/gradlew -p AndroidGarage :android-screenshot-tests:updateDebugScreenshotTest --tests "$classname" -PretainedReferenceScreenshots
+done
+
+echo "All screenshot tests completed."

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -59,6 +59,10 @@ $GRADLE :androidApp:testBenchmarkUnitTest && pass "testBenchmarkUnitTest" || fai
 step "Build Debug APK"
 $GRADLE :androidApp:assembleDebug && pass "assembleDebug" || fail "assembleDebug"
 
+step "Screenshot tests (compile)"
+$GRADLE :android-screenshot-tests:compileDebugScreenshotTestKotlin \
+    && pass "screenshot test compilation" || fail "screenshot test compilation"
+
 step "Room schema drift check"
 # After compilation, Room KSP generates schema JSON files.
 # If they differ from what's committed, the schema changed without being tracked.


### PR DESCRIPTION
## Summary
Adds screenshot test module following battery-butler's pattern. Screenshots are for **image tracking** — documenting how the app looks over time — NOT pixel-perfect CI verification.

### Infrastructure
- New `android-screenshot-tests` module with AGP Screenshot Plugin 0.0.1-alpha12
- `screenshotTest` source set with `@PreviewTest` + `@Preview` pattern
- OOM prevention: blocks single-invocation runs, requires sequential script
- Auto-generated `SCREENSHOT_GALLERY.md` after each update

### Screenshot tests (17 previews, light + dark = 34 images)
- **Screens**: Home, History, Profile
- **Components**: DoorStatusCard, RemoteButton, ErrorCard, UserInfoCard, LogSummaryCard, SnoozeNotificationCard, RecentDoorEventListItem
- **Garage door states**: Closed, Open, Opening, Closing, Midway, GarageIcon

### Scripts
- `scripts/generate-android-screenshots.sh` — sequential generation (avoids OOM)
- `scripts/generate-android-screenshot-gallery.sh` — markdown gallery generator

### Claude skill
- `/update-android-screenshots` — documents purpose and workflow

## Test plan
- [x] `./scripts/validate.sh` passes
- [ ] `./scripts/generate-android-screenshots.sh` generates reference PNGs (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)