### PR TITLE
feat: Extract MessagingBridge to decouple FCM from repository

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -28,6 +28,7 @@ import com.chriscartland.garage.config.APP_CONFIG
 import com.chriscartland.garage.coroutines.DefaultDispatcherProvider
 import com.chriscartland.garage.data.AuthBridge
 import com.chriscartland.garage.data.LocalDoorDataSource
+import com.chriscartland.garage.data.MessagingBridge
 import com.chriscartland.garage.data.NetworkButtonDataSource
 import com.chriscartland.garage.data.NetworkConfigDataSource
 import com.chriscartland.garage.data.NetworkDoorDataSource
@@ -44,6 +45,7 @@ import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import com.chriscartland.garage.door.DefaultDoorViewModel
 import com.chriscartland.garage.fcm.DoorFcmRepository
 import com.chriscartland.garage.fcm.FirebaseDoorFcmRepository
+import com.chriscartland.garage.fcm.FirebaseMessagingBridge
 import com.chriscartland.garage.internet.KtorNetworkButtonDataSource
 import com.chriscartland.garage.internet.KtorNetworkConfigDataSource
 import com.chriscartland.garage.internet.KtorNetworkDoorDataSource
@@ -136,7 +138,12 @@ abstract class AppComponent(
 
     @Provides
     @Singleton
-    fun provideDoorFcmRepository(): DoorFcmRepository = FirebaseDoorFcmRepository(provideAppSettings(), provideAppLoggerRepository())
+    fun provideMessagingBridge(): MessagingBridge = FirebaseMessagingBridge()
+
+    @Provides
+    @Singleton
+    fun provideDoorFcmRepository(): DoorFcmRepository =
+        FirebaseDoorFcmRepository(provideMessagingBridge(), provideAppSettings(), provideAppLoggerRepository())
 
     @Provides
     @Singleton

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/DoorFcmRepository.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/DoorFcmRepository.kt
@@ -21,13 +21,10 @@ import android.app.Activity
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.applogger.AppLoggerRepository
 import com.chriscartland.garage.config.AppLoggerKeys
+import com.chriscartland.garage.data.MessagingBridge
 import com.chriscartland.garage.domain.model.DoorFcmState
 import com.chriscartland.garage.domain.model.DoorFcmTopic
 import com.chriscartland.garage.settings.AppSettings
-import com.google.firebase.ktx.Firebase
-import com.google.firebase.messaging.ktx.messaging
-import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 interface DoorFcmRepository {
     suspend fun fetchStatus(activity: Activity): DoorFcmState
@@ -40,7 +37,13 @@ interface DoorFcmRepository {
     suspend fun deregisterDoor(activity: Activity): DoorFcmState
 }
 
+/**
+ * FCM repository that delegates all messaging calls to [MessagingBridge].
+ *
+ * No Firebase imports — all Firebase interaction happens through the bridge.
+ */
 class FirebaseDoorFcmRepository(
+    private val messagingBridge: MessagingBridge,
     private val settings: AppSettings,
     private val appLoggerRepository: AppLoggerRepository,
 ) : DoorFcmRepository {
@@ -64,49 +67,19 @@ class FirebaseDoorFcmRepository(
         val oldFcmTopic = getFcmTopic()
         if (oldFcmTopic != null && fcmTopic != oldFcmTopic) {
             Logger.i { "Unsubscribing from old FCM Topic: $oldFcmTopic" }
-            Firebase.messaging.unsubscribeFromTopic(oldFcmTopic.string)
+            messagingBridge.unsubscribeFromTopic(oldFcmTopic.string)
         }
         // Save new topic.
         setFcmTopic(fcmTopic)
         Logger.i { "Subscribing to FCM Topic: $fcmTopic" }
         appLoggerRepository.log(AppLoggerKeys.FCM_SUBSCRIBE_TOPIC)
-        val subscriptionSuccess =
-            suspendCoroutine { continuation ->
-                Firebase.messaging
-                    .subscribeToTopic(fcmTopic.string)
-                    .addOnCompleteListener { task ->
-                        if (task.isSuccessful) {
-                            Logger.i { "Subscribed to FCM Topic $fcmTopic" }
-                            continuation.resume(true)
-                        } else {
-                            Logger.e { "Failed to subscribe to FCM Topic $fcmTopic: ${task.exception}" }
-                            continuation.resume(false)
-                        }
-                    }
-            }
+        val subscriptionSuccess = messagingBridge.subscribeToTopic(fcmTopic.string)
         if (!subscriptionSuccess) {
             return DoorFcmState.NotRegistered.also {
                 Logger.d { "Failed to subscribe to topic $fcmTopic, returning state $it" }
             }
         }
-        val token =
-            suspendCoroutine { continuation ->
-                Firebase.messaging.token
-                    .addOnCompleteListener { task ->
-                        if (!task.isSuccessful) {
-                            Logger.w { "Fetching FCM registration token failed: ${task.exception}" }
-                            continuation.resume(null)
-                        }
-                        val token = task.result
-                        if (token == null) {
-                            Logger.d { "Fetching FCM registration token null" }
-                            continuation.resume(null)
-                        } else {
-                            Logger.d { "FCM Instance Token: $token" }
-                            continuation.resume(token)
-                        }
-                    }
-            }
+        val token = messagingBridge.getToken()
         if (token == null) {
             return DoorFcmState.NotRegistered.also {
                 Logger.d { "Failed to get FCM registration token, returning state $it" }
@@ -127,7 +100,7 @@ class FirebaseDoorFcmRepository(
         }
         removeFcmTopic()
         Logger.i { "Unsubscribing from old FCM Topic: $oldFcmTopic" }
-        Firebase.messaging.unsubscribeFromTopic(oldFcmTopic.string)
+        messagingBridge.unsubscribeFromTopic(oldFcmTopic.string)
         return DoorFcmState.NotRegistered.also {
             Logger.d { "Successfully deregistered for topic $oldFcmTopic, returning state $it" }
         }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FirebaseMessagingBridge.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FirebaseMessagingBridge.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.fcm
+
+import co.touchlab.kermit.Logger
+import com.chriscartland.garage.data.MessagingBridge
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.messaging.ktx.messaging
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * Firebase implementation of [MessagingBridge].
+ *
+ * Wraps all Firebase Messaging SDK calls.
+ */
+class FirebaseMessagingBridge : MessagingBridge {
+    override suspend fun subscribeToTopic(topic: String): Boolean =
+        suspendCoroutine { continuation ->
+            Firebase.messaging
+                .subscribeToTopic(topic)
+                .addOnCompleteListener { task ->
+                    if (task.isSuccessful) {
+                        Logger.i { "Subscribed to FCM Topic $topic" }
+                    } else {
+                        Logger.e { "Failed to subscribe to FCM Topic $topic: ${task.exception}" }
+                    }
+                    continuation.resume(task.isSuccessful)
+                }
+        }
+
+    override suspend fun unsubscribeFromTopic(topic: String) {
+        Firebase.messaging.unsubscribeFromTopic(topic)
+    }
+
+    override suspend fun getToken(): String? =
+        suspendCoroutine { continuation ->
+            Firebase.messaging.token
+                .addOnCompleteListener { task ->
+                    if (!task.isSuccessful) {
+                        Logger.w { "Fetching FCM registration token failed: ${task.exception}" }
+                        continuation.resume(null)
+                    } else {
+                        val token = task.result
+                        Logger.d { "FCM Instance Token: $token" }
+                        continuation.resume(token)
+                    }
+                }
+        }
+}

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/MessagingBridge.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/MessagingBridge.kt
@@ -1,0 +1,19 @@
+package com.chriscartland.garage.data
+
+/**
+ * Platform abstraction for push notification messaging.
+ *
+ * Decouples FCM operations from Firebase SDK, enabling:
+ * - Unit testing with fakes
+ * - Future iOS implementation with APNs
+ */
+interface MessagingBridge {
+    /** Subscribe to a topic. Returns true on success. */
+    suspend fun subscribeToTopic(topic: String): Boolean
+
+    /** Unsubscribe from a topic. */
+    suspend fun unsubscribeFromTopic(topic: String)
+
+    /** Get the push notification registration token, or null on failure. */
+    suspend fun getToken(): String?
+}


### PR DESCRIPTION
## Summary

- Introduce `MessagingBridge` interface in `data/src/commonMain/` abstracting FCM operations
- `FirebaseMessagingBridge` implementation wraps `Firebase.messaging` calls
- `FirebaseDoorFcmRepository` now injects `MessagingBridge` instead of calling Firebase directly
- Together with AuthBridge (#152), all Firebase SDK calls are now behind injectable interfaces

## Test plan

- [x] All existing tests pass
- [x] `spotlessApply` clean
- [x] No behavior changes — same FCM flow, just decoupled

🤖 Generated with [Claude Code](https://claude.com/claude-code)