### PR TITLE
refactor: Rename *Impl repos + ADR-008 naming convention

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -30,9 +30,9 @@ import com.chriscartland.garage.data.LocalDoorDataSource
 import com.chriscartland.garage.data.NetworkButtonDataSource
 import com.chriscartland.garage.data.NetworkConfigDataSource
 import com.chriscartland.garage.data.NetworkDoorDataSource
-import com.chriscartland.garage.data.repository.DoorRepositoryImpl
-import com.chriscartland.garage.data.repository.PushRepositoryImpl
-import com.chriscartland.garage.data.repository.ServerConfigRepositoryImpl
+import com.chriscartland.garage.data.repository.CachedServerConfigRepository
+import com.chriscartland.garage.data.repository.NetworkDoorRepository
+import com.chriscartland.garage.data.repository.NetworkPushRepository
 import com.chriscartland.garage.db.AppDatabase
 import com.chriscartland.garage.db.DatabaseLocalDoorDataSource
 import com.chriscartland.garage.domain.repository.AuthRepository
@@ -116,7 +116,7 @@ abstract class AppComponent(
     @Provides
     @Singleton
     fun provideDoorRepository(): DoorRepository =
-        DoorRepositoryImpl(
+        NetworkDoorRepository(
             provideLocalDoorDataSource(),
             provideNetworkDoorDataSource(),
             provideServerConfigRepository(),
@@ -126,7 +126,7 @@ abstract class AppComponent(
     @Provides
     @Singleton
     fun provideServerConfigRepository(): ServerConfigRepository =
-        ServerConfigRepositoryImpl(provideNetworkConfigDataSource(), APP_CONFIG.serverConfigKey)
+        CachedServerConfigRepository(provideNetworkConfigDataSource(), APP_CONFIG.serverConfigKey)
 
     @Provides
     @Singleton
@@ -172,7 +172,7 @@ abstract class AppComponent(
     @Provides
     @Singleton
     fun providePushRepository(): PushRepository =
-        PushRepositoryImpl(
+        NetworkPushRepository(
             provideNetworkButtonDataSource(),
             provideServerConfigRepository(),
             APP_CONFIG.remoteButtonPushEnabled,

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/config/ServerConfigRepositoryTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/config/ServerConfigRepositoryTest.kt
@@ -18,7 +18,7 @@
 package com.chriscartland.garage.config
 
 import com.chriscartland.garage.data.NetworkConfigDataSource
-import com.chriscartland.garage.data.repository.ServerConfigRepositoryImpl
+import com.chriscartland.garage.data.repository.CachedServerConfigRepository
 import com.chriscartland.garage.domain.model.ServerConfig
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -39,7 +39,7 @@ class FakeNetworkConfigDataSource : NetworkConfigDataSource {
 
 class ServerConfigRepositoryTest {
     private lateinit var networkConfig: FakeNetworkConfigDataSource
-    private lateinit var repo: ServerConfigRepositoryImpl
+    private lateinit var repo: CachedServerConfigRepository
 
     private val validConfig = ServerConfig(
         buildTimestamp = "2024-01-15T00:00:00Z",
@@ -50,7 +50,7 @@ class ServerConfigRepositoryTest {
     @Before
     fun setup() {
         networkConfig = FakeNetworkConfigDataSource()
-        repo = ServerConfigRepositoryImpl(networkConfig, "test-config-key")
+        repo = CachedServerConfigRepository(networkConfig, "test-config-key")
     }
 
     @Test

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/PushRepositoryTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/PushRepositoryTest.kt
@@ -18,7 +18,7 @@
 package com.chriscartland.garage.remotebutton
 
 import com.chriscartland.garage.data.NetworkButtonDataSource
-import com.chriscartland.garage.data.repository.PushRepositoryImpl
+import com.chriscartland.garage.data.repository.NetworkPushRepository
 import com.chriscartland.garage.domain.model.PushStatus
 import com.chriscartland.garage.domain.model.ServerConfig
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
@@ -33,7 +33,7 @@ import org.mockito.Mockito.`when`
 class PushRepositoryTest {
     private lateinit var networkButtonDataSource: NetworkButtonDataSource
     private lateinit var serverConfigRepository: ServerConfigRepository
-    private lateinit var repo: PushRepositoryImpl
+    private lateinit var repo: NetworkPushRepository
 
     private val validServerConfig =
         ServerConfig(
@@ -46,7 +46,7 @@ class PushRepositoryTest {
     fun setup() {
         networkButtonDataSource = mock(NetworkButtonDataSource::class.java)
         serverConfigRepository = mock(ServerConfigRepository::class.java)
-        repo = PushRepositoryImpl(
+        repo = NetworkPushRepository(
             networkButtonDataSource,
             serverConfigRepository,
             remoteButtonPushEnabled = true,

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepository.kt
@@ -22,7 +22,7 @@ import com.chriscartland.garage.domain.model.ServerConfig
 import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import kotlinx.coroutines.sync.Mutex
 
-class ServerConfigRepositoryImpl(
+class CachedServerConfigRepository(
     private val networkConfigDataSource: NetworkConfigDataSource,
     private val serverConfigKey: String,
 ) : ServerConfigRepository {

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepository.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
-class DoorRepositoryImpl(
+class NetworkDoorRepository(
     private val localDoorDataSource: LocalDoorDataSource,
     private val networkDoorDataSource: NetworkDoorDataSource,
     private val serverConfigRepository: ServerConfigRepository,

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkPushRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkPushRepository.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.time.delay
 import java.time.Duration
 
-class PushRepositoryImpl(
+class NetworkPushRepository(
     private val networkButtonDataSource: NetworkButtonDataSource,
     private val serverConfigRepository: ServerConfigRepository,
     private val remoteButtonPushEnabled: Boolean,

--- a/AndroidGarage/docs/DECISIONS.md
+++ b/AndroidGarage/docs/DECISIONS.md
@@ -138,7 +138,36 @@ ViewModels depend on UseCases, not Repositories directly. Each UseCase has a sin
 - No flaky CI from font rendering differences across environments
 - Requires disciplined preview authoring (deterministic data)
 
-## ADR-008: Parsing Objects Over Generic Extension Functions
+## ADR-008: Implementation Naming — No "Impl" Suffix
+
+**Status:** Accepted
+
+**Context:** The codebase uses `*Impl` suffixes for interface implementations (`DoorRepositoryImpl`, `AuthRepositoryImpl`). As the architecture grows with fakes, platform variants, and multiple real implementations, `Impl` conveys no information about _which_ implementation or _how_ it works.
+
+**Decision:** Name implementations with a descriptive prefix that explains the strategy. The description comes first. If no better name exists, `Default` is an acceptable prefix.
+
+**Naming patterns:**
+| Pattern | When to use | Example |
+|---------|------------|---------|
+| Strategy prefix | Implementation has a clear strategy | `CachedServerConfigRepository`, `NetworkDoorRepository` |
+| Platform prefix | Platform-specific implementation | `FirebaseAuthRepository`, `RoomAppLoggerRepository` |
+| `Default` prefix | No distinguishing strategy | `DefaultDispatcherProvider` |
+| Fake prefix | Test doubles — describe the fake type | `InMemoryDoorRepository`, `StubAuthRepository` |
+
+**Avoid:**
+- `*Impl` — says nothing about the implementation
+- `Fake*` without further description — `InMemory*` or `Stub*` is more descriptive
+
+**Migration:** Rename existing `*Impl` classes incrementally as they are touched. No bulk rename PR — renames happen alongside functional changes.
+
+**Consequences:**
+- Names communicate implementation strategy at a glance
+- Easier to distinguish multiple implementations of the same interface
+- Slightly longer class names (accepted tradeoff)
+
+## ADR-009: Parsing Objects Over Generic Extension Functions
+
+> _Was ADR-008 before the naming convention ADR was added._
 
 **Status:** Accepted
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,7 +267,8 @@ Push notifications are the hardest feature to verify in production. If topic nam
 ### Code Patterns
 - Prefer parser objects over extension functions on generic types (e.g., `FcmPayloadParser.parse(data)` not `Map.asDoorEvent()`)
 - Avoid bare top-level utility functions — group in an `object {}`
-- See ADR-008 in `docs/DECISIONS.md` for rationale
+- See ADR-009 in `docs/DECISIONS.md` for rationale
+- No `*Impl` suffix on implementations — use descriptive prefixes (`Network*`, `Cached*`, `Firebase*`, `Default*`). See ADR-008
 
 ## Known Limitations
 


### PR DESCRIPTION
## Summary
Establish naming convention (ADR-008) and rename the 3 repository implementations:

| Before | After | Why |
|--------|-------|-----|
| `DoorRepositoryImpl` | `NetworkDoorRepository` | Fetches from network, caches locally |
| `PushRepositoryImpl` | `NetworkPushRepository` | Sends push/snooze over network |
| `ServerConfigRepositoryImpl` | `CachedServerConfigRepository` | Caches config, fetches once |

ADR-008 added to `docs/DECISIONS.md`: no `*Impl` suffix, use descriptive prefixes.
Old ADR-008 (parsing objects) renumbered to ADR-009.

## Test plan
- [x] All 133 unit tests pass
- [x] `./scripts/validate.sh` passes
- [x] Git shows renames

🤖 Generated with [Claude Code](https://claude.com/claude-code)