### PR TITLE
feat: Add integration tests with fake data sources (Phase 16)

### DIFF
--- a/AndroidGarage/data/build.gradle.kts
+++ b/AndroidGarage/data/build.gradle.kts
@@ -18,6 +18,10 @@ kotlin {
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kermit)
         }
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
+        }
     }
 }
 

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepositoryTest.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.data.repository
+
+import com.chriscartland.garage.data.testfakes.FakeNetworkConfigDataSource
+import com.chriscartland.garage.domain.model.ServerConfig
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Integration tests for [CachedServerConfigRepository] with fake network data source.
+ * Tests caching behavior, null handling, and cache invalidation via fetchServerConfig.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CachedServerConfigRepositoryTest {
+    private val configDataSource = FakeNetworkConfigDataSource()
+
+    private fun createRepository() =
+        CachedServerConfigRepository(
+            networkConfigDataSource = configDataSource,
+            serverConfigKey = "test-key",
+        )
+
+    @Test
+    fun getServerConfigCachedFetchesOnFirstCall() =
+        runTest {
+            val config = ServerConfig(
+                buildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonPushKey = "key",
+            )
+            configDataSource.serverConfigResponse = config
+
+            val repo = createRepository()
+            val result = repo.getServerConfigCached()
+
+            assertEquals(config, result)
+            assertEquals(1, configDataSource.fetchCount)
+        }
+
+    @Test
+    fun getServerConfigCachedReturnsCacheOnSecondCall() =
+        runTest {
+            val config = ServerConfig(
+                buildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonPushKey = "key",
+            )
+            configDataSource.serverConfigResponse = config
+
+            val repo = createRepository()
+            repo.getServerConfigCached()
+            repo.getServerConfigCached()
+
+            assertEquals(1, configDataSource.fetchCount)
+        }
+
+    @Test
+    fun getServerConfigCachedReturnsNullWhenNetworkFails() =
+        runTest {
+            configDataSource.serverConfigResponse = null
+
+            val repo = createRepository()
+            assertNull(repo.getServerConfigCached())
+            assertEquals(1, configDataSource.fetchCount)
+        }
+
+    @Test
+    fun getServerConfigCachedRetriesAfterNullResponse() =
+        runTest {
+            configDataSource.serverConfigResponse = null
+
+            val repo = createRepository()
+            assertNull(repo.getServerConfigCached())
+
+            // Second call should retry since cache is still null
+            val config = ServerConfig(
+                buildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonPushKey = "key",
+            )
+            configDataSource.serverConfigResponse = config
+            assertEquals(config, repo.getServerConfigCached())
+            assertEquals(2, configDataSource.fetchCount)
+        }
+
+    @Test
+    fun fetchServerConfigUpdatesCache() =
+        runTest {
+            val config1 = ServerConfig(
+                buildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonPushKey = "key1",
+            )
+            configDataSource.serverConfigResponse = config1
+
+            val repo = createRepository()
+            repo.getServerConfigCached()
+
+            // Update network response and force refresh
+            val config2 = ServerConfig(
+                buildTimestamp = "2024-01-16T00:00:00Z",
+                remoteButtonBuildTimestamp = "2024-01-16T00:00:00Z",
+                remoteButtonPushKey = "key2",
+            )
+            configDataSource.serverConfigResponse = config2
+            repo.fetchServerConfig()
+
+            // Cached value should now be updated
+            assertEquals(config2, repo.getServerConfigCached())
+            // 3 fetches: initial getServerConfigCached, fetchServerConfig, getServerConfigCached (cached)
+            assertEquals(2, configDataSource.fetchCount)
+        }
+
+    @Test
+    fun fetchServerConfigWithNullDoesNotOverwriteCache() =
+        runTest {
+            val config = ServerConfig(
+                buildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonPushKey = "key",
+            )
+            configDataSource.serverConfigResponse = config
+
+            val repo = createRepository()
+            repo.getServerConfigCached()
+
+            // Network now returns null
+            configDataSource.serverConfigResponse = null
+            repo.fetchServerConfig()
+
+            // Cache should retain the old value
+            assertEquals(config, repo.getServerConfigCached())
+        }
+}

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepositoryIntegrationTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepositoryIntegrationTest.kt
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.data.repository
+
+import com.chriscartland.garage.data.testfakes.FakeNetworkConfigDataSource
+import com.chriscartland.garage.data.testfakes.FakeNetworkDoorDataSource
+import com.chriscartland.garage.data.testfakes.InMemoryLocalDoorDataSource
+import com.chriscartland.garage.domain.model.DoorEvent
+import com.chriscartland.garage.domain.model.DoorPosition
+import com.chriscartland.garage.domain.model.ServerConfig
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Integration tests wiring real [NetworkDoorRepository] with fake data sources.
+ * Validates the fetch → cache → expose flow without network or database.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NetworkDoorRepositoryIntegrationTest {
+    private val localDataSource = InMemoryLocalDoorDataSource()
+    private val networkDataSource = FakeNetworkDoorDataSource()
+    private val configDataSource = FakeNetworkConfigDataSource()
+
+    private fun createRepository(): NetworkDoorRepository {
+        val serverConfigRepo = CachedServerConfigRepository(
+            networkConfigDataSource = configDataSource,
+            serverConfigKey = "test-key",
+        )
+        return NetworkDoorRepository(
+            localDoorDataSource = localDataSource,
+            networkDoorDataSource = networkDataSource,
+            serverConfigRepository = serverConfigRepo,
+            recentEventCount = 10,
+        )
+    }
+
+    // --- fetchCurrentDoorEvent ---
+
+    @Test
+    fun fetchCurrentDoorEventStoresInLocal() =
+        runTest {
+            configDataSource.serverConfigResponse = ServerConfig(
+                buildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonPushKey = "key",
+            )
+            val event = DoorEvent(
+                doorPosition = DoorPosition.OPEN,
+                message = "Door is open",
+                lastCheckInTimeSeconds = 1000L,
+                lastChangeTimeSeconds = 900L,
+            )
+            networkDataSource.currentDoorEventResponse = event
+
+            val repo = createRepository()
+            repo.fetchCurrentDoorEvent()
+
+            assertEquals(event, localDataSource.currentDoorEvent.first())
+            assertEquals(1, localDataSource.insertCount)
+            assertEquals(1, networkDataSource.fetchCurrentCount)
+        }
+
+    @Test
+    fun fetchCurrentDoorEventExposedViaFlow() =
+        runTest {
+            configDataSource.serverConfigResponse = ServerConfig(
+                buildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonPushKey = "key",
+            )
+            val event = DoorEvent(
+                doorPosition = DoorPosition.CLOSED,
+                message = "Door is closed",
+            )
+            networkDataSource.currentDoorEventResponse = event
+
+            val repo = createRepository()
+            repo.fetchCurrentDoorEvent()
+
+            assertEquals(event, repo.currentDoorEvent.first())
+            assertEquals(DoorPosition.CLOSED, repo.currentDoorPosition.first())
+        }
+
+    @Test
+    fun fetchCurrentDoorEventWithNullServerConfigDoesNotCallNetwork() =
+        runTest {
+            configDataSource.serverConfigResponse = null
+
+            val repo = createRepository()
+            repo.fetchCurrentDoorEvent()
+
+            assertEquals(0, networkDataSource.fetchCurrentCount)
+            assertEquals(0, localDataSource.insertCount)
+        }
+
+    @Test
+    fun fetchCurrentDoorEventWithNullNetworkResponseDoesNotInsert() =
+        runTest {
+            configDataSource.serverConfigResponse = ServerConfig(
+                buildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonPushKey = "key",
+            )
+            networkDataSource.currentDoorEventResponse = null
+
+            val repo = createRepository()
+            repo.fetchCurrentDoorEvent()
+
+            assertEquals(1, networkDataSource.fetchCurrentCount)
+            assertEquals(0, localDataSource.insertCount)
+            assertNull(repo.currentDoorEvent.first())
+        }
+
+    // --- fetchRecentDoorEvents ---
+
+    @Test
+    fun fetchRecentDoorEventsStoresInLocal() =
+        runTest {
+            configDataSource.serverConfigResponse = ServerConfig(
+                buildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonPushKey = "key",
+            )
+            val events = listOf(
+                DoorEvent(doorPosition = DoorPosition.OPEN, lastChangeTimeSeconds = 300L),
+                DoorEvent(doorPosition = DoorPosition.CLOSED, lastChangeTimeSeconds = 200L),
+                DoorEvent(doorPosition = DoorPosition.OPENING, lastChangeTimeSeconds = 100L),
+            )
+            networkDataSource.recentDoorEventsResponse = events
+
+            val repo = createRepository()
+            repo.fetchRecentDoorEvents()
+
+            assertEquals(events, repo.recentDoorEvents.first())
+            assertEquals(1, localDataSource.replaceCount)
+        }
+
+    @Test
+    fun fetchRecentDoorEventsWithNullServerConfigDoesNotCallNetwork() =
+        runTest {
+            configDataSource.serverConfigResponse = null
+
+            val repo = createRepository()
+            repo.fetchRecentDoorEvents()
+
+            assertEquals(0, networkDataSource.fetchRecentCount)
+            assertEquals(0, localDataSource.replaceCount)
+        }
+
+    @Test
+    fun fetchRecentDoorEventsWithNullNetworkResponseDoesNotReplace() =
+        runTest {
+            configDataSource.serverConfigResponse = ServerConfig(
+                buildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonPushKey = "key",
+            )
+            networkDataSource.recentDoorEventsResponse = null
+
+            val repo = createRepository()
+            repo.fetchRecentDoorEvents()
+
+            assertEquals(1, networkDataSource.fetchRecentCount)
+            assertEquals(0, localDataSource.replaceCount)
+        }
+
+    // --- insertDoorEvent ---
+
+    @Test
+    fun insertDoorEventUpdatesLocalAndPosition() =
+        runTest {
+            val event = DoorEvent(
+                doorPosition = DoorPosition.OPENING,
+                message = "Door opening",
+            )
+
+            val repo = createRepository()
+            repo.insertDoorEvent(event)
+
+            assertEquals(event, repo.currentDoorEvent.first())
+            assertEquals(DoorPosition.OPENING, repo.currentDoorPosition.first())
+        }
+
+    // --- currentDoorPosition ---
+
+    @Test
+    fun currentDoorPositionDefaultsToUnknown() =
+        runTest {
+            val repo = createRepository()
+            assertEquals(DoorPosition.UNKNOWN, repo.currentDoorPosition.first())
+        }
+
+    @Test
+    fun currentDoorPositionTracksInsertedEvents() =
+        runTest {
+            val repo = createRepository()
+
+            repo.insertDoorEvent(DoorEvent(doorPosition = DoorPosition.CLOSED))
+            assertEquals(DoorPosition.CLOSED, repo.currentDoorPosition.first())
+
+            repo.insertDoorEvent(DoorEvent(doorPosition = DoorPosition.OPENING))
+            assertEquals(DoorPosition.OPENING, repo.currentDoorPosition.first())
+        }
+
+    // --- fetchBuildTimestampCached ---
+
+    @Test
+    fun fetchBuildTimestampCachedReturnsFromServerConfig() =
+        runTest {
+            configDataSource.serverConfigResponse = ServerConfig(
+                buildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonPushKey = "key",
+            )
+
+            val repo = createRepository()
+            assertEquals("2024-01-15T00:00:00Z", repo.fetchBuildTimestampCached())
+        }
+
+    @Test
+    fun fetchBuildTimestampCachedReturnsNullWhenNoConfig() =
+        runTest {
+            configDataSource.serverConfigResponse = null
+
+            val repo = createRepository()
+            assertNull(repo.fetchBuildTimestampCached())
+        }
+}

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/testfakes/FakeNetworkConfigDataSource.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/testfakes/FakeNetworkConfigDataSource.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.data.testfakes
+
+import com.chriscartland.garage.data.NetworkConfigDataSource
+import com.chriscartland.garage.domain.model.ServerConfig
+
+class FakeNetworkConfigDataSource : NetworkConfigDataSource {
+    var serverConfigResponse: ServerConfig? = null
+
+    var fetchCount = 0
+        private set
+
+    override suspend fun fetchServerConfig(serverConfigKey: String): ServerConfig? {
+        fetchCount++
+        return serverConfigResponse
+    }
+}

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/testfakes/FakeNetworkDoorDataSource.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/testfakes/FakeNetworkDoorDataSource.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.data.testfakes
+
+import com.chriscartland.garage.data.NetworkDoorDataSource
+import com.chriscartland.garage.domain.model.DoorEvent
+
+class FakeNetworkDoorDataSource : NetworkDoorDataSource {
+    var currentDoorEventResponse: DoorEvent? = null
+    var recentDoorEventsResponse: List<DoorEvent>? = null
+
+    var fetchCurrentCount = 0
+        private set
+    var fetchRecentCount = 0
+        private set
+
+    override suspend fun fetchCurrentDoorEvent(buildTimestamp: String): DoorEvent? {
+        fetchCurrentCount++
+        return currentDoorEventResponse
+    }
+
+    override suspend fun fetchRecentDoorEvents(
+        buildTimestamp: String,
+        count: Int,
+    ): List<DoorEvent>? {
+        fetchRecentCount++
+        return recentDoorEventsResponse
+    }
+}

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/testfakes/InMemoryLocalDoorDataSource.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/testfakes/InMemoryLocalDoorDataSource.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.data.testfakes
+
+import com.chriscartland.garage.data.LocalDoorDataSource
+import com.chriscartland.garage.domain.model.DoorEvent
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class InMemoryLocalDoorDataSource : LocalDoorDataSource {
+    private val _currentDoorEvent = MutableStateFlow<DoorEvent?>(null)
+    private val _recentDoorEvents = MutableStateFlow<List<DoorEvent>>(emptyList())
+
+    override val currentDoorEvent: Flow<DoorEvent?> = _currentDoorEvent
+    override val recentDoorEvents: Flow<List<DoorEvent>> = _recentDoorEvents
+
+    var insertCount = 0
+        private set
+    var replaceCount = 0
+        private set
+
+    override fun insertDoorEvent(doorEvent: DoorEvent) {
+        insertCount++
+        _currentDoorEvent.value = doorEvent
+    }
+
+    override fun replaceDoorEvents(doorEvents: List<DoorEvent>) {
+        replaceCount++
+        _recentDoorEvents.value = doorEvents
+        if (doorEvents.isNotEmpty()) {
+            _currentDoorEvent.value = doorEvents.first()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Create fake data sources in `data/src/commonTest/`: `InMemoryLocalDoorDataSource`, `FakeNetworkDoorDataSource`, `FakeNetworkConfigDataSource`
- 12 integration tests for `NetworkDoorRepository`: fetch→cache→flow pipeline, null server config, null network response, insert, position tracking
- 6 tests for `CachedServerConfigRepository`: caching, retry after null, cache invalidation
- All tests use `kotlin.test` (KMP-compatible, no Mockito)

## Test plan

- [x] All 18 new tests pass
- [x] `./scripts/validate.sh` passes
- [x] No conflicts with PR #139 (different files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)