### PR TITLE
feat: Semantic versioning (2.3.0) with build timestamp

### DIFF
--- a/AndroidGarage/androidApp/build.gradle.kts
+++ b/AndroidGarage/androidApp/build.gradle.kts
@@ -15,7 +15,8 @@
  *
  */
 
-import java.time.LocalDateTime
+import java.time.Instant
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Properties
 
@@ -62,7 +63,11 @@ android {
         // Falls back to 1 for local development builds
         val tagVersionCode = (project.findProperty("VERSION_CODE") as? String)?.toIntOrNull()
         versionCode = tagVersionCode ?: 1
-        versionName = "2.2-" + generateVersionNameTimestamp()
+        // versionName from version.properties (manually bumped, semver)
+        val versionProps = Properties().apply {
+            rootProject.file("version.properties").inputStream().use { load(it) }
+        }
+        versionName = versionProps.getProperty("versionName")
         setProperty("archivesBaseName", "$applicationId-$versionName-$versionCode")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -91,6 +96,15 @@ android {
             "String",
             "GOOGLE_WEB_CLIENT_ID",
             "\"${googleWebClientId ?: ""}\"",
+        )
+        val buildTimestamp = DateTimeFormatter
+            .ofPattern("yyyyMMdd.HHmmss")
+            .withZone(ZoneOffset.UTC)
+            .format(Instant.now())
+        buildConfigField(
+            "String",
+            "BUILD_TIMESTAMP",
+            "\"$buildTimestamp\"",
         )
     }
 
@@ -205,12 +219,6 @@ androidComponents {
             }
         }
     }
-}
-
-fun generateVersionNameTimestamp(): String {
-    val currentDateTime = LocalDateTime.now()
-    val formatter = DateTimeFormatter.ofPattern("yyyyMMdd.HHmmss")
-    return currentDateTime.format(formatter)
 }
 
 room {

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/AndroidAppInfoCard.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/AndroidAppInfoCard.kt
@@ -95,6 +95,11 @@ fun AndroidAppInfoCard(
             textAlign = TextAlign.Center,
         )
         Text(
+            "Build: ${appVersion.buildTimestamp}",
+            style = MaterialTheme.typography.labelSmall,
+            textAlign = TextAlign.Center,
+        )
+        Text(
             "Privacy Policy: $PRIVACY_POLICY_URL",
             style = MaterialTheme.typography.labelSmall,
             textAlign = TextAlign.Center,
@@ -137,7 +142,8 @@ fun AndroidAppInfoCardPreview() {
         appVersion = AppVersion(
             packageName = "com.example",
             versionCode = 1L,
-            versionName = "1.0.0 20241028.095244",
+            versionName = "2.3.0",
+            buildTimestamp = "20260405.120000",
         ),
         startExpanded = true,
     )

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/version/VersionModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/version/VersionModel.kt
@@ -19,13 +19,15 @@ package com.chriscartland.garage.version
 
 import android.content.Context
 import android.os.Build
+import com.chriscartland.garage.BuildConfig
 
 data class AppVersion(
     val packageName: String,
     val versionCode: Long,
     val versionName: String,
+    val buildTimestamp: String,
 ) {
-    override fun toString(): String = "$packageName-$versionCode-$versionName"
+    override fun toString(): String = "$packageName-$versionName-$versionCode ($buildTimestamp)"
 }
 
 fun Context.AppVersion(): AppVersion =
@@ -45,4 +47,5 @@ fun Context.AppVersion(): AppVersion =
                     }
                 },
         versionName = packageManager.getPackageInfo(packageName, 0).versionName ?: "",
+        buildTimestamp = BuildConfig.BUILD_TIMESTAMP,
     )

--- a/AndroidGarage/version.properties
+++ b/AndroidGarage/version.properties
@@ -1,0 +1,1 @@
+versionName=2.3.0


### PR DESCRIPTION
## Summary
- Version name is now `major.minor.patch` in `version.properties` (manually bumped)
- versionCode unchanged — still from release tag (`android/N` → `N`)
- Build timestamp preserved as `BuildConfig.BUILD_TIMESTAMP` (UTC)
- App info screen shows: version name, version code, and build timestamp

## Version strategy
- `version.properties` → `versionName=2.3.0` (semver, bumped manually)
- Release tag → `versionCode` (monotonic, auto-incremented by release script)
- Multiple releases can share the same version name
- Build timestamp distinguishes individual builds

## Test plan
- [x] `./scripts/validate.sh` passes
- [x] APK filename shows `2.3.0`
- [x] `BuildConfig.BUILD_TIMESTAMP` populated at build time

🤖 Generated with [Claude Code](https://claude.com/claude-code)