### PR TITLE
feat: Migrate push/snooze UseCases to typed AppResult (Phase 14)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
@@ -21,6 +21,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
+import com.chriscartland.garage.domain.model.ActionError
+import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.RequestStatus
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
@@ -100,23 +102,36 @@ class DefaultRemoteButtonViewModel(
     override fun pushRemoteButton() {
         Logger.d { "pushRemoteButton" }
         viewModelScope.launch(dispatchers.io) {
-            pushRemoteButtonUseCase(
-                buttonAckToken = createButtonAckToken(Date()),
-            )
+            when (
+                val result = pushRemoteButtonUseCase(
+                    buttonAckToken = createButtonAckToken(Date()),
+                )
+            ) {
+                is AppResult.Success -> { /* State machine tracks via pushButtonStatus flow */ }
+                is AppResult.Error -> when (result.error) {
+                    ActionError.NotAuthenticated -> Logger.w { "Push failed — not authenticated" }
+                    ActionError.MissingData -> Logger.w { "Push failed — missing data" }
+                }
+            }
         }
     }
 
     override fun snoozeOpenDoorsNotifications(snoozeDuration: SnoozeDurationUIOption) {
         Logger.d { "snoozeOpenDoorsNotifications" }
         viewModelScope.launch(dispatchers.io) {
-            val result = snoozeNotificationsUseCase(
-                snoozeDurationHours = snoozeDuration.toServer().duration,
-                lastChangeTimeSeconds = currentDoorEvent.value?.lastChangeTimeSeconds,
-            )
-            if (result) {
-                pushRepository.fetchSnoozeEndTimeSeconds()
-            } else {
-                Logger.e { "Snooze failed — not authenticated or no door event" }
+            when (
+                val result = snoozeNotificationsUseCase(
+                    snoozeDurationHours = snoozeDuration.toServer().duration,
+                    lastChangeTimeSeconds = currentDoorEvent.value?.lastChangeTimeSeconds,
+                )
+            ) {
+                is AppResult.Success -> pushRepository.fetchSnoozeEndTimeSeconds()
+                is AppResult.Error -> when (result.error) {
+                    ActionError.NotAuthenticated ->
+                        Logger.e { "Snooze failed — not authenticated" }
+                    ActionError.MissingData ->
+                        Logger.e { "Snooze failed — no door event timestamp" }
+                }
             }
         }
     }

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/PushRemoteButtonUseCaseTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/PushRemoteButtonUseCaseTest.kt
@@ -17,6 +17,8 @@
 
 package com.chriscartland.garage.usecase
 
+import com.chriscartland.garage.domain.model.ActionError
+import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.DisplayName
 import com.chriscartland.garage.domain.model.Email
@@ -26,7 +28,6 @@ import com.chriscartland.garage.testcommon.FakeAuthRepository
 import com.chriscartland.garage.testcommon.FakePushRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -63,7 +64,7 @@ class PushRemoteButtonUseCaseTest {
         runTest {
             authenticateUser()
             val result = useCase("ack-123")
-            assertTrue("Push should succeed when authenticated", result)
+            assertTrue("Push should succeed", result is AppResult.Success)
             assertEquals(1, fakePush.pushCount)
         }
 
@@ -72,7 +73,8 @@ class PushRemoteButtonUseCaseTest {
         runTest {
             fakeAuth.setAuthState(AuthState.Unauthenticated)
             val result = useCase("ack-123")
-            assertFalse("Push should fail when unauthenticated", result)
+            assertTrue("Should be NotAuthenticated error", result is AppResult.Error)
+            assertEquals(ActionError.NotAuthenticated, (result as AppResult.Error).error)
             assertEquals(0, fakePush.pushCount)
         }
 
@@ -80,7 +82,8 @@ class PushRemoteButtonUseCaseTest {
     fun pushFailsWhenAuthUnknown() =
         runTest {
             val result = useCase("ack-123")
-            assertFalse("Push should fail when auth unknown", result)
+            assertTrue("Should be NotAuthenticated error", result is AppResult.Error)
+            assertEquals(ActionError.NotAuthenticated, (result as AppResult.Error).error)
             assertEquals(0, fakePush.pushCount)
         }
 

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/SnoozeNotificationsUseCaseTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/SnoozeNotificationsUseCaseTest.kt
@@ -17,6 +17,8 @@
 
 package com.chriscartland.garage.usecase
 
+import com.chriscartland.garage.domain.model.ActionError
+import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.DisplayName
 import com.chriscartland.garage.domain.model.Email
@@ -26,7 +28,6 @@ import com.chriscartland.garage.testcommon.FakeAuthRepository
 import com.chriscartland.garage.testcommon.FakePushRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -63,7 +64,7 @@ class SnoozeNotificationsUseCaseTest {
         runTest {
             authenticateUser()
             val result = useCase("1h", 1000L)
-            assertTrue(result)
+            assertTrue("Should succeed", result is AppResult.Success)
             assertEquals(1, fakePush.snoozeCount)
         }
 
@@ -72,7 +73,8 @@ class SnoozeNotificationsUseCaseTest {
         runTest {
             fakeAuth.setAuthState(AuthState.Unauthenticated)
             val result = useCase("1h", 1000L)
-            assertFalse(result)
+            assertTrue("Should be error", result is AppResult.Error)
+            assertEquals(ActionError.NotAuthenticated, (result as AppResult.Error).error)
             assertEquals(0, fakePush.snoozeCount)
         }
 
@@ -80,7 +82,8 @@ class SnoozeNotificationsUseCaseTest {
     fun snoozeFailsWhenAuthUnknown() =
         runTest {
             val result = useCase("1h", 1000L)
-            assertFalse(result)
+            assertTrue("Should be error", result is AppResult.Error)
+            assertEquals(ActionError.NotAuthenticated, (result as AppResult.Error).error)
             assertEquals(0, fakePush.snoozeCount)
         }
 
@@ -89,7 +92,8 @@ class SnoozeNotificationsUseCaseTest {
         runTest {
             authenticateUser()
             val result = useCase("1h", null)
-            assertFalse(result)
+            assertTrue("Should be MissingData error", result is AppResult.Error)
+            assertEquals(ActionError.MissingData, (result as AppResult.Error).error)
             assertEquals(0, fakePush.snoozeCount)
         }
 
@@ -98,6 +102,7 @@ class SnoozeNotificationsUseCaseTest {
         runTest {
             authenticateUser(exp = 1000L)
             useCase("1h", null)
+            // MissingData error returned before token refresh
             assertEquals(0, fakeAuth.refreshCount)
         }
 

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/ActionError.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/ActionError.kt
@@ -1,0 +1,20 @@
+package com.chriscartland.garage.domain.model
+
+/**
+ * Errors that can occur when performing authenticated actions
+ * (push button, snooze notifications).
+ *
+ * Sealed type enables exhaustive `when` handling — adding a new variant
+ * forces all callers to handle it at compile time.
+ */
+sealed interface ActionError : AppError {
+    /** User is not authenticated. */
+    data object NotAuthenticated : ActionError {
+        override val message: String = "Not authenticated"
+    }
+
+    /** Required data is missing (e.g., no door event for snooze timestamp). */
+    data object MissingData : ActionError {
+        override val message: String = "Required data not available"
+    }
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/PushRemoteButtonUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/PushRemoteButtonUseCase.kt
@@ -17,6 +17,8 @@
 
 package com.chriscartland.garage.usecase
 
+import com.chriscartland.garage.domain.model.ActionError
+import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.repository.AuthRepository
 import com.chriscartland.garage.domain.repository.PushRepository
@@ -24,28 +26,24 @@ import com.chriscartland.garage.domain.repository.PushRepository
 /**
  * Pushes the remote garage button.
  *
- * Handles:
- * - Verifying the user is authenticated
- * - Ensuring the auth token is fresh
- * - Delegating to PushRepository
- *
- * @return true if the push was initiated, false if not authenticated
+ * Returns [AppResult] so callers can handle [ActionError.NotAuthenticated]
+ * explicitly with exhaustive `when`.
  */
 class PushRemoteButtonUseCase(
     private val ensureFreshIdToken: EnsureFreshIdTokenUseCase,
     private val authRepository: AuthRepository,
     private val pushRepository: PushRepository,
 ) {
-    suspend operator fun invoke(buttonAckToken: String): Boolean {
+    suspend operator fun invoke(buttonAckToken: String): AppResult<Unit, ActionError> {
         val authState = authRepository.authState.value
         if (authState !is AuthState.Authenticated) {
-            return false
+            return AppResult.Error(ActionError.NotAuthenticated)
         }
         val idToken = ensureFreshIdToken(authState)
         pushRepository.push(
             idToken = idToken.asString(),
             buttonAckToken = buttonAckToken,
         )
-        return true
+        return AppResult.Success(Unit)
     }
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SnoozeNotificationsUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SnoozeNotificationsUseCase.kt
@@ -17,6 +17,8 @@
 
 package com.chriscartland.garage.usecase
 
+import com.chriscartland.garage.domain.model.ActionError
+import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.repository.AuthRepository
 import com.chriscartland.garage.domain.repository.PushRepository
@@ -24,13 +26,8 @@ import com.chriscartland.garage.domain.repository.PushRepository
 /**
  * Snoozes open-door notifications for a specified duration.
  *
- * Handles:
- * - Verifying the user is authenticated
- * - Ensuring the auth token is fresh
- * - Delegating to PushRepository
- *
- * @return true if the snooze was initiated, false if not authenticated
- *   or if lastChangeTimeSeconds is null
+ * Returns [AppResult] so callers can handle [ActionError.NotAuthenticated]
+ * and [ActionError.MissingData] explicitly with exhaustive `when`.
  */
 class SnoozeNotificationsUseCase(
     private val ensureFreshIdToken: EnsureFreshIdTokenUseCase,
@@ -40,13 +37,13 @@ class SnoozeNotificationsUseCase(
     suspend operator fun invoke(
         snoozeDurationHours: String,
         lastChangeTimeSeconds: Long?,
-    ): Boolean {
+    ): AppResult<Unit, ActionError> {
         val authState = authRepository.authState.value
         if (authState !is AuthState.Authenticated) {
-            return false
+            return AppResult.Error(ActionError.NotAuthenticated)
         }
         if (lastChangeTimeSeconds == null) {
-            return false
+            return AppResult.Error(ActionError.MissingData)
         }
         val idToken = ensureFreshIdToken(authState)
         pushRepository.snoozeOpenDoorsNotifications(
@@ -54,6 +51,6 @@ class SnoozeNotificationsUseCase(
             idToken = idToken.asString(),
             snoozeEventTimestampSeconds = lastChangeTimeSeconds,
         )
-        return true
+        return AppResult.Success(Unit)
     }
 }


### PR DESCRIPTION
## Summary

- Replace Boolean returns with `AppResult<Unit, ActionError>` on `PushRemoteButtonUseCase` and `SnoozeNotificationsUseCase`
- Add `ActionError` sealed interface with `NotAuthenticated` and `MissingData` variants
- ViewModel handles each error case with exhaustive `when` — no more ambiguous Boolean false

## Test plan

- [x] All existing tests updated and passing
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)