### PR TITLE
feat: Move snooze + FCM model types to domain module (Phase 19)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModel.kt
@@ -25,11 +25,11 @@ import com.chriscartland.garage.domain.model.ActionError
 import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.RequestStatus
+import com.chriscartland.garage.domain.model.SnoozeDurationUIOption
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
+import com.chriscartland.garage.domain.model.toServer
 import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.domain.repository.PushRepository
-import com.chriscartland.garage.snoozenotifications.SnoozeDurationUIOption
-import com.chriscartland.garage.snoozenotifications.toServer
 import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
 import com.chriscartland.garage.usecase.RemoteButtonStateMachine
 import com.chriscartland.garage.usecase.SnoozeNotificationsUseCase

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
@@ -40,11 +40,11 @@ import com.chriscartland.garage.auth.AuthViewModel
 import com.chriscartland.garage.config.APP_CONFIG
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.SnoozeDurationUIOption
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
 import com.chriscartland.garage.domain.model.User
 import com.chriscartland.garage.permissions.rememberNotificationPermissionState
 import com.chriscartland.garage.remotebutton.RemoteButtonViewModel
-import com.chriscartland.garage.snoozenotifications.SnoozeDurationUIOption
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionState
 import com.google.accompanist.permissions.isGranted

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/SnoozeNotificationCard.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/SnoozeNotificationCard.kt
@@ -41,8 +41,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.chriscartland.garage.domain.model.SnoozeDurationUIOption
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
-import com.chriscartland.garage.snoozenotifications.SnoozeDurationUIOption
 import java.time.Instant
 
 @Composable

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/RegisterFcmUseCase.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/RegisterFcmUseCase.kt
@@ -20,9 +20,9 @@ package com.chriscartland.garage.usecase
 import android.app.Activity
 import com.chriscartland.garage.domain.model.DoorFcmState
 import com.chriscartland.garage.domain.model.FcmRegistrationStatus
+import com.chriscartland.garage.domain.model.toFcmTopic
 import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.fcm.DoorFcmRepository
-import com.chriscartland.garage.fcm.toFcmTopic
 
 /**
  * Maps [DoorFcmState] to the simpler [FcmRegistrationStatus] enum.

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/fcm/DoorFcmModelTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/fcm/DoorFcmModelTest.kt
@@ -17,6 +17,7 @@
 
 package com.chriscartland.garage.fcm
 
+import com.chriscartland.garage.domain.model.toFcmTopic
 import org.junit.Assert.assertEquals
 import org.junit.Test
 

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/fcm/FcmTopicTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/fcm/FcmTopicTest.kt
@@ -17,6 +17,7 @@
 
 package com.chriscartland.garage.fcm
 
+import com.chriscartland.garage.domain.model.toFcmTopic
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/DoorFcmModel.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/DoorFcmModel.kt
@@ -15,9 +15,7 @@
  *
  */
 
-package com.chriscartland.garage.fcm
-
-import com.chriscartland.garage.domain.model.DoorFcmTopic
+package com.chriscartland.garage.domain.model
 
 fun String.toFcmTopic(): DoorFcmTopic = DoorFcmTopic(toDoorOpenFcmTopic())
 

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/SnoozeNotificationsModel.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/SnoozeNotificationsModel.kt
@@ -15,7 +15,7 @@
  *
  */
 
-package com.chriscartland.garage.snoozenotifications
+package com.chriscartland.garage.domain.model
 
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours


### PR DESCRIPTION
## Summary
- Move `SnoozeDurationUIOption`, `SnoozeDurationServerOption`, `toServer()` to `domain/src/commonMain/`
- Move `String.toFcmTopic()` to `domain/src/commonMain/`
- Update all imports in androidApp and tests

## Test plan
- [x] All tests pass
- [x] Compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)