### PR TITLE
refactor: Remove unused Activity from FCM chain (Phase 20)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/MainActivity.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/MainActivity.kt
@@ -56,7 +56,7 @@ class MainActivity : ComponentActivity() {
             }
         }
         Logger.d { "onCreate: Try to subscribe to FCM topic" }
-        doorViewModel.registerFcm(this)
+        doorViewModel.registerFcm()
         appLoggerViewModel.log(AppLoggerKeys.ON_CREATE_FCM_SUBSCRIBE_TOPIC)
     }
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/door/DoorViewModel.kt
@@ -17,7 +17,6 @@
 
 package com.chriscartland.garage.door
 
-import android.app.Activity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
@@ -45,11 +44,11 @@ interface DoorViewModel {
     val currentDoorEvent: StateFlow<LoadingResult<DoorEvent?>>
     val recentDoorEvents: StateFlow<LoadingResult<List<DoorEvent>>>
 
-    fun fetchFcmRegistrationStatus(activity: Activity)
+    fun fetchFcmRegistrationStatus()
 
-    fun registerFcm(activity: Activity)
+    fun registerFcm()
 
-    fun deregisterFcm(activity: Activity)
+    fun deregisterFcm()
 
     fun fetchCurrentDoorEvent()
 
@@ -105,26 +104,26 @@ class DefaultDoorViewModel(
         }
     }
 
-    override fun fetchFcmRegistrationStatus(activity: Activity) {
+    override fun fetchFcmRegistrationStatus() {
         Logger.d { "fetchFcmRegistrationStatus" }
         viewModelScope.launch(dispatchers.io) {
-            _fcmRegistrationStatus.value = fetchFcmStatusUseCase(activity)
+            _fcmRegistrationStatus.value = fetchFcmStatusUseCase()
         }
     }
 
-    override fun registerFcm(activity: Activity) {
+    override fun registerFcm() {
         Logger.d { "registerFcm" }
         viewModelScope.launch(dispatchers.io) {
-            _fcmRegistrationStatus.value = registerFcmUseCase(activity).also {
+            _fcmRegistrationStatus.value = registerFcmUseCase().also {
                 Logger.d { "Updated FcmRegistrationStatus: $it" }
             }
         }
     }
 
-    override fun deregisterFcm(activity: Activity) {
+    override fun deregisterFcm() {
         Logger.d { "deregisterFcm" }
         viewModelScope.launch(dispatchers.io) {
-            _fcmRegistrationStatus.value = deregisterFcmUseCase(activity).also {
+            _fcmRegistrationStatus.value = deregisterFcmUseCase().also {
                 Logger.d { "Updated FcmRegistrationStatus: $it" }
             }
         }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/DoorFcmRepository.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/DoorFcmRepository.kt
@@ -17,7 +17,6 @@
 
 package com.chriscartland.garage.fcm
 
-import android.app.Activity
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.applogger.AppLoggerRepository
 import com.chriscartland.garage.data.MessagingBridge
@@ -27,14 +26,11 @@ import com.chriscartland.garage.domain.model.DoorFcmTopic
 import com.chriscartland.garage.settings.AppSettings
 
 interface DoorFcmRepository {
-    suspend fun fetchStatus(activity: Activity): DoorFcmState
+    suspend fun fetchStatus(): DoorFcmState
 
-    suspend fun registerDoor(
-        activity: Activity,
-        fcmTopic: DoorFcmTopic,
-    ): DoorFcmState
+    suspend fun registerDoor(fcmTopic: DoorFcmTopic): DoorFcmState
 
-    suspend fun deregisterDoor(activity: Activity): DoorFcmState
+    suspend fun deregisterDoor(): DoorFcmState
 }
 
 /**
@@ -47,7 +43,7 @@ class FirebaseDoorFcmRepository(
     private val settings: AppSettings,
     private val appLoggerRepository: AppLoggerRepository,
 ) : DoorFcmRepository {
-    override suspend fun fetchStatus(activity: Activity): DoorFcmState {
+    override suspend fun fetchStatus(): DoorFcmState {
         Logger.d { "fetchStatus" }
         val topic = getFcmTopic()
         Logger.d { "fetchStatus: $topic" }
@@ -58,10 +54,7 @@ class FirebaseDoorFcmRepository(
         }
     }
 
-    override suspend fun registerDoor(
-        activity: Activity,
-        fcmTopic: DoorFcmTopic,
-    ): DoorFcmState {
+    override suspend fun registerDoor(fcmTopic: DoorFcmTopic): DoorFcmState {
         Logger.d { "registerDoor: $fcmTopic" }
         // Unsubscribe from old topic.
         val oldFcmTopic = getFcmTopic()
@@ -90,7 +83,7 @@ class FirebaseDoorFcmRepository(
         }
     }
 
-    override suspend fun deregisterDoor(activity: Activity): DoorFcmState {
+    override suspend fun deregisterDoor(): DoorFcmState {
         Logger.d { "deregisterDoor" }
         val oldFcmTopic = getFcmTopic()
         if (oldFcmTopic == null) {

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FcmRegistration.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FcmRegistration.kt
@@ -48,11 +48,7 @@ fun FCMRegistration() {
         when (fcmState) {
             FcmRegistrationStatus.UNKNOWN -> {
                 Logger.d { "Unknown FCM registration status, fetching..." }
-                if (activity != null) {
-                    viewModel.fetchFcmRegistrationStatus(activity)
-                } else {
-                    Logger.e { "Activity is null, cannot fetch FCM registration status" }
-                }
+                viewModel.fetchFcmRegistrationStatus()
             }
 
             FcmRegistrationStatus.REGISTERED -> {

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
@@ -63,11 +63,7 @@ fun DoorHistoryContent(
             resolvedDoorViewModel.fetchRecentDoorEvents()
         },
         onResetFcm = {
-            if (activity != null) {
-                resolvedDoorViewModel.deregisterFcm(activity)
-            } else {
-                Logger.e { "Activity is null, cannot deregister FCM" }
-            }
+            resolvedDoorViewModel.deregisterFcm()
         },
     )
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -120,11 +120,7 @@ fun HomeContent(
             }
         },
         onResetFcm = {
-            if (activity != null) {
-                resolvedDoorViewModel.deregisterFcm(activity)
-            } else {
-                Logger.e { "Activity is null, cannot deregister FCM" }
-            }
+            resolvedDoorViewModel.deregisterFcm()
         },
         onLogNotificationPermissionRequested = {
             resolvedAppLoggerViewModel.log(AppLoggerKeys.USER_REQUESTED_NOTIFICATION_PERMISSION)

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/RegisterFcmUseCase.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/usecase/RegisterFcmUseCase.kt
@@ -17,7 +17,6 @@
 
 package com.chriscartland.garage.usecase
 
-import android.app.Activity
 import com.chriscartland.garage.domain.model.DoorFcmState
 import com.chriscartland.garage.domain.model.FcmRegistrationStatus
 import com.chriscartland.garage.domain.model.toFcmTopic
@@ -37,13 +36,11 @@ fun DoorFcmState.toRegistrationStatus(): FcmRegistrationStatus =
 /**
  * Fetches the current FCM registration status.
  */
-class FetchFcmStatusUseCase
-    constructor(
-        private val doorFcmRepository: DoorFcmRepository,
-    ) {
-        suspend operator fun invoke(activity: Activity): FcmRegistrationStatus =
-            doorFcmRepository.fetchStatus(activity).toRegistrationStatus()
-    }
+class FetchFcmStatusUseCase(
+    private val doorFcmRepository: DoorFcmRepository,
+) {
+    suspend operator fun invoke(): FcmRegistrationStatus = doorFcmRepository.fetchStatus().toRegistrationStatus()
+}
 
 /**
  * Registers for FCM door notifications.
@@ -51,26 +48,23 @@ class FetchFcmStatusUseCase
  * Fetches the build timestamp from server config, converts it to an FCM topic,
  * and subscribes. Returns NOT_REGISTERED if build timestamp is unavailable.
  */
-class RegisterFcmUseCase
-    constructor(
-        private val doorRepository: DoorRepository,
-        private val doorFcmRepository: DoorFcmRepository,
-    ) {
-        suspend operator fun invoke(activity: Activity): FcmRegistrationStatus {
-            val buildTimestamp = doorRepository.fetchBuildTimestampCached()
-                ?: return FcmRegistrationStatus.NOT_REGISTERED
-            val result = doorFcmRepository.registerDoor(activity, buildTimestamp.toFcmTopic())
-            return result.toRegistrationStatus()
-        }
+class RegisterFcmUseCase(
+    private val doorRepository: DoorRepository,
+    private val doorFcmRepository: DoorFcmRepository,
+) {
+    suspend operator fun invoke(): FcmRegistrationStatus {
+        val buildTimestamp = doorRepository.fetchBuildTimestampCached()
+            ?: return FcmRegistrationStatus.NOT_REGISTERED
+        val result = doorFcmRepository.registerDoor(buildTimestamp.toFcmTopic())
+        return result.toRegistrationStatus()
     }
+}
 
 /**
  * Deregisters from FCM door notifications.
  */
-class DeregisterFcmUseCase
-    constructor(
-        private val doorFcmRepository: DoorFcmRepository,
-    ) {
-        suspend operator fun invoke(activity: Activity): FcmRegistrationStatus =
-            doorFcmRepository.deregisterDoor(activity).toRegistrationStatus()
-    }
+class DeregisterFcmUseCase(
+    private val doorFcmRepository: DoorFcmRepository,
+) {
+    suspend operator fun invoke(): FcmRegistrationStatus = doorFcmRepository.deregisterDoor().toRegistrationStatus()
+}

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/door/DoorViewModelTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/door/DoorViewModelTest.kt
@@ -17,7 +17,6 @@
 
 package com.chriscartland.garage.door
 
-import android.app.Activity
 import com.chriscartland.garage.coroutines.TestDispatcherProvider
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorFcmState
@@ -44,7 +43,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.mock
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DoorViewModelTest {
@@ -186,12 +184,11 @@ class DoorViewModelTest {
     fun fetchFcmRegistrationStatusMapsRegisteredState() =
         runTest {
             val viewModel = createViewModel()
-            val activity = mock(Activity::class.java)
 
             doorFcmRepository.fetchStatusResult =
                 DoorFcmState.Registered(topic = DoorFcmTopic("test-topic"))
 
-            viewModel.fetchFcmRegistrationStatus(activity)
+            viewModel.fetchFcmRegistrationStatus()
             testDispatcher.scheduler.runCurrent()
 
             assertEquals(FcmRegistrationStatus.REGISTERED, viewModel.fcmRegistrationStatus.value)
@@ -201,11 +198,10 @@ class DoorViewModelTest {
     fun fetchFcmRegistrationStatusMapsNotRegisteredState() =
         runTest {
             val viewModel = createViewModel()
-            val activity = mock(Activity::class.java)
 
             doorFcmRepository.fetchStatusResult = DoorFcmState.NotRegistered
 
-            viewModel.fetchFcmRegistrationStatus(activity)
+            viewModel.fetchFcmRegistrationStatus()
             testDispatcher.scheduler.runCurrent()
 
             assertEquals(
@@ -218,11 +214,10 @@ class DoorViewModelTest {
     fun fetchFcmRegistrationStatusMapsUnknownState() =
         runTest {
             val viewModel = createViewModel()
-            val activity = mock(Activity::class.java)
 
             doorFcmRepository.fetchStatusResult = DoorFcmState.Unknown
 
-            viewModel.fetchFcmRegistrationStatus(activity)
+            viewModel.fetchFcmRegistrationStatus()
             testDispatcher.scheduler.runCurrent()
 
             assertEquals(FcmRegistrationStatus.UNKNOWN, viewModel.fcmRegistrationStatus.value)

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakeDoorFcmRepository.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/testcommon/FakeDoorFcmRepository.kt
@@ -17,7 +17,6 @@
 
 package com.chriscartland.garage.testcommon
 
-import android.app.Activity
 import com.chriscartland.garage.domain.model.DoorFcmState
 import com.chriscartland.garage.domain.model.DoorFcmTopic
 import com.chriscartland.garage.fcm.DoorFcmRepository
@@ -27,12 +26,9 @@ class FakeDoorFcmRepository : DoorFcmRepository {
     var registerResult: DoorFcmState = DoorFcmState.NotRegistered
     var deregisterResult: DoorFcmState = DoorFcmState.NotRegistered
 
-    override suspend fun fetchStatus(activity: Activity): DoorFcmState = fetchStatusResult
+    override suspend fun fetchStatus(): DoorFcmState = fetchStatusResult
 
-    override suspend fun registerDoor(
-        activity: Activity,
-        fcmTopic: DoorFcmTopic,
-    ): DoorFcmState = registerResult
+    override suspend fun registerDoor(fcmTopic: DoorFcmTopic): DoorFcmState = registerResult
 
-    override suspend fun deregisterDoor(activity: Activity): DoorFcmState = deregisterResult
+    override suspend fun deregisterDoor(): DoorFcmState = deregisterResult
 }

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/RegisterFcmUseCaseTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/usecase/RegisterFcmUseCaseTest.kt
@@ -17,7 +17,6 @@
 
 package com.chriscartland.garage.usecase
 
-import android.app.Activity
 import com.chriscartland.garage.domain.model.DoorFcmState
 import com.chriscartland.garage.domain.model.DoorFcmTopic
 import com.chriscartland.garage.domain.model.FcmRegistrationStatus
@@ -27,7 +26,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.mock
 
 class FakeDoorFcmRepository : DoorFcmRepository {
     var fetchStatusResult: DoorFcmState = DoorFcmState.Unknown
@@ -36,18 +34,15 @@ class FakeDoorFcmRepository : DoorFcmRepository {
     var registerCount = 0
     var lastRegisteredTopic: DoorFcmTopic? = null
 
-    override suspend fun fetchStatus(activity: Activity): DoorFcmState = fetchStatusResult
+    override suspend fun fetchStatus(): DoorFcmState = fetchStatusResult
 
-    override suspend fun registerDoor(
-        activity: Activity,
-        fcmTopic: DoorFcmTopic,
-    ): DoorFcmState {
+    override suspend fun registerDoor(fcmTopic: DoorFcmTopic): DoorFcmState {
         registerCount++
         lastRegisteredTopic = fcmTopic
         return registerResult
     }
 
-    override suspend fun deregisterDoor(activity: Activity): DoorFcmState = deregisterResult
+    override suspend fun deregisterDoor(): DoorFcmState = deregisterResult
 }
 
 class DoorFcmStateToRegistrationStatusTest {
@@ -75,14 +70,12 @@ class RegisterFcmUseCaseTest {
     private lateinit var fakeDoor: FakeDoorRepository
     private lateinit var fakeFcm: FakeDoorFcmRepository
     private lateinit var useCase: RegisterFcmUseCase
-    private lateinit var mockActivity: Activity
 
     @Before
     fun setup() {
         fakeDoor = FakeDoorRepository()
         fakeFcm = FakeDoorFcmRepository()
         useCase = RegisterFcmUseCase(fakeDoor, fakeFcm)
-        mockActivity = mock(Activity::class.java)
     }
 
     @Test
@@ -92,7 +85,7 @@ class RegisterFcmUseCaseTest {
             fakeFcm.registerResult =
                 DoorFcmState.Registered(DoorFcmTopic("door_open-Sat.Mar.13.14.45.00.2021"))
 
-            val result = useCase(mockActivity)
+            val result = useCase()
 
             assertEquals(FcmRegistrationStatus.REGISTERED, result)
             assertEquals(1, fakeFcm.registerCount)
@@ -102,7 +95,7 @@ class RegisterFcmUseCaseTest {
     fun registerFailsWithNullBuildTimestamp() =
         runTest {
             fakeDoor.buildTimestamp = null
-            val result = useCase(mockActivity)
+            val result = useCase()
 
             assertEquals(FcmRegistrationStatus.NOT_REGISTERED, result)
             assertEquals(0, fakeFcm.registerCount)
@@ -114,7 +107,7 @@ class RegisterFcmUseCaseTest {
             fakeDoor.buildTimestamp = "Sat Mar 13 14:45:00 2021"
             fakeFcm.registerResult = DoorFcmState.Registered(DoorFcmTopic("test"))
 
-            useCase(mockActivity)
+            useCase()
 
             assertEquals("door_open-Sat.Mar.13.14.45.00.2021", fakeFcm.lastRegisteredTopic?.string)
         }
@@ -125,7 +118,7 @@ class RegisterFcmUseCaseTest {
             fakeDoor.buildTimestamp = "timestamp"
             fakeFcm.registerResult = DoorFcmState.NotRegistered
 
-            val result = useCase(mockActivity)
+            val result = useCase()
 
             assertEquals(FcmRegistrationStatus.NOT_REGISTERED, result)
         }


### PR DESCRIPTION
## Summary
- Remove `Activity` parameter from entire FCM chain (interface → impl → use cases → ViewModel → UI)
- Activity was declared but never used in any implementation
- Eliminates null-Activity checks in Compose callers
- FCM use cases are now pure Kotlin — ready for usecase module

## Test plan
- [x] All tests pass (updated fakes and test calls)
- [x] No Mockito left in DoorViewModelTest

🤖 Generated with [Claude Code](https://claude.com/claude-code)