### PR TITLE
chore: Add import boundary for data-local, remove stale exemption

### DIFF
--- a/AndroidGarage/data-local/build.gradle.kts
+++ b/AndroidGarage/data-local/build.gradle.kts
@@ -1,8 +1,18 @@
+import importboundary.ImportBoundaryCheckTask
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.room)
     alias(libs.plugins.google.devtools.ksp)
+}
+
+tasks.register<ImportBoundaryCheckTask>("checkImportBoundary") {
+    sourceDir = "$projectDir/src/commonMain/kotlin"
+    allowedPrefixes = listOf(
+        "androidx.room.",
+        "androidx.sqlite.",
+    )
 }
 
 kotlin {

--- a/AndroidGarage/test-coverage-exemptions.txt
+++ b/AndroidGarage/test-coverage-exemptions.txt
@@ -7,6 +7,5 @@ DefaultAppLoggerViewModel
 DefaultAppSettingsViewModel
 
 # Repositories — pending tests (needs Firebase mocking)
-FirebaseAuthRepository
 FirebaseDoorFcmRepository
 RoomAppLoggerRepository

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -23,7 +23,7 @@ step "Spotless (formatting — all modules)"
 $GRADLE spotlessCheck && pass "spotlessCheck" || fail "spotlessCheck"
 
 step "Import boundary check (shared modules)"
-$GRADLE :domain:checkImportBoundary :data:checkImportBoundary :usecase:checkImportBoundary :presentation-model:checkImportBoundary && pass "import boundaries" || fail "import boundaries"
+$GRADLE :domain:checkImportBoundary :data:checkImportBoundary :data-local:checkImportBoundary :usecase:checkImportBoundary :presentation-model:checkImportBoundary && pass "import boundaries" || fail "import boundaries"
 
 step "No fully qualified names in code"
 $GRADLE checkNoFullyQualifiedNames && pass "no FQNs" || fail "no FQNs"


### PR DESCRIPTION
## Summary
- Add `ImportBoundaryCheckTask` to `data-local` module (allows `androidx.room.*`, `androidx.sqlite.*`)
- Add `data-local` to `validate.sh` import boundary checks
- Remove `FirebaseAuthRepository` from test coverage exemptions (has tests since Phase 22)

## Test plan
- [ ] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)