### PR TITLE
fix: Block git push to branches with auto-merge enabled

### DIFF
--- a/.claude/hooks/git-guardrails.sh
+++ b/.claude/hooks/git-guardrails.sh
@@ -54,6 +54,17 @@ if echo "$STRIPPED" | grep -qE '\bgit\s+push\b'; then
     deny "BLOCKED: Use --force-with-lease instead of --force for safety."
   fi
 
+  # Block push to a branch whose PR has auto-merge enabled (race condition risk)
+  if [ -n "$REPO_ROOT" ]; then
+    PUSH_BRANCH=$(git branch --show-current 2>/dev/null)
+    if [ -n "$PUSH_BRANCH" ] && [ "$PUSH_BRANCH" != "main" ] && [ "$PUSH_BRANCH" != "master" ]; then
+      PR_AUTO_MERGE=$(gh pr list --head "$PUSH_BRANCH" --json number,autoMergeRequest --jq '.[0] | select(.autoMergeRequest != null) | .number' 2>/dev/null || true)
+      if [ -n "$PR_AUTO_MERGE" ]; then
+        deny "BLOCKED: PR #$PR_AUTO_MERGE has auto-merge enabled. Pushing now risks the merge executing before your commits arrive, silently losing them. Disable auto-merge first: gh pr merge --disable-auto $PR_AUTO_MERGE"
+      fi
+    fi
+  fi
+
   # Warn if validate.sh hasn't been run
   if [ -n "$REPO_ROOT" ]; then
     MARKER="$REPO_ROOT/.claude/.validation-passed"


### PR DESCRIPTION
## Summary
- Adds a PreToolUse hook check: before `git push`, queries if the target branch's PR has auto-merge enabled
- If auto-merge is active, the push is **blocked** with instructions to disable auto-merge first
- Prevents the race condition where a squash merge executes before new commits arrive, silently losing them

## Test plan
- [ ] Push to a branch with auto-merge enabled → blocked with clear message
- [ ] Push to a branch without auto-merge → allowed as before
- [ ] Push to a branch with no PR → allowed as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)