### PR TITLE
feat: Extract shared HTTP client config to data module (Phase 24)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/internet/KtorHttpClientProvider.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/internet/KtorHttpClientProvider.kt
@@ -19,29 +19,20 @@ package com.chriscartland.garage.internet
 
 import com.chriscartland.garage.BuildConfig
 import com.chriscartland.garage.config.APP_CONFIG
+import com.chriscartland.garage.data.ktor.configureSharedHttpClient
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.plugins.logging.LogLevel
-import io.ktor.client.plugins.logging.Logging
-import io.ktor.serialization.kotlinx.json.json
-import kotlinx.serialization.json.Json
 
+/**
+ * Android-specific HTTP client using OkHttp engine.
+ *
+ * Shared configuration (JSON, logging, base URL) is applied via
+ * [configureSharedHttpClient]. Only the engine choice is platform-specific.
+ */
 fun provideKtorHttpClient(): HttpClient =
     HttpClient(OkHttp) {
-        install(ContentNegotiation) {
-            json(
-                Json {
-                    ignoreUnknownKeys = true
-                    isLenient = true
-                },
-            )
-        }
-        install(Logging) {
-            level = if (BuildConfig.DEBUG) LogLevel.BODY else LogLevel.NONE
-        }
-        defaultRequest {
-            url(APP_CONFIG.baseUrl)
-        }
+        configureSharedHttpClient(
+            baseUrl = APP_CONFIG.baseUrl,
+            debug = BuildConfig.DEBUG,
+        )
     }

--- a/AndroidGarage/data/build.gradle.kts
+++ b/AndroidGarage/data/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
             implementation(libs.ktor.client.core)
             implementation(libs.ktor.client.content.negotiation)
             implementation(libs.ktor.serialization.kotlinx.json)
+            implementation(libs.ktor.client.logging)
             implementation(libs.kotlinx.serialization.json)
         }
         commonTest.dependencies {

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/ktor/KtorHttpClientFactory.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/ktor/KtorHttpClientFactory.kt
@@ -1,0 +1,36 @@
+package com.chriscartland.garage.data.ktor
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+/**
+ * Configures an [HttpClient] with shared settings (JSON, logging, base URL).
+ *
+ * Platform-specific code provides the engine (OkHttp on Android, Darwin on iOS)
+ * and calls this to apply the common configuration.
+ */
+fun <T : HttpClientConfig<*>> T.configureSharedHttpClient(
+    baseUrl: String,
+    debug: Boolean,
+) {
+    install(ContentNegotiation) {
+        json(
+            Json {
+                ignoreUnknownKeys = true
+                isLenient = true
+            },
+        )
+    }
+    install(Logging) {
+        level = if (debug) LogLevel.BODY else LogLevel.NONE
+    }
+    defaultRequest {
+        url(baseUrl)
+    }
+}


### PR DESCRIPTION
## Summary
- New `configureSharedHttpClient()` in `data/src/commonMain/` with JSON, logging, base URL config
- Android `provideKtorHttpClient()` now just picks OkHttp engine and calls shared config
- iOS will provide Darwin engine with same shared config

## Test plan
- [x] Compiles cleanly
- [x] Import boundary check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)