### PR TITLE
feat: Move ServerConfigRepositoryImpl to data module (Phase 9)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -23,19 +23,20 @@ import com.chriscartland.garage.applogger.AppLoggerRepositoryImpl
 import com.chriscartland.garage.applogger.AppLoggerViewModelImpl
 import com.chriscartland.garage.auth.AuthRepositoryImpl
 import com.chriscartland.garage.auth.AuthViewModelImpl
-import com.chriscartland.garage.config.ServerConfigRepository
-import com.chriscartland.garage.config.ServerConfigRepositoryImpl
+import com.chriscartland.garage.config.APP_CONFIG
 import com.chriscartland.garage.coroutines.DefaultDispatcherProvider
 import com.chriscartland.garage.coroutines.DispatcherProvider
 import com.chriscartland.garage.data.LocalDoorDataSource
 import com.chriscartland.garage.data.NetworkButtonDataSource
 import com.chriscartland.garage.data.NetworkConfigDataSource
 import com.chriscartland.garage.data.NetworkDoorDataSource
+import com.chriscartland.garage.data.repository.ServerConfigRepositoryImpl
 import com.chriscartland.garage.db.AppDatabase
 import com.chriscartland.garage.db.DatabaseLocalDoorDataSource
 import com.chriscartland.garage.domain.repository.AuthRepository
 import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.domain.repository.PushRepository
+import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import com.chriscartland.garage.door.DoorRepositoryImpl
 import com.chriscartland.garage.door.DoorViewModelImpl
 import com.chriscartland.garage.fcm.DoorFcmRepository
@@ -119,7 +120,8 @@ abstract class AppComponent(
 
     @Provides
     @Singleton
-    fun provideServerConfigRepository(): ServerConfigRepository = ServerConfigRepositoryImpl(provideNetworkConfigDataSource())
+    fun provideServerConfigRepository(): ServerConfigRepository =
+        ServerConfigRepositoryImpl(provideNetworkConfigDataSource(), APP_CONFIG.serverConfigKey)
 
     @Provides
     @Singleton

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorRepositoryImpl.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorRepositoryImpl.kt
@@ -19,12 +19,12 @@ package com.chriscartland.garage.door
 
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.config.APP_CONFIG
-import com.chriscartland.garage.config.ServerConfigRepository
 import com.chriscartland.garage.data.LocalDoorDataSource
 import com.chriscartland.garage.data.NetworkDoorDataSource
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.repository.DoorRepository
+import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/PushRepository.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/PushRepository.kt
@@ -19,11 +19,11 @@ package com.chriscartland.garage.remotebutton
 
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.config.APP_CONFIG
-import com.chriscartland.garage.config.ServerConfigRepository
 import com.chriscartland.garage.data.NetworkButtonDataSource
 import com.chriscartland.garage.domain.model.PushStatus
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
 import com.chriscartland.garage.domain.repository.PushRepository
+import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.time.delay

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/config/ServerConfigRepositoryTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/config/ServerConfigRepositoryTest.kt
@@ -18,6 +18,7 @@
 package com.chriscartland.garage.config
 
 import com.chriscartland.garage.data.NetworkConfigDataSource
+import com.chriscartland.garage.data.repository.ServerConfigRepositoryImpl
 import com.chriscartland.garage.domain.model.ServerConfig
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -49,7 +50,7 @@ class ServerConfigRepositoryTest {
     @Before
     fun setup() {
         networkConfig = FakeNetworkConfigDataSource()
-        repo = ServerConfigRepositoryImpl(networkConfig)
+        repo = ServerConfigRepositoryImpl(networkConfig, "test-config-key")
     }
 
     @Test

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/PushRepositoryTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/PushRepositoryTest.kt
@@ -17,11 +17,11 @@
 
 package com.chriscartland.garage.remotebutton
 
-import com.chriscartland.garage.config.ServerConfigRepository
 import com.chriscartland.garage.data.NetworkButtonDataSource
 import com.chriscartland.garage.domain.model.PushStatus
 import com.chriscartland.garage.domain.model.ServerConfig
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
+import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/ServerConfigRepositoryImpl.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/ServerConfigRepositoryImpl.kt
@@ -15,20 +15,16 @@
  *
  */
 
-package com.chriscartland.garage.config
+package com.chriscartland.garage.data.repository
 
 import com.chriscartland.garage.data.NetworkConfigDataSource
 import com.chriscartland.garage.domain.model.ServerConfig
+import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import kotlinx.coroutines.sync.Mutex
-
-interface ServerConfigRepository {
-    suspend fun getServerConfigCached(): ServerConfig?
-
-    suspend fun fetchServerConfig(): ServerConfig?
-}
 
 class ServerConfigRepositoryImpl(
     private val networkConfigDataSource: NetworkConfigDataSource,
+    private val serverConfigKey: String,
 ) : ServerConfigRepository {
     private var serverConfig: ServerConfig? = null
 
@@ -45,7 +41,7 @@ class ServerConfigRepositoryImpl(
     }
 
     override suspend fun fetchServerConfig(): ServerConfig? {
-        val config = networkConfigDataSource.fetchServerConfig(APP_CONFIG.serverConfigKey)
+        val config = networkConfigDataSource.fetchServerConfig(serverConfigKey)
         if (config != null) {
             serverConfig = config
         }


### PR DESCRIPTION
## Summary
First step of Phase 9: move pure Kotlin repository implementations to the shared data module.

- `ServerConfigRepositoryImpl` → `data/src/commonMain/kotlin/` (zero Android deps)
- Inject `serverConfigKey` via constructor instead of global `APP_CONFIG` reference
- Remove duplicate `ServerConfigRepository` interface from `config/` (domain already has it)
- Update all imports and DI wiring

## Test plan
- [x] All 133 unit tests pass (including ServerConfigRepositoryTest)
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)