### PR TITLE
feat: Add typed error system — AppResult<D, E> (Phase 14)

### DIFF
--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/AppResult.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/AppResult.kt
@@ -1,0 +1,120 @@
+package com.chriscartland.garage.domain.model
+
+/**
+ * A typed result that distinguishes success from failure with a specific error type.
+ *
+ * Unlike Kotlin's built-in [kotlin.Result] which uses [Throwable], this uses a sealed
+ * error hierarchy so callers handle specific failure cases at compile time.
+ *
+ * Usage:
+ * ```
+ * when (val result = repository.fetchDoorEvent()) {
+ *     is AppResult.Success -> handleEvent(result.data)
+ *     is AppResult.Error -> handleError(result.error)
+ * }
+ * ```
+ */
+sealed interface AppResult<out D, out E : AppError> {
+    data class Success<D>(
+        val data: D,
+    ) : AppResult<D, Nothing>
+
+    data class Error<E : AppError>(
+        val error: E,
+    ) : AppResult<Nothing, E>
+}
+
+/**
+ * Base interface for all application errors.
+ */
+interface AppError {
+    val message: String
+    val cause: Throwable?
+        get() = null
+}
+
+/**
+ * Data layer errors — network, database, configuration.
+ */
+sealed interface DataError : AppError {
+    sealed interface Network : DataError {
+        data class ConnectionFailed(
+            override val message: String = "Connection failed",
+            override val cause: Throwable? = null,
+        ) : Network
+
+        data class Timeout(
+            override val message: String = "Request timed out",
+            override val cause: Throwable? = null,
+        ) : Network
+
+        data class ServerError(
+            val httpCode: Int,
+            override val message: String = "Server error ($httpCode)",
+            override val cause: Throwable? = null,
+        ) : Network
+
+        data class NotReady(
+            override val message: String = "Server config not loaded",
+        ) : Network
+    }
+
+    data class Unknown(
+        override val message: String = "Unknown error",
+        override val cause: Throwable? = null,
+    ) : DataError
+}
+
+/**
+ * Authentication errors.
+ */
+sealed interface AuthError : AppError {
+    data class NotAuthenticated(
+        override val message: String = "Not authenticated",
+    ) : AuthError
+
+    data class TokenExpired(
+        override val message: String = "Token expired",
+    ) : AuthError
+
+    data class SignInFailed(
+        override val message: String = "Sign-in failed",
+        override val cause: Throwable? = null,
+    ) : AuthError
+}
+
+// --- Extension functions ---
+
+fun <D, E : AppError> AppResult<D, E>.getOrNull(): D? =
+    when (this) {
+        is AppResult.Success -> data
+        is AppResult.Error -> null
+    }
+
+fun <D, E : AppError> AppResult<D, E>.getOrElse(default: (E) -> D): D =
+    when (this) {
+        is AppResult.Success -> data
+        is AppResult.Error -> default(error)
+    }
+
+fun <D, E : AppError, R> AppResult<D, E>.map(transform: (D) -> R): AppResult<R, E> =
+    when (this) {
+        is AppResult.Success -> AppResult.Success(transform(data))
+        is AppResult.Error -> this
+    }
+
+fun <D, E : AppError, F : AppError> AppResult<D, E>.mapError(transform: (E) -> F): AppResult<D, F> =
+    when (this) {
+        is AppResult.Success -> this
+        is AppResult.Error -> AppResult.Error(transform(error))
+    }
+
+fun <D, E : AppError> AppResult<D, E>.onSuccess(action: (D) -> Unit): AppResult<D, E> {
+    if (this is AppResult.Success) action(data)
+    return this
+}
+
+fun <D, E : AppError> AppResult<D, E>.onError(action: (E) -> Unit): AppResult<D, E> {
+    if (this is AppResult.Error) action(error)
+    return this
+}

--- a/AndroidGarage/domain/src/commonTest/kotlin/com/chriscartland/garage/domain/model/AppResultTest.kt
+++ b/AndroidGarage/domain/src/commonTest/kotlin/com/chriscartland/garage/domain/model/AppResultTest.kt
@@ -1,0 +1,90 @@
+package com.chriscartland.garage.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AppResultTest {
+    @Test
+    fun successContainsData() {
+        val result: AppResult<String, DataError> = AppResult.Success("hello")
+        assertIs<AppResult.Success<String>>(result)
+        assertEquals("hello", result.data)
+    }
+
+    @Test
+    fun errorContainsTypedError() {
+        val result: AppResult<String, DataError.Network> =
+            AppResult.Error(DataError.Network.ConnectionFailed())
+        assertIs<AppResult.Error<DataError.Network.ConnectionFailed>>(result)
+        assertEquals("Connection failed", result.error.message)
+    }
+
+    @Test
+    fun getOrNullReturnsDataOnSuccess() {
+        val result: AppResult<Int, DataError> = AppResult.Success(42)
+        assertEquals(42, result.getOrNull())
+    }
+
+    @Test
+    fun getOrNullReturnsNullOnError() {
+        val result: AppResult<Int, DataError> =
+            AppResult.Error(DataError.Unknown("oops"))
+        assertNull(result.getOrNull())
+    }
+
+    @Test
+    fun getOrElseReturnsFallbackOnError() {
+        val result: AppResult<Int, DataError> =
+            AppResult.Error(DataError.Unknown("oops"))
+        assertEquals(-1, result.getOrElse { -1 })
+    }
+
+    @Test
+    fun mapTransformsSuccessData() {
+        val result: AppResult<Int, DataError> = AppResult.Success(10)
+        val mapped = result.map { it * 2 }
+        assertEquals(20, mapped.getOrNull())
+    }
+
+    @Test
+    fun mapPreservesError() {
+        val result: AppResult<Int, DataError> =
+            AppResult.Error(DataError.Unknown("fail"))
+        val mapped = result.map { it * 2 }
+        assertNull(mapped.getOrNull())
+    }
+
+    @Test
+    fun onSuccessCallsActionOnSuccess() {
+        var called = false
+        val result: AppResult<String, DataError> = AppResult.Success("ok")
+        result.onSuccess { called = true }
+        assertTrue(called)
+    }
+
+    @Test
+    fun onErrorCallsActionOnError() {
+        var called = false
+        val result: AppResult<String, DataError> =
+            AppResult.Error(DataError.Unknown())
+        result.onError { called = true }
+        assertTrue(called)
+    }
+
+    @Test
+    fun serverErrorIncludesHttpCode() {
+        val error = DataError.Network.ServerError(httpCode = 500)
+        assertEquals(500, error.httpCode)
+        assertEquals("Server error (500)", error.message)
+    }
+
+    @Test
+    fun authErrorHierarchy() {
+        val notAuth: AppError = AuthError.NotAuthenticated()
+        assertIs<AuthError>(notAuth)
+        assertEquals("Not authenticated", notAuth.message)
+    }
+}


### PR DESCRIPTION
## Summary
Add `AppResult<D, E : AppError>` sealed interface to domain module with typed error hierarchy:

- `AppResult.Success<D>` / `AppResult.Error<E>`
- `DataError.Network` — ConnectionFailed, Timeout, ServerError, NotReady
- `AuthError` — NotAuthenticated, TokenExpired, SignInFailed
- Extensions: `getOrNull`, `getOrElse`, `map`, `mapError`, `onSuccess`, `onError`

Foundation only — no migrations yet. Repositories/UseCases will adopt incrementally.

## Test plan
- [x] 11 new tests in `AppResultTest` (domain commonTest)
- [x] All 144 tests pass (133 app + 11 domain)
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)