### PR TITLE
feat: Move Ktor data sources and FcmPayloadParser to data module (Phase 21)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -27,6 +27,9 @@ import com.chriscartland.garage.auth.FirebaseAuthRepository
 import com.chriscartland.garage.config.APP_CONFIG
 import com.chriscartland.garage.coroutines.DefaultDispatcherProvider
 import com.chriscartland.garage.data.AuthBridge
+import com.chriscartland.garage.data.KtorNetworkButtonDataSource
+import com.chriscartland.garage.data.KtorNetworkConfigDataSource
+import com.chriscartland.garage.data.KtorNetworkDoorDataSource
 import com.chriscartland.garage.data.LocalDoorDataSource
 import com.chriscartland.garage.data.MessagingBridge
 import com.chriscartland.garage.data.NetworkButtonDataSource
@@ -46,9 +49,6 @@ import com.chriscartland.garage.door.DefaultDoorViewModel
 import com.chriscartland.garage.fcm.DoorFcmRepository
 import com.chriscartland.garage.fcm.FirebaseDoorFcmRepository
 import com.chriscartland.garage.fcm.FirebaseMessagingBridge
-import com.chriscartland.garage.internet.KtorNetworkButtonDataSource
-import com.chriscartland.garage.internet.KtorNetworkConfigDataSource
-import com.chriscartland.garage.internet.KtorNetworkDoorDataSource
 import com.chriscartland.garage.internet.provideKtorHttpClient
 import com.chriscartland.garage.remotebutton.DefaultRemoteButtonViewModel
 import com.chriscartland.garage.settings.AppSettings

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
@@ -21,6 +21,7 @@ import co.touchlab.kermit.Logger
 import com.chriscartland.garage.GarageApplication
 import com.chriscartland.garage.applogger.AppLoggerRepository
 import com.chriscartland.garage.config.AppLoggerKeys
+import com.chriscartland.garage.data.FcmPayloadParser
 import com.chriscartland.garage.domain.repository.DoorRepository
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/fcm/FcmPayloadParsingTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/fcm/FcmPayloadParsingTest.kt
@@ -17,6 +17,7 @@
 
 package com.chriscartland.garage.fcm
 
+import com.chriscartland.garage.data.FcmPayloadParser
 import com.chriscartland.garage.domain.model.DoorPosition
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull

--- a/AndroidGarage/data/build.gradle.kts
+++ b/AndroidGarage/data/build.gradle.kts
@@ -3,6 +3,7 @@ import importboundary.ImportBoundaryCheckTask
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 tasks.register<ImportBoundaryCheckTask>("checkImportBoundary") {
@@ -17,6 +18,10 @@ kotlin {
             implementation(project(":domain"))
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kermit)
+            implementation(libs.ktor.client.core)
+            implementation(libs.ktor.client.content.negotiation)
+            implementation(libs.ktor.serialization.kotlinx.json)
+            implementation(libs.kotlinx.serialization.json)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/FcmPayloadParser.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/FcmPayloadParser.kt
@@ -15,7 +15,7 @@
  *
  */
 
-package com.chriscartland.garage.fcm
+package com.chriscartland.garage.data
 
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.domain.model.DoorEvent

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/KtorNetworkButtonDataSource.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/KtorNetworkButtonDataSource.kt
@@ -15,11 +15,9 @@
  *
  */
 
-package com.chriscartland.garage.internet
+package com.chriscartland.garage.data
 
 import co.touchlab.kermit.Logger
-import com.chriscartland.garage.data.NetworkButtonDataSource
-import com.chriscartland.garage.data.NetworkResult
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/KtorNetworkConfigDataSource.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/KtorNetworkConfigDataSource.kt
@@ -15,11 +15,9 @@
  *
  */
 
-package com.chriscartland.garage.internet
+package com.chriscartland.garage.data
 
 import co.touchlab.kermit.Logger
-import com.chriscartland.garage.data.NetworkConfigDataSource
-import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.domain.model.ServerConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -29,8 +27,6 @@ import io.ktor.http.isSuccess
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.net.URLDecoder
-import java.nio.charset.StandardCharsets
 
 class KtorNetworkConfigDataSource(
     private val client: HttpClient,
@@ -66,10 +62,7 @@ class KtorNetworkConfigDataSource(
             NetworkResult.Success(
                 ServerConfig(
                     buildTimestamp = body.buildTimestamp,
-                    remoteButtonBuildTimestamp = URLDecoder.decode(
-                        remoteButtonBuildTimestamp,
-                        StandardCharsets.UTF_8.name(),
-                    ),
+                    remoteButtonBuildTimestamp = percentDecode(remoteButtonBuildTimestamp),
                     remoteButtonPushKey = body.remoteButtonPushKey,
                 ),
             )
@@ -80,6 +73,41 @@ class KtorNetworkConfigDataSource(
             NetworkResult.ConnectionFailed
         }
     }
+}
+
+/**
+ * Simple percent-decode for URL-encoded strings (KMP-compatible).
+ *
+ * Decodes `%XX` sequences to UTF-8 characters and `+` to space.
+ * Sufficient for server config values (e.g., URL-encoded build timestamps).
+ */
+internal fun percentDecode(encoded: String): String {
+    val bytes = mutableListOf<Byte>()
+    var i = 0
+    while (i < encoded.length) {
+        when {
+            encoded[i] == '%' && i + 2 < encoded.length -> {
+                val hex = encoded.substring(i + 1, i + 3)
+                val byte = hex.toIntOrNull(16)
+                if (byte != null) {
+                    bytes.add(byte.toByte())
+                    i += 3
+                } else {
+                    bytes.add(encoded[i].code.toByte())
+                    i++
+                }
+            }
+            encoded[i] == '+' -> {
+                bytes.add(' '.code.toByte())
+                i++
+            }
+            else -> {
+                bytes.add(encoded[i].code.toByte())
+                i++
+            }
+        }
+    }
+    return bytes.toByteArray().decodeToString()
 }
 
 // region Serializable response types

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/KtorNetworkDoorDataSource.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/KtorNetworkDoorDataSource.kt
@@ -15,11 +15,9 @@
  *
  */
 
-package com.chriscartland.garage.internet
+package com.chriscartland.garage.data
 
 import co.touchlab.kermit.Logger
-import com.chriscartland.garage.data.NetworkDoorDataSource
-import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import io.ktor.client.HttpClient


### PR DESCRIPTION
## Summary
- Move `KtorNetworkDoorDataSource`, `KtorNetworkButtonDataSource`, `KtorNetworkConfigDataSource`, and `FcmPayloadParser` from `androidApp` to the `data` module's `commonMain` source set
- Replace `java.net.URLDecoder` with a KMP-compatible `percentDecode` function in `KtorNetworkConfigDataSource`
- Add Ktor client and kotlinx-serialization dependencies to the data module
- Update all import paths in `AppComponent`, `FCMService`, and `FcmPayloadParsingTest`

## Test plan
- [ ] `data:compileDebugKotlinAndroid` passes (verified locally)
- [ ] `data:checkImportBoundary` passes with 0 violations (verified locally)
- [ ] `domain:checkImportBoundary` passes with 0 violations (verified locally)
- [ ] CI pre-submit checks pass
- [ ] FcmPayloadParsingTest still passes with updated import

🤖 Generated with [Claude Code](https://claude.com/claude-code)