### PR TITLE
test: Add missing DefaultAppLoggerViewModelTest

### DIFF
--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAppLoggerViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAppLoggerViewModelTest.kt
@@ -1,0 +1,51 @@
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.AppLoggerKeys
+import com.chriscartland.garage.usecase.testfakes.FakeAppLoggerRepository
+import com.chriscartland.garage.usecase.testfakes.TestDispatcherProvider
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class DefaultAppLoggerViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private val logger = FakeAppLoggerRepository()
+    private val dispatchers = TestDispatcherProvider(testDispatcher)
+    private val viewModel = DefaultAppLoggerViewModel(logger, dispatchers)
+
+    @Test
+    fun logDelegatesToRepository() =
+        runTest(testDispatcher) {
+            viewModel.log(AppLoggerKeys.USER_FETCH_CURRENT_DOOR)
+            advanceUntilIdle()
+
+            assertTrue(logger.loggedKeys.contains(AppLoggerKeys.USER_FETCH_CURRENT_DOOR))
+        }
+
+    @Test
+    fun logMultipleKeysDelegatesToRepository() =
+        runTest(testDispatcher) {
+            viewModel.log(AppLoggerKeys.INIT_CURRENT_DOOR)
+            viewModel.log(AppLoggerKeys.FCM_DOOR_RECEIVED)
+            advanceUntilIdle()
+
+            assertTrue(logger.loggedKeys.contains(AppLoggerKeys.INIT_CURRENT_DOOR))
+            assertTrue(logger.loggedKeys.contains(AppLoggerKeys.FCM_DOOR_RECEIVED))
+        }
+
+    @Test
+    fun countsUpdateAfterLog() =
+        runTest(testDispatcher) {
+            // Init collects counts — advance to let them start
+            advanceUntilIdle()
+
+            // Log a key
+            viewModel.log(AppLoggerKeys.USER_FETCH_CURRENT_DOOR)
+            advanceUntilIdle()
+
+            // The init block collects countKey flows, so the StateFlow should update
+            assertTrue(viewModel.userFetchCurrentDoorCount.value >= 1L)
+        }
+}


### PR DESCRIPTION
## Summary
Add 3 tests for `DefaultAppLoggerViewModel` that were accidentally omitted from PR #191.
- `logDelegatesToRepository` — verifies log calls reach the repository
- `logMultipleKeysDelegatesToRepository` — verifies multiple keys are logged
- `countsUpdateAfterLog` — verifies StateFlow counts update via init collectors

## Test plan
- [ ] `:usecase:testDebugUnitTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)