### PR TITLE
feat: Move repository implementations to data module (Phase 9)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -30,6 +30,8 @@ import com.chriscartland.garage.data.LocalDoorDataSource
 import com.chriscartland.garage.data.NetworkButtonDataSource
 import com.chriscartland.garage.data.NetworkConfigDataSource
 import com.chriscartland.garage.data.NetworkDoorDataSource
+import com.chriscartland.garage.data.repository.DoorRepositoryImpl
+import com.chriscartland.garage.data.repository.PushRepositoryImpl
 import com.chriscartland.garage.data.repository.ServerConfigRepositoryImpl
 import com.chriscartland.garage.db.AppDatabase
 import com.chriscartland.garage.db.DatabaseLocalDoorDataSource
@@ -37,7 +39,6 @@ import com.chriscartland.garage.domain.repository.AuthRepository
 import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.domain.repository.PushRepository
 import com.chriscartland.garage.domain.repository.ServerConfigRepository
-import com.chriscartland.garage.door.DoorRepositoryImpl
 import com.chriscartland.garage.door.DoorViewModelImpl
 import com.chriscartland.garage.fcm.DoorFcmRepository
 import com.chriscartland.garage.fcm.DoorFcmRepositoryImpl
@@ -45,7 +46,6 @@ import com.chriscartland.garage.internet.KtorNetworkButtonDataSource
 import com.chriscartland.garage.internet.KtorNetworkConfigDataSource
 import com.chriscartland.garage.internet.KtorNetworkDoorDataSource
 import com.chriscartland.garage.internet.provideKtorHttpClient
-import com.chriscartland.garage.remotebutton.PushRepositoryImpl
 import com.chriscartland.garage.remotebutton.RemoteButtonViewModelImpl
 import com.chriscartland.garage.settings.AppSettings
 import com.chriscartland.garage.settings.AppSettingsImpl

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
@@ -296,3 +296,21 @@ class RemoteButtonViewModelImpl(
         }
     }
 }
+
+/**
+ * Create a button ack token.
+ *
+ * This token is created by the client so the server can acknowledge the remote button push.
+ * The client can send the same token to the server multiple times and the server is
+ * responsible for only processing the token once.
+ * When the server receives a button press, it will respond with the token to the client.
+ */
+fun createButtonAckToken(now: Date): String {
+    val humanReadable = java.text.SimpleDateFormat("yyyy-MM-dd hh:mm:ss a", java.util.Locale.US).format(now)
+    val timestampMillis = now.time
+    val appVersion = "AppVersionTODO"
+    val buttonAckTokenData = "android-$appVersion-$humanReadable-$timestampMillis"
+    val re = Regex("[^a-zA-Z0-9-_.]")
+    val filtered = re.replace(buttonAckTokenData, ".")
+    return filtered
+}

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/PushRepositoryTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/PushRepositoryTest.kt
@@ -18,6 +18,7 @@
 package com.chriscartland.garage.remotebutton
 
 import com.chriscartland.garage.data.NetworkButtonDataSource
+import com.chriscartland.garage.data.repository.PushRepositoryImpl
 import com.chriscartland.garage.domain.model.PushStatus
 import com.chriscartland.garage.domain.model.ServerConfig
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus

--- a/AndroidGarage/data/build.gradle.kts
+++ b/AndroidGarage/data/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
         commonMain.dependencies {
             implementation(project(":domain"))
             implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kermit)
         }
     }
 }

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/DoorRepositoryImpl.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/DoorRepositoryImpl.kt
@@ -15,7 +15,7 @@
  *
  */
 
-package com.chriscartland.garage.door
+package com.chriscartland.garage.data.repository
 
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.LocalDoorDataSource

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/PushRepositoryImpl.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/PushRepositoryImpl.kt
@@ -15,7 +15,7 @@
  *
  */
 
-package com.chriscartland.garage.remotebutton
+package com.chriscartland.garage.data.repository
 
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.NetworkButtonDataSource
@@ -27,7 +27,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.time.delay
 import java.time.Duration
-import java.util.Date
 
 class PushRepositoryImpl(
     private val networkButtonDataSource: NetworkButtonDataSource,
@@ -119,22 +118,4 @@ class PushRepositoryImpl(
         }
         _snoozeRequestStatus.value = SnoozeRequestStatus.IDLE
     }
-}
-
-/**
- * Create a button ack token.
- *
- * This token is created by the client so the server can acknowledge the remote button push.
- * The client can send the same token to the server multiple times and the server is
- * responsible for only processing the token once.
- * When the server receives a button press, it will respond with the token to the client.
- */
-fun createButtonAckToken(now: Date): String {
-    val humanReadable = java.text.SimpleDateFormat("yyyy-MM-dd hh:mm:ss a", java.util.Locale.US).format(now)
-    val timestampMillis = now.time
-    val appVersion = "AppVersionTODO"
-    val buttonAckTokenData = "android-$appVersion-$humanReadable-$timestampMillis"
-    val re = Regex("[^a-zA-Z0-9-_.]")
-    val filtered = re.replace(buttonAckTokenData, ".")
-    return filtered
 }


### PR DESCRIPTION
## Summary
Move all 3 repository implementations from `androidApp` to `data/src/commonMain/`:
- `DoorRepositoryImpl` — zero Android deps, clean move
- `PushRepositoryImpl` — JVM deps (`Duration`, `Date`) work for Android KMP target
- `ServerConfigRepositoryImpl` — already moved in PR #130

Also:
- `createButtonAckToken()` moved to `RemoteButtonViewModel.kt` (uses `SimpleDateFormat`)
- Kermit added to data module dependencies
- Git shows clean renames

All repository implementations are now in the shared data module, completing Phase 9's core goal.

## Test plan
- [x] All 133 unit tests pass
- [x] `./scripts/validate.sh` passes
- [x] Git shows renames (not delete+create)

🤖 Generated with [Claude Code](https://claude.com/claude-code)