### PR TITLE
fix: Fetch snooze end time immediately after snooze action

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
@@ -113,7 +113,9 @@ class DefaultRemoteButtonViewModel(
                 snoozeDurationHours = snoozeDuration.toServer().duration,
                 lastChangeTimeSeconds = currentDoorEvent.value?.lastChangeTimeSeconds,
             )
-            if (!result) {
+            if (result) {
+                pushRepository.fetchSnoozeEndTimeSeconds()
+            } else {
                 Logger.e { "Snooze failed — not authenticated or no door event" }
             }
         }


### PR DESCRIPTION
## Summary

- After a successful snooze, call `fetchSnoozeEndTimeSeconds()` immediately instead of waiting for the 1-minute polling interval
- Fixes the issue where snooze settings don't visually update until switching tabs

## Test plan

- [x] Existing ViewModel tests pass
- [x] Verify snooze UI updates immediately after saving (manual test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)