### PR TITLE
feat: Import boundary enforcement for shared modules (Phase 17)

### DIFF
--- a/AndroidGarage/buildSrc/src/main/kotlin/importboundary/ImportBoundaryCheckTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/importboundary/ImportBoundaryCheckTask.kt
@@ -1,0 +1,79 @@
+package importboundary
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Gradle task that enforces import boundaries in shared KMP modules.
+ *
+ * Scans `commonMain` source sets for imports that should not appear in shared code
+ * (e.g., `android.*`, `androidx.*`). Violations fail the build.
+ *
+ * Usage in build.gradle.kts:
+ * ```
+ * tasks.register<ImportBoundaryCheckTask>("checkImportBoundary") {
+ *     sourceDir = "$projectDir/src/commonMain/kotlin"
+ *     forbiddenPrefixes = listOf("android.", "androidx.", "com.google.firebase.")
+ * }
+ * ```
+ */
+abstract class ImportBoundaryCheckTask : DefaultTask() {
+    @get:Input
+    var sourceDir: String = ""
+
+    @get:Input
+    var forbiddenPrefixes: List<String> = listOf(
+        "android.",
+        "androidx.",
+        "com.google.firebase.",
+        "com.google.android.",
+    )
+
+    @TaskAction
+    fun check() {
+        val srcDir = File(sourceDir)
+        if (!srcDir.exists()) {
+            logger.lifecycle("Import boundary check: $sourceDir does not exist, skipping.")
+            return
+        }
+
+        val violations = mutableListOf<String>()
+
+        srcDir
+            .walkTopDown()
+            .filter { it.extension == "kt" }
+            .forEach { file ->
+                file.readLines().forEachIndexed { index, line ->
+                    val trimmed = line.trim()
+                    if (trimmed.startsWith("import ")) {
+                        val importPath = trimmed.removePrefix("import ").trim()
+                        for (prefix in forbiddenPrefixes) {
+                            if (importPath.startsWith(prefix)) {
+                                val relativePath = file.relativeTo(srcDir).path
+                                violations.add("  $relativePath:${index + 1}: import $importPath")
+                            }
+                        }
+                    }
+                }
+            }
+
+        if (violations.isNotEmpty()) {
+            val message = buildString {
+                appendLine("Import boundary violations in commonMain:")
+                appendLine("These imports are not allowed in shared KMP modules.")
+                appendLine()
+                violations.forEach { appendLine(it) }
+                appendLine()
+                appendLine("${violations.size} violation(s) found.")
+            }
+            throw GradleException(message)
+        }
+
+        logger.lifecycle(
+            "Import boundary check passed: ${srcDir.walkTopDown().filter { it.extension == "kt" }.count()} files scanned, 0 violations.",
+        )
+    }
+}

--- a/AndroidGarage/data/build.gradle.kts
+++ b/AndroidGarage/data/build.gradle.kts
@@ -1,6 +1,12 @@
+import importboundary.ImportBoundaryCheckTask
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
+}
+
+tasks.register<ImportBoundaryCheckTask>("checkImportBoundary") {
+    sourceDir = "$projectDir/src/commonMain/kotlin"
 }
 
 kotlin {

--- a/AndroidGarage/domain/build.gradle.kts
+++ b/AndroidGarage/domain/build.gradle.kts
@@ -1,6 +1,12 @@
+import importboundary.ImportBoundaryCheckTask
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
+}
+
+tasks.register<ImportBoundaryCheckTask>("checkImportBoundary") {
+    sourceDir = "$projectDir/src/commonMain/kotlin"
 }
 
 kotlin {

--- a/AndroidGarage/usecase/build.gradle.kts
+++ b/AndroidGarage/usecase/build.gradle.kts
@@ -1,6 +1,12 @@
+import importboundary.ImportBoundaryCheckTask
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
+}
+
+tasks.register<ImportBoundaryCheckTask>("checkImportBoundary") {
+    sourceDir = "$projectDir/src/commonMain/kotlin"
 }
 
 kotlin {

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -22,6 +22,9 @@ step() { echo -e "\n${BOLD}--- $1 ---${RESET}"; }
 step "Spotless (formatting — all modules)"
 $GRADLE spotlessCheck && pass "spotlessCheck" || fail "spotlessCheck"
 
+step "Import boundary check (shared modules)"
+$GRADLE :domain:checkImportBoundary :data:checkImportBoundary :usecase:checkImportBoundary && pass "import boundaries" || fail "import boundaries"
+
 step "Detekt (static analysis)"
 $GRADLE :androidApp:detekt && pass "detekt" || fail "detekt"
 


### PR DESCRIPTION
## Summary
Add `ImportBoundaryCheckTask` that scans `commonMain` source sets for forbidden Android imports. Catches accidental platform-specific dependencies in shared modules at build time.

Forbidden prefixes: `android.*`, `androidx.*`, `com.google.firebase.*`, `com.google.android.*`

- Registered in `:domain`, `:data`, `:usecase` build files
- Added to `validate.sh` (runs early, before detekt)
- All 3 modules pass with 0 violations

## Test plan
- [x] `./scripts/validate.sh` passes
- [x] All 3 shared modules scanned, 0 violations
- [ ] Adding `import android.util.Log` to domain/commonMain fails the check

🤖 Generated with [Claude Code](https://claude.com/claude-code)