### PR TITLE
refactor: Move Google Sign-In to Compose layer (Phase 26)

### DIFF
--- a/.claude/hooks/git-guardrails.sh
+++ b/.claude/hooks/git-guardrails.sh
@@ -21,6 +21,11 @@ deny() {
 # Strip heredoc bodies and quoted strings to avoid false positives on PR body text.
 STRIPPED=$(echo "$COMMAND" | sed '/<<.*EOF/,/^EOF/d' | sed -E "s/'[^']*'//g; s/\"[^\"]*\"//g")
 
+# --- Block absolute paths to gradlew (use repo-relative paths) ---
+if echo "$STRIPPED" | grep -qE '(^|[;&|]\s*)/[^ ]*gradlew\b'; then
+  deny "BLOCKED: Use repo-relative path to gradlew (e.g., AndroidGarage/gradlew -p AndroidGarage), not an absolute path."
+fi
+
 # --- Block cd (run everything from repo root) ---
 # Match cd as a command (start of line, or after && || ; |), not as part of a word like "block-cd"
 if echo "$STRIPPED" | grep -qE '(^|[;&|]\s*)cd\s'; then

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/MainActivity.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/MainActivity.kt
@@ -17,27 +17,17 @@
 
 package com.chriscartland.garage
 
-import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.ui.util.trace
 import co.touchlab.kermit.Logger
-import com.chriscartland.garage.auth.RC_ONE_TAP_SIGN_IN
 import com.chriscartland.garage.di.activityViewModel
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.ui.GarageApp
 
 class MainActivity : ComponentActivity() {
-    /**
-     * Activity-scoped ViewModels shared between Compose and Activity callbacks.
-     *
-     * Created via [activityViewModel] to ensure the same instance is stored in the
-     * Activity's ViewModelStore. Compose receives these as parameters and uses the
-     * same instances. This prevents bugs where instance state (like SignInClient)
-     * exists on one ViewModel but is accessed from a different instance.
-     */
     private val component by lazy { (application as GarageApplication).component }
     private val authViewModel by lazy { activityViewModel(this) { component.authViewModel } }
     private val doorViewModel by lazy { activityViewModel(this) { component.doorViewModel } }
@@ -58,29 +48,5 @@ class MainActivity : ComponentActivity() {
         Logger.d { "onCreate: Try to subscribe to FCM topic" }
         doorViewModel.registerFcm()
         appLoggerViewModel.log(AppLoggerKeys.ON_CREATE_FCM_SUBSCRIBE_TOPIC)
-    }
-
-    // TODO: Migrate away from onActivityResult with Activity Result API and ActivityResultContract.
-    @Deprecated(
-        "This method has been deprecated in favor of using the Activity Result API",
-        level = DeprecationLevel.WARNING,
-    )
-    override fun onActivityResult(
-        requestCode: Int,
-        resultCode: Int,
-        data: Intent?,
-    ) {
-        super.onActivityResult(requestCode, resultCode, data)
-        Logger.d { "onActivityResult" }
-        when (requestCode) {
-            RC_ONE_TAP_SIGN_IN -> {
-                Logger.d { "RC_ONE_TAP_SIGN_IN" }
-                if (data == null) {
-                    Logger.e { "onActivityResult: data is null" }
-                    return
-                }
-                authViewModel.processGoogleSignInResult(data)
-            }
-        }
     }
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthConstants.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthConstants.kt
@@ -1,4 +1,0 @@
-package com.chriscartland.garage.auth
-
-/** Request code for Google One-Tap sign-in (Android-specific). */
-const val RC_ONE_TAP_SIGN_IN = 1

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthViewModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/AuthViewModel.kt
@@ -17,159 +17,47 @@
 
 package com.chriscartland.garage.auth
 
-import android.app.Activity
-import android.content.Context
-import android.content.Intent
-import android.content.IntentSender
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
-import com.chriscartland.garage.BuildConfig
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.GoogleIdToken
 import com.chriscartland.garage.domain.repository.AppLoggerRepository
 import com.chriscartland.garage.domain.repository.AuthRepository
-import com.google.android.gms.auth.api.identity.BeginSignInRequest
-import com.google.android.gms.auth.api.identity.Identity
-import com.google.android.gms.auth.api.identity.SignInClient
-import com.google.android.gms.common.api.ApiException
-import com.google.android.gms.common.api.CommonStatusCodes
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Inject
 
 interface AuthViewModel {
     val authState: StateFlow<AuthState>
-    val authRepository: AuthRepository
 
-    fun signInWithGoogle(activity: Activity)
+    fun signInWithGoogle(idToken: GoogleIdToken)
 
     fun signOut()
-
-    fun processGoogleSignInResult(data: Intent)
 }
 
 @Inject
 class DefaultAuthViewModel(
-    private val _authRepository: AuthRepository,
+    private val authRepository: AuthRepository,
     private val appLoggerRepository: AppLoggerRepository,
     private val dispatchers: DispatcherProvider,
 ) : ViewModel(),
     AuthViewModel {
-    override val authRepository: AuthRepository = _authRepository
+    override val authState: StateFlow<AuthState> = authRepository.authState
 
-    override val authState: StateFlow<AuthState> = _authRepository.authState
-
-    override fun signInWithGoogle(activity: Activity) {
+    override fun signInWithGoogle(idToken: GoogleIdToken) {
         viewModelScope.launch(dispatchers.io) {
             appLoggerRepository.log(AppLoggerKeys.BEGIN_GOOGLE_SIGN_IN)
-            checkSignInConfiguration()
-            Logger.d { "beginSignIn" }
-            // Dialog Sign-In configuration.
-            val dialogSignInRequest = BeginSignInRequest
-                .builder()
-                .setGoogleIdTokenRequestOptions(
-                    BeginSignInRequest.GoogleIdTokenRequestOptions
-                        .builder()
-                        .setSupported(true)
-                        .setServerClientId(BuildConfig.GOOGLE_WEB_CLIENT_ID)
-                        .setFilterByAuthorizedAccounts(false)
-                        .build(),
-                ).setAutoSelectEnabled(false) // Let user choose the account.
-                .build()
-            createSignInClient(activity)
-                .beginSignIn(dialogSignInRequest)
-                .addOnSuccessListener(activity) { result ->
-                    try {
-                        activity.startIntentSenderForResult(
-                            result.pendingIntent.intentSender,
-                            RC_ONE_TAP_SIGN_IN,
-                            null,
-                            0,
-                            0,
-                            0,
-                            null,
-                        )
-                    } catch (e: IntentSender.SendIntentException) {
-                        Logger.e { "Couldn't start One Tap UI: ${e.localizedMessage}" }
-                    }
-                }.addOnFailureListener(activity) { e ->
-                    // No saved credentials found. Launch the One Tap sign-up flow, or
-                    // do nothing and continue presenting the signed-out UI.
-                    Logger.d { e.localizedMessage ?: "" }
-                }
+            Logger.d { "signInWithGoogle" }
+            authRepository.signInWithGoogle(idToken)
         }
     }
 
     override fun signOut() {
         viewModelScope.launch(dispatchers.io) {
-            _authRepository.signOut()
-        }
-    }
-
-    override fun processGoogleSignInResult(data: Intent) {
-        viewModelScope.launch(dispatchers.io) {
-            val googleIdToken = googleIdTokenFromIntent(data)
-            if (googleIdToken == null) {
-                Logger.e { "Google sign-in failed" }
-                return@launch
-            }
-            _authRepository.signInWithGoogle(googleIdToken)
-        }
-    }
-
-    /**
-     * Extract the Google ID Token from the Intent.
-     */
-    private fun googleIdTokenFromIntent(data: Intent): GoogleIdToken? {
-        Logger.d { "googleIdTokenFromIntent" }
-        val client = signInClient
-        if (client == null) {
-            Logger.e { "Cannot sign in without a Google client" }
-            return null
-        }
-        try {
-            val credential = client.getSignInCredentialFromIntent(data)
-            return credential.googleIdToken?.let { GoogleIdToken(it) }
-        } catch (e: ApiException) {
-            Logger.e { "ApiException: handleOneTapSignIn ${e.message}" }
-            when (e.statusCode) {
-                CommonStatusCodes.CANCELED -> {
-                    Logger.d { "One-tap dialog was closed." }
-                }
-                CommonStatusCodes.NETWORK_ERROR -> {
-                    Logger.d { "One-tap encountered a network error." }
-                }
-                else -> {
-                    Logger.d { "Couldn't get credential from result. ApiException.statusCode: ${e.statusCode} (${e.localizedMessage})" }
-                }
-            }
-        }
-        return null
-    }
-
-    private var signInClient: SignInClient? = null
-
-    // Google API for identity.
-    private fun createSignInClient(context: Context) = Identity.getSignInClient(context).also { signInClient = it }
-
-    /**
-     * Check to make sure we've updated the client ID.
-     */
-    private val incorrectWebClientId =
-        "123456789012-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.apps.googleusercontent.com"
-
-    /**
-     * Log a warning if the sign-in configuration is not correct.
-     */
-    private fun checkSignInConfiguration() {
-        val googleClientIdForWeb = BuildConfig.GOOGLE_WEB_CLIENT_ID
-        if (googleClientIdForWeb == incorrectWebClientId) {
-            Logger.e {
-                "The web client ID matches the INCORRECT_WEB_CLIENT_ID. One Tap Sign-In with Google will not work. Update the web client ID to be used with setServerClientId(). https://developers.google.com/identity/one-tap/android/get-saved-credentials Create a web client ID in this Google Cloud Console https://console.cloud.google.com/apis/credentials"
-            }
+            authRepository.signOut()
         }
     }
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/GoogleSignInState.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/GoogleSignInState.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.auth
+
+import android.app.Activity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.IntentSenderRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import co.touchlab.kermit.Logger
+import com.chriscartland.garage.BuildConfig
+import com.chriscartland.garage.domain.model.GoogleIdToken
+import com.google.android.gms.auth.api.identity.BeginSignInRequest
+import com.google.android.gms.auth.api.identity.Identity
+import com.google.android.gms.auth.api.identity.SignInClient
+import com.google.android.gms.common.api.ApiException
+import com.google.android.gms.common.api.CommonStatusCodes
+
+/**
+ * Compose-layer Google One-Tap sign-in helper.
+ *
+ * Manages the [SignInClient], [BeginSignInRequest], and [ActivityResultLauncher]
+ * so that ViewModels never touch Activity, Intent, or IntentSender.
+ *
+ * Usage:
+ * ```
+ * val googleSignIn = rememberGoogleSignIn(
+ *     onTokenReceived = { token -> authViewModel.signInWithGoogle(token) },
+ * )
+ * Button(onClick = { googleSignIn.launchSignIn() }) { Text("Sign in") }
+ * ```
+ */
+@Composable
+fun rememberGoogleSignIn(onTokenReceived: (GoogleIdToken) -> Unit): GoogleSignInState {
+    val context = LocalContext.current
+    val signInClient = remember { Identity.getSignInClient(context) }
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartIntentSenderForResult(),
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val data = result.data
+            if (data == null) {
+                Logger.e { "Google sign-in: result data is null" }
+                return@rememberLauncherForActivityResult
+            }
+            extractGoogleIdToken(signInClient, data)?.let(onTokenReceived)
+        }
+    }
+
+    return remember(signInClient, launcher) {
+        GoogleSignInState(signInClient, launcher)
+    }
+}
+
+/**
+ * Holds the sign-in client and launcher. Call [launchSignIn] to start the One-Tap flow.
+ */
+class GoogleSignInState internal constructor(
+    private val signInClient: SignInClient,
+    private val launcher: androidx.activity.result.ActivityResultLauncher<IntentSenderRequest>,
+) {
+    fun launchSignIn() {
+        checkSignInConfiguration()
+        val request = BeginSignInRequest
+            .builder()
+            .setGoogleIdTokenRequestOptions(
+                BeginSignInRequest.GoogleIdTokenRequestOptions
+                    .builder()
+                    .setSupported(true)
+                    .setServerClientId(BuildConfig.GOOGLE_WEB_CLIENT_ID)
+                    .setFilterByAuthorizedAccounts(false)
+                    .build(),
+            ).setAutoSelectEnabled(false)
+            .build()
+
+        signInClient
+            .beginSignIn(request)
+            .addOnSuccessListener { result ->
+                val intentSenderRequest = IntentSenderRequest
+                    .Builder(
+                        result.pendingIntent.intentSender,
+                    ).build()
+                launcher.launch(intentSenderRequest)
+            }.addOnFailureListener { e ->
+                Logger.d { "Google sign-in not available: ${e.localizedMessage}" }
+            }
+    }
+}
+
+/**
+ * Extract the Google ID Token from the sign-in result Intent.
+ */
+private fun extractGoogleIdToken(
+    client: SignInClient,
+    data: android.content.Intent,
+): GoogleIdToken? {
+    try {
+        val credential = client.getSignInCredentialFromIntent(data)
+        return credential.googleIdToken?.let { GoogleIdToken(it) }
+    } catch (e: ApiException) {
+        when (e.statusCode) {
+            CommonStatusCodes.CANCELED -> Logger.d { "One-tap dialog was closed." }
+            CommonStatusCodes.NETWORK_ERROR -> Logger.d { "One-tap encountered a network error." }
+            else -> Logger.d {
+                "Couldn't get credential from result. statusCode: ${e.statusCode} (${e.localizedMessage})"
+            }
+        }
+    }
+    return null
+}
+
+private const val INCORRECT_WEB_CLIENT_ID =
+    "123456789012-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.apps.googleusercontent.com"
+
+private fun checkSignInConfiguration() {
+    if (BuildConfig.GOOGLE_WEB_CLIENT_ID == INCORRECT_WEB_CLIENT_ID) {
+        Logger.e {
+            "The web client ID matches the INCORRECT_WEB_CLIENT_ID. " +
+                "One Tap Sign-In with Google will not work. " +
+                "Update the web client ID. " +
+                "https://console.cloud.google.com/apis/credentials"
+        }
+    }
+}

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -17,7 +17,6 @@
 
 package com.chriscartland.garage.ui
 
-import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.ReportDrawnWhen
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -44,6 +43,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.auth.AuthViewModel
+import com.chriscartland.garage.auth.rememberGoogleSignIn
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.AuthState
@@ -74,7 +74,9 @@ fun HomeContent(
     val resolvedDoorViewModel = doorViewModel ?: viewModel { component.doorViewModel }
     val buttonViewModel: RemoteButtonViewModel = viewModel { component.remoteButtonViewModel }
     val resolvedAppLoggerViewModel = appLoggerViewModel ?: viewModel { component.appLoggerViewModel }
-    val activity = LocalActivity.current
+    val googleSignIn = rememberGoogleSignIn(
+        onTokenReceived = { token -> resolvedAuthViewModel.signInWithGoogle(token) },
+    )
     val currentDoorEvent by resolvedDoorViewModel.currentDoorEvent.collectAsState()
     val buttonRequestStatus by buttonViewModel.requestStatus.collectAsState()
     val authState by resolvedAuthViewModel.authState.collectAsState()
@@ -94,31 +96,17 @@ fun HomeContent(
                 }
 
                 AuthState.Unauthenticated -> {
-                    if (activity != null) {
-                        resolvedAuthViewModel.signInWithGoogle(activity)
-                    } else {
-                        Logger.e { "Activity is null, cannot sign in with Google" }
-                    }
+                    googleSignIn.launchSignIn()
                 }
 
                 AuthState.Unknown -> {
-                    if (activity != null) {
-                        resolvedAuthViewModel.signInWithGoogle(activity)
-                    } else {
-                        Logger.e { "Activity is null, cannot sign in with Google" }
-                    }
+                    googleSignIn.launchSignIn()
                 }
             }
         },
         onResetRemote = { buttonViewModel.resetRemoteButton() },
         authState = authState,
-        onSignIn = {
-            if (activity != null) {
-                resolvedAuthViewModel.signInWithGoogle(activity)
-            } else {
-                Logger.e { "Activity is null, cannot sign in with Google" }
-            }
-        },
+        onSignIn = { googleSignIn.launchSignIn() },
         onResetFcm = {
             resolvedDoorViewModel.deregisterFcm()
         },

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
@@ -17,7 +17,6 @@
 
 package com.chriscartland.garage.ui
 
-import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.ReportDrawn
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Spacer
@@ -35,8 +34,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import co.touchlab.kermit.Logger
 import com.chriscartland.garage.auth.AuthViewModel
+import com.chriscartland.garage.auth.rememberGoogleSignIn
 import com.chriscartland.garage.config.APP_CONFIG
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.AuthState
@@ -60,7 +59,9 @@ fun ProfileContent(
     val component = rememberAppComponent()
     val resolvedAuthViewModel = authViewModel ?: viewModel { component.authViewModel }
     val buttonViewModel: RemoteButtonViewModel = viewModel { component.remoteButtonViewModel }
-    val activity = LocalActivity.current
+    val googleSignIn = rememberGoogleSignIn(
+        onTokenReceived = { token -> resolvedAuthViewModel.signInWithGoogle(token) },
+    )
     val authState by resolvedAuthViewModel.authState.collectAsState()
     val snoozeRequestStatus by buttonViewModel.snoozeRequestStatus.collectAsState()
     val snoozeEndTimeSeconds by buttonViewModel.snoozeEndTimeSeconds.collectAsState()
@@ -78,13 +79,7 @@ fun ProfileContent(
             AuthState.Unknown -> null
         },
         modifier = modifier,
-        signIn = {
-            if (activity != null) {
-                resolvedAuthViewModel.signInWithGoogle(activity)
-            } else {
-                Logger.e { "Activity is null, cannot sign in with Google" }
-            }
-        },
+        signIn = { googleSignIn.launchSignIn() },
         signOut = { resolvedAuthViewModel.signOut() },
         snoozeEndTimeSeconds = snoozeEndTimeSeconds,
         snoozeRequestStatus = snoozeRequestStatus,


### PR DESCRIPTION
## Summary
- Move Google One-Tap sign-in from `DefaultAuthViewModel` to a Compose-layer helper (`GoogleSignInState`)
- Replace deprecated `onActivityResult` + `startIntentSenderForResult` with modern `ActivityResultContracts.StartIntentSenderForResult()`
- Simplify `AuthViewModel` interface: `signInWithGoogle(idToken: GoogleIdToken)` — no Activity, Intent, or IntentSender
- Remove `onActivityResult` override from `MainActivity`
- Delete `AuthConstants.kt` (`RC_ONE_TAP_SIGN_IN` no longer needed)
- Add guardrails hook to block absolute paths to gradlew

## Why
AuthViewModel had Android framework types (Activity, Intent) in its interface, preventing it from moving to a shared KMP module. This is Phase 26 of the migration plan — the last blocker before Phase 30 (move AuthViewModel to shared module).

## Test plan
- [ ] Verify Google Sign-In flow works on device (One-Tap dialog → token → auth state)
- [ ] Verify sign-out works
- [ ] Verify sign-in from Home tab (button click when unauthenticated)
- [ ] Verify sign-in from Profile tab
- [ ] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)