### PR TITLE
refactor: Inject APP_CONFIG into repositories (Phase 9 prep)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -116,7 +116,12 @@ abstract class AppComponent(
     @Provides
     @Singleton
     fun provideDoorRepository(): DoorRepository =
-        DoorRepositoryImpl(provideLocalDoorDataSource(), provideNetworkDoorDataSource(), provideServerConfigRepository())
+        DoorRepositoryImpl(
+            provideLocalDoorDataSource(),
+            provideNetworkDoorDataSource(),
+            provideServerConfigRepository(),
+            APP_CONFIG.recentEventCount,
+        )
 
     @Provides
     @Singleton
@@ -166,7 +171,13 @@ abstract class AppComponent(
     // Repositories — push
     @Provides
     @Singleton
-    fun providePushRepository(): PushRepository = PushRepositoryImpl(provideNetworkButtonDataSource(), provideServerConfigRepository())
+    fun providePushRepository(): PushRepository =
+        PushRepositoryImpl(
+            provideNetworkButtonDataSource(),
+            provideServerConfigRepository(),
+            APP_CONFIG.remoteButtonPushEnabled,
+            APP_CONFIG.snoozeNotificationsOption,
+        )
 
     // Coroutines
     @Provides

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorRepositoryImpl.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorRepositoryImpl.kt
@@ -18,7 +18,6 @@
 package com.chriscartland.garage.door
 
 import co.touchlab.kermit.Logger
-import com.chriscartland.garage.config.APP_CONFIG
 import com.chriscartland.garage.data.LocalDoorDataSource
 import com.chriscartland.garage.data.NetworkDoorDataSource
 import com.chriscartland.garage.domain.model.DoorEvent
@@ -33,6 +32,7 @@ class DoorRepositoryImpl(
     private val localDoorDataSource: LocalDoorDataSource,
     private val networkDoorDataSource: NetworkDoorDataSource,
     private val serverConfigRepository: ServerConfigRepository,
+    private val recentEventCount: Int,
 ) : DoorRepository {
     override val currentDoorPosition: Flow<DoorPosition>
         get() =
@@ -73,7 +73,7 @@ class DoorRepositoryImpl(
         }
         val doorEvents = networkDoorDataSource.fetchRecentDoorEvents(
             buildTimestamp = buildTimestamp,
-            count = APP_CONFIG.recentEventCount,
+            count = recentEventCount,
         )
         if (doorEvents == null) {
             Logger.e { "Failed to fetch recent door events" }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/PushRepository.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/PushRepository.kt
@@ -18,7 +18,6 @@
 package com.chriscartland.garage.remotebutton
 
 import co.touchlab.kermit.Logger
-import com.chriscartland.garage.config.APP_CONFIG
 import com.chriscartland.garage.data.NetworkButtonDataSource
 import com.chriscartland.garage.domain.model.PushStatus
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
@@ -33,6 +32,8 @@ import java.util.Date
 class PushRepositoryImpl(
     private val networkButtonDataSource: NetworkButtonDataSource,
     private val serverConfigRepository: ServerConfigRepository,
+    private val remoteButtonPushEnabled: Boolean,
+    private val snoozeNotificationsOption: Boolean,
 ) : PushRepository {
     private val _pushButtonStatus = MutableStateFlow(PushStatus.IDLE)
     override val pushButtonStatus: StateFlow<PushStatus> = _pushButtonStatus
@@ -54,11 +55,11 @@ class PushRepositoryImpl(
             _pushButtonStatus.value = PushStatus.IDLE
             return
         }
-        if (!APP_CONFIG.remoteButtonPushEnabled) {
+        if (!remoteButtonPushEnabled) {
             Logger.w { "Remote button push is disabled" }
             delay(Duration.ofMillis(500))
         }
-        if (APP_CONFIG.remoteButtonPushEnabled) {
+        if (remoteButtonPushEnabled) {
             networkButtonDataSource.pushButton(
                 remoteButtonBuildTimestamp = serverConfig.remoteButtonBuildTimestamp,
                 buttonAckToken = buttonAckToken,
@@ -75,11 +76,11 @@ class PushRepositoryImpl(
             Logger.e { "Server config is null" }
             return
         }
-        if (!APP_CONFIG.snoozeNotificationsOption) {
+        if (!snoozeNotificationsOption) {
             Logger.w { "Snooze notifications disabled" }
             delay(Duration.ofMillis(500))
         }
-        if (APP_CONFIG.snoozeNotificationsOption) {
+        if (snoozeNotificationsOption) {
             val endTime = networkButtonDataSource.fetchSnoozeEndTimeSeconds(
                 buildTimestamp = serverConfig.buildTimestamp,
             )
@@ -99,11 +100,11 @@ class PushRepositoryImpl(
             _snoozeRequestStatus.value = SnoozeRequestStatus.IDLE
             return
         }
-        if (!APP_CONFIG.snoozeNotificationsOption) {
+        if (!snoozeNotificationsOption) {
             Logger.w { "Snooze notifications disabled" }
             delay(Duration.ofMillis(500))
         }
-        if (APP_CONFIG.snoozeNotificationsOption) {
+        if (snoozeNotificationsOption) {
             val success = networkButtonDataSource.snoozeNotifications(
                 buildTimestamp = serverConfig.buildTimestamp,
                 remoteButtonPushKey = serverConfig.remoteButtonPushKey,

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/PushRepositoryTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/PushRepositoryTest.kt
@@ -45,7 +45,12 @@ class PushRepositoryTest {
     fun setup() {
         networkButtonDataSource = mock(NetworkButtonDataSource::class.java)
         serverConfigRepository = mock(ServerConfigRepository::class.java)
-        repo = PushRepositoryImpl(networkButtonDataSource, serverConfigRepository)
+        repo = PushRepositoryImpl(
+            networkButtonDataSource,
+            serverConfigRepository,
+            remoteButtonPushEnabled = true,
+            snoozeNotificationsOption = true,
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
Remove direct `APP_CONFIG` global references from repository implementations,
replacing with constructor-injected values. This removes the last
Android-specific coupling from these repos, preparing them for extraction
to the shared `data/` module.

| Repository | Injected values |
|-----------|----------------|
| `DoorRepositoryImpl` | `recentEventCount: Int` |
| `PushRepositoryImpl` | `remoteButtonPushEnabled: Boolean`, `snoozeNotificationsOption: Boolean` |

## Test plan
- [x] All 133 unit tests pass
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)