### PR TITLE
feat: Move AppLoggerViewModel to shared module (Phase 29)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -19,7 +19,6 @@ package com.chriscartland.garage.di
 
 import android.app.Application
 import com.chriscartland.garage.applogger.AndroidAppLoggerRepository
-import com.chriscartland.garage.applogger.DefaultAppLoggerViewModel
 import com.chriscartland.garage.applogger.RoomAppLoggerRepository
 import com.chriscartland.garage.auth.DefaultAuthViewModel
 import com.chriscartland.garage.auth.FirebaseAuthBridge
@@ -51,6 +50,7 @@ import com.chriscartland.garage.fcm.FirebaseMessagingBridge
 import com.chriscartland.garage.internet.provideKtorHttpClient
 import com.chriscartland.garage.settings.AppSettings
 import com.chriscartland.garage.settings.DataStoreAppSettings
+import com.chriscartland.garage.usecase.DefaultAppLoggerViewModel
 import com.chriscartland.garage.usecase.DefaultAppSettingsViewModel
 import com.chriscartland.garage.usecase.DefaultDoorViewModel
 import com.chriscartland.garage.usecase.DefaultRemoteButtonViewModel
@@ -82,7 +82,12 @@ abstract class AppComponent(
 ) {
     // ViewModels
     abstract val authViewModel: DefaultAuthViewModel
-    abstract val appLoggerViewModel: DefaultAppLoggerViewModel
+
+    val appLoggerViewModel: DefaultAppLoggerViewModel
+        @Provides get() = DefaultAppLoggerViewModel(
+            provideAppLoggerRepository(),
+            provideDispatcherProvider(),
+        )
 
     val appSettingsViewModel: DefaultAppSettingsViewModel
         @Provides get() = DefaultAppSettingsViewModel(provideAppSettings())

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
@@ -36,11 +36,11 @@ import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import co.touchlab.kermit.Logger
-import com.chriscartland.garage.applogger.AppLoggerViewModel
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.LoadingResult
+import com.chriscartland.garage.usecase.AppLoggerViewModel
 import com.chriscartland.garage.usecase.DoorViewModel
 import java.time.Instant
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import co.touchlab.kermit.Logger
-import com.chriscartland.garage.applogger.AppLoggerViewModel
 import com.chriscartland.garage.auth.AuthViewModel
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.AppLoggerKeys
@@ -53,6 +52,7 @@ import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.domain.model.RequestStatus
 import com.chriscartland.garage.permissions.notificationJustificationText
 import com.chriscartland.garage.permissions.rememberNotificationPermissionState
+import com.chriscartland.garage.usecase.AppLoggerViewModel
 import com.chriscartland.garage.usecase.DoorViewModel
 import com.chriscartland.garage.usecase.RemoteButtonViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/LogSummaryCard.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/LogSummaryCard.kt
@@ -43,8 +43,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.chriscartland.garage.applogger.AppLoggerViewModel
 import com.chriscartland.garage.di.rememberAppComponent
+import com.chriscartland.garage.usecase.AppLoggerViewModel
 import com.chriscartland.garage.usecase.AppSettingsViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import kotlinx.coroutines.Dispatchers
@@ -73,7 +73,10 @@ fun LogSummaryCard(
     LogSummaryCard(
         modifier = modifier,
         onDownload = { context, uri ->
-            appLoggerViewModel.writeCsvToUri(context, uri)
+            val app = context.applicationContext as com.chriscartland.garage.GarageApplication
+            kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO).launch {
+                app.component.provideAndroidAppLoggerRepository().writeCsvToUri(context, uri)
+            }
         },
         initCurrent = initCurrent,
         initRecent = initRecent,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -51,13 +51,13 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import com.chriscartland.garage.applogger.AppLoggerViewModel
 import com.chriscartland.garage.auth.AuthViewModel
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.fcm.FCMRegistration
 import com.chriscartland.garage.ui.theme.AppTheme
 import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
+import com.chriscartland.garage.usecase.AppLoggerViewModel
 import com.chriscartland.garage.usecase.DoorViewModel
 import com.chriscartland.garage.usecase.RemoteButtonViewModel
 import kotlinx.serialization.Serializable

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppLoggerViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppLoggerViewModel.kt
@@ -15,26 +15,19 @@
  *
  */
 
-package com.chriscartland.garage.applogger
+package com.chriscartland.garage.usecase
 
-import android.content.Context
-import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.AppLoggerKeys
+import com.chriscartland.garage.domain.repository.AppLoggerRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import me.tatarka.inject.annotations.Inject
 
 interface AppLoggerViewModel {
     fun log(key: String)
-
-    fun writeCsvToUri(
-        context: Context,
-        uri: Uri,
-    )
 
     val initCurrentDoorCount: StateFlow<Long>
     val initRecentDoorCount: StateFlow<Long>
@@ -46,9 +39,8 @@ interface AppLoggerViewModel {
     val timeWithoutFcmInExpectedRangeCount: StateFlow<Long>
 }
 
-@Inject
 class DefaultAppLoggerViewModel(
-    private val appLoggerRepository: AndroidAppLoggerRepository,
+    private val appLoggerRepository: AppLoggerRepository,
     private val dispatchers: DispatcherProvider,
 ) : ViewModel(),
     AppLoggerViewModel {
@@ -122,15 +114,6 @@ class DefaultAppLoggerViewModel(
     override fun log(key: String) {
         viewModelScope.launch(dispatchers.io) {
             appLoggerRepository.log(key)
-        }
-    }
-
-    override fun writeCsvToUri(
-        context: Context,
-        uri: Uri,
-    ) {
-        viewModelScope.launch(dispatchers.io) {
-            appLoggerRepository.writeCsvToUri(context, uri)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Move `DefaultAppLoggerViewModel` + interface to `usecase/src/commonMain/`
- Remove `writeCsvToUri` from ViewModel interface (Android-specific)
- CSV export called directly from Compose layer via `AndroidAppLoggerRepository`
- 4 of 5 ViewModels now in shared KMP modules

## Test plan
- [x] All tests pass
- [x] Compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)