### PR TITLE
fix: Remove JVM-only imports from commonMain + enforce (Phase A)

### DIFF
--- a/AndroidGarage/buildSrc/src/main/kotlin/importboundary/ImportBoundaryCheckTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/importboundary/ImportBoundaryCheckTask.kt
@@ -30,6 +30,10 @@ abstract class ImportBoundaryCheckTask : DefaultTask() {
         "androidx.",
         "com.google.firebase.",
         "com.google.android.",
+        "java.time.",
+        "java.text.",
+        "java.util.Date",
+        "java.util.Locale",
     )
 
     @TaskAction

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkPushRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkPushRepository.kt
@@ -23,10 +23,9 @@ import com.chriscartland.garage.domain.model.PushStatus
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
 import com.chriscartland.garage.domain.repository.PushRepository
 import com.chriscartland.garage.domain.repository.ServerConfigRepository
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.time.delay
-import java.time.Duration
 
 class NetworkPushRepository(
     private val networkButtonDataSource: NetworkButtonDataSource,
@@ -56,7 +55,7 @@ class NetworkPushRepository(
         }
         if (!remoteButtonPushEnabled) {
             Logger.w { "Remote button push is disabled" }
-            delay(Duration.ofMillis(500))
+            delay(500)
         }
         if (remoteButtonPushEnabled) {
             networkButtonDataSource.pushButton(
@@ -77,7 +76,7 @@ class NetworkPushRepository(
         }
         if (!snoozeNotificationsOption) {
             Logger.w { "Snooze notifications disabled" }
-            delay(Duration.ofMillis(500))
+            delay(500)
         }
         if (snoozeNotificationsOption) {
             val endTime = networkButtonDataSource.fetchSnoozeEndTimeSeconds(
@@ -101,7 +100,7 @@ class NetworkPushRepository(
         }
         if (!snoozeNotificationsOption) {
             Logger.w { "Snooze notifications disabled" }
-            delay(Duration.ofMillis(500))
+            delay(500)
         }
         if (snoozeNotificationsOption) {
             val success = networkButtonDataSource.snoozeNotifications(


### PR DESCRIPTION
## Summary
- Replace `java.time.Duration` with `kotlinx.coroutines.delay(millis)` in NetworkPushRepository
- Add `java.time.`, `java.text.`, `java.util.Date`, `java.util.Locale` to forbidden import prefixes
- Unblocks future iOS builds

## Test plan
- [x] `./scripts/validate.sh` passes
- [x] Import boundary check would catch `java.time` in commonMain

🤖 Generated with [Claude Code](https://claude.com/claude-code)