### PR TITLE
chore: Clean stale detekt baseline entries

### DIFF
--- a/AndroidGarage/androidApp/detekt-baseline.xml
+++ b/AndroidGarage/androidApp/detekt-baseline.xml
@@ -2,14 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
-    <ID>SwallowedException:AuthRepository.kt$FirebaseAuthRepository$e: Exception</ID>
-    <ID>SwallowedException:FcmPayloadParser.kt$FcmPayloadParser$e: IllegalArgumentException</ID>
     <ID>TooGenericExceptionCaught:AppLoggerRepository.kt$RoomAppLoggerRepository$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:AuthRepository.kt$FirebaseAuthRepository$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:FcmPayloadParser.kt$FcmPayloadParser$e: Exception</ID>
     <ID>TooGenericExceptionCaught:FirebaseAuthBridge.kt$FirebaseAuthBridge$e: Exception</ID>
-    <ID>TooGenericExceptionCaught:KtorNetworkButtonDataSource.kt$KtorNetworkButtonDataSource$e: Throwable</ID>
-    <ID>TooGenericExceptionCaught:KtorNetworkConfigDataSource.kt$KtorNetworkConfigDataSource$e: Throwable</ID>
-    <ID>TooGenericExceptionCaught:KtorNetworkDoorDataSource.kt$KtorNetworkDoorDataSource$e: Throwable</ID>
   </CurrentIssues>
 </SmellBaseline>


### PR DESCRIPTION
## Summary
Remove 7 stale detekt baseline entries for files that moved from androidApp to shared modules during Phases 19-32. Only 2 entries remain for files still in androidApp.

Removed (moved to shared modules):
- `AuthRepository.kt` → data/commonMain
- `FcmPayloadParser.kt` → data/commonMain
- `KtorNetworkButtonDataSource.kt` → data/commonMain
- `KtorNetworkConfigDataSource.kt` → data/commonMain
- `KtorNetworkDoorDataSource.kt` → data/commonMain

Kept (still in androidApp):
- `AppLoggerRepository.kt` (uses android.content.Context)
- `FirebaseAuthBridge.kt` (uses Firebase SDK)

## Test plan
- [ ] `detekt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)