### PR TITLE
feat: Migrate from Navigation 2 to Navigation 3

### DIFF
--- a/AndroidGarage/android-screenshot-tests/build.gradle.kts
+++ b/AndroidGarage/android-screenshot-tests/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.chriscartland.garage.screenshottests"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 26

--- a/AndroidGarage/androidApp/build.gradle.kts
+++ b/AndroidGarage/androidApp/build.gradle.kts
@@ -52,7 +52,7 @@ val localProperties = Properties().apply {
 
 android {
     namespace = "com.chriscartland.garage"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.chriscartland.garage"
@@ -241,8 +241,10 @@ dependencies {
     implementation(libs.accompanist.permissions)
     // Baseline Profiles
     implementation(libs.androidx.profileinstaller)
-    // Navigation
-    implementation(libs.androidx.navigation.compose)
+    // Navigation 3
+    implementation(libs.androidx.navigation3.runtime)
+    implementation(libs.androidx.navigation3.ui)
+    implementation(libs.androidx.lifecycle.viewmodel.navigation3)
     implementation(libs.play.services.auth)
     // Testing
     testImplementation(libs.junit)

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -36,21 +36,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.trace
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.NavController
-import androidx.navigation.NavDestination.Companion.hasRoute
-import androidx.navigation.NavGraph.Companion.findStartDestination
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.rememberNavController
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.ui.NavDisplay
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.fcm.FCMRegistration
@@ -83,29 +82,30 @@ fun GarageApp(
  *
  * Each route is a @Serializable object — the compiler ensures route references
  * are valid and navigation arguments (if added later) are type-checked.
+ * Used with Navigation 3's NavDisplay + entryProvider.
  */
-object Route {
+sealed interface Screen {
     @Serializable
-    data object Home
+    data object Home : Screen
 
     @Serializable
-    data object History
+    data object History : Screen
 
     @Serializable
-    data object Profile
+    data object Profile : Screen
 }
 
 /**
- * Navigation tab definition linking a route to its UI metadata.
+ * Navigation tab definition linking a screen to its UI metadata.
  */
 enum class Tab(
-    val route: Any,
+    val screen: Screen,
     val label: String,
     val icon: ImageVector,
 ) {
-    Home(Route.Home, "Home", Icons.Filled.Home),
-    History(Route.History, "History", Icons.Filled.DateRange),
-    Profile(Route.Profile, "Settings", Icons.Filled.Person),
+    Home(Screen.Home, "Home", Icons.Filled.Home),
+    History(Screen.History, "History", Icons.Filled.DateRange),
+    Profile(Screen.Profile, "Settings", Icons.Filled.Person),
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -145,7 +145,10 @@ fun AppNavigation(
         // Register for FCM notifications.
         FCMRegistration()
     }
-    val navController = rememberNavController()
+
+    // Nav3: back stack is a simple mutable list of Screen objects.
+    val backStack = rememberSaveable { mutableStateListOf<Screen>(Screen.Home) }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -166,51 +169,62 @@ fun AppNavigation(
             )
         },
         bottomBar = {
-            BottomNavigationBar(navController)
+            BottomNavigationBar(
+                currentScreen = backStack.lastOrNull(),
+                onTabSelected = { screen ->
+                    // Replace the back stack with a single tab screen.
+                    backStack.clear()
+                    backStack.add(screen)
+                },
+            )
         },
     ) { innerPadding ->
-        NavHost(
-            navController,
-            startDestination = Route.Home,
-            Modifier
-                .padding(innerPadding),
-        ) {
-            composable<Route.Home> {
-                HomeContent(
-                    authViewModel = authViewModel,
-                    doorViewModel = doorViewModel,
-                    appLoggerViewModel = appLoggerViewModel,
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .fillMaxWidth(),
-                )
-            }
-            composable<Route.History> {
-                DoorHistoryContent(
-                    doorViewModel = doorViewModel,
-                    appLoggerViewModel = appLoggerViewModel,
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .fillMaxWidth(),
-                )
-            }
-            composable<Route.Profile> {
-                ProfileContent(
-                    authViewModel = authViewModel,
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp)
-                        .fillMaxWidth(),
-                )
-            }
-        }
+        NavDisplay(
+            backStack = backStack,
+            onBack = { backStack.removeLastOrNull() },
+            entryDecorators = listOf(
+                rememberSaveableStateHolderNavEntryDecorator<Screen>(),
+                rememberViewModelStoreNavEntryDecorator<Screen>(),
+            ),
+            modifier = Modifier.padding(innerPadding),
+            entryProvider = entryProvider {
+                entry<Screen.Home> {
+                    HomeContent(
+                        authViewModel = authViewModel,
+                        doorViewModel = doorViewModel,
+                        appLoggerViewModel = appLoggerViewModel,
+                        modifier = Modifier
+                            .padding(horizontal = 16.dp)
+                            .fillMaxWidth(),
+                    )
+                }
+                entry<Screen.History> {
+                    DoorHistoryContent(
+                        doorViewModel = doorViewModel,
+                        appLoggerViewModel = appLoggerViewModel,
+                        modifier = Modifier
+                            .padding(horizontal = 16.dp)
+                            .fillMaxWidth(),
+                    )
+                }
+                entry<Screen.Profile> {
+                    ProfileContent(
+                        authViewModel = authViewModel,
+                        modifier = Modifier
+                            .padding(horizontal = 16.dp)
+                            .fillMaxWidth(),
+                    )
+                }
+            },
+        )
     }
 }
 
 @Composable
-fun BottomNavigationBar(navController: NavController) {
-    val navBackStackEntry by navController.currentBackStackEntryAsState()
-    val currentDestination = navBackStackEntry?.destination
-
+fun BottomNavigationBar(
+    currentScreen: Screen?,
+    onTabSelected: (Screen) -> Unit,
+) {
     NavigationBar {
         Tab.entries.forEach { tab ->
             NavigationBarItem(
@@ -225,17 +239,8 @@ fun BottomNavigationBar(navController: NavController) {
                         text = tab.label,
                     )
                 },
-                selected = currentDestination?.hasRoute(tab.route::class) == true,
-                onClick = {
-                    navController.navigate(tab.route) {
-                        // Prevent multiple copies of the same destination
-                        popUpTo(navController.graph.findStartDestination().id) {
-                            saveState = true
-                        }
-                        launchSingleTop = true
-                        restoreState = true
-                    }
-                },
+                selected = currentScreen == tab.screen,
+                onClick = { onTabSelected(tab.screen) },
             )
         }
     }

--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -45,6 +45,12 @@ tasks.register<codestyle.NoFullyQualifiedNamesTask>("checkNoFullyQualifiedNames"
     )
 }
 
+tasks.register<codestyle.NoNav2ImportsTask>("checkNoNav2Imports") {
+    sourceDirs = listOf(
+        "$rootDir/androidApp/src/main/java",
+    )
+}
+
 tasks.register<testcoverage.TestCoverageCheckTask>("checkTestCoverage") {
     sourceDir = "$rootDir/androidApp/src/main/java/com/chriscartland/garage"
     testDir = "$rootDir/androidApp/src/test/java/com/chriscartland/garage"

--- a/AndroidGarage/buildSrc/src/main/kotlin/codestyle/NoNav2ImportsTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/codestyle/NoNav2ImportsTask.kt
@@ -1,0 +1,76 @@
+package codestyle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Gradle task that detects Navigation 2 imports in code.
+ *
+ * After migrating to Navigation 3, this ensures nobody accidentally
+ * re-introduces Nav2 dependencies. Nav2 uses `androidx.navigation.compose`
+ * while Nav3 uses `androidx.navigation3`.
+ */
+abstract class NoNav2ImportsTask : DefaultTask() {
+    @get:Input
+    var sourceDirs: List<String> = emptyList()
+
+    /**
+     * Nav2 import prefixes that should not appear after migration to Nav3.
+     */
+    @get:Input
+    var forbiddenPrefixes: List<String> = listOf(
+        "androidx.navigation.compose.",
+        "androidx.navigation.NavHost",
+        "androidx.navigation.NavController",
+        "androidx.navigation.NavGraph",
+        "androidx.navigation.NavDestination",
+    )
+
+    @TaskAction
+    fun check() {
+        val violations = mutableListOf<String>()
+
+        for (dirPath in sourceDirs) {
+            val dir = File(dirPath)
+            if (!dir.exists()) continue
+
+            dir
+                .walkTopDown()
+                .filter { it.extension == "kt" }
+                .forEach { file ->
+                    file.readLines().forEachIndexed { index, line ->
+                        val trimmed = line.trim()
+                        if (!trimmed.startsWith("import ")) return@forEachIndexed
+                        val importPath = trimmed.removePrefix("import ").trim()
+                        for (prefix in forbiddenPrefixes) {
+                            if (importPath.startsWith(prefix)) {
+                                val relativePath = file.relativeTo(dir).path
+                                violations.add("  $relativePath:${index + 1}: $trimmed")
+                                return@forEachIndexed
+                            }
+                        }
+                    }
+                }
+        }
+
+        if (violations.isNotEmpty()) {
+            val message = buildString {
+                appendLine("Navigation 2 imports found — use Navigation 3 (androidx.navigation3) instead:")
+                appendLine()
+                violations.forEach { appendLine(it) }
+                appendLine()
+                appendLine("${violations.size} violation(s). Migrate to Nav3: NavDisplay + entryProvider.")
+            }
+            throw GradleException(message)
+        }
+
+        val fileCount = sourceDirs.sumOf { dirPath ->
+            val dir = File(dirPath)
+            if (dir.exists()) dir.walkTopDown().filter { it.extension == "kt" }.count() else 0
+        }
+        logger.lifecycle("No Nav2 imports: $fileCount files scanned, 0 violations.")
+    }
+}

--- a/AndroidGarage/data-local/build.gradle.kts
+++ b/AndroidGarage/data-local/build.gradle.kts
@@ -39,7 +39,7 @@ kotlin {
 
 android {
     namespace = "com.chriscartland.garage.datalocal"
-    compileSdk = 35
+    compileSdk = 36
     defaultConfig {
         minSdk = 26
     }

--- a/AndroidGarage/data/build.gradle.kts
+++ b/AndroidGarage/data/build.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
 
 android {
     namespace = "com.chriscartland.garage.data"
-    compileSdk = 35
+    compileSdk = 36
     defaultConfig {
         minSdk = 26
     }

--- a/AndroidGarage/domain/build.gradle.kts
+++ b/AndroidGarage/domain/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
 
 android {
     namespace = "com.chriscartland.garage.domain"
-    compileSdk = 35
+    compileSdk = 36
     defaultConfig {
         minSdk = 26
     }

--- a/AndroidGarage/gradle/libs.versions.toml
+++ b/AndroidGarage/gradle/libs.versions.toml
@@ -21,6 +21,8 @@ activityCompose = "1.10.1"
 agp = "8.10.1"
 androidxCore = "1.16.0"
 androidxNavigation = "2.9.0"
+androidxNavigation3 = "1.0.0-alpha02"
+jbLifecycle = "2.10.0-beta01"
 androidxDatastore = "1.1.7"
 composeBom = "2025.06.01"
 coroutines = "1.10.2"
@@ -69,6 +71,9 @@ androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecyc
 androidx-lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "lifecycle" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidxNavigation" }
+androidx-navigation3-runtime = { group = "androidx.navigation3", name = "navigation3-runtime", version.ref = "androidxNavigation3" }
+androidx-navigation3-ui = { group = "org.jetbrains.androidx.navigation3", name = "navigation3-ui", version.ref = "androidxNavigation3" }
+androidx-lifecycle-viewmodel-navigation3 = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel-navigation3", version.ref = "jbLifecycle" }
 androidx-room-common = { group = "androidx.room", name = "room-common", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }

--- a/AndroidGarage/macrobenchmark/build.gradle.kts
+++ b/AndroidGarage/macrobenchmark/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 
 android {
     namespace = "com.chriscartland.macrobenchmark"
-    compileSdk = 35
+    compileSdk = 36
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/AndroidGarage/presentation-model/build.gradle.kts
+++ b/AndroidGarage/presentation-model/build.gradle.kts
@@ -24,7 +24,7 @@ kotlin {
 
 android {
     namespace = "com.chriscartland.garage.presentation"
-    compileSdk = 35
+    compileSdk = 36
     defaultConfig {
         minSdk = 26
     }

--- a/AndroidGarage/shared/build.gradle.kts
+++ b/AndroidGarage/shared/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
     // See: https://kotlinlang.org/docs/multiplatform-discover-project.html#targets
     androidLibrary {
         namespace = "com.chriscartland.garage.shared"
-        compileSdk = 35
+        compileSdk = 36
         minSdk = 24
 
         withHostTestBuilder {

--- a/AndroidGarage/usecase/build.gradle.kts
+++ b/AndroidGarage/usecase/build.gradle.kts
@@ -29,7 +29,7 @@ kotlin {
 
 android {
     namespace = "com.chriscartland.garage.usecase"
-    compileSdk = 35
+    compileSdk = 36
     defaultConfig {
         minSdk = 26
     }

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -28,6 +28,9 @@ $GRADLE :domain:checkImportBoundary :data:checkImportBoundary :data-local:checkI
 step "No fully qualified names in code"
 $GRADLE checkNoFullyQualifiedNames && pass "no FQNs" || fail "no FQNs"
 
+step "No Navigation 2 imports (use Nav3)"
+$GRADLE checkNoNav2Imports && pass "no Nav2" || fail "no Nav2"
+
 step "Detekt (static analysis)"
 $GRADLE :androidApp:detekt && pass "detekt" || fail "detekt"
 


### PR DESCRIPTION
## Summary
Migrate from Jetpack Navigation 2 to Navigation 3, matching the battery-butler pattern.

**Nav3 changes:**
- Replace `NavHost` + `composable<Route>` with `NavDisplay` + `entryProvider` + `entry<Screen>`
- Replace `NavController` with simple `mutableStateListOf<Screen>` back stack
- Replace `Route` sealed object with `Screen` sealed interface
- Tab navigation replaces entire back stack (no `popUpTo`/`saveState` complexity)
- Add `entryDecorators` for ViewModel store and saveable state persistence

**Dependencies:**
- Add `navigation3-runtime` (1.0.0-alpha02), `navigation3-ui`, `lifecycle-viewmodel-navigation3`
- Remove `navigation-compose` (Nav2)
- Bump `compileSdk` 35 → 36 across all modules (required by Nav3)

**Enforcement:**
- `NoNav2ImportsTask` — custom Gradle task that fails if any Nav2 imports (`androidx.navigation.compose.*`, `NavController`, etc.) are found
- Added to `validate.sh`

## Test plan
- [ ] `./scripts/validate.sh` passes (including new Nav2 import check)
- [ ] Verify tab navigation works on device (Home, History, Profile)
- [ ] Verify back button behavior
- [ ] `checkNoNav2Imports` catches any Nav2 imports if accidentally added

🤖 Generated with [Claude Code](https://claude.com/claude-code)