### PR TITLE
feat: Auto-track post-merge CI failures via GitHub issues

### DIFF
--- a/.github/actions/ci-failure-tracker/action.yml
+++ b/.github/actions/ci-failure-tracker/action.yml
@@ -1,0 +1,102 @@
+name: CI Failure Tracker
+description: |
+  Creates a GitHub issue on CI failure, closes it on success.
+  Only one open issue per workflow at a time.
+
+inputs:
+  label:
+    description: Issue label for this workflow (e.g. "ci-failure/instrumented-tests")
+    required: true
+  result:
+    description: Job result ("success" or "failure")
+    required: true
+  workflow-name:
+    description: Human-readable workflow name for issue titles
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: On failure — create or update issue
+      if: inputs.result == 'failure'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        LABEL="${{ inputs.label }}"
+        WORKFLOW_NAME="${{ inputs.workflow-name }}"
+        RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        COMMIT_SHA="${{ github.sha }}"
+        COMMIT_SHORT="${COMMIT_SHA:0:7}"
+        COMMIT_URL="${{ github.server_url }}/${{ github.repository }}/commit/${COMMIT_SHA}"
+
+        # Find the PR that introduced this commit (if any)
+        PR_INFO=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}/pulls" \
+          --jq '.[0] | "PR #\(.number) (\(.title))"' 2>/dev/null || echo "direct push")
+
+        # Ensure label exists
+        gh label create "$LABEL" --color "d73a4a" --description "Auto-created: $WORKFLOW_NAME failure" 2>/dev/null || true
+
+        # Check for existing open issue
+        EXISTING=$(gh issue list --label "$LABEL" --state open --json number --jq '.[0].number' 2>/dev/null)
+
+        if [ -n "$EXISTING" ]; then
+          # Add a comment to existing issue
+          gh issue comment "$EXISTING" --body "$(cat <<EOF
+        ### Still failing
+
+        - **Run:** $RUN_URL
+        - **Commit:** [\`$COMMIT_SHORT\`]($COMMIT_URL)
+        - **Source:** $PR_INFO
+        EOF
+          )"
+          echo "Updated existing issue #$EXISTING"
+        else
+          # Create new issue
+          gh issue create \
+            --title "CI: $WORKFLOW_NAME failing" \
+            --label "$LABEL" \
+            --body "$(cat <<EOF
+        ## $WORKFLOW_NAME is failing on main
+
+        **First failure:**
+        - **Run:** $RUN_URL
+        - **Commit:** [\`$COMMIT_SHORT\`]($COMMIT_URL)
+        - **Source:** $PR_INFO
+
+        This issue was auto-created and will be auto-closed when the workflow passes again.
+        EOF
+          )"
+          echo "Created new issue"
+        fi
+
+    - name: On success — close any open failure issue
+      if: inputs.result == 'success'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        LABEL="${{ inputs.label }}"
+        RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        COMMIT_SHA="${{ github.sha }}"
+        COMMIT_SHORT="${COMMIT_SHA:0:7}"
+        COMMIT_URL="${{ github.server_url }}/${{ github.repository }}/commit/${COMMIT_SHA}"
+
+        PR_INFO=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}/pulls" \
+          --jq '.[0] | "PR #\(.number) (\(.title))"' 2>/dev/null || echo "direct push")
+
+        EXISTING=$(gh issue list --label "$LABEL" --state open --json number --jq '.[0].number' 2>/dev/null)
+
+        if [ -n "$EXISTING" ]; then
+          gh issue close "$EXISTING" --comment "$(cat <<EOF
+        ### Fixed
+
+        - **Run:** $RUN_URL
+        - **Commit:** [\`$COMMIT_SHORT\`]($COMMIT_URL)
+        - **Fixed by:** $PR_INFO
+        EOF
+          )"
+          echo "Closed issue #$EXISTING"
+        else
+          echo "No open failure issue to close"
+        fi

--- a/.github/actions/ci-failure-tracker/action.yml
+++ b/.github/actions/ci-failure-tracker/action.yml
@@ -88,12 +88,23 @@ runs:
         EXISTING=$(gh issue list --label "$LABEL" --state open --json number --jq '.[0].number' 2>/dev/null)
 
         if [ -n "$EXISTING" ]; then
+          # Check if the failing issue mentions the same commit (flaky test)
+          ISSUE_BODY=$(gh issue view "$EXISTING" --json body --jq '.body' 2>/dev/null)
+          ISSUE_COMMENTS=$(gh api "repos/${{ github.repository }}/issues/${EXISTING}/comments" \
+            --jq '.[].body' 2>/dev/null || echo "")
+          ISSUE_TEXT="${ISSUE_BODY}${ISSUE_COMMENTS}"
+
+          FLAKY_NOTE=""
+          if echo "$ISSUE_TEXT" | grep -qF "$COMMIT_SHORT"; then
+            FLAKY_NOTE=$'\n\n> ⚠️ **Flaky test detected:** This passed on the same commit (`'"$COMMIT_SHORT"'`) that previously failed. No code change fixed it — the failure was non-deterministic.'
+          fi
+
           gh issue close "$EXISTING" --comment "$(cat <<EOF
         ### Fixed
 
         - **Run:** $RUN_URL
         - **Commit:** [\`$COMMIT_SHORT\`]($COMMIT_URL)
-        - **Fixed by:** $PR_INFO
+        - **Fixed by:** $PR_INFO${FLAKY_NOTE}
         EOF
           )"
           echo "Closed issue #$EXISTING"

--- a/.github/workflows/instrumented-tests.yml
+++ b/.github/workflows/instrumented-tests.yml
@@ -57,3 +57,16 @@ jobs:
       - name: Clean secrets
         if: always()
         run: release/clean-secrets.sh
+
+  # Track failures via GitHub issues
+  track-failure:
+    if: always() && needs.detect-changes.outputs.android == 'true'
+    needs: [detect-changes, instrumented-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/ci-failure-tracker
+        with:
+          label: ci-failure/instrumented-tests
+          result: ${{ needs.instrumented-tests.result }}
+          workflow-name: Instrumented Tests


### PR DESCRIPTION
## Summary
Reusable `ci-failure-tracker` composite action that automatically manages GitHub issues for post-merge CI failures.

### On failure:
- Creates an issue labeled `ci-failure/<workflow>` with links to the failing run, commit, and source PR
- If an issue already exists, adds a "still failing" comment instead of creating a duplicate

### On success:
- Finds and closes any open failure issue for that workflow
- Adds a "fixed by" comment with links to the fixing run, commit, and PR

### Applied to:
- `instrumented-tests.yml` with label `ci-failure/instrumented-tests`

### Reusable pattern:
Any post-merge workflow can add this in 5 lines:
```yaml
track-failure:
  if: always()
  needs: [my-job]
  steps:
    - uses: ./.github/actions/ci-failure-tracker
      with:
        label: ci-failure/my-workflow
        result: ${{ needs.my-job.result }}
        workflow-name: My Workflow
```

**Note:** This PR includes the `instrumented-tests.yml` workflow file. If PR #105 merges first, this will conflict on that file — rebase required.

## Test plan
- [ ] Manually verify by triggering a failing instrumented test run
- [ ] Verify issue auto-closes on next passing run

🤖 Generated with [Claude Code](https://claude.com/claude-code)