### PR TITLE
feat: Move AuthViewModel to shared usecase module (Phase 30)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -20,7 +20,6 @@ package com.chriscartland.garage.di
 import android.app.Application
 import com.chriscartland.garage.applogger.AndroidAppLoggerRepository
 import com.chriscartland.garage.applogger.RoomAppLoggerRepository
-import com.chriscartland.garage.auth.DefaultAuthViewModel
 import com.chriscartland.garage.auth.FirebaseAuthBridge
 import com.chriscartland.garage.config.APP_CONFIG
 import com.chriscartland.garage.coroutines.DefaultDispatcherProvider
@@ -53,6 +52,7 @@ import com.chriscartland.garage.settings.AppSettings
 import com.chriscartland.garage.settings.DataStoreAppSettings
 import com.chriscartland.garage.usecase.DefaultAppLoggerViewModel
 import com.chriscartland.garage.usecase.DefaultAppSettingsViewModel
+import com.chriscartland.garage.usecase.DefaultAuthViewModel
 import com.chriscartland.garage.usecase.DefaultDoorViewModel
 import com.chriscartland.garage.usecase.DefaultRemoteButtonViewModel
 import com.chriscartland.garage.usecase.DeregisterFcmUseCase
@@ -82,7 +82,12 @@ abstract class AppComponent(
     @get:Provides val application: Application,
 ) {
     // ViewModels
-    abstract val authViewModel: DefaultAuthViewModel
+    val authViewModel: DefaultAuthViewModel
+        @Provides get() = DefaultAuthViewModel(
+            provideAuthRepository(),
+            provideAppLoggerRepository(),
+            provideDispatcherProvider(),
+        )
 
     val appLoggerViewModel: DefaultAppLoggerViewModel
         @Provides get() = DefaultAppLoggerViewModel(

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -42,7 +42,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import co.touchlab.kermit.Logger
-import com.chriscartland.garage.auth.AuthViewModel
 import com.chriscartland.garage.auth.rememberGoogleSignIn
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.AppLoggerKeys
@@ -53,6 +52,7 @@ import com.chriscartland.garage.domain.model.RequestStatus
 import com.chriscartland.garage.permissions.notificationJustificationText
 import com.chriscartland.garage.permissions.rememberNotificationPermissionState
 import com.chriscartland.garage.usecase.AppLoggerViewModel
+import com.chriscartland.garage.usecase.AuthViewModel
 import com.chriscartland.garage.usecase.DoorViewModel
 import com.chriscartland.garage.usecase.RemoteButtonViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/LogSummaryCard.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/LogSummaryCard.kt
@@ -43,10 +43,12 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.chriscartland.garage.GarageApplication
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.usecase.AppLoggerViewModel
 import com.chriscartland.garage.usecase.AppSettingsViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
@@ -73,8 +75,8 @@ fun LogSummaryCard(
     LogSummaryCard(
         modifier = modifier,
         onDownload = { context, uri ->
-            val app = context.applicationContext as com.chriscartland.garage.GarageApplication
-            kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO).launch {
+            val app = context.applicationContext as GarageApplication
+            CoroutineScope(Dispatchers.IO).launch {
                 app.component.provideAndroidAppLoggerRepository().writeCsvToUri(context, uri)
             }
         },

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -51,13 +51,13 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import com.chriscartland.garage.auth.AuthViewModel
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.fcm.FCMRegistration
 import com.chriscartland.garage.ui.theme.AppTheme
 import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
 import com.chriscartland.garage.usecase.AppLoggerViewModel
+import com.chriscartland.garage.usecase.AuthViewModel
 import com.chriscartland.garage.usecase.DoorViewModel
 import com.chriscartland.garage.usecase.RemoteButtonViewModel
 import kotlinx.serialization.Serializable

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.chriscartland.garage.auth.AuthViewModel
 import com.chriscartland.garage.auth.rememberGoogleSignIn
 import com.chriscartland.garage.config.APP_CONFIG
 import com.chriscartland.garage.di.rememberAppComponent
@@ -43,6 +42,7 @@ import com.chriscartland.garage.domain.model.SnoozeDurationUIOption
 import com.chriscartland.garage.domain.model.SnoozeRequestStatus
 import com.chriscartland.garage.domain.model.User
 import com.chriscartland.garage.permissions.rememberNotificationPermissionState
+import com.chriscartland.garage.usecase.AuthViewModel
 import com.chriscartland.garage.usecase.RemoteButtonViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionState

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AuthViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AuthViewModel.kt
@@ -15,7 +15,7 @@
  *
  */
 
-package com.chriscartland.garage.auth
+package com.chriscartland.garage.usecase
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -28,7 +28,6 @@ import com.chriscartland.garage.domain.repository.AppLoggerRepository
 import com.chriscartland.garage.domain.repository.AuthRepository
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import me.tatarka.inject.annotations.Inject
 
 interface AuthViewModel {
     val authState: StateFlow<AuthState>
@@ -38,7 +37,6 @@ interface AuthViewModel {
     fun signOut()
 }
 
-@Inject
 class DefaultAuthViewModel(
     private val authRepository: AuthRepository,
     private val appLoggerRepository: AppLoggerRepository,


### PR DESCRIPTION
## Summary
- Move `AuthViewModel` interface and `DefaultAuthViewModel` to `usecase/src/commonMain/` (shared KMP module)
- Replace `@Inject` + `abstract val` with explicit `@Provides` in `AppComponent`
- Update all UI import paths from `com.chriscartland.garage.auth` to `com.chriscartland.garage.usecase`
- Fix pre-existing FQN violations in `LogSummaryCard.kt`

This completes the ViewModel extraction — **all ViewModels now live in shared KMP modules**:
- `AuthViewModel` → `usecase/commonMain` (this PR)
- `DoorViewModel` → `usecase/commonMain` (PR #177)
- `RemoteButtonViewModel` → `usecase/commonMain` (PR #175)
- `AppSettingsViewModel` → `usecase/commonMain` (PR #178)
- `AppLoggerViewModel` → `usecase/commonMain` (PR #179)

## Test plan
- [ ] `./scripts/validate.sh` passes
- [ ] Verify sign-in/sign-out flow on device
- [ ] Import boundary check confirms no Android imports in commonMain

🤖 Generated with [Claude Code](https://claude.com/claude-code)