### PR TITLE
test: Move DoorEventEntityTest to data-local module

### DIFF
--- a/AndroidGarage/data-local/src/commonTest/kotlin/com/chriscartland/garage/datalocal/DoorEventEntityTest.kt
+++ b/AndroidGarage/data-local/src/commonTest/kotlin/com/chriscartland/garage/datalocal/DoorEventEntityTest.kt
@@ -15,16 +15,13 @@
  *
  */
 
-package com.chriscartland.garage.db
+package com.chriscartland.garage.datalocal
 
-import com.chriscartland.garage.datalocal.DoorEventEntity
-import com.chriscartland.garage.datalocal.toDomain
-import com.chriscartland.garage.datalocal.toEntity
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class DoorEventEntityTest {
     @Test
@@ -113,9 +110,9 @@ class DoorEventEntityTest {
             val original = DoorEvent(doorPosition = position)
             val roundTripped = original.toEntity().toDomain()
             assertEquals(
-                "DoorPosition.$position failed round trip",
                 original,
                 roundTripped,
+                "DoorPosition.$position failed round trip",
             )
         }
     }


### PR DESCRIPTION
## Summary
Move `DoorEventEntityTest` from `androidApp/src/test/` to `data-local/src/commonTest/` — tests should live next to the code they test. Converts from JUnit to kotlin.test for KMP compatibility. All 8 tests preserved.

## Test plan
- [ ] `./scripts/validate.sh` passes
- [ ] 8 entity tests pass in `:data-local:testDebugUnitTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)