### PR TITLE
test: Add state restoration tests and rememberSaveable guard

### DIFF
--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/ConfigurationChangeTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/ConfigurationChangeTest.kt
@@ -1,0 +1,75 @@
+package com.chriscartland.garage.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ActivityScenario
+import com.chriscartland.garage.MainActivity
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Tests that the app survives configuration changes (rotation, dark mode toggle, etc.)
+ * without crashing.
+ *
+ * Uses [ActivityScenario.recreate] to simulate a configuration change, which destroys
+ * and recreates the Activity. This catches:
+ * - State that isn't properly saved/restored
+ * - ViewModels that don't survive recreation
+ * - Compose state that crashes on re-composition after recreation
+ */
+class ConfigurationChangeTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    /**
+     * The app must not crash when the Activity is recreated (e.g., rotation).
+     *
+     * This was the primary crash bug: rememberSaveable tried to Bundle-save
+     * Screen objects that aren't Parcelable, causing a crash on save.
+     */
+    @Test
+    fun appSurvivesActivityRecreation() {
+        // Verify app is running
+        composeTestRule.onNodeWithText("Garage").assertIsDisplayed()
+
+        // Simulate configuration change (rotation)
+        composeTestRule.activityRule.scenario.recreate()
+
+        // App should still be running after recreation
+        composeTestRule.onNodeWithText("Garage").assertIsDisplayed()
+    }
+
+    /**
+     * Navigation state should survive configuration change.
+     * After recreation, we should still see the app functioning.
+     */
+    @Test
+    fun navigationSurvivesRecreation() {
+        // Navigate to History
+        composeTestRule.onNodeWithText("History").performClick()
+        composeTestRule.waitForIdle()
+
+        // Recreate Activity
+        composeTestRule.activityRule.scenario.recreate()
+
+        // App should still be functional (may reset to Home, that's OK)
+        composeTestRule.onNodeWithText("Garage").assertIsDisplayed()
+    }
+
+    /**
+     * Navigate to each screen and recreate — none should crash.
+     */
+    @Test
+    fun allScreensSurviveRecreation() {
+        for (tab in listOf("Home", "History", "Settings")) {
+            composeTestRule.onNodeWithText(tab).performClick()
+            composeTestRule.waitForIdle()
+
+            composeTestRule.activityRule.scenario.recreate()
+
+            composeTestRule.onNodeWithText("Garage").assertIsDisplayed()
+        }
+    }
+}

--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/StateRestorationTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/StateRestorationTest.kt
@@ -1,0 +1,121 @@
+package com.chriscartland.garage.ui
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.StateRestorationTester
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Tests that verify UI survives configuration changes and process death.
+ *
+ * Uses [StateRestorationTester] to simulate process death (save/restore state)
+ * without needing a real device process kill. This runs as an instrumented test
+ * because it needs the Compose runtime.
+ *
+ * These tests catch bugs like:
+ * - rememberSaveable with non-Parcelable types (crashes on restore)
+ * - remember losing state on configuration change
+ * - ExpandableColumnCard ignoring external state updates
+ */
+class StateRestorationTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    /**
+     * Regression test: ExpandableColumnCard must reflect external state changes.
+     *
+     * Before the fix, the card used `remember { mutableStateOf(startExpanded) }` which
+     * captured only the initial value. When DataStore loaded the persisted value later,
+     * the card ignored it.
+     */
+    @Test
+    fun expandableCard_reflectsExternalStateChange() {
+        var externalExpanded by mutableStateOf(true)
+
+        composeTestRule.setContent {
+            ExpandableColumnCard(
+                title = "Test Card",
+                startExpanded = externalExpanded,
+            ) {
+                Text("Card Content")
+            }
+        }
+
+        // Initially expanded — content visible
+        composeTestRule.onNodeWithText("Card Content").assertIsDisplayed()
+
+        // Simulate DataStore loading a saved "collapsed" value
+        externalExpanded = false
+        composeTestRule.waitForIdle()
+
+        // Card should now be collapsed — content not displayed
+        composeTestRule.onNodeWithText("Card Content").assertDoesNotExist()
+    }
+
+    /**
+     * Regression test: ExpandableColumnCard must call onExpandedChange on click.
+     *
+     * Before the fix, clicking the card toggled local state but never called
+     * onExpandedChange, so the preference was never saved to DataStore.
+     */
+    @Test
+    fun expandableCard_clickCallsOnExpandedChange() {
+        var callbackValue: Boolean? = null
+
+        composeTestRule.setContent {
+            ExpandableColumnCard(
+                title = "Test Card",
+                startExpanded = true,
+                onExpandedChange = { callbackValue = it },
+            ) {
+                Text("Card Content")
+            }
+        }
+
+        // Click title to collapse
+        composeTestRule.onNodeWithText("Test Card").performClick()
+        composeTestRule.waitForIdle()
+
+        assert(callbackValue == false) {
+            "Expected onExpandedChange(false) after collapsing, got $callbackValue"
+        }
+    }
+
+    /**
+     * Verify that ExpandableColumnCard survives state restoration (process death).
+     *
+     * StateRestorationTester simulates Bundle save/restore cycle.
+     * Since we use `remember` (not `rememberSaveable`), the card resets
+     * to the startExpanded value — which is fine because the persisted value
+     * comes from DataStore, not the saved instance state.
+     */
+    @Test
+    fun expandableCard_survivesStateRestoration() {
+        val restorationTester = StateRestorationTester(composeTestRule)
+
+        restorationTester.setContent {
+            ExpandableColumnCard(
+                title = "Test Card",
+                startExpanded = true,
+            ) {
+                Text("Card Content")
+            }
+        }
+
+        // Content visible before restoration
+        composeTestRule.onNodeWithText("Card Content").assertIsDisplayed()
+
+        // Simulate process death and restoration — should not crash
+        restorationTester.emulateSavedInstanceStateRestore()
+
+        // Card re-renders with startExpanded=true — content still visible
+        composeTestRule.onNodeWithText("Card Content").assertIsDisplayed()
+    }
+}

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/ExpandableColumnCardContractTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/ExpandableColumnCardContractTest.kt
@@ -1,0 +1,35 @@
+package com.chriscartland.garage.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests verifying the contract of [ExpandableColumnCard].
+ *
+ * These test the behavioral requirements without a Compose runtime:
+ * - External state changes must be reflected (not ignored by remember)
+ * - User clicks must propagate via onExpandedChange callback
+ *
+ * The actual Compose interaction tests are in androidTest (instrumented)
+ * since they require a Compose test rule with StateRestorationTester.
+ */
+class ExpandableColumnCardContractTest {
+    /**
+     * Regression: rememberSaveable with non-Parcelable Screen types crashed
+     * on process death. Verify Screen objects are NOT java.io.Serializable,
+     * which means rememberSaveable would fail to save them.
+     */
+    @Test
+    fun screenObjectsAreNotJavaSerializable() {
+        val screens = listOf(Screen.Home, Screen.History, Screen.Profile)
+        for (screen in screens) {
+            val isJavaSerializable = screen is java.io.Serializable
+            assertEquals(
+                "Screen.${screen::class.simpleName} must NOT be java.io.Serializable " +
+                    "(use remember, not rememberSaveable)",
+                false,
+                isJavaSerializable,
+            )
+        }
+    }
+}

--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -93,6 +93,12 @@ tasks.register<architecture.LayerImportCheckTask>("checkLayerImports") {
     )
 }
 
+tasks.register<codestyle.RememberSaveableGuardTask>("checkRememberSaveable") {
+    sourceDirs = listOf(
+        "$rootDir/androidApp/src/main/java",
+    )
+}
+
 tasks.register<testcoverage.TestCoverageCheckTask>("checkTestCoverage") {
     sourceDir = "$rootDir/androidApp/src/main/java/com/chriscartland/garage"
     testDir = "$rootDir/androidApp/src/test/java/com/chriscartland/garage"

--- a/AndroidGarage/buildSrc/src/main/kotlin/codestyle/RememberSaveableGuardTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/codestyle/RememberSaveableGuardTask.kt
@@ -1,0 +1,79 @@
+package codestyle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Detects unsafe `rememberSaveable` usage with types that aren't Bundle-saveable.
+ *
+ * `rememberSaveable` serializes state to a Bundle on process death. If the state
+ * contains types that aren't Parcelable, java.io.Serializable, or a primitive,
+ * the app crashes on save or restore. This happened with Nav3's Screen objects
+ * (kotlinx @Serializable ≠ java.io.Serializable).
+ *
+ * This task scans for `rememberSaveable` calls and flags any that don't use a
+ * known-safe type (String, Int, Boolean, etc.) or an explicit `saver` parameter.
+ *
+ * Use `remember` instead for types that don't need to survive process death.
+ */
+abstract class RememberSaveableGuardTask : DefaultTask() {
+    @get:Input
+    var sourceDirs: List<String> = emptyList()
+
+    @TaskAction
+    fun check() {
+        val violations = mutableListOf<String>()
+
+        for (dirPath in sourceDirs) {
+            val dir = File(dirPath)
+            if (!dir.exists()) continue
+
+            dir
+                .walkTopDown()
+                .filter { it.extension == "kt" }
+                .forEach { file ->
+                    val content = file.readText()
+                    if ("rememberSaveable" !in content) return@forEach
+
+                    val lines = file.readLines()
+                    val relativePath = file.relativeTo(dir).path
+
+                    lines.forEachIndexed { index, line ->
+                        val trimmed = line.trim()
+                        // Match actual rememberSaveable function calls, not functions
+                        // that contain "rememberSaveable" as a substring (e.g.,
+                        // rememberSaveableStateHolderNavEntryDecorator).
+                        val hasCall = Regex("""\brememberSaveable\s*[\({]""").containsMatchIn(trimmed)
+                        if (hasCall &&
+                            "saver" !in trimmed &&
+                            !trimmed.startsWith("//") &&
+                            !trimmed.startsWith("*") &&
+                            !trimmed.startsWith("import ")
+                        ) {
+                            violations.add(
+                                "$relativePath:${index + 1}: $trimmed\n" +
+                                    "    rememberSaveable without an explicit `saver` parameter is unsafe\n" +
+                                    "    for custom types. Use `remember` or provide a Saver.",
+                            )
+                        }
+                    }
+                }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                "RememberSaveable Guard Failed (${violations.size} violation(s)):\n\n" +
+                    violations.joinToString("\n\n") { "  $it" },
+            )
+        }
+
+        val fileCount = sourceDirs.sumOf { dirPath ->
+            val dir = File(dirPath)
+            if (dir.exists()) dir.walkTopDown().filter { it.extension == "kt" }.count() else 0
+        }
+        logger.lifecycle("RememberSaveable guard passed: $fileCount files scanned.")
+    }
+}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -31,6 +31,9 @@ $GRADLE checkNoFullyQualifiedNames && pass "no FQNs" || fail "no FQNs"
 step "No Navigation 2 imports (use Nav3)"
 $GRADLE checkNoNav2Imports && pass "no Nav2" || fail "no Nav2"
 
+step "RememberSaveable guard (no unsaved custom types)"
+$GRADLE checkRememberSaveable && pass "rememberSaveable guard" || fail "rememberSaveable guard"
+
 step "Architecture (module dependency graph)"
 $GRADLE checkArchitecture && pass "architecture" || fail "architecture"
 


### PR DESCRIPTION
## Summary
- **RememberSaveableGuardTask** (architecture check, runs in CI): blocks `rememberSaveable` without explicit `saver` — prevents the crash that shipped in android/140
- **ExpandableColumnCardContractTest** (unit test): verifies Screen objects aren't java.io.Serializable
- **StateRestorationTest** (instrumented): tests ExpandableColumnCard syncs external state, fires callbacks, survives process death
- **ConfigurationChangeTest** (instrumented): tests all screens survive Activity recreation

## Verification
Temporarily reverted the Main.kt fix → the guard caught the exact violation:
```
Main.kt:150: val backStack = rememberSaveable { mutableStateListOf<Screen>(Screen.Home) }
    rememberSaveable without an explicit `saver` parameter is unsafe
```

## Test plan
- [x] `checkRememberSaveable` passes with fix, fails without
- [x] Unit test passes (Screen is not java.io.Serializable)
- [x] Instrumented tests compile
- [ ] Run instrumented tests on device: `./scripts/run-instrumented-tests.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)