### PR TITLE
refactor: Inject fetchOnInit into DoorViewModel (Phase D)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorViewModel.kt
@@ -22,9 +22,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.applogger.AppLoggerRepository
-import com.chriscartland.garage.config.APP_CONFIG
 import com.chriscartland.garage.config.AppLoggerKeys
-import com.chriscartland.garage.config.FetchOnViewModelInit
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.DoorEvent
@@ -68,6 +66,7 @@ class DefaultDoorViewModel(
     private val fetchFcmStatusUseCase: FetchFcmStatusUseCase,
     private val registerFcmUseCase: RegisterFcmUseCase,
     private val deregisterFcmUseCase: DeregisterFcmUseCase,
+    private val fetchOnInit: Boolean = true,
 ) : ViewModel(),
     DoorViewModel {
     private val _fcmRegistrationStatus =
@@ -96,19 +95,13 @@ class DefaultDoorViewModel(
                 _recentDoorEvents.value = LoadingResult.Complete(it)
             }
         }
-        // Decide whether to fetch with network data when ViewModel is initialized
-        when (APP_CONFIG.fetchOnViewModelInit) {
-            FetchOnViewModelInit.Yes -> {
-                viewModelScope.launch(dispatchers.io) {
-                    appLoggerRepository.log(AppLoggerKeys.INIT_CURRENT_DOOR)
-                    appLoggerRepository.log(AppLoggerKeys.INIT_RECENT_DOOR)
-                }
-                fetchCurrentDoorEvent()
-                fetchRecentDoorEvents()
+        if (fetchOnInit) {
+            viewModelScope.launch(dispatchers.io) {
+                appLoggerRepository.log(AppLoggerKeys.INIT_CURRENT_DOOR)
+                appLoggerRepository.log(AppLoggerKeys.INIT_RECENT_DOOR)
             }
-
-            FetchOnViewModelInit.No -> { // Do nothing
-            }
+            fetchCurrentDoorEvent()
+            fetchRecentDoorEvents()
         }
     }
 

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/door/DoorViewModelTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/door/DoorViewModelTest.kt
@@ -99,7 +99,7 @@ class DoorViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private suspend fun createViewModel(): DefaultDoorViewModel {
+    private suspend fun createViewModel(fetchOnInit: Boolean = true): DefaultDoorViewModel {
         stubFetchSuccess()
         val vm = DefaultDoorViewModel(
             appLoggerRepository,
@@ -110,6 +110,7 @@ class DoorViewModelTest {
             FetchFcmStatusUseCase(doorFcmRepository),
             RegisterFcmUseCase(doorRepository, doorFcmRepository),
             DeregisterFcmUseCase(doorFcmRepository),
+            fetchOnInit = fetchOnInit,
         )
         testDispatcher.scheduler.runCurrent()
         return vm
@@ -253,5 +254,15 @@ class DoorViewModelTest {
             testDispatcher.scheduler.runCurrent()
 
             assertEquals(FcmRegistrationStatus.UNKNOWN, viewModel.fcmRegistrationStatus.value)
+        }
+
+    @Test
+    fun fetchOnInitFalseDoesNotFetchOnCreate() =
+        runTest {
+            val viewModel = createViewModel(fetchOnInit = false)
+
+            // Flow collection still runs (shows repo data), but network fetch was NOT triggered
+            verify(doorRepository, org.mockito.Mockito.never()).fetchCurrentDoorEvent()
+            verify(doorRepository, org.mockito.Mockito.never()).fetchRecentDoorEvents()
         }
 }


### PR DESCRIPTION
## Summary
- Replace global `APP_CONFIG.fetchOnViewModelInit` with constructor parameter `fetchOnInit: Boolean`
- DoorViewModel no longer imports global config
- New test verifies `fetchOnInit = false` doesn't trigger network fetches

## Test plan
- [x] All existing tests pass
- [x] New test: `fetchOnInitFalseDoesNotFetchOnCreate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)