### PR TITLE
feat: Add NoFullyQualifiedNames check, fix all violations

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/applogger/AppLoggerRepository.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/applogger/AppLoggerRepository.kt
@@ -22,6 +22,7 @@ import android.net.Uri
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.applogger.model.AppEvent
 import com.chriscartland.garage.db.AppDatabase
+import com.chriscartland.garage.domain.repository.AppLoggerRepository
 import com.chriscartland.garage.version.AppVersion
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -35,7 +36,7 @@ import java.time.format.DateTimeFormatter
  * Android-specific logger that extends the shared [AppLoggerRepository][com.chriscartland.garage.domain.repository.AppLoggerRepository]
  * with Android-specific CSV export capability.
  */
-interface AndroidAppLoggerRepository : com.chriscartland.garage.domain.repository.AppLoggerRepository {
+interface AndroidAppLoggerRepository : AppLoggerRepository {
     suspend fun writeCsvToUri(
         context: Context,
         uri: Uri,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -41,6 +41,7 @@ import com.chriscartland.garage.data.repository.NetworkPushRepository
 import com.chriscartland.garage.db.AppDatabase
 import com.chriscartland.garage.db.DatabaseLocalDoorDataSource
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
+import com.chriscartland.garage.domain.repository.AppLoggerRepository
 import com.chriscartland.garage.domain.repository.AuthRepository
 import com.chriscartland.garage.domain.repository.DoorFcmRepository
 import com.chriscartland.garage.domain.repository.DoorRepository
@@ -181,7 +182,7 @@ abstract class AppComponent(
 
     @Provides
     @Singleton
-    fun provideAppLoggerRepository(): com.chriscartland.garage.domain.repository.AppLoggerRepository = provideAndroidAppLoggerRepository()
+    fun provideAppLoggerRepository(): AppLoggerRepository = provideAndroidAppLoggerRepository()
 
     // UseCases
     @Provides

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/settings/AppSettings.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/settings/AppSettings.kt
@@ -18,13 +18,14 @@
 package com.chriscartland.garage.settings
 
 import android.content.Context
+import com.chriscartland.garage.domain.repository.AppSettingsRepository
 import com.chriscartland.garage.settings.SettingType.BooleanSetting
 import com.chriscartland.garage.settings.SettingType.IntSetting
 import com.chriscartland.garage.settings.SettingType.LongSetting
 import com.chriscartland.garage.settings.SettingType.StringSetting
 
 interface AppSettings :
-    com.chriscartland.garage.domain.repository.AppSettingsRepository,
+    AppSettingsRepository,
     SettingContract,
     SettingManager
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/settings/SettingManager.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/settings/SettingManager.kt
@@ -19,6 +19,7 @@ package com.chriscartland.garage.settings
 
 import android.content.SharedPreferences
 import co.touchlab.kermit.Logger
+import com.chriscartland.garage.domain.repository.Setting
 import com.chriscartland.garage.settings.SettingType.BooleanSetting
 import com.chriscartland.garage.settings.SettingType.IntSetting
 import com.chriscartland.garage.settings.SettingType.LongSetting
@@ -46,7 +47,7 @@ interface SettingManager {
     ): LongSetting
 }
 
-sealed class SettingType<T> : com.chriscartland.garage.domain.repository.Setting<T> {
+sealed class SettingType<T> : Setting<T> {
     class StringSetting(
         private val prefs: SharedPreferences,
         override val key: String,

--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -33,6 +33,17 @@ plugins {
     alias(libs.plugins.detekt) apply false
 }
 
+tasks.register<codestyle.NoFullyQualifiedNamesTask>("checkNoFullyQualifiedNames") {
+    sourceDirs = listOf(
+        "$rootDir/androidApp/src/main/java",
+        "$rootDir/androidApp/src/test/java",
+        "$rootDir/domain/src/commonMain/kotlin",
+        "$rootDir/data/src/commonMain/kotlin",
+        "$rootDir/usecase/src/commonMain/kotlin",
+        "$rootDir/presentation-model/src/commonMain/kotlin",
+    )
+}
+
 tasks.register<testcoverage.TestCoverageCheckTask>("checkTestCoverage") {
     sourceDir = "$rootDir/androidApp/src/main/java/com/chriscartland/garage"
     testDir = "$rootDir/androidApp/src/test/java/com/chriscartland/garage"

--- a/AndroidGarage/buildSrc/src/main/kotlin/codestyle/NoFullyQualifiedNamesTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/codestyle/NoFullyQualifiedNamesTask.kt
@@ -1,0 +1,83 @@
+package codestyle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Gradle task that detects fully qualified class names used inline in code.
+ *
+ * Fully qualified names hide dependencies — use imports instead so each file's
+ * dependencies are visible at the top. This check scans Kotlin source files
+ * for patterns like `com.example.Foo` outside of import statements.
+ */
+abstract class NoFullyQualifiedNamesTask : DefaultTask() {
+    @get:Input
+    var sourceDirs: List<String> = emptyList()
+
+    /**
+     * Package prefixes to check for inline usage.
+     * Only these prefixes are flagged — standard library and annotation usage is allowed.
+     */
+    @get:Input
+    var checkedPrefixes: List<String> = listOf(
+        "com.chriscartland.garage.",
+        "kotlinx.coroutines.",
+        "kotlinx.serialization.",
+    )
+
+    @TaskAction
+    fun check() {
+        val violations = mutableListOf<String>()
+
+        for (dirPath in sourceDirs) {
+            val dir = File(dirPath)
+            if (!dir.exists()) continue
+
+            dir
+                .walkTopDown()
+                .filter { it.extension == "kt" }
+                .forEach { file ->
+                    file.readLines().forEachIndexed { index, line ->
+                        val trimmed = line.trim()
+                        // Skip import lines, package declarations, and comments
+                        if (trimmed.startsWith("import ") ||
+                            trimmed.startsWith("package ") ||
+                            trimmed.startsWith("//") ||
+                            trimmed.startsWith("*") ||
+                            trimmed.startsWith("/*")
+                        ) {
+                            return@forEachIndexed
+                        }
+                        // Strip string literals to avoid false positives
+                        val withoutStrings = trimmed.replace(Regex("\"[^\"]*\""), "\"\"")
+                        for (prefix in checkedPrefixes) {
+                            if (withoutStrings.contains(prefix)) {
+                                val relativePath = file.relativeTo(dir).path
+                                violations.add("  $relativePath:${index + 1}: $trimmed")
+                            }
+                        }
+                    }
+                }
+        }
+
+        if (violations.isNotEmpty()) {
+            val message = buildString {
+                appendLine("Fully qualified names found in code — use imports instead:")
+                appendLine()
+                violations.forEach { appendLine(it) }
+                appendLine()
+                appendLine("${violations.size} violation(s). Add proper imports at the top of the file.")
+            }
+            throw GradleException(message)
+        }
+
+        val fileCount = sourceDirs.sumOf { dirPath ->
+            val dir = File(dirPath)
+            if (dir.exists()) dir.walkTopDown().filter { it.extension == "kt" }.count() else 0
+        }
+        logger.lifecycle("No fully qualified names: $fileCount files scanned, 0 violations.")
+    }
+}

--- a/AndroidGarage/buildSrc/src/main/kotlin/codestyle/NoFullyQualifiedNamesTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/codestyle/NoFullyQualifiedNamesTask.kt
@@ -10,22 +10,51 @@ import java.io.File
  * Gradle task that detects fully qualified class names used inline in code.
  *
  * Fully qualified names hide dependencies — use imports instead so each file's
- * dependencies are visible at the top. This check scans Kotlin source files
- * for patterns like `com.example.Foo` outside of import statements.
+ * dependencies are visible at the top. Uses two detection strategies:
+ *
+ * 1. **Known prefixes** — exact package prefixes for project and dependencies
+ * 2. **TLD regex** — catches `com.`, `org.`, `io.`, `net.` followed by lowercase
+ *    segments (looks like a Java/Kotlin package path)
  */
 abstract class NoFullyQualifiedNamesTask : DefaultTask() {
     @get:Input
     var sourceDirs: List<String> = emptyList()
 
     /**
-     * Package prefixes to check for inline usage.
-     * Only these prefixes are flagged — standard library and annotation usage is allowed.
+     * Known package prefixes to flag. Covers project code and all dependencies.
      */
     @get:Input
     var checkedPrefixes: List<String> = listOf(
+        // Project
         "com.chriscartland.garage.",
+        // Kotlin/KotlinX
         "kotlinx.coroutines.",
         "kotlinx.serialization.",
+        "kotlin.time.",
+        // AndroidX
+        "androidx.lifecycle.",
+        "androidx.compose.",
+        "androidx.navigation.",
+        "androidx.room.",
+        // Ktor
+        "io.ktor.",
+        // Firebase
+        "com.google.firebase.",
+        "com.google.android.",
+        // Kermit logging
+        "co.touchlab.kermit.",
+        // kotlin-inject
+        "me.tatarka.inject.",
+    )
+
+    /**
+     * Regex patterns that match common TLD-based package paths.
+     * Catches FQNs from libraries not in the known prefix list.
+     * Pattern: TLD + lowercase segment + dot + more segments + uppercase class name.
+     */
+    private val tldPatterns: List<Regex> = listOf(
+        // com.foo.bar.Baz, org.foo.bar.Baz, io.foo.bar.Baz, net.foo.bar.Baz
+        Regex("""(?<!\w)(com|org|io|net)\.[a-z][a-z0-9_]*\.[a-z][a-z0-9_]*\.[A-Z]"""),
     )
 
     @TaskAction
@@ -53,10 +82,22 @@ abstract class NoFullyQualifiedNamesTask : DefaultTask() {
                         }
                         // Strip string literals to avoid false positives
                         val withoutStrings = trimmed.replace(Regex("\"[^\"]*\""), "\"\"")
+
+                        // Check known prefixes
                         for (prefix in checkedPrefixes) {
                             if (withoutStrings.contains(prefix)) {
                                 val relativePath = file.relativeTo(dir).path
                                 violations.add("  $relativePath:${index + 1}: $trimmed")
+                                return@forEachIndexed // One violation per line
+                            }
+                        }
+
+                        // Check TLD regex patterns
+                        for (pattern in tldPatterns) {
+                            if (pattern.containsMatchIn(withoutStrings)) {
+                                val relativePath = file.relativeTo(dir).path
+                                violations.add("  $relativePath:${index + 1}: $trimmed")
+                                return@forEachIndexed
                             }
                         }
                     }

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -25,6 +25,9 @@ $GRADLE spotlessCheck && pass "spotlessCheck" || fail "spotlessCheck"
 step "Import boundary check (shared modules)"
 $GRADLE :domain:checkImportBoundary :data:checkImportBoundary :usecase:checkImportBoundary :presentation-model:checkImportBoundary && pass "import boundaries" || fail "import boundaries"
 
+step "No fully qualified names in code"
+$GRADLE checkNoFullyQualifiedNames && pass "no FQNs" || fail "no FQNs"
+
 step "Detekt (static analysis)"
 $GRADLE :androidApp:detekt && pass "detekt" || fail "detekt"
 


### PR DESCRIPTION
## Summary
- New `checkNoFullyQualifiedNames` Gradle task in buildSrc
- Scans all Kotlin source for inline `com.chriscartland.garage.*` and `kotlinx.coroutines.*` FQNs
- Fixed 4 violations (use imports instead)
- Added to `validate.sh`
- Skips string literals (no false positives)

## Test plan
- [x] Check passes with 0 violations
- [x] All tests pass
- [x] Compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)