### PR TITLE
fix: Inject CoroutineScope into AuthRepository (Phase F)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthRepository.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthRepository.kt
@@ -28,7 +28,6 @@ import com.chriscartland.garage.domain.model.GoogleIdToken
 import com.chriscartland.garage.domain.model.User
 import com.chriscartland.garage.domain.repository.AuthRepository
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -45,12 +44,13 @@ const val RC_ONE_TAP_SIGN_IN = 1
 class FirebaseAuthRepository(
     private val authBridge: AuthBridge,
     private val appLoggerRepository: AppLoggerRepository,
+    externalScope: CoroutineScope,
 ) : AuthRepository {
     private val _authState = MutableStateFlow<AuthState>(AuthState.Unknown)
     override val authState: StateFlow<AuthState> = _authState.asStateFlow()
 
     init {
-        CoroutineScope(Dispatchers.IO).launch {
+        externalScope.launch {
             refreshFirebaseAuthState()
         }
     }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -63,6 +63,9 @@ import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
 import com.chriscartland.garage.usecase.RegisterFcmUseCase
 import com.chriscartland.garage.usecase.SnoozeNotificationsUseCase
 import io.ktor.client.HttpClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.Provides
 
@@ -119,7 +122,12 @@ abstract class AppComponent(
 
     @Provides
     @Singleton
-    fun provideAuthRepository(): AuthRepository = FirebaseAuthRepository(provideAuthBridge(), provideAppLoggerRepository())
+    fun provideApplicationScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @Provides
+    @Singleton
+    fun provideAuthRepository(): AuthRepository =
+        FirebaseAuthRepository(provideAuthBridge(), provideAppLoggerRepository(), provideApplicationScope())
 
     @Provides
     @Singleton

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/auth/FirebaseAuthRepositoryTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/auth/FirebaseAuthRepositoryTest.kt
@@ -23,6 +23,7 @@ import com.chriscartland.garage.domain.model.FirebaseIdToken
 import com.chriscartland.garage.domain.model.GoogleIdToken
 import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
 import com.chriscartland.garage.testcommon.FakeAuthBridge
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -54,7 +55,8 @@ class FirebaseAuthRepositoryTest {
     }
 
     private fun createRepository(): FirebaseAuthRepository {
-        val repo = FirebaseAuthRepository(authBridge, loggerRepo)
+        val testScope = CoroutineScope(testDispatcher)
+        val repo = FirebaseAuthRepository(authBridge, loggerRepo, testScope)
         testDispatcher.scheduler.runCurrent()
         return repo
     }


### PR DESCRIPTION
## Summary
- Replace fire-and-forget `CoroutineScope(Dispatchers.IO)` with injected scope
- AppComponent provides `SupervisorJob() + Dispatchers.IO` application scope
- Tests use test dispatcher for deterministic init behavior

## Test plan
- [x] All 6 FirebaseAuthRepository tests pass
- [x] Compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)