### PR TITLE
refactor: Use DEFAULT_TIMEOUT_MILLIS constant in timeout tests (Phase I)

### DIFF
--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModelTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModelTest.kt
@@ -29,6 +29,7 @@ import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.domain.repository.PushRepository
 import com.chriscartland.garage.usecase.EnsureFreshIdTokenUseCase
 import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
+import com.chriscartland.garage.usecase.RemoteButtonStateMachine
 import com.chriscartland.garage.usecase.SnoozeNotificationsUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -44,6 +45,8 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+
+private val TIMEOUT = RemoteButtonStateMachine.DEFAULT_TIMEOUT_MILLIS
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class RemoteButtonViewModelTest {
@@ -275,7 +278,7 @@ class RemoteButtonViewModelTest {
             assertEquals(RequestStatus.SENDING, viewModel.requestStatus.value)
 
             // Advance past the 10-second timeout
-            advanceTimeBy(10_001)
+            advanceTimeBy(TIMEOUT + 1)
             testDispatcher.scheduler.runCurrent()
             assertEquals(RequestStatus.SENDING_TIMEOUT, viewModel.requestStatus.value)
         }
@@ -292,7 +295,7 @@ class RemoteButtonViewModelTest {
             testDispatcher.scheduler.runCurrent()
             assertEquals(RequestStatus.SENT, viewModel.requestStatus.value)
 
-            advanceTimeBy(10_001)
+            advanceTimeBy(TIMEOUT + 1)
             testDispatcher.scheduler.runCurrent()
             assertEquals(RequestStatus.SENT_TIMEOUT, viewModel.requestStatus.value)
         }
@@ -306,12 +309,12 @@ class RemoteButtonViewModelTest {
             testDispatcher.scheduler.runCurrent()
 
             // First timeout: SENDING -> SENDING_TIMEOUT
-            advanceTimeBy(10_001)
+            advanceTimeBy(TIMEOUT + 1)
             testDispatcher.scheduler.runCurrent()
             assertEquals(RequestStatus.SENDING_TIMEOUT, viewModel.requestStatus.value)
 
             // Second timeout: SENDING_TIMEOUT -> NONE
-            advanceTimeBy(10_001)
+            advanceTimeBy(TIMEOUT + 1)
             testDispatcher.scheduler.runCurrent()
             assertEquals(RequestStatus.NONE, viewModel.requestStatus.value)
         }
@@ -327,12 +330,12 @@ class RemoteButtonViewModelTest {
             testDispatcher.scheduler.runCurrent()
 
             // First timeout: SENT -> SENT_TIMEOUT
-            advanceTimeBy(10_001)
+            advanceTimeBy(TIMEOUT + 1)
             testDispatcher.scheduler.runCurrent()
             assertEquals(RequestStatus.SENT_TIMEOUT, viewModel.requestStatus.value)
 
             // Second timeout: SENT_TIMEOUT -> NONE
-            advanceTimeBy(10_001)
+            advanceTimeBy(TIMEOUT + 1)
             testDispatcher.scheduler.runCurrent()
             assertEquals(RequestStatus.NONE, viewModel.requestStatus.value)
         }
@@ -348,7 +351,7 @@ class RemoteButtonViewModelTest {
             testDispatcher.scheduler.runCurrent()
             assertEquals(RequestStatus.RECEIVED, viewModel.requestStatus.value)
 
-            advanceTimeBy(10_001)
+            advanceTimeBy(TIMEOUT + 1)
             testDispatcher.scheduler.runCurrent()
             assertEquals(RequestStatus.NONE, viewModel.requestStatus.value)
         }
@@ -362,7 +365,7 @@ class RemoteButtonViewModelTest {
             testDispatcher.scheduler.runCurrent()
 
             // Door moves before the 10s timeout
-            advanceTimeBy(5_000)
+            advanceTimeBy(TIMEOUT / 2)
             testDispatcher.scheduler.runCurrent()
             assertEquals(RequestStatus.SENDING, viewModel.requestStatus.value)
 
@@ -371,7 +374,7 @@ class RemoteButtonViewModelTest {
             assertEquals(RequestStatus.RECEIVED, viewModel.requestStatus.value)
 
             // Original timeout fires but should not override RECEIVED
-            advanceTimeBy(6_000)
+            advanceTimeBy(TIMEOUT / 2 + 1_000)
             testDispatcher.scheduler.runCurrent()
             assertEquals(RequestStatus.RECEIVED, viewModel.requestStatus.value)
         }
@@ -393,7 +396,7 @@ class RemoteButtonViewModelTest {
             assertEquals(RequestStatus.NONE, viewModel.requestStatus.value)
 
             // Advance past where timeout would have fired
-            advanceTimeBy(15_000)
+            advanceTimeBy(TIMEOUT + TIMEOUT / 2)
             testDispatcher.scheduler.runCurrent()
             // Should still be NONE — timeout was cancelled by reset
             assertEquals(RequestStatus.NONE, viewModel.requestStatus.value)
@@ -418,7 +421,7 @@ class RemoteButtonViewModelTest {
             assertEquals(RequestStatus.RECEIVED, viewModel.requestStatus.value)
 
             // Only the RECEIVED timeout should be active (10s → NONE)
-            advanceTimeBy(10_001)
+            advanceTimeBy(TIMEOUT + 1)
             testDispatcher.scheduler.runCurrent()
             assertEquals(RequestStatus.NONE, viewModel.requestStatus.value)
         }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonStateMachineTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonStateMachineTest.kt
@@ -29,6 +29,8 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+private val TIMEOUT = RemoteButtonStateMachine.DEFAULT_TIMEOUT_MILLIS
+
 @OptIn(ExperimentalCoroutinesApi::class)
 class RemoteButtonStateMachineTest {
     private lateinit var pushStatusFlow: MutableStateFlow<PushStatus>
@@ -176,7 +178,7 @@ class RemoteButtonStateMachineTest {
             testScheduler.runCurrent()
             assertEquals(RequestStatus.SENDING, sm.requestStatus.value)
 
-            advanceTimeBy(10_001)
+            advanceTimeBy(TIMEOUT + 1)
             testScheduler.runCurrent()
             assertEquals(RequestStatus.SENDING_TIMEOUT, sm.requestStatus.value)
         }
@@ -192,7 +194,7 @@ class RemoteButtonStateMachineTest {
             testScheduler.runCurrent()
             assertEquals(RequestStatus.SENT, sm.requestStatus.value)
 
-            advanceTimeBy(10_001)
+            advanceTimeBy(TIMEOUT + 1)
             testScheduler.runCurrent()
             assertEquals(RequestStatus.SENT_TIMEOUT, sm.requestStatus.value)
         }
@@ -206,12 +208,12 @@ class RemoteButtonStateMachineTest {
             testScheduler.runCurrent()
 
             // First timeout: SENDING -> SENDING_TIMEOUT
-            advanceTimeBy(10_001)
+            advanceTimeBy(TIMEOUT + 1)
             testScheduler.runCurrent()
             assertEquals(RequestStatus.SENDING_TIMEOUT, sm.requestStatus.value)
 
             // Second timeout: SENDING_TIMEOUT -> NONE
-            advanceTimeBy(10_001)
+            advanceTimeBy(TIMEOUT + 1)
             testScheduler.runCurrent()
             assertEquals(RequestStatus.NONE, sm.requestStatus.value)
         }
@@ -227,12 +229,12 @@ class RemoteButtonStateMachineTest {
             testScheduler.runCurrent()
 
             // First timeout: SENT -> SENT_TIMEOUT
-            advanceTimeBy(10_001)
+            advanceTimeBy(TIMEOUT + 1)
             testScheduler.runCurrent()
             assertEquals(RequestStatus.SENT_TIMEOUT, sm.requestStatus.value)
 
             // Second timeout: SENT_TIMEOUT -> NONE
-            advanceTimeBy(10_001)
+            advanceTimeBy(TIMEOUT + 1)
             testScheduler.runCurrent()
             assertEquals(RequestStatus.NONE, sm.requestStatus.value)
         }
@@ -248,7 +250,7 @@ class RemoteButtonStateMachineTest {
             testScheduler.runCurrent()
             assertEquals(RequestStatus.RECEIVED, sm.requestStatus.value)
 
-            advanceTimeBy(10_001)
+            advanceTimeBy(TIMEOUT + 1)
             testScheduler.runCurrent()
             assertEquals(RequestStatus.NONE, sm.requestStatus.value)
         }
@@ -262,7 +264,7 @@ class RemoteButtonStateMachineTest {
             testScheduler.runCurrent()
 
             // Door moves before the 10s timeout
-            advanceTimeBy(5_000)
+            advanceTimeBy(TIMEOUT / 2)
             testScheduler.runCurrent()
             assertEquals(RequestStatus.SENDING, sm.requestStatus.value)
 
@@ -271,7 +273,7 @@ class RemoteButtonStateMachineTest {
             assertEquals(RequestStatus.RECEIVED, sm.requestStatus.value)
 
             // Original timeout fires but should not override RECEIVED
-            advanceTimeBy(6_000)
+            advanceTimeBy(TIMEOUT / 2 + 1_000)
             testScheduler.runCurrent()
             assertEquals(RequestStatus.RECEIVED, sm.requestStatus.value)
         }
@@ -293,7 +295,7 @@ class RemoteButtonStateMachineTest {
             assertEquals(RequestStatus.NONE, sm.requestStatus.value)
 
             // Advance past where timeout would have fired
-            advanceTimeBy(15_000)
+            advanceTimeBy(TIMEOUT + TIMEOUT / 2)
             testScheduler.runCurrent()
             // Should still be NONE — timeout was cancelled by reset
             assertEquals(RequestStatus.NONE, sm.requestStatus.value)
@@ -318,7 +320,7 @@ class RemoteButtonStateMachineTest {
             assertEquals(RequestStatus.RECEIVED, sm.requestStatus.value)
 
             // Only the RECEIVED timeout should be active (10s → NONE)
-            advanceTimeBy(10_001)
+            advanceTimeBy(TIMEOUT + 1)
             testScheduler.runCurrent()
             assertEquals(RequestStatus.NONE, sm.requestStatus.value)
         }


### PR DESCRIPTION
## Summary
- Replace magic numbers in timeout tests with `RemoteButtonStateMachine.DEFAULT_TIMEOUT_MILLIS`
- Both `RemoteButtonStateMachineTest` (19 tests) and `RemoteButtonViewModelTest` (26 tests) updated

## Test plan
- [x] All timeout tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)