### PR TITLE
feat: Extract AppLoggerDataSource to data module (Phase 25)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/applogger/AppLoggerRepository.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/applogger/AppLoggerRepository.kt
@@ -31,15 +31,15 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
-interface AppLoggerRepository {
-    suspend fun log(key: String)
-
+/**
+ * Android-specific logger repository that extends the shared [AppLoggerDataSource]
+ * with Android-specific CSV export capability.
+ */
+interface AppLoggerRepository : com.chriscartland.garage.data.AppLoggerDataSource {
     suspend fun writeCsvToUri(
         context: Context,
         uri: Uri,
     )
-
-    fun countKey(key: String): Flow<Long>
 }
 
 class RoomAppLoggerRepository(

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/AppLoggerDataSource.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/AppLoggerDataSource.kt
@@ -1,0 +1,16 @@
+package com.chriscartland.garage.data
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Shared interface for application event logging.
+ *
+ * Platform-specific implementations handle storage (Room on Android,
+ * CoreData on iOS). The Android implementation adds writeCsvToUri()
+ * as an extension — that method is not part of the shared contract.
+ */
+interface AppLoggerDataSource {
+    suspend fun log(key: String)
+
+    fun countKey(key: String): Flow<Long>
+}


### PR DESCRIPTION
## Summary
- New `AppLoggerDataSource` interface in `data/src/commonMain/` with `log()` and `countKey()`
- Android `AppLoggerRepository` extends it, adding `writeCsvToUri()`
- Enables shared repositories to depend on logger without Android imports

## Test plan
- [x] All tests pass
- [x] Compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)