### PR TITLE
feat: Move FirebaseAuthRepository to data module (Phase 22)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthConstants.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthConstants.kt
@@ -1,0 +1,4 @@
+package com.chriscartland.garage.auth
+
+/** Request code for Google One-Tap sign-in (Android-specific). */
+const val RC_ONE_TAP_SIGN_IN = 1

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -23,7 +23,6 @@ import com.chriscartland.garage.applogger.DefaultAppLoggerViewModel
 import com.chriscartland.garage.applogger.RoomAppLoggerRepository
 import com.chriscartland.garage.auth.DefaultAuthViewModel
 import com.chriscartland.garage.auth.FirebaseAuthBridge
-import com.chriscartland.garage.auth.FirebaseAuthRepository
 import com.chriscartland.garage.config.APP_CONFIG
 import com.chriscartland.garage.coroutines.DefaultDispatcherProvider
 import com.chriscartland.garage.data.AuthBridge
@@ -36,6 +35,7 @@ import com.chriscartland.garage.data.ktor.KtorNetworkButtonDataSource
 import com.chriscartland.garage.data.ktor.KtorNetworkConfigDataSource
 import com.chriscartland.garage.data.ktor.KtorNetworkDoorDataSource
 import com.chriscartland.garage.data.repository.CachedServerConfigRepository
+import com.chriscartland.garage.data.repository.FirebaseAuthRepository
 import com.chriscartland.garage.data.repository.NetworkDoorRepository
 import com.chriscartland.garage.data.repository.NetworkPushRepository
 import com.chriscartland.garage.db.AppDatabase

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/auth/FirebaseAuthRepositoryTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/auth/FirebaseAuthRepositoryTest.kt
@@ -18,6 +18,7 @@
 package com.chriscartland.garage.auth
 
 import com.chriscartland.garage.data.AuthUserInfo
+import com.chriscartland.garage.data.repository.FirebaseAuthRepository
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.FirebaseIdToken
 import com.chriscartland.garage.domain.model.GoogleIdToken

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepository.kt
@@ -15,10 +15,10 @@
  *
  */
 
-package com.chriscartland.garage.auth
+package com.chriscartland.garage.data.repository
 
 import co.touchlab.kermit.Logger
-import com.chriscartland.garage.applogger.AppLoggerRepository
+import com.chriscartland.garage.data.AppLoggerDataSource
 import com.chriscartland.garage.data.AuthBridge
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.AuthState
@@ -33,8 +33,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
-const val RC_ONE_TAP_SIGN_IN = 1
-
 /**
  * Auth repository that delegates all platform auth calls to [AuthBridge].
  *
@@ -43,7 +41,7 @@ const val RC_ONE_TAP_SIGN_IN = 1
  */
 class FirebaseAuthRepository(
     private val authBridge: AuthBridge,
-    private val appLoggerRepository: AppLoggerRepository,
+    private val appLogger: AppLoggerDataSource,
     externalScope: CoroutineScope,
 ) : AuthRepository {
     private val _authState = MutableStateFlow<AuthState>(AuthState.Unknown)
@@ -85,13 +83,13 @@ class FirebaseAuthRepository(
         Logger.d { "AuthState.commit(): $this" }
         when (this) {
             is AuthState.Authenticated ->
-                appLoggerRepository.log(AppLoggerKeys.USER_AUTHENTICATED)
+                appLogger.log(AppLoggerKeys.USER_AUTHENTICATED)
 
             AuthState.Unauthenticated ->
-                appLoggerRepository.log(AppLoggerKeys.USER_UNAUTHENTICATED)
+                appLogger.log(AppLoggerKeys.USER_UNAUTHENTICATED)
 
             AuthState.Unknown ->
-                appLoggerRepository.log(AppLoggerKeys.USER_AUTH_UNKNOWN)
+                appLogger.log(AppLoggerKeys.USER_AUTH_UNKNOWN)
         }
         return this.also {
             _authState.value = it


### PR DESCRIPTION
## Summary
- Move `FirebaseAuthRepository` from androidApp to `data/src/commonMain/`
- Depend on `AppLoggerDataSource` (shared) instead of `AppLoggerRepository` (Android)
- Keep `RC_ONE_TAP_SIGN_IN` in androidApp (Android sign-in constant)
- Import boundary check passes

## Test plan
- [x] All tests pass
- [x] Import boundary clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)