### PR TITLE
feat: Move RemoteButtonViewModel to shared usecase module (Phase 27)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -50,10 +50,10 @@ import com.chriscartland.garage.fcm.DoorFcmRepository
 import com.chriscartland.garage.fcm.FirebaseDoorFcmRepository
 import com.chriscartland.garage.fcm.FirebaseMessagingBridge
 import com.chriscartland.garage.internet.provideKtorHttpClient
-import com.chriscartland.garage.remotebutton.DefaultRemoteButtonViewModel
 import com.chriscartland.garage.settings.AppSettings
 import com.chriscartland.garage.settings.DataStoreAppSettings
 import com.chriscartland.garage.settings.DefaultAppSettingsViewModel
+import com.chriscartland.garage.usecase.DefaultRemoteButtonViewModel
 import com.chriscartland.garage.usecase.DeregisterFcmUseCase
 import com.chriscartland.garage.usecase.EnsureFreshIdTokenUseCase
 import com.chriscartland.garage.usecase.FetchCurrentDoorEventUseCase
@@ -84,8 +84,16 @@ abstract class AppComponent(
     abstract val appSettingsViewModel: DefaultAppSettingsViewModel
     abstract val authViewModel: DefaultAuthViewModel
     abstract val doorViewModel: DefaultDoorViewModel
-    abstract val remoteButtonViewModel: DefaultRemoteButtonViewModel
     abstract val appLoggerViewModel: DefaultAppLoggerViewModel
+
+    val remoteButtonViewModel: DefaultRemoteButtonViewModel
+        @Provides get() = DefaultRemoteButtonViewModel(
+            providePushRepository(),
+            provideDoorRepository(),
+            provideDispatcherProvider(),
+            providePushRemoteButtonUseCase(),
+            provideSnoozeNotificationsUseCase(),
+        )
 
     // Settings
     @Provides

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -54,7 +54,7 @@ import com.chriscartland.garage.domain.model.RequestStatus
 import com.chriscartland.garage.door.DoorViewModel
 import com.chriscartland.garage.permissions.notificationJustificationText
 import com.chriscartland.garage.permissions.rememberNotificationPermissionState
-import com.chriscartland.garage.remotebutton.RemoteButtonViewModel
+import com.chriscartland.garage.usecase.RemoteButtonViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionState
 import com.google.accompanist.permissions.PermissionStatus

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -57,9 +57,9 @@ import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.door.DoorViewModel
 import com.chriscartland.garage.fcm.FCMRegistration
-import com.chriscartland.garage.remotebutton.RemoteButtonViewModel
 import com.chriscartland.garage.ui.theme.AppTheme
 import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
+import com.chriscartland.garage.usecase.RemoteButtonViewModel
 import kotlinx.serialization.Serializable
 import java.time.Instant
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
@@ -44,7 +44,7 @@ import com.chriscartland.garage.domain.model.SnoozeDurationUIOption
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
 import com.chriscartland.garage.domain.model.User
 import com.chriscartland.garage.permissions.rememberNotificationPermissionState
-import com.chriscartland.garage.remotebutton.RemoteButtonViewModel
+import com.chriscartland.garage.usecase.RemoteButtonViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionState
 import com.google.accompanist.permissions.isGranted

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModelTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/remotebutton/RemoteButtonViewModelTest.kt
@@ -27,6 +27,7 @@ import com.chriscartland.garage.domain.model.SnoozeRequestStatus
 import com.chriscartland.garage.domain.repository.AuthRepository
 import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.domain.repository.PushRepository
+import com.chriscartland.garage.usecase.DefaultRemoteButtonViewModel
 import com.chriscartland.garage.usecase.EnsureFreshIdTokenUseCase
 import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
 import com.chriscartland.garage.usecase.RemoteButtonStateMachine

--- a/AndroidGarage/buildSrc/src/main/kotlin/importboundary/ImportBoundaryCheckTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/importboundary/ImportBoundaryCheckTask.kt
@@ -36,6 +36,13 @@ abstract class ImportBoundaryCheckTask : DefaultTask() {
         "java.util.Locale",
     )
 
+    /**
+     * Prefixes that are allowed even if they match a forbidden prefix.
+     * Use for KMP-compatible androidx libraries (e.g., "androidx.lifecycle.").
+     */
+    @get:Input
+    var allowedPrefixes: List<String> = emptyList()
+
     @TaskAction
     fun check() {
         val srcDir = File(sourceDir)
@@ -54,10 +61,13 @@ abstract class ImportBoundaryCheckTask : DefaultTask() {
                     val trimmed = line.trim()
                     if (trimmed.startsWith("import ")) {
                         val importPath = trimmed.removePrefix("import ").trim()
-                        for (prefix in forbiddenPrefixes) {
-                            if (importPath.startsWith(prefix)) {
-                                val relativePath = file.relativeTo(srcDir).path
-                                violations.add("  $relativePath:${index + 1}: import $importPath")
+                        val isAllowed = allowedPrefixes.any { importPath.startsWith(it) }
+                        if (!isAllowed) {
+                            for (prefix in forbiddenPrefixes) {
+                                if (importPath.startsWith(prefix)) {
+                                    val relativePath = file.relativeTo(srcDir).path
+                                    violations.add("  $relativePath:${index + 1}: import $importPath")
+                                }
                             }
                         }
                     }

--- a/AndroidGarage/gradle/libs.versions.toml
+++ b/AndroidGarage/gradle/libs.versions.toml
@@ -65,6 +65,7 @@ androidx-datastore-preferences = { group = "androidx.datastore", name = "datasto
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "lifecycle" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidxNavigation" }
 androidx-room-common = { group = "androidx.room", name = "room-common", version.ref = "room" }

--- a/AndroidGarage/usecase/build.gradle.kts
+++ b/AndroidGarage/usecase/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 tasks.register<ImportBoundaryCheckTask>("checkImportBoundary") {
     sourceDir = "$projectDir/src/commonMain/kotlin"
+    allowedPrefixes = listOf("androidx.lifecycle.")
 }
 
 kotlin {
@@ -17,6 +18,7 @@ kotlin {
             implementation(project(":domain"))
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kermit)
+            implementation(libs.androidx.lifecycle.viewmodel)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
@@ -15,7 +15,7 @@
  *
  */
 
-package com.chriscartland.garage.remotebutton
+package com.chriscartland.garage.usecase
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -30,14 +30,9 @@ import com.chriscartland.garage.domain.model.SnoozeRequestStatus
 import com.chriscartland.garage.domain.model.toServer
 import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.domain.repository.PushRepository
-import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
-import com.chriscartland.garage.usecase.RemoteButtonStateMachine
-import com.chriscartland.garage.usecase.SnoozeNotificationsUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import me.tatarka.inject.annotations.Inject
-import java.util.Date
 
 interface RemoteButtonViewModel {
     val requestStatus: StateFlow<RequestStatus>
@@ -53,7 +48,6 @@ interface RemoteButtonViewModel {
     fun fetchSnoozeEndTimeSeconds()
 }
 
-@Inject
 class DefaultRemoteButtonViewModel(
     private val pushRepository: PushRepository,
     private val doorRepository: DoorRepository,
@@ -104,7 +98,9 @@ class DefaultRemoteButtonViewModel(
         viewModelScope.launch(dispatchers.io) {
             when (
                 val result = pushRemoteButtonUseCase(
-                    buttonAckToken = createButtonAckToken(Date()),
+                    buttonAckToken = createButtonAckToken(
+                        currentTimeMillis = System.currentTimeMillis(),
+                    ),
                 )
             ) {
                 is AppResult.Success -> { /* State machine tracks via pushButtonStatus flow */ }
@@ -148,18 +144,15 @@ class DefaultRemoteButtonViewModel(
 }
 
 /**
- * Create a button ack token.
+ * Create a button ack token from the current time.
  *
  * This token is created by the client so the server can acknowledge the remote button push.
  * The client can send the same token to the server multiple times and the server is
  * responsible for only processing the token once.
- * When the server receives a button press, it will respond with the token to the client.
  */
-fun createButtonAckToken(now: Date): String {
-    val humanReadable = java.text.SimpleDateFormat("yyyy-MM-dd hh:mm:ss a", java.util.Locale.US).format(now)
-    val timestampMillis = now.time
+fun createButtonAckToken(currentTimeMillis: Long): String {
     val appVersion = "AppVersionTODO"
-    val buttonAckTokenData = "android-$appVersion-$humanReadable-$timestampMillis"
+    val buttonAckTokenData = "android-$appVersion-$currentTimeMillis"
     val re = Regex("[^a-zA-Z0-9-_.]")
     val filtered = re.replace(buttonAckTokenData, ".")
     return filtered


### PR DESCRIPTION
## Summary
- Move `DefaultRemoteButtonViewModel` + interface from androidApp to `usecase/src/commonMain/`
- Add `androidx.lifecycle:lifecycle-viewmodel` KMP dependency (2.9.1, KMP since 2.8.0)
- Add `allowedPrefixes` to `ImportBoundaryCheckTask` for KMP-compatible androidx libraries
- Replace `java.util.Date` with `Long` in `createButtonAckToken()` for KMP compatibility
- Remove `@Inject` — DI wiring via explicit `@Provides` in AppComponent

## Test plan
- [x] All tests pass (usecase + androidApp)
- [x] Import boundary check passes with `allowedPrefixes`
- [x] Compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)