### PR TITLE
docs: Dump session context — crash fixes and testing

### DIFF
--- a/AndroidGarage/docs/TESTING.md
+++ b/AndroidGarage/docs/TESTING.md
@@ -13,8 +13,8 @@
 
 ## Current State
 
-- **234 unit tests** across 30 test files (19 androidApp + 3 domain + 4 usecase + 3 data + 1 data-local), including ViewModelTests, RepositoryTests, UseCaseTests, RemoteButtonStateMachineTest, data module integration tests, and 8 fake implementations across modules
-- **18 instrumented tests** across 3 test files (Room sanity, DI graph, navigation smoke)
+- **235 unit tests** across 31 test files (20 androidApp + 3 domain + 4 usecase + 3 data + 1 data-local), including ViewModelTests, RepositoryTests, UseCaseTests, RemoteButtonStateMachineTest, data module integration tests, and 8 fake implementations across modules
+- **25 instrumented tests** across 5 test files (Room sanity, DI graph, navigation smoke, state restoration, configuration change)
 - **CI architecture:** pre-submit (`ci.yml` → `ci-checks.yml`) + post-merge (`ci-post-merge.yml` → `ci-checks.yml` + instrumented tests)
 - **CI gate jobs:** `CI Complete` (PRs), `Post-Merge Complete` (main) — single check-run names for branch protection and release script
 - **CI checks:** unit tests (3 build variants), Spotless formatting (all modules), Detekt, Android Lint, screenshot test compilation, debug APK build, release AAB build
@@ -24,7 +24,7 @@
 - **Safety guardrails:** git hooks warn on Room entity changes, block push to main, enforce squash merge, block direct screenshot Gradle tasks, block absolute paths to gradlew
 - **DI system:** kotlin-inject (Hilt fully removed as of Phase 3), Ktor HTTP (Retrofit fully removed as of Phase 4)
 - **Navigation:** Navigation 3 (Nav2 fully removed, enforcement check blocks re-introduction)
-- **Architecture enforcement:** ArchitectureCheckTask (module deps), SingletonGuardTask (DB/Settings/HTTP scoping), LayerImportCheckTask (ViewModel→UseCase, UseCase→domain boundaries)
+- **Architecture enforcement:** ArchitectureCheckTask (module deps), SingletonGuardTask (DB/Settings/HTTP scoping), LayerImportCheckTask (ViewModel→UseCase, UseCase→domain boundaries), RememberSaveableGuardTask (blocks unsafe rememberSaveable without saver)
 - **Test coverage:** Only `RoomAppLoggerRepository` exempt (requires Android Context for CSV export)
 - **Completed:** Phase 1 (CI hardening), Phase 2 (network error tests), Phase 3 (auth token fix + UseCase tests + AuthBridge extraction), Phase 4 (state machine completeness), Phase 5.2-5.3 (release safety), Phase 6.1 (ESLint migration), Phase 7 (instrumented tests)
 - **Remaining:** Phase 6.2 (server contract tests)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,8 @@ Use `./scripts/release-android.sh` — never create or push tags directly (hooks
 ./scripts/release-android.sh              # Interactive (terminal only)
 ./scripts/release-android.sh --check      # Print latest + next tag
 ./scripts/release-android.sh --confirm-tag android/N  # Non-interactive
+./scripts/release-android.sh --confirm-tag android/N --confirm-hash android/M  # Rollback to old tag
+./scripts/release-android.sh --confirm-tag android/N --skip-validation  # Skip validation gate
 ./scripts/release-android.sh --dry-run    # Preview without releasing
 ```
 
@@ -217,7 +219,7 @@ gh pr update-branch <number>
 
 **Watch for PR starvation:** When many PRs queue up, the last one keeps getting pushed back as others merge ahead of it. Each merge makes it stale, requiring another CI run. If a PR has been open for a long time, prioritize merging it before creating new ones.
 
-**Auto-merge race condition:** Never push fix commits to a PR that has auto-merge enabled. The squash merge may execute before the fix arrives, losing the fix silently. If a PR needs a fix after `gh pr merge --auto` is set, check `gh pr view N --json state` first — if still open, create a NEW PR for the fix instead.
+**Auto-merge race condition:** Never push commits to a PR that has auto-merge enabled. The squash merge may execute before the push arrives, losing commits silently. A guardrail hook blocks `git push` when auto-merge is active on the target PR. If a PR needs changes after `gh pr merge --auto` is set, disable auto-merge first, push, then re-enable.
 
 ### Dev Mode
 Toggle: `touch .claude/.dev-mode` (enable) / `rm .claude/.dev-mode` (disable).
@@ -237,7 +239,7 @@ When active, a Stop hook blocks Claude from ending its turn and directs it to:
 
 ### Claude Hooks (.claude/hooks/)
 - **block-admin-bypass.sh** — Denies `--admin` on PR merges
-- **git-guardrails.sh** — Blocks push to main, force push, destructive commands; enforces squash merge; warns on stale validation
+- **git-guardrails.sh** — Blocks push to main, force push, destructive commands; enforces squash merge; warns on stale validation; blocks push to branches with auto-merge enabled
 - **check-pr-backlog.sh** — Warns at 5+ open PRs, blocks at 10+
 - **dev-mode.sh** — Keeps Claude working when `.claude/.dev-mode` exists
 - **warn-shell-loops.sh** — Warns on `for`/`while` loops (prefer separate Bash calls)


### PR DESCRIPTION
## Summary
- TESTING.md: updated test counts (235 unit, 25 instrumented), added rememberSaveable guard
- CLAUDE.md: documented release script overrides (--confirm-hash, --skip-validation), auto-merge guard hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)