### PR TITLE
docs: Dump session context — hardening complete

### DIFF
--- a/AndroidGarage/docs/MIGRATION.md
+++ b/AndroidGarage/docs/MIGRATION.md
@@ -364,6 +364,20 @@ Several UseCases pass repositories as `invoke()` arguments instead of constructo
 | 15. Kermit Logging | Small | None | **COMPLETE** |
 | 16. Integration Tests | Medium | Phase 9 | **COMPLETE** (data module) |
 | 17. Architecture Rules | Small | Phase 8 | **COMPLETE** (import boundaries) |
-| 18. Presentation-Model | Small | Phase 10 | TODO (optional) |
+| 18. Presentation-Model | Small | Phase 10 | **COMPLETE** |
+
+### Architecture Hardening (completed alongside migration)
+
+| Phase | Description | PR |
+|-------|-------------|-----|
+| A | JVM import boundary enforcement | #156 |
+| B | Detekt error handling rules + ADR-011 | #157 |
+| C | NetworkResult<T> typed data sources | #158 |
+| D | Inject APP_CONFIG into ViewModel | #159 |
+| E | FCMService structured concurrency | #161 |
+| F | AuthRepository inject scope | #162 |
+| G | Error state propagation to UI | #163 |
+| H | Migrate DoorViewModelTest to fakes | #164 |
+| I | Test timeout constants | #160 |
 
 **Rule:** Finish each phase before starting the next. Update this document with commit hashes when items complete.

--- a/AndroidGarage/docs/TESTING.md
+++ b/AndroidGarage/docs/TESTING.md
@@ -13,7 +13,7 @@
 
 ## Current State
 
-- **192 unit tests** across 27 test files (20 androidApp + 4 domain + 1 usecase + 2 data), including FirebaseAuthRepositoryTest, RemoteButtonStateMachineTest, and data module integration tests
+- **192 unit tests** across 31 test files (21 androidApp + 4 domain + 1 usecase + 2 data + 3 androidApp fakes), including FirebaseAuthRepositoryTest, RemoteButtonStateMachineTest, data module integration tests, and 5 fake implementations
 - **18 instrumented tests** across 3 test files (Room sanity, DI graph, navigation smoke)
 - **CI architecture:** pre-submit (`ci.yml` → `ci-checks.yml`) + post-merge (`ci-post-merge.yml` → `ci-checks.yml` + instrumented tests)
 - **CI gate jobs:** `CI Complete` (PRs), `Post-Merge Complete` (main) — single check-run names for branch protection and release script

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,10 +75,11 @@ idf.py menuconfig      # Enable fake implementations for testing
 - **UseCase module** (`usecase/`): Shared business logic in `commonMain` — `RemoteButtonStateMachine`, fetch/push/snooze use cases
 - **ViewModels**: `DoorViewModel`, `AuthViewModel`, `RemoteButtonViewModel` — delegate to UseCases
 - **Repositories**: `DoorRepository`, `AuthRepository`, `PushRepository` — implement domain interfaces, depend on data interfaces
-- **Typed errors**: `AppResult<D, E>` with sealed error types (`FetchError`, `ActionError`) — exhaustive `when` handling. See ADR-010
+- **Typed errors**: `AppResult<D, E>` and `NetworkResult<T>` with sealed error types — exhaustive `when`, no `else`. See ADR-010, ADR-011
+- **Platform bridges**: `AuthBridge`, `MessagingBridge` decouple Firebase SDK — enables unit testing and future iOS
 - **DI**: kotlin-inject (`AppComponent`) — Hilt fully removed. See `docs/DI-MIGRATION.md`
 - **Local storage**: Room database with offline-first caching
-- **Network**: Ktor HTTP client + kotlinx.serialization for API communication
+- **Network**: Ktor HTTP client + kotlinx.serialization, `NetworkResult<T>` at data source boundary
 
 ### ESP32 Component Architecture
 ```


### PR DESCRIPTION
## Summary
- CLAUDE.md: Add NetworkResult, platform bridges to architecture section
- TESTING.md: 192 unit tests across 31 files
- MIGRATION.md: Phase 18 complete, hardening phases A-I table added

🤖 Generated with [Claude Code](https://claude.com/claude-code)