### PR TITLE
docs: Mark Phase 11 and Phase 3.1 complete

### DIFF
--- a/AndroidGarage/docs/MIGRATION.md
+++ b/AndroidGarage/docs/MIGRATION.md
@@ -238,15 +238,26 @@ Several UseCases pass repositories as `invoke()` arguments instead of constructo
 - ViewModels still depend on `androidx.lifecycle.ViewModel` and `viewModelScope`
 - Full extraction to KMP module deferred until iOS target is added
 
-## Phase 11: Platform Abstractions (expect/actual)
+## Phase 11: Platform Abstractions — COMPLETE
 
-**Goal:** Define platform boundary contracts for iOS.
+**Goal:** Decouple platform SDKs behind injectable interfaces for testability and iOS readiness.
 
-- `expect class HttpClientFactory` — Android: OkHttp, iOS: Darwin engine
-- `expect class AuthBridge` — Android: Firebase Auth, iOS: native auth
-- `expect class PushNotificationBridge` — Android: FCM, iOS: APNs
-- `expect class LocalStorageBridge` — Android: Room + DataStore, iOS: CoreData + UserDefaults
-- iOS `actual` implementations come when adding iOS target
+### 11.1 AuthBridge — COMPLETE (#152)
+- `AuthBridge` interface in `data/src/commonMain/` abstracts Firebase Auth
+- `FirebaseAuthBridge` implementation in androidApp
+- `FirebaseAuthRepository` no longer imports Firebase directly
+- 6 new unit tests via `FakeAuthBridge`
+- Fixed: double-resume bug in original token refresh callback
+
+### 11.2 MessagingBridge — COMPLETE (#153)
+- `MessagingBridge` interface in `data/src/commonMain/` abstracts FCM
+- `FirebaseMessagingBridge` implementation in androidApp
+- Fixed: double-resume bug in original getToken callback
+
+### 11.3 Existing Abstractions
+- HTTP: `NetworkDoorDataSource`, `NetworkConfigDataSource`, `NetworkButtonDataSource` (Ktor behind interfaces)
+- Local storage: `LocalDoorDataSource` (Room behind interface)
+- `expect/actual` declarations deferred until iOS target is added
 
 ## Phase 12: Type-Safe Navigation — IN PROGRESS
 
@@ -346,7 +357,7 @@ Several UseCases pass repositories as `invoke()` arguments instead of constructo
 | 8. UseCase Refactor + Module | Medium | Phase 2 | **COMPLETE** |
 | 9. Data Module Repos | Medium | Phase 8 | **COMPLETE** |
 | 10. Shared ViewModels | Medium | Phase 9 | 10.1 COMPLETE (state machine extracted) |
-| 11. Platform Abstractions | Small | Phase 9 | TODO |
+| 11. Platform Abstractions | Small | Phase 9 | **COMPLETE** (bridges extracted) |
 | 12. Type-Safe Navigation | Medium | None | 12.1 COMPLETE (Nav3 deferred) |
 | 13. iOS Target | Large | Phases 10-11 | TODO |
 | 14. Typed Errors | Medium | Phase 8 | **COMPLETE** |

--- a/AndroidGarage/docs/TESTING.md
+++ b/AndroidGarage/docs/TESTING.md
@@ -13,7 +13,7 @@
 
 ## Current State
 
-- **186 unit tests** across 26 test files (19 androidApp + 4 domain + 1 usecase + 2 data), including DaoNullabilityTest, AppResultTest, RemoteButtonStateMachineTest, and data module integration tests
+- **192 unit tests** across 27 test files (20 androidApp + 4 domain + 1 usecase + 2 data), including FirebaseAuthRepositoryTest, RemoteButtonStateMachineTest, and data module integration tests
 - **18 instrumented tests** across 3 test files (Room sanity, DI graph, navigation smoke)
 - **CI architecture:** pre-submit (`ci.yml` → `ci-checks.yml`) + post-merge (`ci-post-merge.yml` → `ci-checks.yml` + instrumented tests)
 - **CI gate jobs:** `CI Complete` (PRs), `Post-Merge Complete` (main) — single check-run names for branch protection and release script
@@ -23,8 +23,8 @@
 - **Local validation:** `./scripts/validate.sh` mirrors CI + Room schema drift check + auto-discovered module tests + screenshot compilation + import boundary check (shared modules)
 - **Safety guardrails:** git hooks warn on Room entity changes, block push to main, enforce squash merge, block direct screenshot Gradle tasks
 - **DI system:** kotlin-inject (Hilt fully removed as of Phase 3), Ktor HTTP (Retrofit fully removed as of Phase 4)
-- **Completed:** Phase 1 (CI hardening), Phase 2 (network error tests), Phase 3 (auth token fix + UseCase tests), Phase 4 (state machine completeness), Phase 5.2-5.3 (release safety), Phase 6.1 (ESLint migration), Phase 7 (instrumented tests)
-- **Remaining:** Phase 3.1 (auth token tests — needs Firebase wrapper refactor), Phase 6.2 (server contract tests)
+- **Completed:** Phase 1 (CI hardening), Phase 2 (network error tests), Phase 3 (auth token fix + UseCase tests + AuthBridge extraction), Phase 4 (state machine completeness), Phase 5.2-5.3 (release safety), Phase 6.1 (ESLint migration), Phase 7 (instrumented tests)
+- **Remaining:** Phase 6.2 (server contract tests)
 
 ---
 
@@ -264,7 +264,7 @@ Verify all screens are reachable via navigation. Catches crashes from missing co
 | 4.1 Timeout edge cases | Small | Medium | Done |
 | 5.2 Disable release logging | Small | High | Done |
 | 5.3 BuildConfig validation | Small | Medium | Done |
-| 3.1 Auth token tests | Large | High | TODO — needs Firebase wrapper refactor |
+| 3.1 Auth token tests | Large | High | Done (#152) — AuthBridge extraction + 6 tests |
 | 5.1 ProGuard smoke test | Medium | Medium | Covered by Phase 7 |
 | 7.1 Gradle Managed Device setup | Medium | High | Done (#105) |
 | 7.2 Room database sanity | Small | High | Done (#105) |


### PR DESCRIPTION
## Summary
- Mark Phase 11 (platform abstractions) complete — AuthBridge + MessagingBridge
- Mark Phase 3.1 (auth token tests) complete — enabled by AuthBridge extraction
- Update test count: 192 across 27 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)