### PR TITLE
feat: Tighten Detekt error handling rules + ADR-011 (Phase B)

### DIFF
--- a/AndroidGarage/androidApp/detekt-baseline.xml
+++ b/AndroidGarage/androidApp/detekt-baseline.xml
@@ -2,24 +2,14 @@
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
-    <ID>ConstructorParameterNaming:AuthViewModel.kt$DefaultAuthViewModel$private val _authRepository: AuthRepository</ID>
-    <ID>ConstructorParameterNaming:ServerConfigResponse.kt$ServerConfigResponse.Body$@Json(name = "remoteButtonBuildTimestamp") val _remoteButtonBuildTimestamp: String?</ID>
-    <ID>ImplicitDefaultLocale:TimeFormats.kt$String.format( "%d day%s, %dh %dm %ds", days, if (days &gt; 1) "s" else "", hours, minutes, seconds, )</ID>
-    <ID>ImplicitDefaultLocale:TimeFormats.kt$String.format("%dh %dm %ds", hours, minutes, seconds)</ID>
-    <ID>ImplicitDefaultLocale:TimeFormats.kt$String.format("%dm %ds", minutes, seconds)</ID>
-    <ID>ImplicitDefaultLocale:TimeFormats.kt$String.format("%ds", seconds)</ID>
-    <ID>MatchingDeclarationName:Parallelogram.kt$ParallelogramShape : Shape</ID>
-    <ID>MatchingDeclarationName:VersionModel.kt$AppVersion</ID>
     <ID>SwallowedException:AuthRepository.kt$FirebaseAuthRepository$e: Exception</ID>
-    <ID>SwallowedException:FCMService.kt$e: IllegalArgumentException</ID>
-    <ID>UnusedPrivateMember:RemoteButtonContent.kt$private fun ButtonColors.selectContainer(enabled: Boolean)</ID>
-    <ID>UnusedPrivateMember:RemoteButtonContent.kt$private fun ButtonColors.selectContent(enabled: Boolean)</ID>
-    <ID>UnusedPrivateProperty:AppSettings.kt$private const val TAG = "AppSettings"</ID>
-    <ID>UnusedPrivateProperty:DoorRepository.kt$private const val DIRECT_CURRENT = "com.chriscartland.garage.repository.DIRECT_CURRENT_DOOR_UPDATE"</ID>
-    <ID>UnusedPrivateProperty:DoorRepository.kt$private const val DIRECT_RECENT = "com.chriscartland.garage.repository.DIRECT_RECENT_DOOR_UPDATE"</ID>
-    <ID>UnusedPrivateProperty:DoorRepository.kt$private const val NETWORK_CURRENT = "com.chriscartland.garage.repository.NETWORK_CURRENT_DOOR_UPDATE"</ID>
-    <ID>UnusedPrivateProperty:DoorRepository.kt$private const val NETWORK_RECENT = "com.chriscartland.garage.repository.NETWORK_RECENT_DOOR_UPDATE"</ID>
-    <ID>UnusedPrivateProperty:PushRepository.kt$private const val TAG = "PushRepository"</ID>
-    <ID>UnusedPrivateProperty:PushRepositoryTest.kt$PushRepositoryTest$private val validServerConfig = ServerConfig( buildTimestamp = "2024-01-15T00:00:00Z", remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z", remoteButtonPushKey = "test-push-key", )</ID>
+    <ID>SwallowedException:FcmPayloadParser.kt$FcmPayloadParser$e: IllegalArgumentException</ID>
+    <ID>TooGenericExceptionCaught:AppLoggerRepository.kt$RoomAppLoggerRepository$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:AuthRepository.kt$FirebaseAuthRepository$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FcmPayloadParser.kt$FcmPayloadParser$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:FirebaseAuthBridge.kt$FirebaseAuthBridge$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:KtorNetworkButtonDataSource.kt$KtorNetworkButtonDataSource$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:KtorNetworkConfigDataSource.kt$KtorNetworkConfigDataSource$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:KtorNetworkDoorDataSource.kt$KtorNetworkDoorDataSource$e: Exception</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/AndroidGarage/detekt.yml
+++ b/AndroidGarage/detekt.yml
@@ -18,11 +18,13 @@ exceptions:
     active: true
     ignoredExceptionTypes:
       - InterruptedException
-      - NumberFormatException
-      - ParseException
-      - Exception
+      - CancellationException
   TooGenericExceptionCaught:
-    active: false
+    active: true
+    exceptionNames:
+      - Exception
+      - RuntimeException
+      - Throwable
 
 naming:
   active: true

--- a/AndroidGarage/docs/DECISIONS.md
+++ b/AndroidGarage/docs/DECISIONS.md
@@ -237,6 +237,33 @@ when (val result = fetchUseCase(token)) {
 - Slightly more verbose than nullable returns, but the safety is worth it
 - Requires migrating existing nullable/Boolean APIs incrementally
 
+## ADR-011: No-Throw Error Handling
+
+**Status:** Accepted
+
+**Context:** The codebase has multiple places where library exceptions are caught and silently swallowed (`catch (e: Exception) { Logger.e { ... } }`). Callers can't distinguish success from failure. The Detekt `SwallowedException` rule was allowing `Exception` in its ignore list, defeating its purpose.
+
+**Decision:** Adopt a no-throw error handling policy:
+
+1. **Never throw** from application code (except `CancellationException` for coroutine cancellation)
+2. **Catch at boundaries** — library exceptions (Ktor, Firebase, Room) are caught at the data source/bridge layer and converted to sealed error types
+3. **Return sealed results** — use `AppResult<D, E>` or `NetworkResult<T>` instead of nullable returns or Boolean success flags
+4. **No `else` in `when` on sealed types** — always list every variant explicitly so the compiler forces handling new variants
+5. **Detekt enforcement** — `SwallowedException` and `TooGenericExceptionCaught` rules are active. Existing violations are baselined and must be resolved incrementally
+
+**Rules:**
+- Data sources return `NetworkResult<T>` (Success, HttpError, ConnectionFailed)
+- Repositories return `AppResult<D, FetchError>` or `AppResult<D, ActionError>`
+- UseCases return `AppResult<D, E>` to ViewModels
+- ViewModels handle errors with exhaustive `when` and update UI state accordingly
+- Only `CancellationException` may propagate — all others must be caught and typed
+
+**Consequences:**
+- Every error path is visible and compiler-checked
+- Adding a new error variant forces all callers to handle it
+- Baselined Detekt violations track technical debt — each resolved violation is a win
+- New code cannot swallow exceptions or catch generic Exception without baseline entry
+
 **Example — preferred:**
 ```kotlin
 object ButtonAckTokens {


### PR DESCRIPTION
## Summary
- Enable `TooGenericExceptionCaught` rule (was disabled)
- Tighten `SwallowedException` — only allow CancellationException and InterruptedException
- Generate baseline for 9 existing violations (fix incrementally)
- Add ADR-011: No-throw error handling — catch at boundaries, return sealed types, no `else` in `when`

## Test plan
- [x] Detekt passes with baseline
- [x] New code that swallows exceptions will fail Detekt

🤖 Generated with [Claude Code](https://claude.com/claude-code)