### PR TITLE
fix: Update release checks for post-merge CI + recover lost files

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -89,6 +89,28 @@ jobs:
         working-directory: AndroidGarage
         run: ./release/clean-secrets.sh
 
+  # Gate job — single check-run name for release script to verify.
+  post-merge-complete:
+    name: Post-Merge Complete
+    if: always()
+    needs: [checks, instrumented-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        run: |
+          echo "Checks: ${{ needs.checks.result }}"
+          echo "Instrumented: ${{ needs.instrumented-tests.result }}"
+
+          if [[ "${{ needs.checks.result }}" == "failure" || \
+                "${{ needs.instrumented-tests.result }}" == "failure" || \
+                "${{ needs.checks.result }}" == "cancelled" || \
+                "${{ needs.instrumented-tests.result }}" == "cancelled" ]]; then
+            echo "::error::Post-merge CI failed"
+            exit 1
+          fi
+
+          echo "All post-merge checks passed (or skipped — no Android changes)"
+
   # Track post-merge failures via a single GitHub issue
   track-failure:
     name: Track Post-Merge Failure

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -35,12 +35,13 @@ jobs:
           TAG_SHA="${{ steps.get-sha.outputs.sha }}"
           echo "Checking CI status for commit $TAG_SHA..."
 
+          # Check post-merge CI results (check-run names from ci-checks.yml reusable workflow)
           TESTS_CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA/check-runs" \
-            --jq '[.check_runs[] | select(.name == "Unit Tests")] | last | .conclusion')
+            --jq '[.check_runs[] | select(.name | contains("Unit Tests"))] | last | .conclusion')
           FORMAT_CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA/check-runs" \
-            --jq '[.check_runs[] | select(.name == "Formatting & Static Analysis")] | last | .conclusion')
+            --jq '[.check_runs[] | select(.name | contains("Formatting"))] | last | .conclusion')
           BUILD_CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA/check-runs" \
-            --jq '[.check_runs[] | select(.name == "Build Debug APK")] | last | .conclusion')
+            --jq '[.check_runs[] | select(.name | contains("Build Debug APK"))] | last | .conclusion')
 
           echo "Tests: $TESTS_CONCLUSION"
           echo "Formatting: $FORMAT_CONCLUSION"

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -35,36 +35,18 @@ jobs:
           TAG_SHA="${{ steps.get-sha.outputs.sha }}"
           echo "Checking CI status for commit $TAG_SHA..."
 
-          # Check post-merge CI results (check-run names from ci-checks.yml reusable workflow)
-          TESTS_CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA/check-runs" \
-            --jq '[.check_runs[] | select(.name | contains("Unit Tests"))] | last | .conclusion')
-          FORMAT_CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA/check-runs" \
-            --jq '[.check_runs[] | select(.name | contains("Formatting"))] | last | .conclusion')
-          BUILD_CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA/check-runs" \
-            --jq '[.check_runs[] | select(.name | contains("Build Debug APK"))] | last | .conclusion')
+          # Check the single post-merge gate job
+          POST_MERGE=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA/check-runs" \
+            --jq '[.check_runs[] | select(.name == "Post-Merge Complete")] | last | .conclusion')
 
-          echo "Tests: $TESTS_CONCLUSION"
-          echo "Formatting: $FORMAT_CONCLUSION"
-          echo "Build: $BUILD_CONCLUSION"
+          echo "Post-Merge Complete: $POST_MERGE"
 
-          FAILED=false
-          if [ "$TESTS_CONCLUSION" != "success" ]; then
-            echo "::error::Unit Tests concluded '$TESTS_CONCLUSION', expected 'success'"
-            FAILED=true
-          fi
-          if [ "$FORMAT_CONCLUSION" != "success" ]; then
-            echo "::error::Formatting concluded '$FORMAT_CONCLUSION', expected 'success'"
-            FAILED=true
-          fi
-          if [ "$BUILD_CONCLUSION" != "success" ]; then
-            echo "::error::Build concluded '$BUILD_CONCLUSION', expected 'success'"
-            FAILED=true
-          fi
-          if [ "$FAILED" = true ]; then
+          if [ "$POST_MERGE" != "success" ]; then
+            echo "::error::Post-Merge Complete concluded '$POST_MERGE', expected 'success'"
             exit 1
           fi
 
-          echo "All CI checks passed on commit $TAG_SHA"
+          echo "Post-merge CI passed on commit $TAG_SHA"
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/db/DaoNullabilityTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/db/DaoNullabilityTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.db
+
+import org.junit.Assert.fail
+import org.junit.Test
+import java.io.File
+
+/**
+ * Scans Room DAO source files for non-nullable single-row return types.
+ *
+ * Room throws IllegalStateException at runtime when a query returns no rows
+ * but the return type is non-nullable. This is a common bug that only
+ * manifests on empty databases (fresh install, cleared data).
+ *
+ * Rule: Any @Query DAO method returning a single object (not List, not
+ * aggregate like Long/Int) must use a nullable return type (T? or Flow<T?>).
+ */
+class DaoNullabilityTest {
+    private val daoDir = File("src/main/java/com/chriscartland/garage")
+
+    @Test
+    fun daoQueriesReturningSingleObjectsMustBeNullable() {
+        val daoFiles = daoDir
+            .walkTopDown()
+            .filter { it.name.endsWith("Dao.kt") }
+            .toList()
+
+        if (daoFiles.isEmpty()) {
+            fail("No DAO files found in $daoDir")
+        }
+
+        val violations = daoFiles.flatMap { findNullabilityViolations(it) }
+
+        if (violations.isNotEmpty()) {
+            fail(
+                "Found ${violations.size} DAO method(s) with non-nullable single-object return types:\n\n" +
+                    violations.joinToString("\n\n"),
+            )
+        }
+    }
+
+    private fun findNullabilityViolations(file: File): List<String> {
+        val lines = file.readLines()
+        return lines.indices
+            .filter { lines[it].trim().startsWith("@Query(") }
+            .mapNotNull { i ->
+                val funLine = findFunLine(lines, i) ?: return@mapNotNull null
+                val returnType = extractReturnType(funLine) ?: return@mapNotNull null
+                if (isSingleObjectReturn(returnType) && !isNullable(returnType)) {
+                    "${file.name}: $funLine\n" +
+                        "  Return type '$returnType' should be nullable. " +
+                        "Room throws IllegalStateException on empty result with non-nullable types."
+                } else {
+                    null
+                }
+            }
+    }
+
+    private fun findFunLine(
+        lines: List<String>,
+        queryLineIndex: Int,
+    ): String? {
+        // The fun declaration may be on the same line or within the next few lines
+        for (j in queryLineIndex..minOf(queryLineIndex + 3, lines.size - 1)) {
+            val line = lines[j].trim()
+            if (line.startsWith("fun ") || line.contains(" fun ")) {
+                return line
+            }
+        }
+        return null
+    }
+
+    private fun extractReturnType(funLine: String): String? {
+        // Match ): ReturnType or ): ReturnType<Generic>
+        val match = Regex("""\):\s*(.+)$""").find(funLine) ?: return null
+        return match.groupValues[1].trim()
+    }
+
+    private fun isSingleObjectReturn(returnType: String): Boolean {
+        // Skip List returns — they return empty list, not null
+        if (returnType.contains("List<")) return false
+        // Skip aggregate returns (COUNT, SUM, etc. always return a value)
+        if (returnType.startsWith("Int") || returnType.startsWith("Long")) return false
+        if (returnType.startsWith("Flow<Int") || returnType.startsWith("Flow<Long")) return false
+        // Skip Unit/void
+        if (returnType == "Unit" || returnType.isEmpty()) return false
+        // Everything else is a single-object return
+        return true
+    }
+
+    private fun isNullable(returnType: String): Boolean {
+        // Flow<T?> or T?
+        return returnType.endsWith("?>") || returnType.endsWith("?")
+    }
+}

--- a/AndroidGarage/docs/library-bugs/README.md
+++ b/AndroidGarage/docs/library-bugs/README.md
@@ -1,0 +1,15 @@
+# Library Bugs & Issues
+
+Known bugs or design issues in third-party libraries that affect this project. One file per issue.
+
+Each file documents:
+- **What** — the bug and how to reproduce
+- **Impact** — when it manifests in our code
+- **Mitigation** — our safeguards (tests, lint, patterns)
+- **Upstream status** — whether a bug has been filed and its state
+
+## Index
+
+| File | Library | Summary | Mitigated? |
+|------|---------|---------|------------|
+| [room-nullability.md](room-nullability.md) | Room 2.7.2 | Non-nullable `@Query` return types crash on empty tables instead of compile-time error | Yes — unit test + nullable types |

--- a/AndroidGarage/docs/library-bugs/room-nullability.md
+++ b/AndroidGarage/docs/library-bugs/room-nullability.md
@@ -1,0 +1,66 @@
+# Room Nullability Bug
+
+## The Problem
+
+Room silently accepts non-nullable return types on `@Query` methods that can return zero rows, then throws `IllegalStateException` at runtime instead of failing at compile time.
+
+```kotlin
+// COMPILES but CRASHES at runtime on empty table
+@Query("SELECT * FROM DoorEvent ORDER BY lastChangeTimeSeconds DESC LIMIT 1")
+fun currentDoorEvent(): Flow<DoorEventEntity>
+```
+
+```
+java.lang.IllegalStateException: The query result was empty,
+but expected a single row to return a NON-NULL object of type
+<com.chriscartland.garage.db.DoorEventEntity>.
+```
+
+## Why This Is a Bug
+
+Kotlin's type system guarantees that non-nullable types never hold null. Room's annotation processor (`room-compiler`) generates the DAO implementation at compile time — it knows the query, knows the return type, and knows that `LIMIT 1` can return zero rows. It should either:
+
+1. **Fail at compile time** with an error: "Query may return no rows but return type is non-nullable. Use `DoorEventEntity?`."
+2. **Not emit** to the Flow when there are no rows (instead of throwing).
+
+Instead, Room generates code that calls `__db.assertNotSuspendingTransaction()` and then throws when the cursor is empty. The non-nullable contract is violated at the Room-generated boundary, not in user code.
+
+## When It Manifests
+
+- Fresh app install (database empty, first network fetch hasn't completed)
+- After clearing app data
+- In instrumented tests on a fresh emulator
+- Any race condition where a Room Flow is collected before data is inserted
+
+The bug is timing-dependent: if data arrives before the Flow emits, the crash never happens. This makes it hard to catch in manual testing.
+
+## The Fix
+
+Use nullable return types for any `@Query` that can return zero rows:
+
+```kotlin
+// CORRECT — nullable, handles empty table
+@Query("SELECT * FROM DoorEvent ORDER BY lastChangeTimeSeconds DESC LIMIT 1")
+fun currentDoorEvent(): Flow<DoorEventEntity?>
+```
+
+Queries returning `List<T>` are safe — Room returns an empty list, not null.
+
+Aggregate queries (`SELECT COUNT(*)`) are safe — they always return a value.
+
+## Our Safeguards
+
+1. **`DaoNullabilityTest`** — Source-scanning unit test that checks all `*Dao.kt` files for `@Query` methods returning non-nullable single objects. Fails the build if found.
+
+2. **Instrumented tests** — `ComponentGraphTest` creates all ViewModels (which trigger Room queries), catching this crash on an empty database.
+
+3. **Git hook** — Warns on push when Room/DAO files are modified, suggesting `./scripts/run-instrumented-tests.sh`.
+
+## Affected Versions
+
+Observed in Room 2.7.2 (our version). This behavior has existed since Room first supported Kotlin coroutines. As of April 2026, there is no compile-time check from Room for this issue.
+
+## References
+
+- [Our fix commit](https://github.com/cartland/SmartGarageDoor/pull/115) — Made `currentDoorEvent` nullable through DAO → DataSource → Repository chain
+- [Room documentation](https://developer.android.com/training/data-storage/room/accessing-data) — Does not warn about this behavior

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,7 @@ Detailed project documentation lives in `AndroidGarage/docs/`:
 - [Decisions](AndroidGarage/docs/DECISIONS.md) — Architectural decision records (ADRs): server-centric design, tech stack, testing philosophy, migration targets
 - [Migration](AndroidGarage/docs/MIGRATION.md) — Phased roadmap toward battery-butler tech stack (kotlin-inject, Ktor, clean architecture, KMP)
 - [Testing](AndroidGarage/docs/TESTING.md) — CI stability plan, testing phases, priority order
+- [Library Bugs](AndroidGarage/docs/library-bugs/) — Known third-party library bugs with mitigations
 
 ## Safety Rules
 

--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -199,32 +199,24 @@ check_existing_tags
 echo "Checking CI status on HEAD..."
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
 if [ -n "$REPO" ]; then
-    # Check the required CI checks (matches job names from ci-checks.yml reusable workflow)
-    # Names are "Checks / Unit Tests" (post-merge) or "Unit Tests" (PR). Use contains() for both.
-    TESTS_STATUS=$(gh api "repos/${REPO}/commits/${CURRENT_COMMIT}/check-runs" \
-        --jq '[.check_runs[] | select(.name | contains("Unit Tests"))] | last | .conclusion' 2>/dev/null || echo "")
-    FORMAT_STATUS=$(gh api "repos/${REPO}/commits/${CURRENT_COMMIT}/check-runs" \
-        --jq '[.check_runs[] | select(.name | contains("Formatting"))] | last | .conclusion' 2>/dev/null || echo "")
-    BUILD_STATUS=$(gh api "repos/${REPO}/commits/${CURRENT_COMMIT}/check-runs" \
-        --jq '[.check_runs[] | select(.name | contains("Build Debug APK"))] | last | .conclusion' 2>/dev/null || echo "")
+    # Check the single post-merge gate job (ci-post-merge.yml → Post-Merge Complete)
+    POST_MERGE_STATUS=$(gh api "repos/${REPO}/commits/${CURRENT_COMMIT}/check-runs" \
+        --jq '[.check_runs[] | select(.name == "Post-Merge Complete")] | last | .conclusion' 2>/dev/null || echo "")
 
-    if [ "$TESTS_STATUS" = "success" ] && [ "$FORMAT_STATUS" = "success" ] && [ "$BUILD_STATUS" = "success" ]; then
+    if [ "$POST_MERGE_STATUS" = "success" ]; then
         echo -e "${GREEN}CI passed on HEAD.${RESET}"
-    elif [ -z "$TESTS_STATUS" ] && [ -z "$FORMAT_STATUS" ] && [ -z "$BUILD_STATUS" ]; then
-        echo -e "${YELLOW}Warning: No CI results found for HEAD.${RESET}"
+    elif [ -z "$POST_MERGE_STATUS" ] || [ "$POST_MERGE_STATUS" = "null" ]; then
+        echo -e "${YELLOW}Warning: Post-merge CI has not completed on HEAD.${RESET}"
         if [ "$MODE" = "interactive" ]; then
             read -p "Continue anyway? (y/N) " -n 1 -r
             echo ""
             [[ $REPLY =~ ^[Yy]$ ]] || { echo "Aborted."; exit 1; }
         else
-            echo -e "${RED}Error: CI has not run on HEAD. Cannot release without CI.${RESET}"
+            echo -e "${RED}Error: Post-merge CI has not run on HEAD. Cannot release without CI.${RESET}"
             exit 1
         fi
     else
-        echo -e "${RED}Error: CI did not pass on HEAD.${RESET}"
-        echo "  Tests: $TESTS_STATUS"
-        echo "  Formatting: $FORMAT_STATUS"
-        echo "  Build: $BUILD_STATUS"
+        echo -e "${RED}Error: Post-merge CI failed on HEAD (status: $POST_MERGE_STATUS).${RESET}"
         exit 1
     fi
 fi

--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -199,13 +199,14 @@ check_existing_tags
 echo "Checking CI status on HEAD..."
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
 if [ -n "$REPO" ]; then
-    # Check the required CI checks (matches job names in ci.yml)
+    # Check the required CI checks (matches job names from ci-checks.yml reusable workflow)
+    # Names are "Checks / Unit Tests" (post-merge) or "Unit Tests" (PR). Use contains() for both.
     TESTS_STATUS=$(gh api "repos/${REPO}/commits/${CURRENT_COMMIT}/check-runs" \
-        --jq '[.check_runs[] | select(.name == "Unit Tests")] | last | .conclusion' 2>/dev/null || echo "")
+        --jq '[.check_runs[] | select(.name | contains("Unit Tests"))] | last | .conclusion' 2>/dev/null || echo "")
     FORMAT_STATUS=$(gh api "repos/${REPO}/commits/${CURRENT_COMMIT}/check-runs" \
-        --jq '[.check_runs[] | select(.name == "Formatting & Static Analysis")] | last | .conclusion' 2>/dev/null || echo "")
+        --jq '[.check_runs[] | select(.name | contains("Formatting"))] | last | .conclusion' 2>/dev/null || echo "")
     BUILD_STATUS=$(gh api "repos/${REPO}/commits/${CURRENT_COMMIT}/check-runs" \
-        --jq '[.check_runs[] | select(.name == "Build Debug APK")] | last | .conclusion' 2>/dev/null || echo "")
+        --jq '[.check_runs[] | select(.name | contains("Build Debug APK"))] | last | .conclusion' 2>/dev/null || echo "")
 
     if [ "$TESTS_STATUS" = "success" ] && [ "$FORMAT_STATUS" = "success" ] && [ "$BUILD_STATUS" = "success" ]; then
         echo -e "${GREEN}CI passed on HEAD.${RESET}"


### PR DESCRIPTION
## Summary
- Release script and workflow now match post-merge check-run names (`Checks / Unit Tests` etc.) using `contains()`
- Recovers files lost to auto-merge race in PR #115:
  - `DaoNullabilityTest` — catches non-nullable Room DAO return types at unit test time
  - `docs/library-bugs/` — directory for known third-party issues
  - `docs/library-bugs/room-nullability.md` — Room nullability bug docs

## Test plan
- [x] `./scripts/validate.sh` passes
- [ ] `scripts/release-android.sh --check` works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)