### PR TITLE
feat: Move AppSettingsViewModel to shared module (Phase 28)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -51,7 +51,7 @@ import com.chriscartland.garage.fcm.FirebaseMessagingBridge
 import com.chriscartland.garage.internet.provideKtorHttpClient
 import com.chriscartland.garage.settings.AppSettings
 import com.chriscartland.garage.settings.DataStoreAppSettings
-import com.chriscartland.garage.settings.DefaultAppSettingsViewModel
+import com.chriscartland.garage.usecase.DefaultAppSettingsViewModel
 import com.chriscartland.garage.usecase.DefaultDoorViewModel
 import com.chriscartland.garage.usecase.DefaultRemoteButtonViewModel
 import com.chriscartland.garage.usecase.DeregisterFcmUseCase
@@ -81,9 +81,11 @@ abstract class AppComponent(
     @get:Provides val application: Application,
 ) {
     // ViewModels
-    abstract val appSettingsViewModel: DefaultAppSettingsViewModel
     abstract val authViewModel: DefaultAuthViewModel
     abstract val appLoggerViewModel: DefaultAppLoggerViewModel
+
+    val appSettingsViewModel: DefaultAppSettingsViewModel
+        @Provides get() = DefaultAppSettingsViewModel(provideAppSettings())
 
     val doorViewModel: DefaultDoorViewModel
         @Provides get() = DefaultDoorViewModel(

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/settings/AppSettings.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/settings/AppSettings.kt
@@ -24,6 +24,7 @@ import com.chriscartland.garage.settings.SettingType.LongSetting
 import com.chriscartland.garage.settings.SettingType.StringSetting
 
 interface AppSettings :
+    com.chriscartland.garage.domain.repository.AppSettingsRepository,
     SettingContract,
     SettingManager
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/settings/SettingManager.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/settings/SettingManager.kt
@@ -46,17 +46,7 @@ interface SettingManager {
     ): LongSetting
 }
 
-interface Setting<T> {
-    val key: String
-
-    fun get(): T
-
-    fun set(value: T)
-
-    fun restoreDefault()
-}
-
-sealed class SettingType<T> : Setting<T> {
+sealed class SettingType<T> : com.chriscartland.garage.domain.repository.Setting<T> {
     class StringSetting(
         private val prefs: SharedPreferences,
         override val key: String,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/AndroidAppInfoCard.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/AndroidAppInfoCard.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.chriscartland.garage.di.rememberAppComponent
-import com.chriscartland.garage.settings.AppSettingsViewModel
+import com.chriscartland.garage.usecase.AppSettingsViewModel
 import com.chriscartland.garage.version.AppVersion
 
 const val PRIVACY_POLICY_URL: String = "https://chriscart.land/garage-privacy-policy"

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/LogSummaryCard.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/LogSummaryCard.kt
@@ -45,7 +45,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.chriscartland.garage.applogger.AppLoggerViewModel
 import com.chriscartland.garage.di.rememberAppComponent
-import com.chriscartland.garage.settings.AppSettingsViewModel
+import com.chriscartland.garage.usecase.AppSettingsViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/UserInfoCard.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/UserInfoCard.kt
@@ -38,7 +38,7 @@ import com.chriscartland.garage.domain.model.DisplayName
 import com.chriscartland.garage.domain.model.Email
 import com.chriscartland.garage.domain.model.FirebaseIdToken
 import com.chriscartland.garage.domain.model.User
-import com.chriscartland.garage.settings.AppSettingsViewModel
+import com.chriscartland.garage.usecase.AppSettingsViewModel
 
 @Composable
 fun UserInfoCard(

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/AppSettingsRepository.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/AppSettingsRepository.kt
@@ -1,0 +1,27 @@
+package com.chriscartland.garage.domain.repository
+
+/**
+ * Platform-agnostic key-value setting.
+ */
+interface Setting<T> {
+    val key: String
+
+    fun get(): T
+
+    fun set(value: T)
+
+    fun restoreDefault()
+}
+
+/**
+ * Platform-agnostic settings contract.
+ *
+ * Defines the settings the app needs without referencing SharedPreferences
+ * or any other platform storage.
+ */
+interface AppSettingsRepository {
+    val fcmDoorTopic: Setting<String>
+    val profileAppCardExpanded: Setting<Boolean>
+    val profileLogCardExpanded: Setting<Boolean>
+    val profileUserCardExpanded: Setting<Boolean>
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppSettingsViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppSettingsViewModel.kt
@@ -15,12 +15,12 @@
  *
  */
 
-package com.chriscartland.garage.settings
+package com.chriscartland.garage.usecase
 
 import androidx.lifecycle.ViewModel
+import com.chriscartland.garage.domain.repository.AppSettingsRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import me.tatarka.inject.annotations.Inject
 
 interface AppSettingsViewModel {
     val fcmDoorTopic: StateFlow<String>
@@ -37,9 +37,8 @@ interface AppSettingsViewModel {
     fun setProfileAppCardExpanded(expanded: Boolean)
 }
 
-@Inject
 class DefaultAppSettingsViewModel(
-    private val settings: AppSettings,
+    private val settings: AppSettingsRepository,
 ) : ViewModel(),
     AppSettingsViewModel {
     private val _fcmDoorTopic = MutableStateFlow(settings.fcmDoorTopic.get())


### PR DESCRIPTION
## Summary
- Extract `Setting<T>` and `AppSettingsRepository` interfaces to `domain/src/commonMain/`
- Move `DefaultAppSettingsViewModel` to `usecase/src/commonMain/`
- Android `AppSettings` extends domain `AppSettingsRepository`
- 3 of 5 ViewModels now in shared KMP modules

## Test plan
- [x] All tests pass
- [x] Compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)