### PR TITLE
feat: Add architecture enforcement checks (3 Gradle tasks)

### DIFF
--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -51,6 +51,48 @@ tasks.register<codestyle.NoNav2ImportsTask>("checkNoNav2Imports") {
     )
 }
 
+tasks.register<architecture.ArchitectureCheckTask>("checkArchitecture") {
+    // Capture module dependencies at configuration time (Gradle 9 compatible)
+    moduleDependencies = subprojects
+        .flatMap { subproject ->
+            val moduleName = ":" + subproject.path.removePrefix(":")
+            subproject.configurations
+                .filter { config ->
+                    val name = config.name.lowercase()
+                    !name.contains("test") && !name.contains("ksp") && !name.contains("detekt")
+                }.flatMap { config ->
+                    config.dependencies
+                        .filterIsInstance<org.gradle.api.artifacts.ProjectDependency>()
+                        .map { dep -> "$moduleName -> ${dep.path}" }
+                }
+        }.distinct()
+}
+
+tasks.register<architecture.SingletonGuardTask>("checkSingletonGuard") {
+    sourceDir = "$rootDir/androidApp/src/main/java"
+}
+
+tasks.register<architecture.LayerImportCheckTask>("checkLayerImports") {
+    sourceDirs = listOf(
+        "$rootDir/usecase/src/commonMain/kotlin",
+        "$rootDir/androidApp/src/main/java",
+    )
+    rules = listOf(
+        // ViewModels must not import DataSource or concrete Repository/Bridge implementations
+        listOf(
+            ".*ViewModel\\.kt",
+            "com.chriscartland.garage.data.Local,com.chriscartland.garage.data.Network,com.chriscartland.garage.data.ktor.,com.chriscartland.garage.data.repository.,com.chriscartland.garage.datalocal.",
+            "ViewModels must depend on UseCases and domain interfaces, not data layer implementations.",
+        ),
+        // UseCases must not import DataSource or concrete implementations
+        listOf(
+            ".*UseCase\\.kt",
+            "com.chriscartland.garage.data.Local,com.chriscartland.garage.data.Network,com.chriscartland.garage.data.ktor.,com.chriscartland.garage.data.repository.,com.chriscartland.garage.datalocal.",
+            "UseCases must depend on domain repository interfaces, not data layer implementations.",
+        ),
+    )
+}
+
 tasks.register<testcoverage.TestCoverageCheckTask>("checkTestCoverage") {
     sourceDir = "$rootDir/androidApp/src/main/java/com/chriscartland/garage"
     testDir = "$rootDir/androidApp/src/test/java/com/chriscartland/garage"

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/ArchitectureCheckTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/ArchitectureCheckTask.kt
@@ -1,0 +1,69 @@
+package architecture
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Enforces the module dependency graph at build time.
+ *
+ * Each module declares which other modules it may depend on.
+ * Any undeclared project dependency fails the build, preventing
+ * accidental layer violations (e.g., usecase depending on data).
+ *
+ * Modules not listed are unchecked. Modules with "*" allow all deps.
+ * Add new modules here as they're created.
+ */
+abstract class ArchitectureCheckTask : DefaultTask() {
+    /**
+     * Map of module name → allowed dependency module names.
+     * Use "*" to allow all dependencies (for app modules).
+     * Set at configuration time from build.gradle.kts.
+     */
+    @get:Input
+    var allowedDependencies: Map<String, List<String>> = mapOf(
+        ":domain" to listOf(),
+        ":data" to listOf(":domain"),
+        ":data-local" to listOf(":domain", ":data"),
+        ":usecase" to listOf(":domain"),
+        ":presentation-model" to listOf(":domain"),
+        ":androidApp" to listOf("*"),
+        ":android-screenshot-tests" to listOf("*"),
+        ":macrobenchmark" to listOf("*"),
+        ":shared" to listOf("*"),
+    )
+
+    /**
+     * Actual module dependencies, captured at configuration time.
+     * Each entry: "moduleName -> depPath"
+     */
+    @get:Input
+    var moduleDependencies: List<String> = emptyList()
+
+    @TaskAction
+    fun check() {
+        val violations = mutableListOf<String>()
+
+        for (entry in moduleDependencies) {
+            val (moduleName, depPath) = entry.split(" -> ")
+            val allowed = allowedDependencies[moduleName] ?: continue
+            if (allowed.contains("*")) continue
+
+            if (!allowed.contains(depPath)) {
+                violations.add(
+                    "Module '$moduleName' depends on '$depPath' " +
+                        "which is not in its allowed list: $allowed",
+                )
+            }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                "Architecture Check Failed:\n" +
+                    violations.distinct().joinToString("\n") { "  $it" },
+            )
+        }
+        logger.lifecycle("Architecture check passed: module dependency graph is clean.")
+    }
+}

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/LayerImportCheckTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/LayerImportCheckTask.kt
@@ -1,0 +1,102 @@
+package architecture
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Enforces clean layer boundaries by scanning source imports.
+ *
+ * Catches violations that module-level dependency checks miss —
+ * for example, when `:usecase` doesn't depend on `:data` but a
+ * ViewModel in androidApp accidentally imports a DataSource directly.
+ *
+ * Rules:
+ * - ViewModel classes must not import DataSource, Repository impl, or Bridge impl
+ * - UseCase classes must not import DataSource or Bridge impl
+ * - Repository impls must not import other Repository impls
+ *
+ * Configure via [rules] — each rule specifies a file pattern, forbidden
+ * import prefixes, and a human-readable explanation.
+ */
+abstract class LayerImportCheckTask : DefaultTask() {
+    @get:Input
+    var sourceDirs: List<String> = emptyList()
+
+    /**
+     * Each rule: Triple(fileNamePattern, forbiddenImportPrefixes, explanation).
+     *
+     * fileNamePattern: regex matched against the file name (e.g., ".*ViewModel\\.kt")
+     * forbiddenImportPrefixes: import prefixes that should not appear in matching files
+     * explanation: shown in the error message
+     */
+    @get:Input
+    var rules: List<List<String>> = emptyList()
+
+    @TaskAction
+    fun check() {
+        val parsedRules = rules.map { parts ->
+            require(parts.size == 3) {
+                "Each rule must have 3 parts: [filePattern, forbiddenPrefixes (comma-separated), explanation]"
+            }
+            Triple(
+                Regex(parts[0]),
+                parts[1].split(",").map { it.trim() },
+                parts[2],
+            )
+        }
+
+        val violations = mutableListOf<String>()
+
+        for (dirPath in sourceDirs) {
+            val dir = File(dirPath)
+            if (!dir.exists()) continue
+
+            dir
+                .walkTopDown()
+                .filter { it.extension == "kt" }
+                .forEach { file ->
+                    val matchingRules = parsedRules.filter { (pattern, _, _) ->
+                        pattern.matches(file.name)
+                    }
+                    if (matchingRules.isEmpty()) return@forEach
+
+                    val lines = file.readLines()
+                    val relativePath = file.relativeTo(dir).path
+
+                    lines.forEachIndexed { index, line ->
+                        val trimmed = line.trim()
+                        if (!trimmed.startsWith("import ")) return@forEachIndexed
+                        val importPath = trimmed.removePrefix("import ").trim()
+
+                        for ((_, forbidden, explanation) in matchingRules) {
+                            for (prefix in forbidden) {
+                                if (importPath.startsWith(prefix)) {
+                                    violations.add(
+                                        "$relativePath:${index + 1}: $trimmed\n" +
+                                            "    $explanation",
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                "Layer Import Check Failed (${violations.size} violation(s)):\n\n" +
+                    violations.joinToString("\n\n") { "  $it" },
+            )
+        }
+
+        val ruleCount = parsedRules.size
+        val fileCount = sourceDirs.sumOf { dirPath ->
+            val dir = File(dirPath)
+            if (dir.exists()) dir.walkTopDown().filter { it.extension == "kt" }.count() else 0
+        }
+        logger.lifecycle("Layer import check passed: $fileCount files scanned, $ruleCount rules enforced.")
+    }
+}

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/SingletonGuardTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/SingletonGuardTask.kt
@@ -1,0 +1,82 @@
+package architecture
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Ensures critical @Provides methods have @Singleton scope.
+ *
+ * Database and Settings instances crash or corrupt if created more than once.
+ * This check catches missing @Singleton annotations before runtime.
+ */
+abstract class SingletonGuardTask : DefaultTask() {
+    @get:Input
+    var sourceDir: String = ""
+
+    /**
+     * Method name patterns that MUST be annotated with @Singleton.
+     * Uses substring matching — "provideAppDatabase" matches "fun provideAppDatabase()".
+     */
+    @get:Input
+    var guardedMethodPatterns: List<String> = listOf(
+        "provideAppDatabase",
+        "provideAppSettings",
+        "provideHttpClient",
+    )
+
+    @get:Input
+    var scopeAnnotations: List<String> = listOf("@Singleton")
+
+    @TaskAction
+    fun check() {
+        val dir = File(sourceDir)
+        if (!dir.exists()) return
+
+        val violations = mutableListOf<String>()
+
+        dir
+            .walkTopDown()
+            .filter { it.extension == "kt" }
+            .forEach { file ->
+                val lines = file.readLines()
+                val relativePath = file.relativeTo(dir).path
+
+                lines.forEachIndexed { index, line ->
+                    val trimmed = line.trim()
+                    val matchedMethod = guardedMethodPatterns.firstOrNull { pattern ->
+                        trimmed.contains("fun $pattern(")
+                    } ?: return@forEachIndexed
+
+                    // Check preceding 5 lines for @Provides and @Singleton
+                    val lookbackStart = maxOf(0, index - 5)
+                    val precedingLines = lines.subList(lookbackStart, index + 1)
+
+                    val hasProvides = precedingLines.any { it.trim().contains("@Provides") }
+                    if (!hasProvides) return@forEachIndexed
+
+                    val hasScope = precedingLines.any { precedingLine ->
+                        scopeAnnotations.any { precedingLine.trim().contains(it) }
+                    }
+
+                    if (!hasScope) {
+                        violations.add(
+                            "$relativePath:${index + 1}: $matchedMethod() is @Provides " +
+                                "but missing ${scopeAnnotations.joinToString(" or ")}. " +
+                                "Database/Settings instances crash if created more than once.",
+                        )
+                    }
+                }
+            }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                "Singleton Guard Failed (${violations.size} violation(s)):\n" +
+                    violations.joinToString("\n") { "  $it" },
+            )
+        }
+        logger.lifecycle("Singleton guard passed: all critical providers are scoped.")
+    }
+}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -31,6 +31,15 @@ $GRADLE checkNoFullyQualifiedNames && pass "no FQNs" || fail "no FQNs"
 step "No Navigation 2 imports (use Nav3)"
 $GRADLE checkNoNav2Imports && pass "no Nav2" || fail "no Nav2"
 
+step "Architecture (module dependency graph)"
+$GRADLE checkArchitecture && pass "architecture" || fail "architecture"
+
+step "Singleton guard (Database, Settings, HttpClient)"
+$GRADLE checkSingletonGuard && pass "singleton guard" || fail "singleton guard"
+
+step "Layer imports (ViewModel→UseCase, UseCase→domain)"
+$GRADLE checkLayerImports && pass "layer imports" || fail "layer imports"
+
 step "Detekt (static analysis)"
 $GRADLE :androidApp:detekt && pass "detekt" || fail "detekt"
 


### PR DESCRIPTION
## Summary
Add three automated build-time architecture enforcement checks, modeled after battery-butler patterns.

### 1. ArchitectureCheckTask — Module dependency graph
Enforces that each module only depends on its declared allowed modules:
- `:domain` → nothing
- `:data` → `:domain`
- `:data-local` → `:domain`, `:data`
- `:usecase` → `:domain`
- `:presentation-model` → `:domain`
- `:androidApp` → everything (wires DI)

Catches: `:usecase` accidentally depending on `:data`

### 2. SingletonGuardTask — Critical provider scoping
Enforces `@Singleton` on `@Provides` methods for:
- `provideAppDatabase` — Room crashes with duplicate instances
- `provideAppSettings` — SharedPreferences corruption
- `provideHttpClient` — connection pool waste

### 3. LayerImportCheckTask — Source-level layer boundaries
Pattern-based rules (future-proof for new files):
- `*ViewModel.kt` must not import `data.Local*`, `data.Network*`, `data.ktor.*`, `data.repository.*`, `datalocal.*`
- `*UseCase.kt` must not import the same data-layer packages

Rules are generic — any new ViewModel or UseCase automatically gets checked.

## Test plan
- [ ] `./scripts/validate.sh` passes (includes all 3 new checks)
- [ ] Architecture check: `checkArchitecture`
- [ ] Singleton guard: `checkSingletonGuard`
- [ ] Layer imports: `checkLayerImports`

🤖 Generated with [Claude Code](https://claude.com/claude-code)