### PR TITLE
feat: Migrate DoorRepository to typed AppResult returns (Phase 14)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorViewModel.kt
@@ -26,8 +26,10 @@ import com.chriscartland.garage.config.APP_CONFIG
 import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.config.FetchOnViewModelInit
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
+import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.FcmRegistrationStatus
+import com.chriscartland.garage.domain.model.FetchError
 import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.usecase.DeregisterFcmUseCase
@@ -139,7 +141,15 @@ class DefaultDoorViewModel(
         Logger.d { "fetchCurrentDoorEvent" }
         viewModelScope.launch(dispatchers.io) {
             _currentDoorEvent.value = LoadingResult.Loading(_currentDoorEvent.value.data)
-            fetchCurrentDoorEventUseCase()
+            when (val result = fetchCurrentDoorEventUseCase()) {
+                is AppResult.Success -> {
+                    // Data flows through repository → local cache → Flow observation
+                }
+                is AppResult.Error -> when (result.error) {
+                    FetchError.NotReady -> Logger.w { "Server config not ready" }
+                    FetchError.NetworkFailed -> Logger.w { "Network request failed" }
+                }
+            }
         }
     }
 
@@ -147,7 +157,15 @@ class DefaultDoorViewModel(
         Logger.d { "fetchRecentDoorEvents" }
         viewModelScope.launch(dispatchers.io) {
             _recentDoorEvents.value = LoadingResult.Loading(_recentDoorEvents.value.data)
-            fetchRecentDoorEventsUseCase()
+            when (val result = fetchRecentDoorEventsUseCase()) {
+                is AppResult.Success -> {
+                    // Data flows through repository → local cache → Flow observation
+                }
+                is AppResult.Error -> when (result.error) {
+                    FetchError.NotReady -> Logger.w { "Server config not ready" }
+                    FetchError.NetworkFailed -> Logger.w { "Network request failed" }
+                }
+            }
         }
     }
 }

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/door/DoorViewModelTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/door/DoorViewModelTest.kt
@@ -20,6 +20,7 @@ package com.chriscartland.garage.door
 import android.app.Activity
 import com.chriscartland.garage.applogger.AppLoggerRepository
 import com.chriscartland.garage.coroutines.TestDispatcherProvider
+import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorFcmState
 import com.chriscartland.garage.domain.model.DoorFcmTopic
@@ -86,12 +87,20 @@ class DoorViewModelTest {
         `when`(doorRepository.currentDoorPosition).thenReturn(currentDoorPositionFlow)
     }
 
+    private suspend fun stubFetchSuccess() {
+        `when`(doorRepository.fetchCurrentDoorEvent())
+            .thenReturn(AppResult.Success(testDoorEvent))
+        `when`(doorRepository.fetchRecentDoorEvents())
+            .thenReturn(AppResult.Success(listOf(testDoorEvent)))
+    }
+
     @After
     fun tearDown() {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel(): DefaultDoorViewModel {
+    private suspend fun createViewModel(): DefaultDoorViewModel {
+        stubFetchSuccess()
         val vm = DefaultDoorViewModel(
             appLoggerRepository,
             doorRepository,
@@ -107,11 +116,12 @@ class DoorViewModelTest {
     }
 
     @Test
-    fun initialFcmRegistrationStatusIsUnknown() {
-        val viewModel = createViewModel()
+    fun initialFcmRegistrationStatusIsUnknown() =
+        runTest {
+            val viewModel = createViewModel()
 
-        assertEquals(FcmRegistrationStatus.UNKNOWN, viewModel.fcmRegistrationStatus.value)
-    }
+            assertEquals(FcmRegistrationStatus.UNKNOWN, viewModel.fcmRegistrationStatus.value)
+        }
 
     @Test
     fun collectsCurrentDoorEventFromRepository() =

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakeDoorRepository.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakeDoorRepository.kt
@@ -17,8 +17,10 @@
 
 package com.chriscartland.garage.testcommon
 
+import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
+import com.chriscartland.garage.domain.model.FetchError
 import com.chriscartland.garage.domain.repository.DoorRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -54,11 +56,13 @@ class FakeDoorRepository : DoorRepository {
         _currentDoorPosition.value = doorEvent.doorPosition ?: DoorPosition.UNKNOWN
     }
 
-    override suspend fun fetchCurrentDoorEvent() {
+    override suspend fun fetchCurrentDoorEvent(): AppResult<DoorEvent, FetchError> {
         fetchCurrentDoorEventCount++
+        return AppResult.Success(_currentDoorEvent.value)
     }
 
-    override suspend fun fetchRecentDoorEvents() {
+    override suspend fun fetchRecentDoorEvents(): AppResult<List<DoorEvent>, FetchError> {
         fetchRecentDoorEventsCount++
+        return AppResult.Success(_recentDoorEvents.value)
     }
 }

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepository.kt
@@ -20,8 +20,10 @@ package com.chriscartland.garage.data.repository
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.LocalDoorDataSource
 import com.chriscartland.garage.data.NetworkDoorDataSource
+import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
+import com.chriscartland.garage.domain.model.FetchError
 import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import kotlinx.coroutines.flow.Flow
@@ -50,26 +52,27 @@ class NetworkDoorRepository(
         localDoorDataSource.insertDoorEvent(doorEvent)
     }
 
-    override suspend fun fetchCurrentDoorEvent() {
+    override suspend fun fetchCurrentDoorEvent(): AppResult<DoorEvent, FetchError> {
         val buildTimestamp = fetchBuildTimestampCached()
         if (buildTimestamp == null) {
             Logger.e { "Server config is null" }
-            return
+            return AppResult.Error(FetchError.NotReady)
         }
         val doorEvent = networkDoorDataSource.fetchCurrentDoorEvent(buildTimestamp)
         if (doorEvent == null) {
             Logger.e { "Failed to fetch current door event" }
-            return
+            return AppResult.Error(FetchError.NetworkFailed)
         }
         Logger.d { "Success: $doorEvent" }
         localDoorDataSource.insertDoorEvent(doorEvent)
+        return AppResult.Success(doorEvent)
     }
 
-    override suspend fun fetchRecentDoorEvents() {
+    override suspend fun fetchRecentDoorEvents(): AppResult<List<DoorEvent>, FetchError> {
         val buildTimestamp = fetchBuildTimestampCached()
         if (buildTimestamp == null) {
             Logger.e { "Server config is null" }
-            return
+            return AppResult.Error(FetchError.NotReady)
         }
         val doorEvents = networkDoorDataSource.fetchRecentDoorEvents(
             buildTimestamp = buildTimestamp,
@@ -77,9 +80,10 @@ class NetworkDoorRepository(
         )
         if (doorEvents == null) {
             Logger.e { "Failed to fetch recent door events" }
-            return
+            return AppResult.Error(FetchError.NetworkFailed)
         }
         Logger.d { "Success: $doorEvents" }
         localDoorDataSource.replaceDoorEvents(doorEvents)
+        return AppResult.Success(doorEvents)
     }
 }

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepositoryIntegrationTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepositoryIntegrationTest.kt
@@ -20,14 +20,17 @@ package com.chriscartland.garage.data.repository
 import com.chriscartland.garage.data.testfakes.FakeNetworkConfigDataSource
 import com.chriscartland.garage.data.testfakes.FakeNetworkDoorDataSource
 import com.chriscartland.garage.data.testfakes.InMemoryLocalDoorDataSource
+import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
+import com.chriscartland.garage.domain.model.FetchError
 import com.chriscartland.garage.domain.model.ServerConfig
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNull
 
 /**
@@ -72,8 +75,10 @@ class NetworkDoorRepositoryIntegrationTest {
             networkDataSource.currentDoorEventResponse = event
 
             val repo = createRepository()
-            repo.fetchCurrentDoorEvent()
+            val result = repo.fetchCurrentDoorEvent()
 
+            assertIs<AppResult.Success<*>>(result)
+            assertEquals(event, result.data)
             assertEquals(event, localDataSource.currentDoorEvent.first())
             assertEquals(1, localDataSource.insertCount)
             assertEquals(1, networkDataSource.fetchCurrentCount)
@@ -101,19 +106,21 @@ class NetworkDoorRepositoryIntegrationTest {
         }
 
     @Test
-    fun fetchCurrentDoorEventWithNullServerConfigDoesNotCallNetwork() =
+    fun fetchCurrentDoorEventWithNullServerConfigReturnsNotReady() =
         runTest {
             configDataSource.serverConfigResponse = null
 
             val repo = createRepository()
-            repo.fetchCurrentDoorEvent()
+            val result = repo.fetchCurrentDoorEvent()
 
+            assertIs<AppResult.Error<*>>(result)
+            assertEquals(FetchError.NotReady, result.error)
             assertEquals(0, networkDataSource.fetchCurrentCount)
             assertEquals(0, localDataSource.insertCount)
         }
 
     @Test
-    fun fetchCurrentDoorEventWithNullNetworkResponseDoesNotInsert() =
+    fun fetchCurrentDoorEventWithNullNetworkResponseReturnsNetworkFailed() =
         runTest {
             configDataSource.serverConfigResponse = ServerConfig(
                 buildTimestamp = "2024-01-15T00:00:00Z",
@@ -123,8 +130,10 @@ class NetworkDoorRepositoryIntegrationTest {
             networkDataSource.currentDoorEventResponse = null
 
             val repo = createRepository()
-            repo.fetchCurrentDoorEvent()
+            val result = repo.fetchCurrentDoorEvent()
 
+            assertIs<AppResult.Error<*>>(result)
+            assertEquals(FetchError.NetworkFailed, result.error)
             assertEquals(1, networkDataSource.fetchCurrentCount)
             assertEquals(0, localDataSource.insertCount)
             assertNull(repo.currentDoorEvent.first())
@@ -148,26 +157,29 @@ class NetworkDoorRepositoryIntegrationTest {
             networkDataSource.recentDoorEventsResponse = events
 
             val repo = createRepository()
-            repo.fetchRecentDoorEvents()
+            val result = repo.fetchRecentDoorEvents()
 
+            assertIs<AppResult.Success<*>>(result)
             assertEquals(events, repo.recentDoorEvents.first())
             assertEquals(1, localDataSource.replaceCount)
         }
 
     @Test
-    fun fetchRecentDoorEventsWithNullServerConfigDoesNotCallNetwork() =
+    fun fetchRecentDoorEventsWithNullServerConfigReturnsNotReady() =
         runTest {
             configDataSource.serverConfigResponse = null
 
             val repo = createRepository()
-            repo.fetchRecentDoorEvents()
+            val result = repo.fetchRecentDoorEvents()
 
+            assertIs<AppResult.Error<*>>(result)
+            assertEquals(FetchError.NotReady, result.error)
             assertEquals(0, networkDataSource.fetchRecentCount)
             assertEquals(0, localDataSource.replaceCount)
         }
 
     @Test
-    fun fetchRecentDoorEventsWithNullNetworkResponseDoesNotReplace() =
+    fun fetchRecentDoorEventsWithNullNetworkResponseReturnsNetworkFailed() =
         runTest {
             configDataSource.serverConfigResponse = ServerConfig(
                 buildTimestamp = "2024-01-15T00:00:00Z",
@@ -177,8 +189,10 @@ class NetworkDoorRepositoryIntegrationTest {
             networkDataSource.recentDoorEventsResponse = null
 
             val repo = createRepository()
-            repo.fetchRecentDoorEvents()
+            val result = repo.fetchRecentDoorEvents()
 
+            assertIs<AppResult.Error<*>>(result)
+            assertEquals(FetchError.NetworkFailed, result.error)
             assertEquals(1, networkDataSource.fetchRecentCount)
             assertEquals(0, localDataSource.replaceCount)
         }

--- a/AndroidGarage/docs/DECISIONS.md
+++ b/AndroidGarage/docs/DECISIONS.md
@@ -190,6 +190,53 @@ fun createButtonAckToken(now: Date): String { ... }
 private fun <K, V> Map<K, V>.asDoorEvent(): DoorEvent? { ... }
 ```
 
+## ADR-010: Typed API Patterns — Observation and One-Time Requests
+
+**Status:** Accepted
+
+**Context:** The app has two fundamental interaction patterns: ongoing state observation (door position, auth state) and discrete actions (push button, snooze, fetch data). Both patterns currently use nullable returns or Boolean success flags, which fail silently and don't enforce handling of edge cases.
+
+**Decision:** Adopt two typed API patterns throughout UseCase and ViewModel layers:
+
+1. **Observation APIs** — `Flow<Result<D, E>>` or `StateFlow<UiState>` where `UiState` is a sealed class with `Loading`, `Success`, `Error` variants. Use these for multi-stage transitions (e.g., button press tracking: SENDING → SENT → RECEIVED). The UI can show each phase.
+
+2. **One-time Request APIs** — `suspend fun action(): AppResult<D, E>` where both `D` (data) and `E` (error) are sealed or enum types. Use exhaustive `when` statements to handle every case at compile time. New edge cases produce compiler errors, not silent failures.
+
+**Rules:**
+- `D` and `E` should be sealed classes or enums — never open types
+- `invoke()` on UseCases returns `AppResult<D, E>`, not nullable types
+- ViewModels translate `AppResult` into UI-observable state (Flow or StateFlow)
+- Add new sealed variants when new edge cases are discovered — the compiler forces all call sites to handle them
+
+**Example:**
+```kotlin
+// UseCase returns typed result
+suspend operator fun invoke(token: String): AppResult<DoorEvent, FetchError>
+
+// Error is a sealed type — exhaustive when
+sealed interface FetchError : AppError {
+    data object NotReady : FetchError
+    data object NetworkFailed : FetchError
+    data class ServerError(val code: Int) : FetchError
+}
+
+// ViewModel handles exhaustively
+when (val result = fetchUseCase(token)) {
+    is AppResult.Success -> _state.value = UiState.Loaded(result.data)
+    is AppResult.Error -> when (result.error) {
+        FetchError.NotReady -> _state.value = UiState.ConfigMissing
+        FetchError.NetworkFailed -> _state.value = UiState.Offline
+        is FetchError.ServerError -> _state.value = UiState.Error(result.error.code)
+    }
+}
+```
+
+**Consequences:**
+- Eliminates silent failures — every error path is visible
+- New edge cases caught at compile time via exhaustive `when`
+- Slightly more verbose than nullable returns, but the safety is worth it
+- Requires migrating existing nullable/Boolean APIs incrementally
+
 **Example — preferred:**
 ```kotlin
 object ButtonAckTokens {

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/FetchError.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/FetchError.kt
@@ -1,0 +1,19 @@
+package com.chriscartland.garage.domain.model
+
+/**
+ * Errors that can occur when fetching door events from the server.
+ *
+ * Sealed type enables exhaustive `when` handling — adding a new variant
+ * forces all callers to handle it at compile time.
+ */
+sealed interface FetchError : AppError {
+    /** Server configuration has not been loaded yet. */
+    data object NotReady : FetchError {
+        override val message: String = "Server config not loaded"
+    }
+
+    /** Network request failed or returned no data. */
+    data object NetworkFailed : FetchError {
+        override val message: String = "Network request failed"
+    }
+}

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/DoorRepository.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/DoorRepository.kt
@@ -1,19 +1,28 @@
 package com.chriscartland.garage.domain.repository
 
+import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
+import com.chriscartland.garage.domain.model.FetchError
 import kotlinx.coroutines.flow.Flow
 
 interface DoorRepository {
+    /** Observation: current door position derived from latest event. */
     val currentDoorPosition: Flow<DoorPosition>
+
+    /** Observation: current door event from local cache. */
     val currentDoorEvent: Flow<DoorEvent?>
+
+    /** Observation: recent door events from local cache. */
     val recentDoorEvents: Flow<List<DoorEvent>>
 
     suspend fun fetchBuildTimestampCached(): String?
 
     fun insertDoorEvent(doorEvent: DoorEvent)
 
-    suspend fun fetchCurrentDoorEvent()
+    /** One-time request: fetch current door event from server and cache locally. */
+    suspend fun fetchCurrentDoorEvent(): AppResult<DoorEvent, FetchError>
 
-    suspend fun fetchRecentDoorEvents()
+    /** One-time request: fetch recent door events from server and cache locally. */
+    suspend fun fetchRecentDoorEvents(): AppResult<List<DoorEvent>, FetchError>
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/FetchDoorEventsUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/FetchDoorEventsUseCase.kt
@@ -17,34 +17,31 @@
 
 package com.chriscartland.garage.usecase
 
+import com.chriscartland.garage.domain.model.AppResult
+import com.chriscartland.garage.domain.model.DoorEvent
+import com.chriscartland.garage.domain.model.FetchError
 import com.chriscartland.garage.domain.repository.DoorRepository
 
 /**
  * Fetches the current door event from the network.
  *
- * Delegates to [DoorRepository.fetchCurrentDoorEvent]. The repository handles
- * server config lookup, network requests, and local database insertion.
+ * Returns [AppResult] so callers can handle [FetchError.NotReady] and
+ * [FetchError.NetworkFailed] explicitly with exhaustive `when`.
  */
-class FetchCurrentDoorEventUseCase
-    constructor(
-        private val doorRepository: DoorRepository,
-    ) {
-        suspend operator fun invoke() {
-            doorRepository.fetchCurrentDoorEvent()
-        }
-    }
+class FetchCurrentDoorEventUseCase(
+    private val doorRepository: DoorRepository,
+) {
+    suspend operator fun invoke(): AppResult<DoorEvent, FetchError> = doorRepository.fetchCurrentDoorEvent()
+}
 
 /**
  * Fetches recent door events from the network.
  *
- * Delegates to [DoorRepository.fetchRecentDoorEvents]. The repository handles
- * server config lookup, network requests, and local database replacement.
+ * Returns [AppResult] so callers can handle [FetchError.NotReady] and
+ * [FetchError.NetworkFailed] explicitly with exhaustive `when`.
  */
-class FetchRecentDoorEventsUseCase
-    constructor(
-        private val doorRepository: DoorRepository,
-    ) {
-        suspend operator fun invoke() {
-            doorRepository.fetchRecentDoorEvents()
-        }
-    }
+class FetchRecentDoorEventsUseCase(
+    private val doorRepository: DoorRepository,
+) {
+    suspend operator fun invoke(): AppResult<List<DoorEvent>, FetchError> = doorRepository.fetchRecentDoorEvents()
+}


### PR DESCRIPTION
## Summary

- Replace silent `Unit` returns with `AppResult<D, FetchError>` on `fetchCurrentDoorEvent()` and `fetchRecentDoorEvents()`
- Add `FetchError` sealed interface with `NotReady` and `NetworkFailed` variants for exhaustive `when` handling
- ViewModel handles each error case explicitly at compile time
- Add ADR-010: Typed API patterns (observation + one-time requests with sealed Result types)

## Test plan

- [x] All existing tests pass (updated mocks/fakes for new return types)
- [x] Integration tests verify typed error returns (NotReady, NetworkFailed)
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)