### PR TITLE
fix: Make currentDoorEvent nullable to handle empty database

### DIFF
--- a/.claude/hooks/git-guardrails.sh
+++ b/.claude/hooks/git-guardrails.sh
@@ -106,6 +106,26 @@ if echo "$STRIPPED" | grep -qE '\bgit\s+(add|commit)\b'; then
   fi
 fi
 
+# --- Warn when changes should trigger instrumented tests ---
+if echo "$STRIPPED" | grep -qE '\bgit\s+push\b'; then
+  if [ -n "$REPO_ROOT" ]; then
+    CHANGED_FILES=$(git diff --name-only origin/main...HEAD 2>/dev/null)
+    NEEDS_INSTRUMENTED=false
+    for f in $CHANGED_FILES; do
+      case "$f" in
+        *Entity.kt|*Dao.kt|*AppDatabase.kt|*AppComponent.kt|*MainActivity.kt|*Main.kt|*Navigation*.kt|*LocalDoorDataSource.kt|*DoorRepository*.kt)
+          NEEDS_INSTRUMENTED=true
+          break
+          ;;
+      esac
+    done
+    if [ "$NEEDS_INSTRUMENTED" = "true" ]; then
+      echo "WARNING: Changes touch Room/DI/navigation code." >&2
+      echo "  Consider running instrumented tests: ./scripts/run-instrumented-tests.sh" >&2
+    fi
+  fi
+fi
+
 # --- Block destructive git commands ---
 if echo "$STRIPPED" | grep -qE '\bgit\s+reset\s+--hard\b'; then
   deny "BLOCKED: git reset --hard discards commits. Use git stash or a backup branch."

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/db/DatabaseLocalDoorDataSource.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/db/DatabaseLocalDoorDataSource.kt
@@ -26,8 +26,8 @@ import kotlinx.coroutines.flow.map
 class DatabaseLocalDoorDataSource(
     private val appDatabase: AppDatabase,
 ) : LocalDoorDataSource {
-    override val currentDoorEvent: Flow<DoorEvent> =
-        appDatabase.doorEventDao().currentDoorEvent().map { it.toDomain() }
+    override val currentDoorEvent: Flow<DoorEvent?> =
+        appDatabase.doorEventDao().currentDoorEvent().map { it?.toDomain() }
     override val recentDoorEvents: Flow<List<DoorEvent>> =
         appDatabase.doorEventDao().recentDoorEvents().map { entities ->
             entities.map { it.toDomain() }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/db/DoorEventDao.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/db/DoorEventDao.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface DoorEventDao {
     @Query("SELECT * FROM DoorEvent ORDER BY lastChangeTimeSeconds DESC LIMIT 1")
-    fun currentDoorEvent(): Flow<DoorEventEntity>
+    fun currentDoorEvent(): Flow<DoorEventEntity?>
 
     @Query("SELECT * FROM DoorEvent ORDER BY lastChangeTimeSeconds DESC")
     fun recentDoorEvents(): Flow<List<DoorEventEntity>>

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorRepositoryImpl.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorRepositoryImpl.kt
@@ -38,10 +38,9 @@ class DoorRepositoryImpl(
         get() =
             localDoorDataSource.currentDoorEvent
                 .map {
-                    // [it] can be null -- this might be a Kotlin bug
                     it?.doorPosition ?: DoorPosition.UNKNOWN
                 }.distinctUntilChanged()
-    override val currentDoorEvent: Flow<DoorEvent> = localDoorDataSource.currentDoorEvent
+    override val currentDoorEvent: Flow<DoorEvent?> = localDoorDataSource.currentDoorEvent
     override val recentDoorEvents: Flow<List<DoorEvent>> = localDoorDataSource.recentDoorEvents
 
     override suspend fun fetchBuildTimestampCached(): String? = serverConfigRepository.getServerConfigCached()?.buildTimestamp

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakeDoorRepository.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakeDoorRepository.kt
@@ -29,7 +29,7 @@ class FakeDoorRepository : DoorRepository {
     private val _currentDoorPosition = MutableStateFlow(DoorPosition.UNKNOWN)
 
     override val currentDoorPosition: Flow<DoorPosition> = _currentDoorPosition
-    override val currentDoorEvent: Flow<DoorEvent> = _currentDoorEvent
+    override val currentDoorEvent: Flow<DoorEvent?> = _currentDoorEvent
     override val recentDoorEvents: Flow<List<DoorEvent>> = _recentDoorEvents
 
     var fetchCurrentDoorEventCount = 0

--- a/AndroidGarage/data/src/main/kotlin/com/chriscartland/garage/data/LocalDoorDataSource.kt
+++ b/AndroidGarage/data/src/main/kotlin/com/chriscartland/garage/data/LocalDoorDataSource.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.Flow
  * without leaking implementation details to the Repository layer.
  */
 interface LocalDoorDataSource {
-    val currentDoorEvent: Flow<DoorEvent>
+    val currentDoorEvent: Flow<DoorEvent?>
     val recentDoorEvents: Flow<List<DoorEvent>>
 
     fun insertDoorEvent(doorEvent: DoorEvent)

--- a/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/repository/DoorRepository.kt
+++ b/AndroidGarage/domain/src/main/kotlin/com/chriscartland/garage/domain/repository/DoorRepository.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface DoorRepository {
     val currentDoorPosition: Flow<DoorPosition>
-    val currentDoorEvent: Flow<DoorEvent>
+    val currentDoorEvent: Flow<DoorEvent?>
     val recentDoorEvents: Flow<List<DoorEvent>>
 
     suspend fun fetchBuildTimestampCached(): String?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,9 @@ Firestore Functions: Event-driven processing on data changes
 ### Local Validation
 Run `./scripts/validate.sh` before pushing. It mirrors CI: spotless (all modules), lint, unit tests (3 variants), domain tests, debug build, screenshot test compilation, and Room schema drift check. Writes a validation marker so the git-guardrails hook can warn on stale pushes.
 
+### Instrumented Tests
+Run `./scripts/run-instrumented-tests.sh` when changing Room entities/DAOs, DI wiring (AppComponent), navigation, or Activity lifecycle code. Requires a connected device or emulator. Not part of `validate.sh` (too slow for every run). A git hook warns on push when these files are changed.
+
 ### CI Architecture
 - **Pre-submit** (`ci.yml` → `ci-checks.yml`): Runs on PRs. Gate job `CI Complete` is the required status check.
 - **Post-merge** (`ci-post-merge.yml` → `ci-checks.yml` + instrumented tests): Runs on push to main. Auto-creates GitHub issue on failure (`ci-failure/post-merge`), auto-closes on fix with flakiness detection.

--- a/scripts/run-instrumented-tests.sh
+++ b/scripts/run-instrumented-tests.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run instrumented tests on a connected device or emulator.
+# Not part of validate.sh — run manually when touching Room, DI, navigation, or Activity code.
+#
+# Requires: a connected device or running emulator (check with `adb devices`)
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GRADLE="$REPO_ROOT/AndroidGarage/gradlew -p $REPO_ROOT/AndroidGarage"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+# Check for connected device
+if ! adb devices 2>/dev/null | grep -q "device$"; then
+    echo -e "${RED}No device/emulator connected.${RESET}"
+    echo "Start an emulator or connect a device, then retry."
+    echo ""
+    echo "  # Start an emulator:"
+    echo "  emulator -avd <name> &"
+    echo ""
+    echo "  # Or use Gradle Managed Device (slower, no physical device needed):"
+    echo "  $GRADLE :androidApp:pixel6Api34DebugAndroidTest"
+    exit 1
+fi
+
+echo -e "${BOLD}Running instrumented tests on connected device...${RESET}"
+echo ""
+
+$GRADLE :androidApp:connectedDebugAndroidTest
+
+echo ""
+echo -e "${GREEN}${BOLD}All instrumented tests passed.${RESET}"


### PR DESCRIPTION
## Summary
Fix `IllegalStateException` in instrumented tests (and potentially on first app launch) caused by Room querying an empty table with a non-nullable return type.

The `DoorEventDao.currentDoorEvent()` returned `Flow<DoorEventEntity>` — when the table is empty, Room throws because it expects a non-null row. Changed to `Flow<DoorEventEntity?>` through the entire data chain.

**This fixes the CI failure in issue #112.**

## Changes
- `DoorEventDao`: `Flow<DoorEventEntity>` → `Flow<DoorEventEntity?>`
- `LocalDoorDataSource`: `Flow<DoorEvent>` → `Flow<DoorEvent?>`
- `DoorRepository`: `Flow<DoorEvent>` → `Flow<DoorEvent?>`
- Implementations and test fakes updated to match

The UI already handled null (`LoadingResult<DoorEvent?>`) so no UI changes needed.

## Test plan
- [x] `./scripts/validate.sh` passes (all 135+ unit tests pass)
- [x] Room schema unchanged
- [ ] Instrumented tests pass on CI (this was the failing test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)