### PR TITLE
fix: Add issues:write permission and scripts/ change detection

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -9,6 +9,10 @@ on:
   push:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+  issues: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -33,10 +37,10 @@ jobs:
             exit 0
           fi
 
-          if echo "$CHANGED" | grep -qE '^(AndroidGarage/|\.github/(workflows|actions)/)'; then
+          if echo "$CHANGED" | grep -qE '^(AndroidGarage/|scripts/|\.github/(workflows|actions)/)'; then
             echo "android=true" >> $GITHUB_OUTPUT
             echo "Android files changed:"
-            echo "$CHANGED" | grep -E '^(AndroidGarage/|\.github/(workflows|actions)/)'
+            echo "$CHANGED" | grep -E '^(AndroidGarage/|scripts/|\.github/(workflows|actions)/)'
           else
             echo "android=false" >> $GITHUB_OUTPUT
             echo "No Android files changed. Changed files:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,10 @@ jobs:
             exit 0
           fi
 
-          if echo "$CHANGED" | grep -qE '^(AndroidGarage/|\.github/(workflows|actions)/)'; then
+          if echo "$CHANGED" | grep -qE '^(AndroidGarage/|scripts/|\.github/(workflows|actions)/)'; then
             echo "android=true" >> $GITHUB_OUTPUT
             echo "Android files changed:"
-            echo "$CHANGED" | grep -E '^(AndroidGarage/|\.github/(workflows|actions)/)'
+            echo "$CHANGED" | grep -E '^(AndroidGarage/|scripts/|\.github/(workflows|actions)/)'
           else
             echo "android=false" >> $GITHUB_OUTPUT
             echo "No Android files changed. Changed files:"


### PR DESCRIPTION
## Summary
Two fixes that were pushed to PR #109 after it auto-merged:

1. **`permissions: issues: write`** on `ci-post-merge.yml` — required for `ci-failure-tracker` to create labels and issues. Without this, the tracker job fails with "could not add label: not found".
2. **`scripts/` in change detection** — changes to `validate.sh`, release scripts, etc. now trigger CI in both PR and post-merge workflows.

## Test plan
- [ ] Post-merge CI creates issue on instrumented test failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)