### PR TITLE
feat: Kermit multiplatform logging (Phase 15)

### DIFF
--- a/AndroidGarage/androidApp/build.gradle.kts
+++ b/AndroidGarage/androidApp/build.gradle.kts
@@ -229,6 +229,7 @@ dependencies {
     implementation(project(":domain"))
     implementation(project(":data"))
     implementation(project(":usecase"))
+    implementation(libs.kermit)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/MainActivity.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/MainActivity.kt
@@ -19,11 +19,11 @@ package com.chriscartland.garage
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.ui.util.trace
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.auth.RC_ONE_TAP_SIGN_IN
 import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.di.activityViewModel
@@ -55,7 +55,7 @@ class MainActivity : ComponentActivity() {
                 )
             }
         }
-        Log.d(TAG, "onCreate: Try to subscribe to FCM topic")
+        Logger.d { "onCreate: Try to subscribe to FCM topic" }
         doorViewModel.registerFcm(this)
         appLoggerViewModel.log(AppLoggerKeys.ON_CREATE_FCM_SUBSCRIBE_TOPIC)
     }
@@ -71,12 +71,12 @@ class MainActivity : ComponentActivity() {
         data: Intent?,
     ) {
         super.onActivityResult(requestCode, resultCode, data)
-        Log.d("MainActivity", "onActivityResult")
+        Logger.d { "onActivityResult" }
         when (requestCode) {
             RC_ONE_TAP_SIGN_IN -> {
-                Log.d("MainActivity", "RC_ONE_TAP_SIGN_IN")
+                Logger.d { "RC_ONE_TAP_SIGN_IN" }
                 if (data == null) {
-                    Log.e("MainActivity", "onActivityResult: data is null")
+                    Logger.e { "onActivityResult: data is null" }
                     return
                 }
                 authViewModel.processGoogleSignInResult(data)
@@ -84,5 +84,3 @@ class MainActivity : ComponentActivity() {
         }
     }
 }
-
-private const val TAG = "MainActivity"

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/applogger/AppLoggerRepository.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/applogger/AppLoggerRepository.kt
@@ -19,7 +19,7 @@ package com.chriscartland.garage.applogger
 
 import android.content.Context
 import android.net.Uri
-import android.util.Log
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.applogger.model.AppEvent
 import com.chriscartland.garage.db.AppDatabase
 import com.chriscartland.garage.version.AppVersion
@@ -47,7 +47,7 @@ class AppLoggerRepositoryImpl(
     private val appDatabase: AppDatabase,
 ) : AppLoggerRepository {
     override suspend fun log(key: String) {
-        Log.d(TAG, "Logging key: $key")
+        Logger.d { "Logging key: $key" }
         appDatabase.appLoggerDao().insert(
             AppEvent(
                 eventKey = key,
@@ -80,7 +80,7 @@ class AppLoggerRepositoryImpl(
                 }
             } catch (e: Exception) {
                 // Handle exceptions (e.g., file I/O errors)
-                Log.d("CreateTxtFile", "Error writing to file: ${e.message}")
+                Logger.d { "Error writing to file: ${e.message}" }
             }
         }
     }
@@ -94,5 +94,3 @@ class AppLoggerRepositoryImpl(
         return formatter.format(instant)
     }
 }
-
-private const val TAG = "AppLoggerRepository"

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthRepository.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthRepository.kt
@@ -17,7 +17,7 @@
 
 package com.chriscartland.garage.auth
 
-import android.util.Log
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.applogger.AppLoggerRepository
 import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.domain.model.AuthState
@@ -67,15 +67,15 @@ class AuthRepositoryImpl(
      */
     private suspend fun firebaseSignInWithGoogle(idToken: GoogleIdToken) {
         suspendCoroutine { continuation ->
-            Log.d(TAG, "firebaseAuthWithGoogle")
+            Logger.d { "firebaseAuthWithGoogle" }
             val credential = GoogleAuthProvider.getCredential(idToken.asString(), null)
             Firebase.auth
                 .signInWithCredential(credential)
                 .addOnCompleteListener { task ->
                     if (task.isSuccessful) {
-                        Log.d(TAG, "Firebase signInWithGoogle: success")
+                        Logger.d { "Firebase signInWithGoogle: success" }
                     } else {
-                        Log.w(TAG, "Firebase signInWithGoogle: failure", task.exception)
+                        Logger.w { "Firebase signInWithGoogle: failure: ${task.exception}" }
                     }
                     continuation.resume(Unit)
                 }
@@ -96,7 +96,7 @@ class AuthRepositoryImpl(
                     currentUser
                         .getIdToken(true)
                         .addOnSuccessListener { result ->
-                            Log.d(TAG, "Firebase ID Token: ${result.token}")
+                            Logger.d { "Firebase ID Token: ${result.token}" }
                             continuation.resume(
                                 result.token?.let {
                                     FirebaseIdToken(
@@ -106,7 +106,7 @@ class AuthRepositoryImpl(
                                 },
                             )
                         }.addOnFailureListener { exception ->
-                            Log.e(TAG, "Failed to get Firebase ID Token", exception)
+                            Logger.e { "Failed to get Firebase ID Token: $exception" }
                             continuation.resume(null)
                         }
                 }
@@ -131,7 +131,7 @@ class AuthRepositoryImpl(
      * Commit the new AuthState and handle any side effects.
      */
     private suspend fun AuthState.commit(): AuthState {
-        Log.d(TAG, "AuthState.commit(): $this")
+        Logger.d { "AuthState.commit(): $this" }
         when (this) {
             is AuthState.Authenticated ->
                 appLoggerRepository.log(AppLoggerKeys.USER_AUTHENTICATED)
@@ -152,9 +152,7 @@ class AuthRepositoryImpl(
         try {
             Firebase.auth.signOut()
         } catch (e: Exception) {
-            Log.e(TAG, e.toString())
+            Logger.e { e.toString() }
         }
     }
 }
-
-private const val TAG = "AuthRepository"

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthViewModel.kt
@@ -21,9 +21,9 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.IntentSender
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.BuildConfig
 import com.chriscartland.garage.applogger.AppLoggerRepository
 import com.chriscartland.garage.config.AppLoggerKeys
@@ -66,7 +66,7 @@ class AuthViewModelImpl(
         viewModelScope.launch(dispatchers.io) {
             appLoggerRepository.log(AppLoggerKeys.BEGIN_GOOGLE_SIGN_IN)
             checkSignInConfiguration()
-            Log.d(TAG, "beginSignIn")
+            Logger.d { "beginSignIn" }
             // Dialog Sign-In configuration.
             val dialogSignInRequest = BeginSignInRequest
                 .builder()
@@ -93,12 +93,12 @@ class AuthViewModelImpl(
                             null,
                         )
                     } catch (e: IntentSender.SendIntentException) {
-                        Log.e(TAG, "Couldn't start One Tap UI: ${e.localizedMessage}")
+                        Logger.e { "Couldn't start One Tap UI: ${e.localizedMessage}" }
                     }
                 }.addOnFailureListener(activity) { e ->
                     // No saved credentials found. Launch the One Tap sign-up flow, or
                     // do nothing and continue presenting the signed-out UI.
-                    Log.d(TAG, e.localizedMessage ?: "")
+                    Logger.d { e.localizedMessage ?: "" }
                 }
         }
     }
@@ -113,7 +113,7 @@ class AuthViewModelImpl(
         viewModelScope.launch(dispatchers.io) {
             val googleIdToken = googleIdTokenFromIntent(data)
             if (googleIdToken == null) {
-                Log.e(TAG, "Google sign-in failed")
+                Logger.e { "Google sign-in failed" }
                 return@launch
             }
             _authRepository.signInWithGoogle(googleIdToken)
@@ -124,31 +124,26 @@ class AuthViewModelImpl(
      * Extract the Google ID Token from the Intent.
      */
     private fun googleIdTokenFromIntent(data: Intent): GoogleIdToken? {
-        Log.d(TAG, "googleIdTokenFromIntent")
+        Logger.d { "googleIdTokenFromIntent" }
         val client = signInClient
         if (client == null) {
-            Log.e(TAG, "Cannot sign in without a Google client")
+            Logger.e { "Cannot sign in without a Google client" }
             return null
         }
         try {
             val credential = client.getSignInCredentialFromIntent(data)
             return credential.googleIdToken?.let { GoogleIdToken(it) }
         } catch (e: ApiException) {
-            Log.e(TAG, "ApiException: handleOneTapSignIn ${e.message}")
+            Logger.e { "ApiException: handleOneTapSignIn ${e.message}" }
             when (e.statusCode) {
                 CommonStatusCodes.CANCELED -> {
-                    Log.d(TAG, "One-tap dialog was closed.")
+                    Logger.d { "One-tap dialog was closed." }
                 }
                 CommonStatusCodes.NETWORK_ERROR -> {
-                    Log.d(TAG, "One-tap encountered a network error.")
+                    Logger.d { "One-tap encountered a network error." }
                 }
                 else -> {
-                    Log.d(
-                        TAG,
-                        "Couldn't get credential from result." +
-                            " ApiException.statusCode: ${e.statusCode}" +
-                            " (${e.localizedMessage})",
-                    )
+                    Logger.d { "Couldn't get credential from result. ApiException.statusCode: ${e.statusCode} (${e.localizedMessage})" }
                 }
             }
         }
@@ -172,17 +167,9 @@ class AuthViewModelImpl(
     private fun checkSignInConfiguration() {
         val googleClientIdForWeb = BuildConfig.GOOGLE_WEB_CLIENT_ID
         if (googleClientIdForWeb == incorrectWebClientId) {
-            Log.e(
-                "checkSignInConfiguration",
-                "The web client ID matches the INCORRECT_WEB_CLIENT_ID. " +
-                    "One Tap Sign-In with Google will not work. " +
-                    "Update the web client ID to be used with setServerClientId(). " +
-                    "https://developers.google.com/identity/one-tap/android/get-saved-credentials " +
-                    "Create a web client ID in this Google Cloud Console " +
-                    "https://console.cloud.google.com/apis/credentials",
-            )
+            Logger.e {
+                "The web client ID matches the INCORRECT_WEB_CLIENT_ID. One Tap Sign-In with Google will not work. Update the web client ID to be used with setServerClientId(). https://developers.google.com/identity/one-tap/android/get-saved-credentials Create a web client ID in this Google Cloud Console https://console.cloud.google.com/apis/credentials"
+            }
         }
     }
 }
-
-private const val TAG = "AuthViewModel"

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/db/DatabaseLocalDoorDataSource.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/db/DatabaseLocalDoorDataSource.kt
@@ -17,7 +17,7 @@
 
 package com.chriscartland.garage.db
 
-import android.util.Log
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.LocalDoorDataSource
 import com.chriscartland.garage.domain.model.DoorEvent
 import kotlinx.coroutines.flow.Flow
@@ -34,14 +34,12 @@ class DatabaseLocalDoorDataSource(
         }
 
     override fun insertDoorEvent(doorEvent: DoorEvent) {
-        Log.d(TAG, "Inserting DoorEvent: $doorEvent")
+        Logger.d { "Inserting DoorEvent: $doorEvent" }
         appDatabase.doorEventDao().insert(doorEvent.toEntity())
     }
 
     override fun replaceDoorEvents(doorEvents: List<DoorEvent>) {
-        Log.d(TAG, "Replacing DoorEvents: $doorEvents")
+        Logger.d { "Replacing DoorEvents: $doorEvents" }
         appDatabase.doorEventDao().replaceAll(doorEvents.map { it.toEntity() })
     }
 }
-
-private const val TAG = "LocalDoorDataSource"

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorRepositoryImpl.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorRepositoryImpl.kt
@@ -17,7 +17,7 @@
 
 package com.chriscartland.garage.door
 
-import android.util.Log
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.config.APP_CONFIG
 import com.chriscartland.garage.config.ServerConfigRepository
 import com.chriscartland.garage.data.LocalDoorDataSource
@@ -46,29 +46,29 @@ class DoorRepositoryImpl(
     override suspend fun fetchBuildTimestampCached(): String? = serverConfigRepository.getServerConfigCached()?.buildTimestamp
 
     override fun insertDoorEvent(doorEvent: DoorEvent) {
-        Log.d(TAG, "Inserting DoorEvent: $doorEvent")
+        Logger.d { "Inserting DoorEvent: $doorEvent" }
         localDoorDataSource.insertDoorEvent(doorEvent)
     }
 
     override suspend fun fetchCurrentDoorEvent() {
         val buildTimestamp = fetchBuildTimestampCached()
         if (buildTimestamp == null) {
-            Log.e(TAG, "Server config is null")
+            Logger.e { "Server config is null" }
             return
         }
         val doorEvent = networkDoorDataSource.fetchCurrentDoorEvent(buildTimestamp)
         if (doorEvent == null) {
-            Log.e(TAG, "Failed to fetch current door event")
+            Logger.e { "Failed to fetch current door event" }
             return
         }
-        Log.d(TAG, "Success: $doorEvent")
+        Logger.d { "Success: $doorEvent" }
         localDoorDataSource.insertDoorEvent(doorEvent)
     }
 
     override suspend fun fetchRecentDoorEvents() {
         val buildTimestamp = fetchBuildTimestampCached()
         if (buildTimestamp == null) {
-            Log.e(TAG, "Server config is null")
+            Logger.e { "Server config is null" }
             return
         }
         val doorEvents = networkDoorDataSource.fetchRecentDoorEvents(
@@ -76,12 +76,10 @@ class DoorRepositoryImpl(
             count = APP_CONFIG.recentEventCount,
         )
         if (doorEvents == null) {
-            Log.e(TAG, "Failed to fetch recent door events")
+            Logger.e { "Failed to fetch recent door events" }
             return
         }
-        Log.d(TAG, "Success: $doorEvents")
+        Logger.d { "Success: $doorEvents" }
         localDoorDataSource.replaceDoorEvents(doorEvents)
     }
 }
-
-private const val TAG = "DoorRepository"

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorViewModel.kt
@@ -18,9 +18,9 @@
 package com.chriscartland.garage.door
 
 import android.app.Activity
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.applogger.AppLoggerRepository
 import com.chriscartland.garage.config.APP_CONFIG
 import com.chriscartland.garage.config.AppLoggerKeys
@@ -81,16 +81,16 @@ class DoorViewModelImpl(
     override val recentDoorEvents: StateFlow<LoadingResult<List<DoorEvent>>> = _recentDoorEvents
 
     init {
-        Log.d(TAG, "init")
+        Logger.d { "init" }
         viewModelScope.launch(dispatchers.io) {
             doorRepository.currentDoorEvent.collect {
-                Log.d(TAG, "currentDoorEvent collect: $it")
+                Logger.d { "currentDoorEvent collect: $it" }
                 _currentDoorEvent.value = LoadingResult.Complete(it)
             }
         }
         viewModelScope.launch(dispatchers.io) {
             doorRepository.recentDoorEvents.collect {
-                Log.d(TAG, "recentDoorEvents collect: $it")
+                Logger.d { "recentDoorEvents collect: $it" }
                 _recentDoorEvents.value = LoadingResult.Complete(it)
             }
         }
@@ -111,32 +111,32 @@ class DoorViewModelImpl(
     }
 
     override fun fetchFcmRegistrationStatus(activity: Activity) {
-        Log.d(TAG, "fetchFcmRegistrationStatus")
+        Logger.d { "fetchFcmRegistrationStatus" }
         viewModelScope.launch(dispatchers.io) {
             _fcmRegistrationStatus.value = fetchFcmStatusUseCase(activity)
         }
     }
 
     override fun registerFcm(activity: Activity) {
-        Log.d(TAG, "registerFcm")
+        Logger.d { "registerFcm" }
         viewModelScope.launch(dispatchers.io) {
             _fcmRegistrationStatus.value = registerFcmUseCase(activity).also {
-                Log.d(TAG, "Updated FcmRegistrationStatus: $it")
+                Logger.d { "Updated FcmRegistrationStatus: $it" }
             }
         }
     }
 
     override fun deregisterFcm(activity: Activity) {
-        Log.d(TAG, "deregisterFcm")
+        Logger.d { "deregisterFcm" }
         viewModelScope.launch(dispatchers.io) {
             _fcmRegistrationStatus.value = deregisterFcmUseCase(activity).also {
-                Log.d(TAG, "Updated FcmRegistrationStatus: $it")
+                Logger.d { "Updated FcmRegistrationStatus: $it" }
             }
         }
     }
 
     override fun fetchCurrentDoorEvent() {
-        Log.d(TAG, "fetchCurrentDoorEvent")
+        Logger.d { "fetchCurrentDoorEvent" }
         viewModelScope.launch(dispatchers.io) {
             _currentDoorEvent.value = LoadingResult.Loading(_currentDoorEvent.value.data)
             fetchCurrentDoorEventUseCase()
@@ -144,12 +144,10 @@ class DoorViewModelImpl(
     }
 
     override fun fetchRecentDoorEvents() {
-        Log.d(TAG, "fetchRecentDoorEvents")
+        Logger.d { "fetchRecentDoorEvents" }
         viewModelScope.launch(dispatchers.io) {
             _recentDoorEvents.value = LoadingResult.Loading(_recentDoorEvents.value.data)
             fetchRecentDoorEventsUseCase()
         }
     }
 }
-
-private const val TAG = "DoorViewModel"

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/DoorFcmRepository.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/DoorFcmRepository.kt
@@ -18,7 +18,7 @@
 package com.chriscartland.garage.fcm
 
 import android.app.Activity
-import android.util.Log
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.applogger.AppLoggerRepository
 import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.domain.model.DoorFcmState
@@ -45,9 +45,9 @@ class DoorFcmRepositoryImpl(
     private val appLoggerRepository: AppLoggerRepository,
 ) : DoorFcmRepository {
     override suspend fun fetchStatus(activity: Activity): DoorFcmState {
-        Log.d(TAG, "fetchStatus")
+        Logger.d { "fetchStatus" }
         val topic = getFcmTopic()
-        Log.d(TAG, "fetchStatus: $topic")
+        Logger.d { "fetchStatus: $topic" }
         return if (topic == null) {
             DoorFcmState.NotRegistered
         } else {
@@ -59,16 +59,16 @@ class DoorFcmRepositoryImpl(
         activity: Activity,
         fcmTopic: DoorFcmTopic,
     ): DoorFcmState {
-        Log.d(TAG, "registerDoor: $fcmTopic")
+        Logger.d { "registerDoor: $fcmTopic" }
         // Unsubscribe from old topic.
         val oldFcmTopic = getFcmTopic()
         if (oldFcmTopic != null && fcmTopic != oldFcmTopic) {
-            Log.i(TAG, "Unsubscribing from old FCM Topic: $oldFcmTopic")
+            Logger.i { "Unsubscribing from old FCM Topic: $oldFcmTopic" }
             Firebase.messaging.unsubscribeFromTopic(oldFcmTopic.string)
         }
         // Save new topic.
         setFcmTopic(fcmTopic)
-        Log.i(TAG, "Subscribing to FCM Topic: $fcmTopic")
+        Logger.i { "Subscribing to FCM Topic: $fcmTopic" }
         appLoggerRepository.log(AppLoggerKeys.FCM_SUBSCRIBE_TOPIC)
         val subscriptionSuccess =
             suspendCoroutine { continuation ->
@@ -76,20 +76,17 @@ class DoorFcmRepositoryImpl(
                     .subscribeToTopic(fcmTopic.string)
                     .addOnCompleteListener { task ->
                         if (task.isSuccessful) {
-                            Log.i(TAG, "Subscribed to FCM Topic $fcmTopic")
+                            Logger.i { "Subscribed to FCM Topic $fcmTopic" }
                             continuation.resume(true)
                         } else {
-                            Log.e(
-                                TAG,
-                                "Failed to subscribe to FCM Topic $fcmTopic: " + task.exception.toString(),
-                            )
+                            Logger.e { "Failed to subscribe to FCM Topic $fcmTopic: ${task.exception}" }
                             continuation.resume(false)
                         }
                     }
             }
         if (!subscriptionSuccess) {
             return DoorFcmState.NotRegistered.also {
-                Log.d(TAG, "Failed to subscribe to topic $fcmTopic, returning state $it")
+                Logger.d { "Failed to subscribe to topic $fcmTopic, returning state $it" }
             }
         }
         val token =
@@ -97,61 +94,59 @@ class DoorFcmRepositoryImpl(
                 Firebase.messaging.token
                     .addOnCompleteListener { task ->
                         if (!task.isSuccessful) {
-                            Log.w(TAG, "Fetching FCM registration token failed", task.exception)
+                            Logger.w { "Fetching FCM registration token failed: ${task.exception}" }
                             continuation.resume(null)
                         }
                         val token = task.result
                         if (token == null) {
-                            Log.d(TAG, "Fetching FCM registration token null")
+                            Logger.d { "Fetching FCM registration token null" }
                             continuation.resume(null)
                         } else {
-                            Log.d(TAG, "FCM Instance Token: $token")
+                            Logger.d { "FCM Instance Token: $token" }
                             continuation.resume(token)
                         }
                     }
             }
         if (token == null) {
             return DoorFcmState.NotRegistered.also {
-                Log.d(TAG, "Failed to get FCM registration token, returning state $it")
+                Logger.d { "Failed to get FCM registration token, returning state $it" }
             }
         }
         return DoorFcmState.Registered(topic = fcmTopic).also {
-            Log.d(TAG, "Successfully registered for topic $fcmTopic, returning state $it")
+            Logger.d { "Successfully registered for topic $fcmTopic, returning state $it" }
         }
     }
 
     override suspend fun deregisterDoor(activity: Activity): DoorFcmState {
-        Log.d(TAG, "deregisterDoor")
+        Logger.d { "deregisterDoor" }
         val oldFcmTopic = getFcmTopic()
         if (oldFcmTopic == null) {
             return DoorFcmState.NotRegistered.also {
-                Log.d(TAG, "No FCM topic to deregister, returning state $it")
+                Logger.d { "No FCM topic to deregister, returning state $it" }
             }
         }
         removeFcmTopic()
-        Log.i(TAG, "Unsubscribing from old FCM Topic: $oldFcmTopic")
+        Logger.i { "Unsubscribing from old FCM Topic: $oldFcmTopic" }
         Firebase.messaging.unsubscribeFromTopic(oldFcmTopic.string)
         return DoorFcmState.NotRegistered.also {
-            Log.d(TAG, "Successfully deregistered for topic $oldFcmTopic, returning state $it")
+            Logger.d { "Successfully deregistered for topic $oldFcmTopic, returning state $it" }
         }
     }
 
     private fun getFcmTopic(): DoorFcmTopic? {
-        Log.d(TAG, "getFcmTopic")
+        Logger.d { "getFcmTopic" }
         return settings.fcmDoorTopic.get().let {
             DoorFcmTopic(it)
         }
     }
 
     private fun setFcmTopic(topic: DoorFcmTopic) {
-        Log.d(TAG, "setFcmTopic: $topic")
+        Logger.d { "setFcmTopic: $topic" }
         settings.fcmDoorTopic.set(topic.string)
     }
 
     private fun removeFcmTopic() {
-        Log.d(TAG, "removeFcmTopic")
+        Logger.d { "removeFcmTopic" }
         settings.fcmDoorTopic.restoreDefault()
     }
 }
-
-private const val TAG = "DoorFcmRepository"

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
@@ -17,7 +17,7 @@
 
 package com.chriscartland.garage.fcm
 
-import android.util.Log
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.GarageApplication
 import com.chriscartland.garage.applogger.AppLoggerRepository
 import com.chriscartland.garage.config.AppLoggerKeys
@@ -44,25 +44,25 @@ class FCMService : FirebaseMessagingService() {
     private val coroutineScope = CoroutineScope(Dispatchers.Main + supervisorJob)
 
     override fun onNewToken(token: String) {
-        Log.d(TAG, "FCM Instance Token: $token")
+        Logger.d { "FCM Instance Token: $token" }
     }
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
         // Not getting messages here? See why this may be: https://goo.gl/39bRNJ
-        Log.d(TAG, "onMessageReceived, from: ${remoteMessage.from}")
+        Logger.d { "onMessageReceived, from: ${remoteMessage.from}" }
 
         // Check if message contains a data payload.
         if (remoteMessage.data.isNotEmpty()) {
-            Log.d(TAG, "Message data payload: ${remoteMessage.data}")
+            Logger.d { "Message data payload: ${remoteMessage.data}" }
 
             val doorEvent = FcmPayloadParser.parseDoorEvent(remoteMessage.data)
             if (doorEvent == null) {
-                Log.e(TAG, "Unknown message type: ${remoteMessage.data.entries.joinToString()}")
+                Logger.e { "Unknown message type: ${remoteMessage.data.entries.joinToString()}" }
                 return
             }
-            Log.d(TAG, "DoorData: $doorEvent")
+            Logger.d { "DoorData: $doorEvent" }
             coroutineScope.launch(Dispatchers.IO) {
-                Log.d(TAG, "Logging FCM_DOOR_RECEIVED: ${AppLoggerKeys.FCM_DOOR_RECEIVED}")
+                Logger.d { "Logging FCM_DOOR_RECEIVED: ${AppLoggerKeys.FCM_DOOR_RECEIVED}" }
                 appLoggerRepository.log(AppLoggerKeys.FCM_DOOR_RECEIVED)
             }
             if (false) {
@@ -75,29 +75,29 @@ class FCMService : FirebaseMessagingService() {
                 handleNow(doorEvent)
             }
         } else {
-            Log.d(TAG, "Message data payload is empty")
+            Logger.d { "Message data payload is empty" }
         }
 
         // Check if message contains a notification payload.
         remoteMessage.notification?.let {
-            Log.d(TAG, "Message Notification Body: ${it.body}")
+            Logger.d { "Message Notification Body: ${it.body}" }
         }
     }
 
     private fun scheduleJob() {
-        Log.d(TAG, "scheduleJob...")
+        Logger.d { "scheduleJob..." }
     }
 
     /**
      * Handle the new door info now (complete within 10 seconds).
      */
     private fun handleNow(doorEvent: DoorEvent?) {
-        Log.d(TAG, "handleNow...")
+        Logger.d { "handleNow..." }
         if (doorEvent == null) {
-            Log.d(TAG, "DoorEvent is null")
+            Logger.d { "DoorEvent is null" }
             return
         }
-        Log.d(TAG, "Inserting DoorEvent: $doorEvent")
+        Logger.d { "Inserting DoorEvent: $doorEvent" }
         doorRepository.insertDoorEvent(doorEvent)
     }
 
@@ -106,5 +106,3 @@ class FCMService : FirebaseMessagingService() {
         supervisorJob.cancel()
     }
 }
-
-private const val TAG = "FCMService"

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FcmPayloadParser.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FcmPayloadParser.kt
@@ -17,7 +17,7 @@
 
 package com.chriscartland.garage.fcm
 
-import android.util.Log
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 
@@ -56,7 +56,7 @@ object FcmPayloadParser {
                 lastCheckInTimeSeconds = checkInTimestampSeconds,
             )
         } catch (e: Exception) {
-            Log.e("FcmPayloadParser", "Error parsing DoorEvent: $e")
+            Logger.e { "Error parsing DoorEvent: $e" }
             return null
         }
     }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FcmRegistration.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FcmRegistration.kt
@@ -17,13 +17,13 @@
 
 package com.chriscartland.garage.fcm
 
-import android.util.Log
 import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.viewmodel.compose.viewModel
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.FcmRegistrationStatus
 import com.chriscartland.garage.door.DoorViewModel
@@ -47,23 +47,21 @@ fun FCMRegistration() {
         // Subscribe to FCM updates.
         when (fcmState) {
             FcmRegistrationStatus.UNKNOWN -> {
-                Log.d(TAG, "Unknown FCM registration status, fetching...")
+                Logger.d { "Unknown FCM registration status, fetching..." }
                 if (activity != null) {
                     viewModel.fetchFcmRegistrationStatus(activity)
                 } else {
-                    Log.e(TAG, "Activity is null, cannot fetch FCM registration status")
+                    Logger.e { "Activity is null, cannot fetch FCM registration status" }
                 }
             }
 
             FcmRegistrationStatus.REGISTERED -> {
-                Log.d(TAG, "FCM registration status is registered")
+                Logger.d { "FCM registration status is registered" }
             }
 
             FcmRegistrationStatus.NOT_REGISTERED -> {
-                Log.d(TAG, "FCM registration status is not registered, registering...")
+                Logger.d { "FCM registration status is not registered, registering..." }
             }
         }
     }
 }
-
-private const val TAG: String = "FcmRegistration"

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/internet/KtorNetworkButtonDataSource.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/internet/KtorNetworkButtonDataSource.kt
@@ -17,7 +17,7 @@
 
 package com.chriscartland.garage.internet
 
-import android.util.Log
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.NetworkButtonDataSource
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -44,10 +44,10 @@ class KtorNetworkButtonDataSource(
                 header("X-RemoteButtonPushKey", remoteButtonPushKey)
                 header("X-AuthTokenGoogle", idToken)
             }
-            Log.i(TAG, "Push response: ${response.status.value}")
+            Logger.i { "Push response: ${response.status.value}" }
             response.status.isSuccess()
         } catch (e: Exception) {
-            Log.e(TAG, "Push error: $e")
+            Logger.e { "Push error: $e" }
             false
         }
 
@@ -66,18 +66,18 @@ class KtorNetworkButtonDataSource(
                 parameter("snoozeDuration", snoozeDurationHours)
                 parameter("snoozeEventTimestamp", snoozeEventTimestampSeconds)
             }
-            Log.i(TAG, "Snooze response: ${response.status.value}")
+            Logger.i { "Snooze response: ${response.status.value}" }
             if (!response.status.isSuccess()) {
                 return false
             }
             val body = response.body<KtorSnoozeResponse>()
             if (body.error != null) {
-                Log.e(TAG, "Snooze error: ${body.error}")
+                Logger.e { "Snooze error: ${body.error}" }
                 return false
             }
             true
         } catch (e: Exception) {
-            Log.e(TAG, "Snooze error: $e")
+            Logger.e { "Snooze error: $e" }
             false
         }
     }
@@ -89,18 +89,16 @@ class KtorNetworkButtonDataSource(
             }
             val body = response.body<KtorGetSnoozeResponse>()
             if (body.error != null) {
-                Log.e(TAG, "Snooze fetch error: ${body.error}")
+                Logger.e { "Snooze fetch error: ${body.error}" }
                 return 0L
             }
             body.snooze?.snoozeEndTimeSeconds ?: 0L
         } catch (e: Exception) {
-            Log.e(TAG, "Snooze fetch error: $e")
+            Logger.e { "Snooze fetch error: $e" }
             0L
         }
     }
 }
-
-private const val TAG = "KtorNetworkButton"
 
 // region Serializable response types
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/internet/KtorNetworkConfigDataSource.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/internet/KtorNetworkConfigDataSource.kt
@@ -17,7 +17,7 @@
 
 package com.chriscartland.garage.internet
 
-import android.util.Log
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.NetworkConfigDataSource
 import com.chriscartland.garage.domain.model.ServerConfig
 import io.ktor.client.HttpClient
@@ -39,26 +39,26 @@ class KtorNetworkConfigDataSource(
                 header("X-ServerConfigKey", serverConfigKey)
             }
             if (!response.status.isSuccess()) {
-                Log.e(TAG, "Response code is ${response.status.value}")
+                Logger.e { "Response code is ${response.status.value}" }
                 return null
             }
             val result = response.body<KtorServerConfigResponse>()
             val body = result.body
             if (body == null) {
-                Log.e(TAG, "Response body is null")
+                Logger.e { "Response body is null" }
                 return null
             }
             if (body.buildTimestamp.isNullOrEmpty()) {
-                Log.e(TAG, "buildTimestamp is empty")
+                Logger.e { "buildTimestamp is empty" }
                 return null
             }
             val remoteButtonBuildTimestamp = body.remoteButtonBuildTimestamp
             if (remoteButtonBuildTimestamp.isNullOrEmpty()) {
-                Log.e(TAG, "remoteButtonBuildTimestamp is empty")
+                Logger.e { "remoteButtonBuildTimestamp is empty" }
                 return null
             }
             if (body.remoteButtonPushKey.isNullOrEmpty()) {
-                Log.e(TAG, "remoteButtonPushKey is empty")
+                Logger.e { "remoteButtonPushKey is empty" }
                 return null
             }
             ServerConfig(
@@ -70,13 +70,11 @@ class KtorNetworkConfigDataSource(
                 remoteButtonPushKey = body.remoteButtonPushKey,
             )
         } catch (e: Exception) {
-            Log.e(TAG, "Error fetching server config: $e")
+            Logger.e { "Error fetching server config: $e" }
             null
         }
     }
 }
-
-private const val TAG = "KtorNetworkConfig"
 
 // region Serializable response types
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/internet/KtorNetworkDoorDataSource.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/internet/KtorNetworkDoorDataSource.kt
@@ -17,7 +17,7 @@
 
 package com.chriscartland.garage.internet
 
-import android.util.Log
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.NetworkDoorDataSource
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
@@ -38,15 +38,15 @@ class KtorNetworkDoorDataSource(
                 parameter("buildTimestamp", buildTimestamp)
             }
             if (!response.status.isSuccess()) {
-                Log.e(TAG, "Response code is ${response.status.value}")
+                Logger.e { "Response code is ${response.status.value}" }
                 return null
             }
             val body = response.body<KtorCurrentEventDataResponse>()
             body.currentEventData?.currentEvent?.toDoorEvent().also {
-                if (it == null) Log.e(TAG, "Door event is null")
+                if (it == null) Logger.e { "Door event is null" }
             }
         } catch (e: Exception) {
-            Log.e(TAG, "Error fetching current door event: $e")
+            Logger.e { "Error fetching current door event: $e" }
             null
         }
     }
@@ -61,33 +61,27 @@ class KtorNetworkDoorDataSource(
                 parameter("eventHistoryMaxCount", count)
             }
             if (!response.status.isSuccess()) {
-                Log.e(TAG, "Response code is ${response.status.value}")
+                Logger.e { "Response code is ${response.status.value}" }
                 return null
             }
             val body = response.body<KtorRecentEventDataResponse>()
             if (body.eventHistory.isNullOrEmpty()) {
-                Log.i(TAG, "recentEventData is empty")
+                Logger.i { "recentEventData is empty" }
                 return null
             }
             val doorEvents = body.eventHistory.mapNotNull {
                 it.currentEvent?.toDoorEvent()
             }
             if (doorEvents.size != body.eventHistory.size) {
-                Log.e(
-                    TAG,
-                    "Door events size ${doorEvents.size} " +
-                        "does not match response size ${body.eventHistory.size}",
-                )
+                Logger.e { "Door events size ${doorEvents.size} does not match response size ${body.eventHistory.size}" }
             }
             doorEvents
         } catch (e: Exception) {
-            Log.e(TAG, "Error fetching recent door events: $e")
+            Logger.e { "Error fetching recent door events: $e" }
             null
         }
     }
 }
-
-private const val TAG = "KtorNetworkDoor"
 
 // region Serializable response types
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/PushRepository.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/PushRepository.kt
@@ -17,7 +17,7 @@
 
 package com.chriscartland.garage.remotebutton
 
-import android.util.Log
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.config.APP_CONFIG
 import com.chriscartland.garage.config.ServerConfigRepository
 import com.chriscartland.garage.data.NetworkButtonDataSource
@@ -50,12 +50,12 @@ class PushRepositoryImpl(
         _pushButtonStatus.value = PushStatus.SENDING
         val serverConfig = serverConfigRepository.getServerConfigCached()
         if (serverConfig == null) {
-            Log.e(TAG, "Server config is null")
+            Logger.e { "Server config is null" }
             _pushButtonStatus.value = PushStatus.IDLE
             return
         }
         if (!APP_CONFIG.remoteButtonPushEnabled) {
-            Log.w(TAG, "Remote button push is disabled")
+            Logger.w { "Remote button push is disabled" }
             delay(Duration.ofMillis(500))
         }
         if (APP_CONFIG.remoteButtonPushEnabled) {
@@ -72,11 +72,11 @@ class PushRepositoryImpl(
     override suspend fun fetchSnoozeEndTimeSeconds() {
         val serverConfig = serverConfigRepository.getServerConfigCached()
         if (serverConfig == null) {
-            Log.e(TAG, "Server config is null")
+            Logger.e { "Server config is null" }
             return
         }
         if (!APP_CONFIG.snoozeNotificationsOption) {
-            Log.w(TAG, "Snooze notifications disabled")
+            Logger.w { "Snooze notifications disabled" }
             delay(Duration.ofMillis(500))
         }
         if (APP_CONFIG.snoozeNotificationsOption) {
@@ -95,12 +95,12 @@ class PushRepositoryImpl(
         _snoozeRequestStatus.value = SnoozeRequestStatus.SENDING
         val serverConfig = serverConfigRepository.getServerConfigCached()
         if (serverConfig == null) {
-            Log.e(TAG, "Server config is null")
+            Logger.e { "Server config is null" }
             _snoozeRequestStatus.value = SnoozeRequestStatus.IDLE
             return
         }
         if (!APP_CONFIG.snoozeNotificationsOption) {
-            Log.w(TAG, "Snooze notifications disabled")
+            Logger.w { "Snooze notifications disabled" }
             delay(Duration.ofMillis(500))
         }
         if (APP_CONFIG.snoozeNotificationsOption) {
@@ -137,5 +137,3 @@ fun createButtonAckToken(now: Date): String {
     val filtered = re.replace(buttonAckTokenData, ".")
     return filtered
 }
-
-private const val TAG = "PushRepository"

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
@@ -17,9 +17,9 @@
 
 package com.chriscartland.garage.remotebutton
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.PushStatus
@@ -122,10 +122,7 @@ class RemoteButtonViewModelImpl(
                         }
                     }
                 }
-                Log.d(
-                    TAG,
-                    "ButtonRequestStateMachine network: old $old -> " + "new ${_requestStatus.value.name}",
-                )
+                Logger.d { "ButtonRequestStateMachine network: old $old -> new ${_requestStatus.value.name}" }
             }
         }
     }
@@ -154,10 +151,7 @@ class RemoteButtonViewModelImpl(
 
                     RequestStatus.RECEIVED -> _requestStatus.value = RequestStatus.RECEIVED
                 }
-                Log.d(
-                    TAG,
-                    "ButtonRequestStateMachine door: old $old -> " + "new ${_requestStatus.value.name}",
-                )
+                Logger.d { "ButtonRequestStateMachine door: old $old -> new ${_requestStatus.value.name}" }
             }
         }
     }
@@ -191,7 +185,7 @@ class RemoteButtonViewModelImpl(
                             delay(Duration.ofSeconds(10))
                             // Check to make sure state has not changed.
                             if (_requestStatus.value != RequestStatus.SENDING) {
-                                Log.wtf(TAG, "ButtonRequestStatus unexpectedly changed")
+                                Logger.e { "ButtonRequestStatus unexpectedly changed" }
                             } else {
                                 _requestStatus.value = RequestStatus.SENDING_TIMEOUT
                             }
@@ -205,7 +199,7 @@ class RemoteButtonViewModelImpl(
                         job = viewModelScope.launch(dispatchers.io) {
                             delay(Duration.ofSeconds(10))
                             if (_requestStatus.value != RequestStatus.SENT) {
-                                Log.wtf(TAG, "ButtonRequestStatus unexpectedly changed")
+                                Logger.e { "ButtonRequestStatus unexpectedly changed" }
                             } else {
                                 _requestStatus.value = RequestStatus.SENT_TIMEOUT
                             }
@@ -219,7 +213,7 @@ class RemoteButtonViewModelImpl(
                         job = viewModelScope.launch(dispatchers.io) {
                             delay(Duration.ofSeconds(10))
                             if (_requestStatus.value != RequestStatus.RECEIVED) {
-                                Log.wtf(TAG, "ButtonRequestStatus unexpectedly changed")
+                                Logger.e { "ButtonRequestStatus unexpectedly changed" }
                             }
                             _requestStatus.value = RequestStatus.NONE
                         }
@@ -232,7 +226,7 @@ class RemoteButtonViewModelImpl(
                         job = viewModelScope.launch(dispatchers.io) {
                             delay(Duration.ofSeconds(10))
                             if (_requestStatus.value != RequestStatus.SENDING_TIMEOUT) {
-                                Log.wtf(TAG, "ButtonRequestStatus unexpectedly changed")
+                                Logger.e { "ButtonRequestStatus unexpectedly changed" }
                             }
                             _requestStatus.value = RequestStatus.NONE
                         }
@@ -245,17 +239,14 @@ class RemoteButtonViewModelImpl(
                         job = viewModelScope.launch(dispatchers.io) {
                             delay(Duration.ofSeconds(10))
                             if (_requestStatus.value != RequestStatus.SENT_TIMEOUT) {
-                                Log.wtf(TAG, "ButtonRequestStatus unexpectedly changed")
+                                Logger.e { "ButtonRequestStatus unexpectedly changed" }
                             }
                             _requestStatus.value = RequestStatus.NONE
                         }
                         mutex.unlock()
                     }
                 }
-                Log.d(
-                    TAG,
-                    "ButtonRequestStateMachine timeouts: " + _requestStatus.value.name,
-                )
+                Logger.d { "ButtonRequestStateMachine timeouts: ${_requestStatus.value.name}" }
             }
         }
     }
@@ -274,7 +265,7 @@ class RemoteButtonViewModelImpl(
      * Requires an authenticated user.
      */
     override fun pushRemoteButton() {
-        Log.d(TAG, "pushRemoteButton")
+        Logger.d { "pushRemoteButton" }
         viewModelScope.launch(dispatchers.io) {
             pushRemoteButtonUseCase(
                 buttonAckToken = createButtonAckToken(Date()),
@@ -283,14 +274,14 @@ class RemoteButtonViewModelImpl(
     }
 
     override fun snoozeOpenDoorsNotifications(snoozeDuration: SnoozeDurationUIOption) {
-        Log.d(TAG, "snoozeOpenDoorsNotifications")
+        Logger.d { "snoozeOpenDoorsNotifications" }
         viewModelScope.launch(dispatchers.io) {
             val result = snoozeNotificationsUseCase(
                 snoozeDurationHours = snoozeDuration.toServer().duration,
                 lastChangeTimeSeconds = currentDoorEvent.value?.lastChangeTimeSeconds,
             )
             if (!result) {
-                Log.e(TAG, "Snooze failed — not authenticated or no door event")
+                Logger.e { "Snooze failed — not authenticated or no door event" }
             }
         }
     }
@@ -305,5 +296,3 @@ class RemoteButtonViewModelImpl(
         }
     }
 }
-
-private const val TAG = "RemoteButtonViewModel"

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/settings/SettingManager.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/settings/SettingManager.kt
@@ -18,7 +18,7 @@
 package com.chriscartland.garage.settings
 
 import android.content.SharedPreferences
-import android.util.Log
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.settings.SettingType.BooleanSetting
 import com.chriscartland.garage.settings.SettingType.IntSetting
 import com.chriscartland.garage.settings.SettingType.LongSetting
@@ -64,11 +64,11 @@ sealed class SettingType<T> : Setting<T> {
     ) : SettingType<String>() {
         override fun get(): String =
             (prefs.getString(key, default) ?: default).also {
-                Log.d(TAG, "get: String $key = $it")
+                Logger.d { "get: String $key = $it" }
             }
 
         override fun set(value: String) {
-            Log.d(TAG, "set: String $key = $value")
+            Logger.d { "set: String $key = $value" }
             with(prefs.edit()) {
                 putString(key, value)
                 apply()
@@ -76,7 +76,7 @@ sealed class SettingType<T> : Setting<T> {
         }
 
         override fun restoreDefault() {
-            Log.d(TAG, "restoreDefault: String $key = $default")
+            Logger.d { "restoreDefault: String $key = $default" }
             with(prefs.edit()) {
                 remove(key)
                 apply()
@@ -91,11 +91,11 @@ sealed class SettingType<T> : Setting<T> {
     ) : SettingType<Boolean>() {
         override fun get(): Boolean =
             prefs.getBoolean(key, default).also {
-                Log.d(TAG, "get: Boolean $key = $it")
+                Logger.d { "get: Boolean $key = $it" }
             }
 
         override fun set(value: Boolean) {
-            Log.d(TAG, "set: Boolean $key = $value")
+            Logger.d { "set: Boolean $key = $value" }
             with(prefs.edit()) {
                 putBoolean(key, value)
                 apply()
@@ -103,7 +103,7 @@ sealed class SettingType<T> : Setting<T> {
         }
 
         override fun restoreDefault() {
-            Log.d(TAG, "restoreDefault: Boolean $key = $default")
+            Logger.d { "restoreDefault: Boolean $key = $default" }
             with(prefs.edit()) {
                 remove(key)
                 apply()
@@ -118,11 +118,11 @@ sealed class SettingType<T> : Setting<T> {
     ) : SettingType<Int>() {
         override fun get(): Int =
             prefs.getInt(key, default).also {
-                Log.d(TAG, "get: Int $key = $it")
+                Logger.d { "get: Int $key = $it" }
             }
 
         override fun set(value: Int) {
-            Log.d(TAG, "set: Int $key = $value")
+            Logger.d { "set: Int $key = $value" }
             with(prefs.edit()) {
                 putInt(key, value)
                 apply()
@@ -130,7 +130,7 @@ sealed class SettingType<T> : Setting<T> {
         }
 
         override fun restoreDefault() {
-            Log.d(TAG, "restoreDefault: Int $key = $default")
+            Logger.d { "restoreDefault: Int $key = $default" }
             with(prefs.edit()) {
                 remove(key)
                 apply()
@@ -141,7 +141,7 @@ sealed class SettingType<T> : Setting<T> {
             val newValue = get() + 1
             set(newValue)
             return newValue.also {
-                Log.d(TAG, "increment: Int $key = $it")
+                Logger.d { "increment: Int $key = $it" }
             }
         }
     }
@@ -153,11 +153,11 @@ sealed class SettingType<T> : Setting<T> {
     ) : SettingType<Long>() {
         override fun get(): Long =
             prefs.getLong(key, default).also {
-                Log.d(TAG, "get: Long $key = $it")
+                Logger.d { "get: Long $key = $it" }
             }
 
         override fun set(value: Long) {
-            Log.d(TAG, "set: Long $key = $value")
+            Logger.d { "set: Long $key = $value" }
             with(prefs.edit()) {
                 putLong(key, value)
                 apply()
@@ -165,7 +165,7 @@ sealed class SettingType<T> : Setting<T> {
         }
 
         override fun restoreDefault() {
-            Log.d(TAG, "restoreDefault: Long $key = $default")
+            Logger.d { "restoreDefault: Long $key = $default" }
             with(prefs.edit()) {
                 remove(key)
                 apply()
@@ -176,10 +176,8 @@ sealed class SettingType<T> : Setting<T> {
             val newValue = get() + 1
             set(newValue)
             return newValue.also {
-                Log.d(TAG, "increment: Long $key = $it")
+                Logger.d { "increment: Long $key = $it" }
             }
         }
     }
 }
-
-private const val TAG = "SettingManager"

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
@@ -17,7 +17,6 @@
 
 package com.chriscartland.garage.ui
 
-import android.util.Log
 import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.ReportDrawnWhen
 import androidx.compose.foundation.clickable
@@ -36,6 +35,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.applogger.AppLoggerViewModel
 import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.di.rememberAppComponent
@@ -66,7 +66,7 @@ fun DoorHistoryContent(
             if (activity != null) {
                 resolvedDoorViewModel.deregisterFcm(activity)
             } else {
-                Log.e(TAG, "Activity is null, cannot deregister FCM")
+                Logger.e { "Activity is null, cannot deregister FCM" }
             }
         },
     )
@@ -92,10 +92,7 @@ fun DoorHistoryContent(
                     OldLastCheckInBanner(
                         modifier = Modifier.fillMaxWidth(),
                         action = {
-                            Log.e(
-                                TAG,
-                                "Trying to fix outdated info. Resetting FCM, and fetching data.",
-                            )
+                            Logger.e { "Trying to fix outdated info. Resetting FCM, and fetching data." }
                             onResetFcm()
                             onFetchRecentDoorEvents()
                         },
@@ -143,5 +140,3 @@ fun DoorHistoryContentPreview() {
         recentDoorEvents = LoadingResult.Complete(demoDoorEvents),
     )
 }
-
-private const val TAG = "DoorHistoryContent"

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -17,7 +17,6 @@
 
 package com.chriscartland.garage.ui
 
-import android.util.Log
 import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.ReportDrawnWhen
 import androidx.compose.foundation.clickable
@@ -43,6 +42,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.applogger.AppLoggerViewModel
 import com.chriscartland.garage.auth.AuthViewModel
 import com.chriscartland.garage.config.AppLoggerKeys
@@ -89,11 +89,7 @@ fun HomeContent(
         onRemoteButtonClick = {
             when (authState) {
                 is AuthState.Authenticated -> {
-                    Log.d(
-                        TAG,
-                        "Remote button clicked. " +
-                            "AuthViewModel authState $authState",
-                    )
+                    Logger.d { "Remote button clicked. AuthViewModel authState $authState" }
                     buttonViewModel.pushRemoteButton()
                 }
 
@@ -101,7 +97,7 @@ fun HomeContent(
                     if (activity != null) {
                         resolvedAuthViewModel.signInWithGoogle(activity)
                     } else {
-                        Log.e(TAG, "Activity is null, cannot sign in with Google")
+                        Logger.e { "Activity is null, cannot sign in with Google" }
                     }
                 }
 
@@ -109,7 +105,7 @@ fun HomeContent(
                     if (activity != null) {
                         resolvedAuthViewModel.signInWithGoogle(activity)
                     } else {
-                        Log.e(TAG, "Activity is null, cannot sign in with Google")
+                        Logger.e { "Activity is null, cannot sign in with Google" }
                     }
                 }
             }
@@ -120,14 +116,14 @@ fun HomeContent(
             if (activity != null) {
                 resolvedAuthViewModel.signInWithGoogle(activity)
             } else {
-                Log.e(TAG, "Activity is null, cannot sign in with Google")
+                Logger.e { "Activity is null, cannot sign in with Google" }
             }
         },
         onResetFcm = {
             if (activity != null) {
                 resolvedDoorViewModel.deregisterFcm(activity)
             } else {
-                Log.e(TAG, "Activity is null, cannot deregister FCM")
+                Logger.e { "Activity is null, cannot deregister FCM" }
             }
         },
         onLogNotificationPermissionRequested = {
@@ -166,7 +162,7 @@ fun HomeContent(
             if (isOld) {
                 OldLastCheckInBanner(
                     action = {
-                        Log.e(TAG, "Trying to fix outdated info. Resetting FCM, and fetching data.")
+                        Logger.e { "Trying to fix outdated info. Resetting FCM, and fetching data." }
                         onResetFcm()
                         onFetchCurrentDoorEvent()
                     },
@@ -237,7 +233,7 @@ fun HomeContent(
                             modifier = Modifier
                                 .fillMaxSize(),
                             onSubmit = {
-                                Log.d("HomeContent", "Remote button clicked")
+                                Logger.d { "Remote button clicked" }
                                 onRemoteButtonClick()
                             },
                             onArming = {
@@ -269,5 +265,3 @@ fun HomeContentPreview() {
         },
     )
 }
-
-private const val TAG = "HomeContent"

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
@@ -17,7 +17,6 @@
 
 package com.chriscartland.garage.ui
 
-import android.util.Log
 import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.ReportDrawn
 import androidx.compose.foundation.layout.Arrangement
@@ -36,6 +35,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.auth.AuthViewModel
 import com.chriscartland.garage.config.APP_CONFIG
 import com.chriscartland.garage.di.rememberAppComponent
@@ -82,7 +82,7 @@ fun ProfileContent(
             if (activity != null) {
                 resolvedAuthViewModel.signInWithGoogle(activity)
             } else {
-                Log.e(TAG, "Activity is null, cannot sign in with Google")
+                Logger.e { "Activity is null, cannot sign in with Google" }
             }
         },
         signOut = { resolvedAuthViewModel.signOut() },
@@ -165,5 +165,3 @@ fun ProfileContent(
 fun ProfileContentPreview() {
     ProfileContent()
 }
-
-private const val TAG = "ProfileContent"

--- a/AndroidGarage/gradle/libs.versions.toml
+++ b/AndroidGarage/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ gms = "4.4.2"
 kotlinInject = "0.9.0"
 kotlinxSerialization = "1.8.1"
 ktor = "3.1.3"
+kermit = "2.0.4"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 kotlin = "2.1.20"
@@ -87,6 +88,7 @@ ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "kto
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
+kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }


### PR DESCRIPTION
## Summary
Replace `android.util.Log` with Kermit (`co.touchlab:kermit` 2.0.4) across all 20 files. Kermit is KMP-compatible, unblocking Phase 9 (moving repos/data sources to `commonMain`).

- `Log.d(TAG, "msg")` → `Logger.d { "msg" }` (lazy evaluation)
- String concatenation → string templates
- Removed all TAG constants
- Zero `android.util.Log` imports remain
- Net -69 lines

## Test plan
- [x] All 133 unit tests pass
- [x] `./scripts/validate.sh` passes
- [x] Zero `android.util.Log` imports in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)