### PR TITLE
feat: Move Ktor data sources to data module (Phase 21)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -32,6 +32,9 @@ import com.chriscartland.garage.data.MessagingBridge
 import com.chriscartland.garage.data.NetworkButtonDataSource
 import com.chriscartland.garage.data.NetworkConfigDataSource
 import com.chriscartland.garage.data.NetworkDoorDataSource
+import com.chriscartland.garage.data.ktor.KtorNetworkButtonDataSource
+import com.chriscartland.garage.data.ktor.KtorNetworkConfigDataSource
+import com.chriscartland.garage.data.ktor.KtorNetworkDoorDataSource
 import com.chriscartland.garage.data.repository.CachedServerConfigRepository
 import com.chriscartland.garage.data.repository.NetworkDoorRepository
 import com.chriscartland.garage.data.repository.NetworkPushRepository
@@ -46,9 +49,6 @@ import com.chriscartland.garage.door.DefaultDoorViewModel
 import com.chriscartland.garage.fcm.DoorFcmRepository
 import com.chriscartland.garage.fcm.FirebaseDoorFcmRepository
 import com.chriscartland.garage.fcm.FirebaseMessagingBridge
-import com.chriscartland.garage.internet.KtorNetworkButtonDataSource
-import com.chriscartland.garage.internet.KtorNetworkConfigDataSource
-import com.chriscartland.garage.internet.KtorNetworkDoorDataSource
 import com.chriscartland.garage.internet.provideKtorHttpClient
 import com.chriscartland.garage.remotebutton.DefaultRemoteButtonViewModel
 import com.chriscartland.garage.settings.AppSettings

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
@@ -20,6 +20,7 @@ package com.chriscartland.garage.fcm
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.GarageApplication
 import com.chriscartland.garage.applogger.AppLoggerRepository
+import com.chriscartland.garage.data.FcmPayloadParser
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.repository.DoorRepository
 import com.google.firebase.messaging.FirebaseMessagingService

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/fcm/FcmPayloadParsingTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/fcm/FcmPayloadParsingTest.kt
@@ -17,6 +17,7 @@
 
 package com.chriscartland.garage.fcm
 
+import com.chriscartland.garage.data.FcmPayloadParser
 import com.chriscartland.garage.domain.model.DoorPosition
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull

--- a/AndroidGarage/data/build.gradle.kts
+++ b/AndroidGarage/data/build.gradle.kts
@@ -3,6 +3,7 @@ import importboundary.ImportBoundaryCheckTask
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 tasks.register<ImportBoundaryCheckTask>("checkImportBoundary") {
@@ -17,6 +18,10 @@ kotlin {
             implementation(project(":domain"))
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kermit)
+            implementation(libs.ktor.client.core)
+            implementation(libs.ktor.client.content.negotiation)
+            implementation(libs.ktor.serialization.kotlinx.json)
+            implementation(libs.kotlinx.serialization.json)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/FcmPayloadParser.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/FcmPayloadParser.kt
@@ -15,7 +15,7 @@
  *
  */
 
-package com.chriscartland.garage.fcm
+package com.chriscartland.garage.data
 
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.domain.model.DoorEvent

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/ktor/KtorNetworkButtonDataSource.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/ktor/KtorNetworkButtonDataSource.kt
@@ -15,7 +15,7 @@
  *
  */
 
-package com.chriscartland.garage.internet
+package com.chriscartland.garage.data.ktor
 
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.NetworkButtonDataSource

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/ktor/KtorNetworkConfigDataSource.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/ktor/KtorNetworkConfigDataSource.kt
@@ -15,7 +15,7 @@
  *
  */
 
-package com.chriscartland.garage.internet
+package com.chriscartland.garage.data.ktor
 
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.NetworkConfigDataSource
@@ -29,8 +29,6 @@ import io.ktor.http.isSuccess
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.net.URLDecoder
-import java.nio.charset.StandardCharsets
 
 class KtorNetworkConfigDataSource(
     private val client: HttpClient,
@@ -66,10 +64,7 @@ class KtorNetworkConfigDataSource(
             NetworkResult.Success(
                 ServerConfig(
                     buildTimestamp = body.buildTimestamp,
-                    remoteButtonBuildTimestamp = URLDecoder.decode(
-                        remoteButtonBuildTimestamp,
-                        StandardCharsets.UTF_8.name(),
-                    ),
+                    remoteButtonBuildTimestamp = percentDecode(remoteButtonBuildTimestamp),
                     remoteButtonPushKey = body.remoteButtonPushKey,
                 ),
             )
@@ -97,3 +92,28 @@ private data class KtorServerConfigBody(
 )
 
 // endregion
+
+/**
+ * KMP-compatible percent-decode (replaces java.net.URLDecoder).
+ */
+private fun percentDecode(encoded: String): String =
+    buildString {
+        var i = 0
+        while (i < encoded.length) {
+            if (encoded[i] == '%' && i + 2 < encoded.length) {
+                val hex = encoded.substring(i + 1, i + 3)
+                val code = hex.toIntOrNull(16)
+                if (code != null) {
+                    append(code.toChar())
+                    i += 3
+                    continue
+                }
+            }
+            if (encoded[i] == '+') {
+                append(' ')
+            } else {
+                append(encoded[i])
+            }
+            i++
+        }
+    }

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/ktor/KtorNetworkDoorDataSource.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/ktor/KtorNetworkDoorDataSource.kt
@@ -15,7 +15,7 @@
  *
  */
 
-package com.chriscartland.garage.internet
+package com.chriscartland.garage.data.ktor
 
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.NetworkDoorDataSource


### PR DESCRIPTION
## Summary
- Move 3 Ktor HTTP data sources + FcmPayloadParser from androidApp to `data/src/commonMain/`
- Replace `java.net.URLDecoder` with KMP-compatible `percentDecode()`
- Add Ktor + kotlinx.serialization dependencies to data module
- Import boundary check passes (0 violations)

## Test plan
- [x] All tests pass
- [x] Import boundary check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)