### PR TITLE
refactor: Move demo data to shared presentation-model module

### DIFF
--- a/AndroidGarage/androidApp/build.gradle.kts
+++ b/AndroidGarage/androidApp/build.gradle.kts
@@ -229,6 +229,7 @@ dependencies {
     implementation(project(":domain"))
     implementation(project(":data"))
     implementation(project(":usecase"))
+    implementation(project(":presentation-model"))
     implementation(libs.kermit)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
@@ -40,6 +40,7 @@ import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.LoadingResult
+import com.chriscartland.garage.presentation.demoDoorEvents
 import com.chriscartland.garage.usecase.AppLoggerViewModel
 import com.chriscartland.garage.usecase.DoorViewModel
 import java.time.Instant

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorStatusCard.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorStatusCard.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import com.chriscartland.garage.R
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
+import com.chriscartland.garage.presentation.demoDoorEvents
 import com.chriscartland.garage.ui.theme.DoorColorState
 import com.chriscartland.garage.ui.theme.DoorStatusColorScheme
 import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -51,6 +51,7 @@ import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.domain.model.RequestStatus
 import com.chriscartland.garage.permissions.notificationJustificationText
 import com.chriscartland.garage.permissions.rememberNotificationPermissionState
+import com.chriscartland.garage.presentation.demoDoorEvents
 import com.chriscartland.garage.usecase.AppLoggerViewModel
 import com.chriscartland.garage.usecase.AuthViewModel
 import com.chriscartland.garage.usecase.DoorViewModel

--- a/AndroidGarage/presentation-model/src/commonMain/kotlin/com/chriscartland/garage/presentation/DemoData.kt
+++ b/AndroidGarage/presentation-model/src/commonMain/kotlin/com/chriscartland/garage/presentation/DemoData.kt
@@ -15,17 +15,18 @@
  *
  */
 
-package com.chriscartland.garage.ui
+package com.chriscartland.garage.presentation
 
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
-import java.time.Instant
 
 /**
  * Fixed timestamp for deterministic previews and screenshot tests.
  * Never use Clock/Instant.now() in preview data — it causes screenshot diffs on every run.
+ *
+ * Equivalent to Instant.parse("2026-01-15T12:00:00Z").epochSecond
  */
-private val DEMO_TIMESTAMP = Instant.parse("2026-01-15T12:00:00Z").epochSecond
+private const val DEMO_TIMESTAMP = 1768507200L
 
 val demoDoorEvents = generateDoorEventDemoData()
 


### PR DESCRIPTION
## Summary
- Move `DemoData` (door event fixtures) from androidApp to `presentation-model/commonMain`
- Replace `java.time.Instant.parse` with a Long constant for KMP compatibility
- Add `presentation-model` dependency to androidApp
- iOS previews can now reuse the same test fixtures

## Test plan
- [ ] `./scripts/validate.sh` passes
- [ ] Preview composables still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)