### PR TITLE
fix: Unify post-merge failure tracking into single issue

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -89,29 +89,28 @@ jobs:
         working-directory: AndroidGarage
         run: ./release/clean-secrets.sh
 
-  # Track build/test failures via GitHub issues
-  track-checks-failure:
-    name: Track Build Failure
+  # Track post-merge failures via a single GitHub issue
+  track-failure:
+    name: Track Post-Merge Failure
     if: always() && needs.changes.outputs.android == 'true'
-    needs: [changes, checks]
+    needs: [changes, checks, instrumented-tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Determine overall result
+        id: result
+        run: |
+          CHECKS="${{ needs.checks.result }}"
+          INSTRUMENTED="${{ needs.instrumented-tests.result }}"
+          echo "checks=$CHECKS" >> $GITHUB_OUTPUT
+          echo "instrumented=$INSTRUMENTED" >> $GITHUB_OUTPUT
+          if [[ "$CHECKS" == "failure" || "$INSTRUMENTED" == "failure" ]]; then
+            echo "overall=failure" >> $GITHUB_OUTPUT
+          else
+            echo "overall=success" >> $GITHUB_OUTPUT
+          fi
       - uses: ./.github/actions/ci-failure-tracker
         with:
-          label: ci-failure/build
-          result: ${{ needs.checks.result }}
-          workflow-name: Post-Merge Build Checks
-
-  track-instrumented-failure:
-    name: Track Instrumented Tests Failure
-    if: always() && needs.changes.outputs.android == 'true'
-    needs: [changes, instrumented-tests]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/ci-failure-tracker
-        with:
-          label: ci-failure/instrumented-tests
-          result: ${{ needs.instrumented-tests.result }}
-          workflow-name: Instrumented Tests
+          label: ci-failure/post-merge
+          result: ${{ steps.result.outputs.overall }}
+          workflow-name: "Post-Merge CI (checks: ${{ steps.result.outputs.checks }}, instrumented: ${{ steps.result.outputs.instrumented }})"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ Run `./scripts/validate.sh` before pushing. It mirrors CI: spotless (all modules
 
 ### CI Architecture
 - **Pre-submit** (`ci.yml` → `ci-checks.yml`): Runs on PRs. Gate job `CI Complete` is the required status check.
-- **Post-merge** (`ci-post-merge.yml` → `ci-checks.yml` + instrumented tests): Runs on push to main. Auto-creates GitHub issues on failure (`ci-failure/build`, `ci-failure/instrumented-tests`), auto-closes on fix with flakiness detection.
+- **Post-merge** (`ci-post-merge.yml` → `ci-checks.yml` + instrumented tests): Runs on push to main. Auto-creates GitHub issue on failure (`ci-failure/post-merge`), auto-closes on fix with flakiness detection.
 - **Screenshot generation**: Use `./scripts/generate-android-screenshots.sh` (never run screenshot Gradle tasks directly — hooks block this).
 
 ### Room Database Safety


### PR DESCRIPTION
## Summary
Replace two separate failure trackers with one:

**Before:** Two labels, two issues for the same broken commit
- `ci-failure/build` — shared checks failures
- `ci-failure/instrumented-tests` — instrumented test failures

**After:** One label, one issue
- `ci-failure/post-merge` — any post-merge failure
- Issue title includes which jobs failed: "Post-Merge CI (checks: success, instrumented: failure)"

Closes #112 (will be replaced by unified tracking)

## Test plan
- [ ] Next post-merge failure creates issue with `ci-failure/post-merge` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)