### PR TITLE
feat: Replace nullable data source returns with typed NetworkResult (Phase C)

### DIFF
--- a/AndroidGarage/androidApp/detekt-baseline.xml
+++ b/AndroidGarage/androidApp/detekt-baseline.xml
@@ -8,8 +8,8 @@
     <ID>TooGenericExceptionCaught:AuthRepository.kt$FirebaseAuthRepository$e: Exception</ID>
     <ID>TooGenericExceptionCaught:FcmPayloadParser.kt$FcmPayloadParser$e: Exception</ID>
     <ID>TooGenericExceptionCaught:FirebaseAuthBridge.kt$FirebaseAuthBridge$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:KtorNetworkButtonDataSource.kt$KtorNetworkButtonDataSource$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:KtorNetworkConfigDataSource.kt$KtorNetworkConfigDataSource$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:KtorNetworkDoorDataSource.kt$KtorNetworkDoorDataSource$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:KtorNetworkButtonDataSource.kt$KtorNetworkButtonDataSource$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:KtorNetworkConfigDataSource.kt$KtorNetworkConfigDataSource$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:KtorNetworkDoorDataSource.kt$KtorNetworkDoorDataSource$e: Throwable</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/internet/KtorNetworkButtonDataSource.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/internet/KtorNetworkButtonDataSource.kt
@@ -19,6 +19,7 @@ package com.chriscartland.garage.internet
 
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.NetworkButtonDataSource
+import com.chriscartland.garage.data.NetworkResult
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
@@ -26,6 +27,7 @@ import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.http.isSuccess
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.Serializable
 
 class KtorNetworkButtonDataSource(
@@ -36,7 +38,7 @@ class KtorNetworkButtonDataSource(
         buttonAckToken: String,
         remoteButtonPushKey: String,
         idToken: String,
-    ): Boolean =
+    ): NetworkResult<Unit> =
         try {
             val response = client.post("addRemoteButtonCommand") {
                 parameter("buildTimestamp", remoteButtonBuildTimestamp)
@@ -45,10 +47,16 @@ class KtorNetworkButtonDataSource(
                 header("X-AuthTokenGoogle", idToken)
             }
             Logger.i { "Push response: ${response.status.value}" }
-            response.status.isSuccess()
-        } catch (e: Exception) {
+            if (response.status.isSuccess()) {
+                NetworkResult.Success(Unit)
+            } else {
+                NetworkResult.HttpError(response.status.value)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
             Logger.e { "Push error: $e" }
-            false
+            NetworkResult.ConnectionFailed
         }
 
     override suspend fun snoozeNotifications(
@@ -57,7 +65,7 @@ class KtorNetworkButtonDataSource(
         idToken: String,
         snoozeDurationHours: String,
         snoozeEventTimestampSeconds: Long,
-    ): Boolean {
+    ): NetworkResult<Unit> {
         return try {
             val response = client.post("snoozeNotificationsRequest") {
                 parameter("buildTimestamp", buildTimestamp)
@@ -68,34 +76,41 @@ class KtorNetworkButtonDataSource(
             }
             Logger.i { "Snooze response: ${response.status.value}" }
             if (!response.status.isSuccess()) {
-                return false
+                return NetworkResult.HttpError(response.status.value)
             }
             val body = response.body<KtorSnoozeResponse>()
             if (body.error != null) {
                 Logger.e { "Snooze error: ${body.error}" }
-                return false
+                return NetworkResult.HttpError(response.status.value)
             }
-            true
-        } catch (e: Exception) {
+            NetworkResult.Success(Unit)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
             Logger.e { "Snooze error: $e" }
-            false
+            NetworkResult.ConnectionFailed
         }
     }
 
-    override suspend fun fetchSnoozeEndTimeSeconds(buildTimestamp: String): Long {
+    override suspend fun fetchSnoozeEndTimeSeconds(buildTimestamp: String): NetworkResult<Long> {
         return try {
             val response = client.get("snoozeNotificationsLatest") {
                 parameter("buildTimestamp", buildTimestamp)
             }
+            if (!response.status.isSuccess()) {
+                return NetworkResult.HttpError(response.status.value)
+            }
             val body = response.body<KtorGetSnoozeResponse>()
             if (body.error != null) {
                 Logger.e { "Snooze fetch error: ${body.error}" }
-                return 0L
+                return NetworkResult.HttpError(response.status.value)
             }
-            body.snooze?.snoozeEndTimeSeconds ?: 0L
-        } catch (e: Exception) {
+            NetworkResult.Success(body.snooze?.snoozeEndTimeSeconds ?: 0L)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
             Logger.e { "Snooze fetch error: $e" }
-            0L
+            NetworkResult.ConnectionFailed
         }
     }
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/internet/KtorNetworkConfigDataSource.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/internet/KtorNetworkConfigDataSource.kt
@@ -19,12 +19,14 @@ package com.chriscartland.garage.internet
 
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.NetworkConfigDataSource
+import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.domain.model.ServerConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.http.isSuccess
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.net.URLDecoder
@@ -33,45 +35,49 @@ import java.nio.charset.StandardCharsets
 class KtorNetworkConfigDataSource(
     private val client: HttpClient,
 ) : NetworkConfigDataSource {
-    override suspend fun fetchServerConfig(serverConfigKey: String): ServerConfig? {
+    override suspend fun fetchServerConfig(serverConfigKey: String): NetworkResult<ServerConfig> {
         return try {
             val response = client.get("serverConfig") {
                 header("X-ServerConfigKey", serverConfigKey)
             }
             if (!response.status.isSuccess()) {
                 Logger.e { "Response code is ${response.status.value}" }
-                return null
+                return NetworkResult.HttpError(response.status.value)
             }
             val result = response.body<KtorServerConfigResponse>()
             val body = result.body
             if (body == null) {
                 Logger.e { "Response body is null" }
-                return null
+                return NetworkResult.HttpError(response.status.value)
             }
             if (body.buildTimestamp.isNullOrEmpty()) {
                 Logger.e { "buildTimestamp is empty" }
-                return null
+                return NetworkResult.HttpError(response.status.value)
             }
             val remoteButtonBuildTimestamp = body.remoteButtonBuildTimestamp
             if (remoteButtonBuildTimestamp.isNullOrEmpty()) {
                 Logger.e { "remoteButtonBuildTimestamp is empty" }
-                return null
+                return NetworkResult.HttpError(response.status.value)
             }
             if (body.remoteButtonPushKey.isNullOrEmpty()) {
                 Logger.e { "remoteButtonPushKey is empty" }
-                return null
+                return NetworkResult.HttpError(response.status.value)
             }
-            ServerConfig(
-                buildTimestamp = body.buildTimestamp,
-                remoteButtonBuildTimestamp = URLDecoder.decode(
-                    remoteButtonBuildTimestamp,
-                    StandardCharsets.UTF_8.name(),
+            NetworkResult.Success(
+                ServerConfig(
+                    buildTimestamp = body.buildTimestamp,
+                    remoteButtonBuildTimestamp = URLDecoder.decode(
+                        remoteButtonBuildTimestamp,
+                        StandardCharsets.UTF_8.name(),
+                    ),
+                    remoteButtonPushKey = body.remoteButtonPushKey,
                 ),
-                remoteButtonPushKey = body.remoteButtonPushKey,
             )
-        } catch (e: Exception) {
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
             Logger.e { "Error fetching server config: $e" }
-            null
+            NetworkResult.ConnectionFailed
         }
     }
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/internet/KtorNetworkDoorDataSource.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/internet/KtorNetworkDoorDataSource.kt
@@ -19,6 +19,7 @@ package com.chriscartland.garage.internet
 
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.NetworkDoorDataSource
+import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import io.ktor.client.HttpClient
@@ -26,35 +27,41 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.http.isSuccess
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 class KtorNetworkDoorDataSource(
     private val client: HttpClient,
 ) : NetworkDoorDataSource {
-    override suspend fun fetchCurrentDoorEvent(buildTimestamp: String): DoorEvent? {
+    override suspend fun fetchCurrentDoorEvent(buildTimestamp: String): NetworkResult<DoorEvent> {
         return try {
             val response = client.get("currentEventData") {
                 parameter("buildTimestamp", buildTimestamp)
             }
             if (!response.status.isSuccess()) {
                 Logger.e { "Response code is ${response.status.value}" }
-                return null
+                return NetworkResult.HttpError(response.status.value)
             }
             val body = response.body<KtorCurrentEventDataResponse>()
-            body.currentEventData?.currentEvent?.toDoorEvent().also {
-                if (it == null) Logger.e { "Door event is null" }
+            val doorEvent = body.currentEventData?.currentEvent?.toDoorEvent()
+            if (doorEvent == null) {
+                Logger.e { "Door event is null in response" }
+                return NetworkResult.HttpError(response.status.value)
             }
-        } catch (e: Exception) {
+            NetworkResult.Success(doorEvent)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
             Logger.e { "Error fetching current door event: $e" }
-            null
+            NetworkResult.ConnectionFailed
         }
     }
 
     override suspend fun fetchRecentDoorEvents(
         buildTimestamp: String,
         count: Int,
-    ): List<DoorEvent>? {
+    ): NetworkResult<List<DoorEvent>> {
         return try {
             val response = client.get("eventHistory") {
                 parameter("buildTimestamp", buildTimestamp)
@@ -62,12 +69,12 @@ class KtorNetworkDoorDataSource(
             }
             if (!response.status.isSuccess()) {
                 Logger.e { "Response code is ${response.status.value}" }
-                return null
+                return NetworkResult.HttpError(response.status.value)
             }
             val body = response.body<KtorRecentEventDataResponse>()
             if (body.eventHistory.isNullOrEmpty()) {
                 Logger.i { "recentEventData is empty" }
-                return null
+                return NetworkResult.Success(emptyList())
             }
             val doorEvents = body.eventHistory.mapNotNull {
                 it.currentEvent?.toDoorEvent()
@@ -75,10 +82,12 @@ class KtorNetworkDoorDataSource(
             if (doorEvents.size != body.eventHistory.size) {
                 Logger.e { "Door events size ${doorEvents.size} does not match response size ${body.eventHistory.size}" }
             }
-            doorEvents
-        } catch (e: Exception) {
+            NetworkResult.Success(doorEvents)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
             Logger.e { "Error fetching recent door events: $e" }
-            null
+            NetworkResult.ConnectionFailed
         }
     }
 }

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/config/ServerConfigRepositoryTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/config/ServerConfigRepositoryTest.kt
@@ -18,6 +18,7 @@
 package com.chriscartland.garage.config
 
 import com.chriscartland.garage.data.NetworkConfigDataSource
+import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.data.repository.CachedServerConfigRepository
 import com.chriscartland.garage.domain.model.ServerConfig
 import kotlinx.coroutines.test.runTest
@@ -28,12 +29,12 @@ import org.junit.Before
 import org.junit.Test
 
 class FakeNetworkConfigDataSource : NetworkConfigDataSource {
-    var serverConfig: ServerConfig? = null
+    var serverConfigResult: NetworkResult<ServerConfig> = NetworkResult.ConnectionFailed
     var fetchCount = 0
 
-    override suspend fun fetchServerConfig(serverConfigKey: String): ServerConfig? {
+    override suspend fun fetchServerConfig(serverConfigKey: String): NetworkResult<ServerConfig> {
         fetchCount++
-        return serverConfig
+        return serverConfigResult
     }
 }
 
@@ -56,7 +57,7 @@ class ServerConfigRepositoryTest {
     @Test
     fun fetchServerConfigReturnsConfigOnSuccess() =
         runTest {
-            networkConfig.serverConfig = validConfig
+            networkConfig.serverConfigResult = NetworkResult.Success(validConfig)
 
             val result = repo.fetchServerConfig()
 
@@ -68,7 +69,7 @@ class ServerConfigRepositoryTest {
     @Test
     fun fetchServerConfigReturnsNullOnFailure() =
         runTest {
-            networkConfig.serverConfig = null
+            networkConfig.serverConfigResult = NetworkResult.ConnectionFailed
 
             assertNull(repo.fetchServerConfig())
         }
@@ -76,7 +77,7 @@ class ServerConfigRepositoryTest {
     @Test
     fun getServerConfigCachedReturnsCachedValueOnSecondCall() =
         runTest {
-            networkConfig.serverConfig = validConfig
+            networkConfig.serverConfigResult = NetworkResult.Success(validConfig)
 
             val first = repo.getServerConfigCached()
             val second = repo.getServerConfigCached()
@@ -88,7 +89,7 @@ class ServerConfigRepositoryTest {
     @Test
     fun getServerConfigCachedFetchesWhenNotCached() =
         runTest {
-            networkConfig.serverConfig = validConfig
+            networkConfig.serverConfigResult = NetworkResult.Success(validConfig)
 
             val result = repo.getServerConfigCached()
 
@@ -99,7 +100,7 @@ class ServerConfigRepositoryTest {
     @Test
     fun getServerConfigCachedReturnsNullWhenFetchFails() =
         runTest {
-            networkConfig.serverConfig = null
+            networkConfig.serverConfigResult = NetworkResult.ConnectionFailed
 
             assertNull(repo.getServerConfigCached())
         }

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/NetworkButtonDataSource.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/NetworkButtonDataSource.kt
@@ -1,41 +1,25 @@
 package com.chriscartland.garage.data
 
 /**
- * Pure data source interface for remote button and snooze operations.
+ * Data source interface for remote button and snooze operations.
  *
- * Implementations handle HTTP communication. The Repository layer
- * never sees HTTP response codes or network DTOs.
+ * Returns [NetworkResult] so callers handle errors with exhaustive `when`.
  */
 interface NetworkButtonDataSource {
-    /**
-     * Send a remote button push request.
-     *
-     * @return true if the server acknowledged the request
-     */
     suspend fun pushButton(
         remoteButtonBuildTimestamp: String,
         buttonAckToken: String,
         remoteButtonPushKey: String,
         idToken: String,
-    ): Boolean
+    ): NetworkResult<Unit>
 
-    /**
-     * Request to snooze open-door notifications.
-     *
-     * @return true if the server acknowledged, false on error
-     */
     suspend fun snoozeNotifications(
         buildTimestamp: String,
         remoteButtonPushKey: String,
         idToken: String,
         snoozeDurationHours: String,
         snoozeEventTimestampSeconds: Long,
-    ): Boolean
+    ): NetworkResult<Unit>
 
-    /**
-     * Fetch the current snooze end time.
-     *
-     * @return Snooze end time in epoch seconds, or 0 if not snoozing
-     */
-    suspend fun fetchSnoozeEndTimeSeconds(buildTimestamp: String): Long
+    suspend fun fetchSnoozeEndTimeSeconds(buildTimestamp: String): NetworkResult<Long>
 }

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/NetworkConfigDataSource.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/NetworkConfigDataSource.kt
@@ -3,17 +3,10 @@ package com.chriscartland.garage.data
 import com.chriscartland.garage.domain.model.ServerConfig
 
 /**
- * Pure data source interface for fetching server configuration.
+ * Data source interface for fetching server configuration.
  *
- * Implementations handle HTTP communication and map responses
- * to domain [ServerConfig] objects.
+ * Returns [NetworkResult] so callers handle errors with exhaustive `when`.
  */
 interface NetworkConfigDataSource {
-    /**
-     * Fetch the server configuration.
-     *
-     * @param serverConfigKey API key for authentication
-     * @return The server config, or null if the request failed or config is invalid
-     */
-    suspend fun fetchServerConfig(serverConfigKey: String): ServerConfig?
+    suspend fun fetchServerConfig(serverConfigKey: String): NetworkResult<ServerConfig>
 }

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/NetworkDoorDataSource.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/NetworkDoorDataSource.kt
@@ -3,30 +3,16 @@ package com.chriscartland.garage.data
 import com.chriscartland.garage.domain.model.DoorEvent
 
 /**
- * Pure data source interface for fetching door events from the network.
+ * Data source interface for fetching door events from the network.
  *
- * Implementations handle HTTP communication (Retrofit, Ktor, etc.)
- * and map network response DTOs to domain types. The Repository layer
- * never sees HTTP response codes, network DTOs, or serialization details.
+ * Returns [NetworkResult] so callers handle success, HTTP errors, and
+ * connection failures with exhaustive `when`.
  */
 interface NetworkDoorDataSource {
-    /**
-     * Fetch the current door event from the server.
-     *
-     * @param buildTimestamp Server build timestamp for the API request
-     * @return The current door event, or null if the request failed
-     */
-    suspend fun fetchCurrentDoorEvent(buildTimestamp: String): DoorEvent?
+    suspend fun fetchCurrentDoorEvent(buildTimestamp: String): NetworkResult<DoorEvent>
 
-    /**
-     * Fetch recent door events from the server.
-     *
-     * @param buildTimestamp Server build timestamp for the API request
-     * @param count Maximum number of events to return
-     * @return List of door events, or null if the request failed
-     */
     suspend fun fetchRecentDoorEvents(
         buildTimestamp: String,
         count: Int,
-    ): List<DoorEvent>?
+    ): NetworkResult<List<DoorEvent>>
 }

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/NetworkResult.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/NetworkResult.kt
@@ -1,0 +1,26 @@
+package com.chriscartland.garage.data
+
+/**
+ * Typed result from network data sources.
+ *
+ * Replaces nullable returns and Boolean success flags so callers can
+ * distinguish between success, HTTP errors, and connection failures
+ * using exhaustive `when` (no `else` branch).
+ *
+ * Caught at the data source boundary — Ktor/HTTP exceptions are
+ * converted here, never propagated to repositories.
+ */
+sealed interface NetworkResult<out T> {
+    /** Request succeeded with data. */
+    data class Success<T>(
+        val data: T,
+    ) : NetworkResult<T>
+
+    /** Server responded with a non-success HTTP status code. */
+    data class HttpError(
+        val code: Int,
+    ) : NetworkResult<Nothing>
+
+    /** Network request failed (timeout, DNS, connection refused, etc.). */
+    data object ConnectionFailed : NetworkResult<Nothing>
+}

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepository.kt
@@ -18,6 +18,7 @@
 package com.chriscartland.garage.data.repository
 
 import com.chriscartland.garage.data.NetworkConfigDataSource
+import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.domain.model.ServerConfig
 import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import kotlinx.coroutines.sync.Mutex
@@ -41,7 +42,11 @@ class CachedServerConfigRepository(
     }
 
     override suspend fun fetchServerConfig(): ServerConfig? {
-        val config = networkConfigDataSource.fetchServerConfig(serverConfigKey)
+        val config = when (val result = networkConfigDataSource.fetchServerConfig(serverConfigKey)) {
+            is NetworkResult.Success -> result.data
+            is NetworkResult.HttpError -> null
+            NetworkResult.ConnectionFailed -> null
+        }
         if (config != null) {
             serverConfig = config
         }

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepository.kt
@@ -20,6 +20,7 @@ package com.chriscartland.garage.data.repository
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.LocalDoorDataSource
 import com.chriscartland.garage.data.NetworkDoorDataSource
+import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
@@ -58,14 +59,21 @@ class NetworkDoorRepository(
             Logger.e { "Server config is null" }
             return AppResult.Error(FetchError.NotReady)
         }
-        val doorEvent = networkDoorDataSource.fetchCurrentDoorEvent(buildTimestamp)
-        if (doorEvent == null) {
-            Logger.e { "Failed to fetch current door event" }
-            return AppResult.Error(FetchError.NetworkFailed)
+        return when (val result = networkDoorDataSource.fetchCurrentDoorEvent(buildTimestamp)) {
+            is NetworkResult.Success -> {
+                Logger.d { "Success: ${result.data}" }
+                localDoorDataSource.insertDoorEvent(result.data)
+                AppResult.Success(result.data)
+            }
+            is NetworkResult.HttpError -> {
+                Logger.e { "HTTP ${result.code} fetching current door event" }
+                AppResult.Error(FetchError.NetworkFailed)
+            }
+            NetworkResult.ConnectionFailed -> {
+                Logger.e { "Connection failed fetching current door event" }
+                AppResult.Error(FetchError.NetworkFailed)
+            }
         }
-        Logger.d { "Success: $doorEvent" }
-        localDoorDataSource.insertDoorEvent(doorEvent)
-        return AppResult.Success(doorEvent)
     }
 
     override suspend fun fetchRecentDoorEvents(): AppResult<List<DoorEvent>, FetchError> {
@@ -74,16 +82,25 @@ class NetworkDoorRepository(
             Logger.e { "Server config is null" }
             return AppResult.Error(FetchError.NotReady)
         }
-        val doorEvents = networkDoorDataSource.fetchRecentDoorEvents(
-            buildTimestamp = buildTimestamp,
-            count = recentEventCount,
-        )
-        if (doorEvents == null) {
-            Logger.e { "Failed to fetch recent door events" }
-            return AppResult.Error(FetchError.NetworkFailed)
+        return when (
+            val result = networkDoorDataSource.fetchRecentDoorEvents(
+                buildTimestamp = buildTimestamp,
+                count = recentEventCount,
+            )
+        ) {
+            is NetworkResult.Success -> {
+                Logger.d { "Success: ${result.data}" }
+                localDoorDataSource.replaceDoorEvents(result.data)
+                AppResult.Success(result.data)
+            }
+            is NetworkResult.HttpError -> {
+                Logger.e { "HTTP ${result.code} fetching recent door events" }
+                AppResult.Error(FetchError.NetworkFailed)
+            }
+            NetworkResult.ConnectionFailed -> {
+                Logger.e { "Connection failed fetching recent door events" }
+                AppResult.Error(FetchError.NetworkFailed)
+            }
         }
-        Logger.d { "Success: $doorEvents" }
-        localDoorDataSource.replaceDoorEvents(doorEvents)
-        return AppResult.Success(doorEvents)
     }
 }

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkPushRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkPushRepository.kt
@@ -19,6 +19,7 @@ package com.chriscartland.garage.data.repository
 
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.NetworkButtonDataSource
+import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.domain.model.PushStatus
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
 import com.chriscartland.garage.domain.repository.PushRepository
@@ -58,12 +59,18 @@ class NetworkPushRepository(
             delay(500)
         }
         if (remoteButtonPushEnabled) {
-            networkButtonDataSource.pushButton(
-                remoteButtonBuildTimestamp = serverConfig.remoteButtonBuildTimestamp,
-                buttonAckToken = buttonAckToken,
-                remoteButtonPushKey = serverConfig.remoteButtonPushKey,
-                idToken = idToken,
-            )
+            when (
+                val result = networkButtonDataSource.pushButton(
+                    remoteButtonBuildTimestamp = serverConfig.remoteButtonBuildTimestamp,
+                    buttonAckToken = buttonAckToken,
+                    remoteButtonPushKey = serverConfig.remoteButtonPushKey,
+                    idToken = idToken,
+                )
+            ) {
+                is NetworkResult.Success -> Logger.d { "Push succeeded" }
+                is NetworkResult.HttpError -> Logger.e { "Push HTTP ${result.code}" }
+                NetworkResult.ConnectionFailed -> Logger.e { "Push connection failed" }
+            }
         }
         _pushButtonStatus.value = PushStatus.IDLE
     }
@@ -79,10 +86,15 @@ class NetworkPushRepository(
             delay(500)
         }
         if (snoozeNotificationsOption) {
-            val endTime = networkButtonDataSource.fetchSnoozeEndTimeSeconds(
-                buildTimestamp = serverConfig.buildTimestamp,
-            )
-            _snoozeEndTimeSeconds.value = endTime
+            when (
+                val result = networkButtonDataSource.fetchSnoozeEndTimeSeconds(
+                    buildTimestamp = serverConfig.buildTimestamp,
+                )
+            ) {
+                is NetworkResult.Success -> _snoozeEndTimeSeconds.value = result.data
+                is NetworkResult.HttpError -> Logger.e { "Snooze fetch HTTP ${result.code}" }
+                NetworkResult.ConnectionFailed -> Logger.e { "Snooze fetch connection failed" }
+            }
         }
     }
 
@@ -103,16 +115,29 @@ class NetworkPushRepository(
             delay(500)
         }
         if (snoozeNotificationsOption) {
-            val success = networkButtonDataSource.snoozeNotifications(
-                buildTimestamp = serverConfig.buildTimestamp,
-                remoteButtonPushKey = serverConfig.remoteButtonPushKey,
-                idToken = idToken,
-                snoozeDurationHours = snoozeDurationHours,
-                snoozeEventTimestampSeconds = snoozeEventTimestampSeconds,
-            )
-            if (!success) {
-                _snoozeRequestStatus.value = SnoozeRequestStatus.ERROR
-                return
+            when (
+                val result = networkButtonDataSource.snoozeNotifications(
+                    buildTimestamp = serverConfig.buildTimestamp,
+                    remoteButtonPushKey = serverConfig.remoteButtonPushKey,
+                    idToken = idToken,
+                    snoozeDurationHours = snoozeDurationHours,
+                    snoozeEventTimestampSeconds = snoozeEventTimestampSeconds,
+                )
+            ) {
+                is NetworkResult.Success -> {
+                    _snoozeRequestStatus.value = SnoozeRequestStatus.IDLE
+                    return
+                }
+                is NetworkResult.HttpError -> {
+                    Logger.e { "Snooze HTTP ${result.code}" }
+                    _snoozeRequestStatus.value = SnoozeRequestStatus.ERROR
+                    return
+                }
+                NetworkResult.ConnectionFailed -> {
+                    Logger.e { "Snooze connection failed" }
+                    _snoozeRequestStatus.value = SnoozeRequestStatus.ERROR
+                    return
+                }
             }
         }
         _snoozeRequestStatus.value = SnoozeRequestStatus.IDLE

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepositoryTest.kt
@@ -17,6 +17,7 @@
 
 package com.chriscartland.garage.data.repository
 
+import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.data.testfakes.FakeNetworkConfigDataSource
 import com.chriscartland.garage.domain.model.ServerConfig
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -47,7 +48,7 @@ class CachedServerConfigRepositoryTest {
                 remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
                 remoteButtonPushKey = "key",
             )
-            configDataSource.serverConfigResponse = config
+            configDataSource.serverConfigResult = NetworkResult.Success(config)
 
             val repo = createRepository()
             val result = repo.getServerConfigCached()
@@ -64,7 +65,7 @@ class CachedServerConfigRepositoryTest {
                 remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
                 remoteButtonPushKey = "key",
             )
-            configDataSource.serverConfigResponse = config
+            configDataSource.serverConfigResult = NetworkResult.Success(config)
 
             val repo = createRepository()
             repo.getServerConfigCached()
@@ -76,7 +77,7 @@ class CachedServerConfigRepositoryTest {
     @Test
     fun getServerConfigCachedReturnsNullWhenNetworkFails() =
         runTest {
-            configDataSource.serverConfigResponse = null
+            configDataSource.serverConfigResult = NetworkResult.ConnectionFailed
 
             val repo = createRepository()
             assertNull(repo.getServerConfigCached())
@@ -86,7 +87,7 @@ class CachedServerConfigRepositoryTest {
     @Test
     fun getServerConfigCachedRetriesAfterNullResponse() =
         runTest {
-            configDataSource.serverConfigResponse = null
+            configDataSource.serverConfigResult = NetworkResult.ConnectionFailed
 
             val repo = createRepository()
             assertNull(repo.getServerConfigCached())
@@ -97,7 +98,7 @@ class CachedServerConfigRepositoryTest {
                 remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
                 remoteButtonPushKey = "key",
             )
-            configDataSource.serverConfigResponse = config
+            configDataSource.serverConfigResult = NetworkResult.Success(config)
             assertEquals(config, repo.getServerConfigCached())
             assertEquals(2, configDataSource.fetchCount)
         }
@@ -110,7 +111,7 @@ class CachedServerConfigRepositoryTest {
                 remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
                 remoteButtonPushKey = "key1",
             )
-            configDataSource.serverConfigResponse = config1
+            configDataSource.serverConfigResult = NetworkResult.Success(config1)
 
             val repo = createRepository()
             repo.getServerConfigCached()
@@ -121,7 +122,7 @@ class CachedServerConfigRepositoryTest {
                 remoteButtonBuildTimestamp = "2024-01-16T00:00:00Z",
                 remoteButtonPushKey = "key2",
             )
-            configDataSource.serverConfigResponse = config2
+            configDataSource.serverConfigResult = NetworkResult.Success(config2)
             repo.fetchServerConfig()
 
             // Cached value should now be updated
@@ -138,13 +139,13 @@ class CachedServerConfigRepositoryTest {
                 remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
                 remoteButtonPushKey = "key",
             )
-            configDataSource.serverConfigResponse = config
+            configDataSource.serverConfigResult = NetworkResult.Success(config)
 
             val repo = createRepository()
             repo.getServerConfigCached()
 
             // Network now returns null
-            configDataSource.serverConfigResponse = null
+            configDataSource.serverConfigResult = NetworkResult.ConnectionFailed
             repo.fetchServerConfig()
 
             // Cache should retain the old value

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepositoryIntegrationTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepositoryIntegrationTest.kt
@@ -17,6 +17,7 @@
 
 package com.chriscartland.garage.data.repository
 
+import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.data.testfakes.FakeNetworkConfigDataSource
 import com.chriscartland.garage.data.testfakes.FakeNetworkDoorDataSource
 import com.chriscartland.garage.data.testfakes.InMemoryLocalDoorDataSource
@@ -61,10 +62,12 @@ class NetworkDoorRepositoryIntegrationTest {
     @Test
     fun fetchCurrentDoorEventStoresInLocal() =
         runTest {
-            configDataSource.serverConfigResponse = ServerConfig(
-                buildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonPushKey = "key",
+            configDataSource.serverConfigResult = NetworkResult.Success(
+                ServerConfig(
+                    buildTimestamp = "2024-01-15T00:00:00Z",
+                    remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+                    remoteButtonPushKey = "key",
+                ),
             )
             val event = DoorEvent(
                 doorPosition = DoorPosition.OPEN,
@@ -72,7 +75,7 @@ class NetworkDoorRepositoryIntegrationTest {
                 lastCheckInTimeSeconds = 1000L,
                 lastChangeTimeSeconds = 900L,
             )
-            networkDataSource.currentDoorEventResponse = event
+            networkDataSource.currentDoorEventResult = NetworkResult.Success(event)
 
             val repo = createRepository()
             val result = repo.fetchCurrentDoorEvent()
@@ -87,16 +90,18 @@ class NetworkDoorRepositoryIntegrationTest {
     @Test
     fun fetchCurrentDoorEventExposedViaFlow() =
         runTest {
-            configDataSource.serverConfigResponse = ServerConfig(
-                buildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonPushKey = "key",
+            configDataSource.serverConfigResult = NetworkResult.Success(
+                ServerConfig(
+                    buildTimestamp = "2024-01-15T00:00:00Z",
+                    remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+                    remoteButtonPushKey = "key",
+                ),
             )
             val event = DoorEvent(
                 doorPosition = DoorPosition.CLOSED,
                 message = "Door is closed",
             )
-            networkDataSource.currentDoorEventResponse = event
+            networkDataSource.currentDoorEventResult = NetworkResult.Success(event)
 
             val repo = createRepository()
             repo.fetchCurrentDoorEvent()
@@ -108,7 +113,7 @@ class NetworkDoorRepositoryIntegrationTest {
     @Test
     fun fetchCurrentDoorEventWithNullServerConfigReturnsNotReady() =
         runTest {
-            configDataSource.serverConfigResponse = null
+            configDataSource.serverConfigResult = NetworkResult.ConnectionFailed
 
             val repo = createRepository()
             val result = repo.fetchCurrentDoorEvent()
@@ -122,12 +127,14 @@ class NetworkDoorRepositoryIntegrationTest {
     @Test
     fun fetchCurrentDoorEventWithNullNetworkResponseReturnsNetworkFailed() =
         runTest {
-            configDataSource.serverConfigResponse = ServerConfig(
-                buildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonPushKey = "key",
+            configDataSource.serverConfigResult = NetworkResult.Success(
+                ServerConfig(
+                    buildTimestamp = "2024-01-15T00:00:00Z",
+                    remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+                    remoteButtonPushKey = "key",
+                ),
             )
-            networkDataSource.currentDoorEventResponse = null
+            networkDataSource.currentDoorEventResult = NetworkResult.ConnectionFailed
 
             val repo = createRepository()
             val result = repo.fetchCurrentDoorEvent()
@@ -144,17 +151,19 @@ class NetworkDoorRepositoryIntegrationTest {
     @Test
     fun fetchRecentDoorEventsStoresInLocal() =
         runTest {
-            configDataSource.serverConfigResponse = ServerConfig(
-                buildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonPushKey = "key",
+            configDataSource.serverConfigResult = NetworkResult.Success(
+                ServerConfig(
+                    buildTimestamp = "2024-01-15T00:00:00Z",
+                    remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+                    remoteButtonPushKey = "key",
+                ),
             )
             val events = listOf(
                 DoorEvent(doorPosition = DoorPosition.OPEN, lastChangeTimeSeconds = 300L),
                 DoorEvent(doorPosition = DoorPosition.CLOSED, lastChangeTimeSeconds = 200L),
                 DoorEvent(doorPosition = DoorPosition.OPENING, lastChangeTimeSeconds = 100L),
             )
-            networkDataSource.recentDoorEventsResponse = events
+            networkDataSource.recentDoorEventsResult = NetworkResult.Success(events)
 
             val repo = createRepository()
             val result = repo.fetchRecentDoorEvents()
@@ -167,7 +176,7 @@ class NetworkDoorRepositoryIntegrationTest {
     @Test
     fun fetchRecentDoorEventsWithNullServerConfigReturnsNotReady() =
         runTest {
-            configDataSource.serverConfigResponse = null
+            configDataSource.serverConfigResult = NetworkResult.ConnectionFailed
 
             val repo = createRepository()
             val result = repo.fetchRecentDoorEvents()
@@ -181,12 +190,14 @@ class NetworkDoorRepositoryIntegrationTest {
     @Test
     fun fetchRecentDoorEventsWithNullNetworkResponseReturnsNetworkFailed() =
         runTest {
-            configDataSource.serverConfigResponse = ServerConfig(
-                buildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonPushKey = "key",
+            configDataSource.serverConfigResult = NetworkResult.Success(
+                ServerConfig(
+                    buildTimestamp = "2024-01-15T00:00:00Z",
+                    remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+                    remoteButtonPushKey = "key",
+                ),
             )
-            networkDataSource.recentDoorEventsResponse = null
+            networkDataSource.recentDoorEventsResult = NetworkResult.ConnectionFailed
 
             val repo = createRepository()
             val result = repo.fetchRecentDoorEvents()
@@ -240,10 +251,12 @@ class NetworkDoorRepositoryIntegrationTest {
     @Test
     fun fetchBuildTimestampCachedReturnsFromServerConfig() =
         runTest {
-            configDataSource.serverConfigResponse = ServerConfig(
-                buildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonPushKey = "key",
+            configDataSource.serverConfigResult = NetworkResult.Success(
+                ServerConfig(
+                    buildTimestamp = "2024-01-15T00:00:00Z",
+                    remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+                    remoteButtonPushKey = "key",
+                ),
             )
 
             val repo = createRepository()
@@ -253,7 +266,7 @@ class NetworkDoorRepositoryIntegrationTest {
     @Test
     fun fetchBuildTimestampCachedReturnsNullWhenNoConfig() =
         runTest {
-            configDataSource.serverConfigResponse = null
+            configDataSource.serverConfigResult = NetworkResult.ConnectionFailed
 
             val repo = createRepository()
             assertNull(repo.fetchBuildTimestampCached())

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/testfakes/FakeNetworkConfigDataSource.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/testfakes/FakeNetworkConfigDataSource.kt
@@ -18,16 +18,17 @@
 package com.chriscartland.garage.data.testfakes
 
 import com.chriscartland.garage.data.NetworkConfigDataSource
+import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.domain.model.ServerConfig
 
 class FakeNetworkConfigDataSource : NetworkConfigDataSource {
-    var serverConfigResponse: ServerConfig? = null
+    var serverConfigResult: NetworkResult<ServerConfig> = NetworkResult.ConnectionFailed
 
     var fetchCount = 0
         private set
 
-    override suspend fun fetchServerConfig(serverConfigKey: String): ServerConfig? {
+    override suspend fun fetchServerConfig(serverConfigKey: String): NetworkResult<ServerConfig> {
         fetchCount++
-        return serverConfigResponse
+        return serverConfigResult
     }
 }

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/testfakes/FakeNetworkDoorDataSource.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/testfakes/FakeNetworkDoorDataSource.kt
@@ -18,27 +18,28 @@
 package com.chriscartland.garage.data.testfakes
 
 import com.chriscartland.garage.data.NetworkDoorDataSource
+import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.domain.model.DoorEvent
 
 class FakeNetworkDoorDataSource : NetworkDoorDataSource {
-    var currentDoorEventResponse: DoorEvent? = null
-    var recentDoorEventsResponse: List<DoorEvent>? = null
+    var currentDoorEventResult: NetworkResult<DoorEvent> = NetworkResult.ConnectionFailed
+    var recentDoorEventsResult: NetworkResult<List<DoorEvent>> = NetworkResult.ConnectionFailed
 
     var fetchCurrentCount = 0
         private set
     var fetchRecentCount = 0
         private set
 
-    override suspend fun fetchCurrentDoorEvent(buildTimestamp: String): DoorEvent? {
+    override suspend fun fetchCurrentDoorEvent(buildTimestamp: String): NetworkResult<DoorEvent> {
         fetchCurrentCount++
-        return currentDoorEventResponse
+        return currentDoorEventResult
     }
 
     override suspend fun fetchRecentDoorEvents(
         buildTimestamp: String,
         count: Int,
-    ): List<DoorEvent>? {
+    ): NetworkResult<List<DoorEvent>> {
         fetchRecentCount++
-        return recentDoorEventsResponse
+        return recentDoorEventsResult
     }
 }


### PR DESCRIPTION
## Summary

- New `NetworkResult<T>` sealed interface: `Success<T>`, `HttpError(code)`, `ConnectionFailed`
- All 3 data source interfaces return `NetworkResult<T>` instead of nullable/Boolean/Long
- Ktor implementations catch at boundary, rethrow CancellationException, map others to typed results
- Repositories handle each variant with exhaustive `when` (no `else`)
- All fakes and 18+ tests updated

This eliminates silent null/false/0L returns — callers now distinguish success from HTTP errors from connection failures.

## Test plan

- [x] All existing tests pass (updated fakes)
- [x] `./scripts/validate.sh` passes
- [x] Detekt passes with updated baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)