### PR TITLE
fix: Surface fetch errors to UI — exit Loading on failure (Phase G)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorViewModel.kt
@@ -138,9 +138,13 @@ class DefaultDoorViewModel(
                 is AppResult.Success -> {
                     // Data flows through repository → local cache → Flow observation
                 }
-                is AppResult.Error -> when (result.error) {
-                    FetchError.NotReady -> Logger.w { "Server config not ready" }
-                    FetchError.NetworkFailed -> Logger.w { "Network request failed" }
+                is AppResult.Error -> {
+                    // Restore previous data so UI exits Loading state
+                    _currentDoorEvent.value = LoadingResult.Complete(_currentDoorEvent.value.data)
+                    when (result.error) {
+                        FetchError.NotReady -> Logger.w { "Server config not ready" }
+                        FetchError.NetworkFailed -> Logger.w { "Network request failed" }
+                    }
                 }
             }
         }
@@ -154,9 +158,13 @@ class DefaultDoorViewModel(
                 is AppResult.Success -> {
                     // Data flows through repository → local cache → Flow observation
                 }
-                is AppResult.Error -> when (result.error) {
-                    FetchError.NotReady -> Logger.w { "Server config not ready" }
-                    FetchError.NetworkFailed -> Logger.w { "Network request failed" }
+                is AppResult.Error -> {
+                    // Restore previous data so UI exits Loading state
+                    _recentDoorEvents.value = LoadingResult.Complete(_recentDoorEvents.value.data)
+                    when (result.error) {
+                        FetchError.NotReady -> Logger.w { "Server config not ready" }
+                        FetchError.NetworkFailed -> Logger.w { "Network request failed" }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- On fetch error, transition from `LoadingResult.Loading` back to `LoadingResult.Complete` with previous data
- Users no longer see infinite loading spinner on network errors
- Error is logged with exhaustive `when` on `FetchError` variants

## Test plan
- [x] Compiles cleanly
- [x] No conflict with other open PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)