### PR TITLE
docs: Update test count (138 unit + 18 instrumented)

### DIFF
--- a/AndroidGarage/docs/TESTING.md
+++ b/AndroidGarage/docs/TESTING.md
@@ -13,7 +13,7 @@
 
 ## Current State
 
-- **~135 unit tests** across 17 test files (15 androidApp + 2 domain module)
+- **138 unit tests** across 21 test files (19 androidApp + 2 domain module), including DaoNullabilityTest
 - **18 instrumented tests** across 4 test files (Room sanity, DI graph, navigation smoke, example)
 - **CI architecture:** pre-submit (`ci.yml` → `ci-checks.yml`) + post-merge (`ci-post-merge.yml` → `ci-checks.yml` + instrumented tests)
 - **CI checks:** unit tests (3 build variants), Spotless formatting (all modules), Detekt, Android Lint, screenshot test compilation, debug APK build, release AAB build


### PR DESCRIPTION
## Summary
- Update TESTING.md: 138 unit tests across 21 files (was ~135 across 17)
- DaoNullabilityTest is the new addition

## Test plan
- Docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)