### PR TITLE
docs: Dump session context — Phases 10,14,16 complete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,9 +72,10 @@ idf.py menuconfig      # Enable fake implementations for testing
 ### Android Clean Architecture
 - **Domain module** (`domain/`): Pure Kotlin types and repository interfaces — no Android deps
 - **Data module** (`data/`): Pure Kotlin data source interfaces (`LocalDoorDataSource`, `NetworkDoorDataSource`, etc.) — abstracts Room/Ktor
-- **UseCases** (`androidApp/usecase/`): Business logic extracted from ViewModels
+- **UseCase module** (`usecase/`): Shared business logic in `commonMain` — `RemoteButtonStateMachine`, fetch/push/snooze use cases
 - **ViewModels**: `DoorViewModel`, `AuthViewModel`, `RemoteButtonViewModel` — delegate to UseCases
 - **Repositories**: `DoorRepository`, `AuthRepository`, `PushRepository` — implement domain interfaces, depend on data interfaces
+- **Typed errors**: `AppResult<D, E>` with sealed error types (`FetchError`, `ActionError`) — exhaustive `when` handling. See ADR-010
 - **DI**: kotlin-inject (`AppComponent`) — Hilt fully removed. See `docs/DI-MIGRATION.md`
 - **Local storage**: Room database with offline-first caching
 - **Network**: Ktor HTTP client + kotlinx.serialization for API communication


### PR DESCRIPTION
## Summary

- Update CLAUDE.md: architecture reflects usecase module + typed errors (AppResult, ADR-010)
- Session completed Phases 10, 14, 16 + snooze bug fix + validate.sh KMP discovery fix
- Released android/138

🤖 Generated with [Claude Code](https://claude.com/claude-code)