### PR TITLE
feat: UseCase constructor injection (Phase 8.1)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -146,13 +146,15 @@ abstract class AppComponent(
     fun provideDeregisterFcmUseCase(): DeregisterFcmUseCase = DeregisterFcmUseCase(provideDoorFcmRepository())
 
     @Provides
-    fun provideEnsureFreshIdTokenUseCase(): EnsureFreshIdTokenUseCase = EnsureFreshIdTokenUseCase()
+    fun provideEnsureFreshIdTokenUseCase(): EnsureFreshIdTokenUseCase = EnsureFreshIdTokenUseCase(provideAuthRepository())
 
     @Provides
-    fun providePushRemoteButtonUseCase(): PushRemoteButtonUseCase = PushRemoteButtonUseCase(provideEnsureFreshIdTokenUseCase())
+    fun providePushRemoteButtonUseCase(): PushRemoteButtonUseCase =
+        PushRemoteButtonUseCase(provideEnsureFreshIdTokenUseCase(), provideAuthRepository(), providePushRepository())
 
     @Provides
-    fun provideSnoozeNotificationsUseCase(): SnoozeNotificationsUseCase = SnoozeNotificationsUseCase(provideEnsureFreshIdTokenUseCase())
+    fun provideSnoozeNotificationsUseCase(): SnoozeNotificationsUseCase =
+        SnoozeNotificationsUseCase(provideEnsureFreshIdTokenUseCase(), provideAuthRepository(), providePushRepository())
 
     // Network — button
     @Provides

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/PushRepository.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/PushRepository.kt
@@ -17,7 +17,6 @@
 
 package com.chriscartland.garage.remotebutton
 
-import android.text.format.DateFormat
 import android.util.Log
 import com.chriscartland.garage.config.APP_CONFIG
 import com.chriscartland.garage.config.ServerConfigRepository
@@ -130,7 +129,7 @@ class PushRepositoryImpl(
  * When the server receives a button press, it will respond with the token to the client.
  */
 fun createButtonAckToken(now: Date): String {
-    val humanReadable = DateFormat.format("yyyy-MM-dd hh:mm:ss a", now).toString()
+    val humanReadable = java.text.SimpleDateFormat("yyyy-MM-dd hh:mm:ss a", java.util.Locale.US).format(now)
     val timestampMillis = now.time
     val appVersion = "AppVersionTODO"
     val buttonAckTokenData = "android-$appVersion-$humanReadable-$timestampMillis"

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
@@ -21,12 +21,10 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chriscartland.garage.coroutines.DispatcherProvider
-import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.PushStatus
 import com.chriscartland.garage.domain.model.RequestStatus
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
-import com.chriscartland.garage.domain.repository.AuthRepository
 import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.domain.repository.PushRepository
 import com.chriscartland.garage.snoozenotifications.SnoozeDurationUIOption
@@ -48,14 +46,11 @@ interface RemoteButtonViewModel {
     val snoozeRequestStatus: StateFlow<SnoozeRequestStatus>
     val snoozeEndTimeSeconds: StateFlow<Long>
 
-    fun pushRemoteButton(authRepository: AuthRepository)
+    fun pushRemoteButton()
 
     fun resetRemoteButton()
 
-    fun snoozeOpenDoorsNotifications(
-        authRepository: AuthRepository,
-        snoozeDuration: SnoozeDurationUIOption,
-    )
+    fun snoozeOpenDoorsNotifications(snoozeDuration: SnoozeDurationUIOption)
 
     fun fetchSnoozeEndTimeSeconds()
 }
@@ -278,30 +273,19 @@ class RemoteButtonViewModelImpl(
      *
      * Requires an authenticated user.
      */
-    override fun pushRemoteButton(authRepository: AuthRepository) {
+    override fun pushRemoteButton() {
         Log.d(TAG, "pushRemoteButton")
         viewModelScope.launch(dispatchers.io) {
-            if (authRepository.authState.value !is AuthState.Authenticated) {
-                Log.e(TAG, "Not authenticated — push skipped")
-                return@launch
-            }
             pushRemoteButtonUseCase(
-                authRepository = authRepository,
-                pushRepository = pushRepository,
                 buttonAckToken = createButtonAckToken(Date()),
             )
         }
     }
 
-    override fun snoozeOpenDoorsNotifications(
-        authRepository: AuthRepository,
-        snoozeDuration: SnoozeDurationUIOption,
-    ) {
+    override fun snoozeOpenDoorsNotifications(snoozeDuration: SnoozeDurationUIOption) {
         Log.d(TAG, "snoozeOpenDoorsNotifications")
         viewModelScope.launch(dispatchers.io) {
             val result = snoozeNotificationsUseCase(
-                authRepository = authRepository,
-                pushRepository = pushRepository,
                 snoozeDurationHours = snoozeDuration.toServer().duration,
                 lastChangeTimeSeconds = currentDoorEvent.value?.lastChangeTimeSeconds,
             )

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -94,7 +94,7 @@ fun HomeContent(
                         "Remote button clicked. " +
                             "AuthViewModel authState $authState",
                     )
-                    buttonViewModel.pushRemoteButton(resolvedAuthViewModel.authRepository)
+                    buttonViewModel.pushRemoteButton()
                 }
 
                 AuthState.Unauthenticated -> {

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
@@ -89,10 +89,7 @@ fun ProfileContent(
         snoozeEndTimeSeconds = snoozeEndTimeSeconds,
         snoozeRequestStatus = snoozeRequestStatus,
         onSnooze = {
-            buttonViewModel.snoozeOpenDoorsNotifications(
-                resolvedAuthViewModel.authRepository,
-                it,
-            )
+            buttonViewModel.snoozeOpenDoorsNotifications(it)
         },
     )
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/EnsureFreshIdTokenUseCase.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/EnsureFreshIdTokenUseCase.kt
@@ -29,9 +29,10 @@ import com.chriscartland.garage.domain.repository.AuthRepository
  * - Otherwise, refresh the auth state and return the new token
  * - If refresh fails (user becomes unauthenticated), fall back to the cached token
  */
-class EnsureFreshIdTokenUseCase {
+class EnsureFreshIdTokenUseCase(
+    private val authRepository: AuthRepository,
+) {
     suspend operator fun invoke(
-        authRepository: AuthRepository,
         currentAuth: AuthState.Authenticated,
         currentTimeMillis: Long = System.currentTimeMillis(),
     ): FirebaseIdToken =

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/PushRemoteButtonUseCase.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/PushRemoteButtonUseCase.kt
@@ -31,24 +31,21 @@ import com.chriscartland.garage.domain.repository.PushRepository
  *
  * @return true if the push was initiated, false if not authenticated
  */
-class PushRemoteButtonUseCase
-    constructor(
-        private val ensureFreshIdToken: EnsureFreshIdTokenUseCase,
-    ) {
-        suspend operator fun invoke(
-            authRepository: AuthRepository,
-            pushRepository: PushRepository,
-            buttonAckToken: String,
-        ): Boolean {
-            val authState = authRepository.authState.value
-            if (authState !is AuthState.Authenticated) {
-                return false
-            }
-            val idToken = ensureFreshIdToken(authRepository, authState)
-            pushRepository.push(
-                idToken = idToken.asString(),
-                buttonAckToken = buttonAckToken,
-            )
-            return true
+class PushRemoteButtonUseCase(
+    private val ensureFreshIdToken: EnsureFreshIdTokenUseCase,
+    private val authRepository: AuthRepository,
+    private val pushRepository: PushRepository,
+) {
+    suspend operator fun invoke(buttonAckToken: String): Boolean {
+        val authState = authRepository.authState.value
+        if (authState !is AuthState.Authenticated) {
+            return false
         }
+        val idToken = ensureFreshIdToken(authState)
+        pushRepository.push(
+            idToken = idToken.asString(),
+            buttonAckToken = buttonAckToken,
+        )
+        return true
     }
+}

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/SnoozeNotificationsUseCase.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/SnoozeNotificationsUseCase.kt
@@ -32,29 +32,28 @@ import com.chriscartland.garage.domain.repository.PushRepository
  * @return true if the snooze was initiated, false if not authenticated
  *   or if lastChangeTimeSeconds is null
  */
-class SnoozeNotificationsUseCase
-    constructor(
-        private val ensureFreshIdToken: EnsureFreshIdTokenUseCase,
-    ) {
-        suspend operator fun invoke(
-            authRepository: AuthRepository,
-            pushRepository: PushRepository,
-            snoozeDurationHours: String,
-            lastChangeTimeSeconds: Long?,
-        ): Boolean {
-            val authState = authRepository.authState.value
-            if (authState !is AuthState.Authenticated) {
-                return false
-            }
-            if (lastChangeTimeSeconds == null) {
-                return false
-            }
-            val idToken = ensureFreshIdToken(authRepository, authState)
-            pushRepository.snoozeOpenDoorsNotifications(
-                snoozeDurationHours = snoozeDurationHours,
-                idToken = idToken.asString(),
-                snoozeEventTimestampSeconds = lastChangeTimeSeconds,
-            )
-            return true
+class SnoozeNotificationsUseCase(
+    private val ensureFreshIdToken: EnsureFreshIdTokenUseCase,
+    private val authRepository: AuthRepository,
+    private val pushRepository: PushRepository,
+) {
+    suspend operator fun invoke(
+        snoozeDurationHours: String,
+        lastChangeTimeSeconds: Long?,
+    ): Boolean {
+        val authState = authRepository.authState.value
+        if (authState !is AuthState.Authenticated) {
+            return false
         }
+        if (lastChangeTimeSeconds == null) {
+            return false
+        }
+        val idToken = ensureFreshIdToken(authState)
+        pushRepository.snoozeOpenDoorsNotifications(
+            snoozeDurationHours = snoozeDurationHours,
+            idToken = idToken.asString(),
+            snoozeEventTimestampSeconds = lastChangeTimeSeconds,
+        )
+        return true
     }
+}

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModelTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModelTest.kt
@@ -84,14 +84,18 @@ class RemoteButtonViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel(): RemoteButtonViewModelImpl {
-        val ensureFreshIdToken = EnsureFreshIdTokenUseCase()
+    private lateinit var authRepository: AuthRepository
+
+    private fun createViewModel(authState: AuthState = AuthState.Unauthenticated): RemoteButtonViewModelImpl {
+        authRepository = mock(AuthRepository::class.java)
+        `when`(authRepository.authState).thenReturn(MutableStateFlow(authState))
+        val ensureFreshIdToken = EnsureFreshIdTokenUseCase(authRepository)
         val vm = RemoteButtonViewModelImpl(
             pushRepository,
             doorRepository,
             TestDispatcherProvider(testDispatcher),
-            PushRemoteButtonUseCase(ensureFreshIdToken),
-            SnoozeNotificationsUseCase(ensureFreshIdToken),
+            PushRemoteButtonUseCase(ensureFreshIdToken, authRepository, pushRepository),
+            SnoozeNotificationsUseCase(ensureFreshIdToken, authRepository, pushRepository),
         )
         testDispatcher.scheduler.runCurrent()
         return vm
@@ -219,13 +223,9 @@ class RemoteButtonViewModelTest {
     @Test
     fun pushRemoteButtonDoesNothingWhenNotAuthenticated() =
         runTest {
-            val viewModel = createViewModel()
-            val authRepository = mock(AuthRepository::class.java)
-            `when`(authRepository.authState).thenReturn(
-                MutableStateFlow<AuthState>(AuthState.Unauthenticated),
-            )
+            val viewModel = createViewModel(authState = AuthState.Unauthenticated)
 
-            viewModel.pushRemoteButton(authRepository)
+            viewModel.pushRemoteButton()
             testDispatcher.scheduler.runCurrent()
 
             // Status should remain NONE since auth check fails before sending

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/EnsureFreshIdTokenUseCaseTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/EnsureFreshIdTokenUseCaseTest.kt
@@ -34,8 +34,8 @@ class EnsureFreshIdTokenUseCaseTest {
 
     @Before
     fun setup() {
-        useCase = EnsureFreshIdTokenUseCase()
         fakeAuth = FakeAuthRepository()
+        useCase = EnsureFreshIdTokenUseCase(fakeAuth)
     }
 
     private fun makeAuth(
@@ -54,7 +54,7 @@ class EnsureFreshIdTokenUseCaseTest {
     fun returnsCachedTokenWhenNotExpired() =
         runTest {
             val auth = makeAuth(token = "cached-token", exp = 5000L)
-            val result = useCase(fakeAuth, auth, currentTimeMillis = 4999L)
+            val result = useCase(auth, currentTimeMillis = 4999L)
 
             assertEquals("cached-token", result.asString())
             assertEquals(0, fakeAuth.refreshCount)
@@ -67,7 +67,7 @@ class EnsureFreshIdTokenUseCaseTest {
             val refreshedAuth = makeAuth(token = "new-token", exp = 9000L)
             fakeAuth.refreshResult = refreshedAuth
 
-            val result = useCase(fakeAuth, auth, currentTimeMillis = 2000L)
+            val result = useCase(auth, currentTimeMillis = 2000L)
 
             assertEquals("new-token", result.asString())
             assertEquals(1, fakeAuth.refreshCount)
@@ -80,7 +80,7 @@ class EnsureFreshIdTokenUseCaseTest {
             val refreshedAuth = makeAuth(token = "new-token", exp = 9000L)
             fakeAuth.refreshResult = refreshedAuth
 
-            val result = useCase(fakeAuth, auth, currentTimeMillis = 1000L)
+            val result = useCase(auth, currentTimeMillis = 1000L)
 
             assertEquals("new-token", result.asString())
             assertEquals(1, fakeAuth.refreshCount)
@@ -92,7 +92,7 @@ class EnsureFreshIdTokenUseCaseTest {
             val auth = makeAuth(token = "old-token", exp = 1000L)
             fakeAuth.refreshResult = AuthState.Unauthenticated
 
-            val result = useCase(fakeAuth, auth, currentTimeMillis = 2000L)
+            val result = useCase(auth, currentTimeMillis = 2000L)
 
             assertEquals("old-token", result.asString())
             assertEquals(1, fakeAuth.refreshCount)
@@ -104,7 +104,7 @@ class EnsureFreshIdTokenUseCaseTest {
             val auth = makeAuth(token = "old-token", exp = 1000L)
             fakeAuth.refreshResult = AuthState.Unknown
 
-            val result = useCase(fakeAuth, auth, currentTimeMillis = 2000L)
+            val result = useCase(auth, currentTimeMillis = 2000L)
 
             assertEquals("old-token", result.asString())
             assertEquals(1, fakeAuth.refreshCount)
@@ -114,7 +114,7 @@ class EnsureFreshIdTokenUseCaseTest {
     fun doesNotRefreshWhenTokenHasLargeMargin() =
         runTest {
             val auth = makeAuth(token = "cached-token", exp = Long.MAX_VALUE)
-            val result = useCase(fakeAuth, auth, currentTimeMillis = System.currentTimeMillis())
+            val result = useCase(auth, currentTimeMillis = System.currentTimeMillis())
 
             assertEquals("cached-token", result.asString())
             assertEquals(0, fakeAuth.refreshCount)

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/PushRemoteButtonUseCaseTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/PushRemoteButtonUseCaseTest.kt
@@ -38,9 +38,9 @@ class PushRemoteButtonUseCaseTest {
 
     @Before
     fun setup() {
-        useCase = PushRemoteButtonUseCase(EnsureFreshIdTokenUseCase())
         fakeAuth = FakeAuthRepository()
         fakePush = FakePushRepository()
+        useCase = PushRemoteButtonUseCase(EnsureFreshIdTokenUseCase(fakeAuth), fakeAuth, fakePush)
     }
 
     private fun authenticateUser(
@@ -62,7 +62,7 @@ class PushRemoteButtonUseCaseTest {
     fun pushSucceedsWhenAuthenticated() =
         runTest {
             authenticateUser()
-            val result = useCase(fakeAuth, fakePush, "ack-123")
+            val result = useCase("ack-123")
             assertTrue("Push should succeed when authenticated", result)
             assertEquals(1, fakePush.pushCount)
         }
@@ -71,7 +71,7 @@ class PushRemoteButtonUseCaseTest {
     fun pushFailsWhenUnauthenticated() =
         runTest {
             fakeAuth.setAuthState(AuthState.Unauthenticated)
-            val result = useCase(fakeAuth, fakePush, "ack-123")
+            val result = useCase("ack-123")
             assertFalse("Push should fail when unauthenticated", result)
             assertEquals(0, fakePush.pushCount)
         }
@@ -79,7 +79,7 @@ class PushRemoteButtonUseCaseTest {
     @Test
     fun pushFailsWhenAuthUnknown() =
         runTest {
-            val result = useCase(fakeAuth, fakePush, "ack-123")
+            val result = useCase("ack-123")
             assertFalse("Push should fail when auth unknown", result)
             assertEquals(0, fakePush.pushCount)
         }
@@ -88,7 +88,7 @@ class PushRemoteButtonUseCaseTest {
     fun pushPassesCorrectIdToken() =
         runTest {
             authenticateUser(token = "my-token-123")
-            useCase(fakeAuth, fakePush, "ack-456")
+            useCase("ack-456")
             assertEquals("my-token-123", fakePush.lastIdToken)
         }
 
@@ -96,7 +96,7 @@ class PushRemoteButtonUseCaseTest {
     fun pushPassesButtonAckToken() =
         runTest {
             authenticateUser()
-            useCase(fakeAuth, fakePush, "ack-unique-789")
+            useCase("ack-unique-789")
             assertEquals(1, fakePush.pushCount)
         }
 
@@ -113,7 +113,7 @@ class PushRemoteButtonUseCaseTest {
             )
             fakeAuth.refreshResult = refreshedAuth
 
-            useCase(fakeAuth, fakePush, "ack-123")
+            useCase("ack-123")
 
             assertEquals("new-token", fakePush.lastIdToken)
             assertEquals(1, fakeAuth.refreshCount)

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/SnoozeNotificationsUseCaseTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/SnoozeNotificationsUseCaseTest.kt
@@ -38,9 +38,9 @@ class SnoozeNotificationsUseCaseTest {
 
     @Before
     fun setup() {
-        useCase = SnoozeNotificationsUseCase(EnsureFreshIdTokenUseCase())
         fakeAuth = FakeAuthRepository()
         fakePush = FakePushRepository()
+        useCase = SnoozeNotificationsUseCase(EnsureFreshIdTokenUseCase(fakeAuth), fakeAuth, fakePush)
     }
 
     private fun authenticateUser(
@@ -62,7 +62,7 @@ class SnoozeNotificationsUseCaseTest {
     fun snoozeSucceedsWhenAuthenticatedWithTimestamp() =
         runTest {
             authenticateUser()
-            val result = useCase(fakeAuth, fakePush, "1h", 1000L)
+            val result = useCase("1h", 1000L)
             assertTrue(result)
             assertEquals(1, fakePush.snoozeCount)
         }
@@ -71,7 +71,7 @@ class SnoozeNotificationsUseCaseTest {
     fun snoozeFailsWhenUnauthenticated() =
         runTest {
             fakeAuth.setAuthState(AuthState.Unauthenticated)
-            val result = useCase(fakeAuth, fakePush, "1h", 1000L)
+            val result = useCase("1h", 1000L)
             assertFalse(result)
             assertEquals(0, fakePush.snoozeCount)
         }
@@ -79,7 +79,7 @@ class SnoozeNotificationsUseCaseTest {
     @Test
     fun snoozeFailsWhenAuthUnknown() =
         runTest {
-            val result = useCase(fakeAuth, fakePush, "1h", 1000L)
+            val result = useCase("1h", 1000L)
             assertFalse(result)
             assertEquals(0, fakePush.snoozeCount)
         }
@@ -88,7 +88,7 @@ class SnoozeNotificationsUseCaseTest {
     fun snoozeFailsWhenTimestampIsNull() =
         runTest {
             authenticateUser()
-            val result = useCase(fakeAuth, fakePush, "1h", null)
+            val result = useCase("1h", null)
             assertFalse(result)
             assertEquals(0, fakePush.snoozeCount)
         }
@@ -97,7 +97,7 @@ class SnoozeNotificationsUseCaseTest {
     fun snoozeDoesNotRefreshTokenWhenTimestampNull() =
         runTest {
             authenticateUser(exp = 1000L)
-            useCase(fakeAuth, fakePush, "1h", null)
+            useCase("1h", null)
             assertEquals(0, fakeAuth.refreshCount)
         }
 
@@ -112,7 +112,7 @@ class SnoozeNotificationsUseCaseTest {
                     idToken = FirebaseIdToken(idToken = "fresh", exp = Long.MAX_VALUE),
                 ),
             )
-            useCase(fakeAuth, fakePush, "4h", 2000L)
+            useCase("4h", 2000L)
             assertEquals(1, fakeAuth.refreshCount)
         }
 }


### PR DESCRIPTION
## Summary
Move repository dependencies from `invoke()` arguments to constructors in 3 UseCases:

| UseCase | Before (invoke args) | After (constructor) |
|---------|---------------------|-------------------|
| `EnsureFreshIdTokenUseCase` | `authRepository` | `authRepository` |
| `PushRemoteButtonUseCase` | `authRepository`, `pushRepository` | `authRepository`, `pushRepository` |
| `SnoozeNotificationsUseCase` | `authRepository`, `pushRepository` | `authRepository`, `pushRepository` |

`invoke()` now only takes request-specific arguments (token, duration), not dependencies. This follows the battery-butler pattern and unblocks extracting UseCases to a shared KMP module.

Also:
- ViewModel interface simplified — `pushRemoteButton()` and `snoozeOpenDoorsNotifications()` no longer take `authRepository`
- UI callers no longer pass `authRepository` through the view layer
- Replaced `android.text.format.DateFormat` with `java.text.SimpleDateFormat` in `createButtonAckToken` (fixes NPE in unit tests)
- Net -21 lines

## Test plan
- [x] All 133 unit tests pass
- [x] `./scripts/validate.sh` passes
- [x] UseCase tests updated to provide dependencies via constructor

🤖 Generated with [Claude Code](https://claude.com/claude-code)