### PR TITLE
feat: Extract AppConfig types and AppLoggerKeys to domain module

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/MainActivity.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/MainActivity.kt
@@ -25,8 +25,8 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.ui.util.trace
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.auth.RC_ONE_TAP_SIGN_IN
-import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.di.activityViewModel
+import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.ui.GarageApp
 
 class MainActivity : ComponentActivity() {

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/applogger/AppLoggerViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/applogger/AppLoggerViewModel.kt
@@ -21,8 +21,8 @@ import android.content.Context
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
+import com.chriscartland.garage.domain.model.AppLoggerKeys
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthRepository.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthRepository.kt
@@ -19,8 +19,8 @@ package com.chriscartland.garage.auth
 
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.applogger.AppLoggerRepository
-import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.data.AuthBridge
+import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.DisplayName
 import com.chriscartland.garage.domain.model.Email

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthViewModel.kt
@@ -26,8 +26,8 @@ import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.BuildConfig
 import com.chriscartland.garage.applogger.AppLoggerRepository
-import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
+import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.GoogleIdToken
 import com.chriscartland.garage.domain.repository.AuthRepository

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/config/LocalConfig.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/config/LocalConfig.kt
@@ -18,33 +18,10 @@
 package com.chriscartland.garage.config
 
 import com.chriscartland.garage.BuildConfig
-
-data class AppConfig(
-    val server: Server,
-    val baseUrl: String,
-    val initialData: InitialData,
-    val fetchOnViewModelInit: FetchOnViewModelInit,
-    val recentEventCount: Int,
-    val serverConfigKey: String,
-    val snoozeNotificationsOption: Boolean,
-    val remoteButtonPushEnabled: Boolean,
-    val logSummary: Boolean,
-)
-
-enum class Server {
-    Development,
-    Production,
-}
-
-enum class InitialData {
-    Demo,
-    Empty,
-}
-
-enum class FetchOnViewModelInit {
-    Yes,
-    No,
-}
+import com.chriscartland.garage.domain.model.AppConfig
+import com.chriscartland.garage.domain.model.FetchOnViewModelInit
+import com.chriscartland.garage.domain.model.InitialData
+import com.chriscartland.garage.domain.model.Server
 
 // private val SERVER = Server.Development
 private val SERVER = Server.Production
@@ -54,30 +31,6 @@ private val INITIAL_DATA = InitialData.Empty
 
 // private val FETCH_ON_VIEW_MODEL_INIT = FetchOnViewModelInit.No
 private val FETCH_ON_VIEW_MODEL_INIT = FetchOnViewModelInit.Yes
-
-object AppLoggerKeys {
-    // Door updates
-    const val INIT_CURRENT_DOOR = "init_current_door"
-    const val INIT_RECENT_DOOR = "init_recent_door"
-    const val USER_FETCH_CURRENT_DOOR = "user_fetch_current_door"
-    const val USER_FETCH_RECENT_DOOR = "user_fetch_recent_door"
-    const val FCM_DOOR_RECEIVED = "fcm_door_received"
-    const val FCM_SUBSCRIBE_TOPIC = "fcm_subscribe_topic"
-    const val ON_CREATE_FCM_SUBSCRIBE_TOPIC = "on_create_fcm_subscribe_topic"
-
-    // Stale data
-    const val EXCEEDED_EXPECTED_TIME_WITHOUT_FCM = "exceeded_expected_time_without_fcm"
-    const val TIME_WITHOUT_FCM_IN_EXPECTED_RANGE = "time_without_fcm_in_expected_range"
-
-    // Permission
-    const val USER_REQUESTED_NOTIFICATION_PERMISSION = "user_requested_notification_permission"
-
-    // Auth
-    const val BEGIN_GOOGLE_SIGN_IN = "begin_google_sign_in"
-    const val USER_AUTHENTICATED = "user_authenticated"
-    const val USER_UNAUTHENTICATED = "user_unauthenticated"
-    const val USER_AUTH_UNKNOWN = "user_auth_unknown"
-}
 
 val APP_CONFIG =
     AppConfig(

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorViewModel.kt
@@ -22,8 +22,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.applogger.AppLoggerRepository
-import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
+import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.FcmRegistrationStatus

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/DoorFcmRepository.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/DoorFcmRepository.kt
@@ -20,8 +20,8 @@ package com.chriscartland.garage.fcm
 import android.app.Activity
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.applogger.AppLoggerRepository
-import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.data.MessagingBridge
+import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.DoorFcmState
 import com.chriscartland.garage.domain.model.DoorFcmTopic
 import com.chriscartland.garage.settings.AppSettings

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
@@ -20,7 +20,7 @@ package com.chriscartland.garage.fcm
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.GarageApplication
 import com.chriscartland.garage.applogger.AppLoggerRepository
-import com.chriscartland.garage.config.AppLoggerKeys
+import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.repository.DoorRepository
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
@@ -37,8 +37,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.applogger.AppLoggerViewModel
-import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.di.rememberAppComponent
+import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.door.DoorViewModel

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -45,8 +45,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.applogger.AppLoggerViewModel
 import com.chriscartland.garage.auth.AuthViewModel
-import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.di.rememberAppComponent
+import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.LoadingResult

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -53,8 +53,8 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.chriscartland.garage.applogger.AppLoggerViewModel
 import com.chriscartland.garage.auth.AuthViewModel
-import com.chriscartland.garage.config.AppLoggerKeys
 import com.chriscartland.garage.di.rememberAppComponent
+import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.door.DoorViewModel
 import com.chriscartland.garage.fcm.FCMRegistration
 import com.chriscartland.garage.remotebutton.RemoteButtonViewModel

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/AppConfig.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/AppConfig.kt
@@ -1,0 +1,28 @@
+package com.chriscartland.garage.domain.model
+
+data class AppConfig(
+    val server: Server,
+    val baseUrl: String,
+    val initialData: InitialData,
+    val fetchOnViewModelInit: FetchOnViewModelInit,
+    val recentEventCount: Int,
+    val serverConfigKey: String,
+    val snoozeNotificationsOption: Boolean,
+    val remoteButtonPushEnabled: Boolean,
+    val logSummary: Boolean,
+)
+
+enum class Server {
+    Development,
+    Production,
+}
+
+enum class InitialData {
+    Demo,
+    Empty,
+}
+
+enum class FetchOnViewModelInit {
+    Yes,
+    No,
+}

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/AppLoggerKeys.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/AppLoggerKeys.kt
@@ -1,0 +1,25 @@
+package com.chriscartland.garage.domain.model
+
+object AppLoggerKeys {
+    // Door updates
+    const val INIT_CURRENT_DOOR = "init_current_door"
+    const val INIT_RECENT_DOOR = "init_recent_door"
+    const val USER_FETCH_CURRENT_DOOR = "user_fetch_current_door"
+    const val USER_FETCH_RECENT_DOOR = "user_fetch_recent_door"
+    const val FCM_DOOR_RECEIVED = "fcm_door_received"
+    const val FCM_SUBSCRIBE_TOPIC = "fcm_subscribe_topic"
+    const val ON_CREATE_FCM_SUBSCRIBE_TOPIC = "on_create_fcm_subscribe_topic"
+
+    // Stale data
+    const val EXCEEDED_EXPECTED_TIME_WITHOUT_FCM = "exceeded_expected_time_without_fcm"
+    const val TIME_WITHOUT_FCM_IN_EXPECTED_RANGE = "time_without_fcm_in_expected_range"
+
+    // Permission
+    const val USER_REQUESTED_NOTIFICATION_PERMISSION = "user_requested_notification_permission"
+
+    // Auth
+    const val BEGIN_GOOGLE_SIGN_IN = "begin_google_sign_in"
+    const val USER_AUTHENTICATED = "user_authenticated"
+    const val USER_UNAUTHENTICATED = "user_unauthenticated"
+    const val USER_AUTH_UNKNOWN = "user_auth_unknown"
+}


### PR DESCRIPTION
## Summary
- Extract pure Kotlin config types (`AppConfig`, `Server`, `InitialData`, `FetchOnViewModelInit`) from `androidApp/config/LocalConfig.kt` to `domain/model/AppConfig.kt`
- Extract `AppLoggerKeys` object to `domain/model/AppLoggerKeys.kt`
- `APP_CONFIG` singleton stays in `androidApp` (depends on `BuildConfig`)
- Update all 10 import sites in androidApp to reference new domain package

## Test plan
- [ ] CI passes: spotless, lint, unit tests, domain compilation
- [ ] Verify no remaining references to `com.chriscartland.garage.config.AppLoggerKeys`
- [ ] Verify `APP_CONFIG` still compiles with `BuildConfig` dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)