### PR TITLE
fix: Remove CI check from release workflow

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -12,47 +12,8 @@ permissions:
   contents: read
 
 jobs:
-  verify-ci:
-    name: Verify CI Passed
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Get tagged commit SHA
-        id: get-sha
-        run: |
-          TAG="${GITHUB_REF#refs/tags/}"
-          SHA=$(gh api repos/${{ github.repository }}/git/ref/tags/${TAG} --jq '.object.sha' 2>/dev/null || echo "")
-          if [ -z "$SHA" ]; then
-            SHA="${GITHUB_SHA}"
-          fi
-          echo "sha=$SHA" >> $GITHUB_OUTPUT
-          echo "Tagged commit: $SHA"
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Verify CI passed on tagged commit
-        run: |
-          TAG_SHA="${{ steps.get-sha.outputs.sha }}"
-          echo "Checking CI status for commit $TAG_SHA..."
-
-          # Check the single post-merge gate job
-          POST_MERGE=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA/check-runs" \
-            --jq '[.check_runs[] | select(.name == "Post-Merge Complete")] | last | .conclusion')
-
-          echo "Post-Merge Complete: $POST_MERGE"
-
-          if [ "$POST_MERGE" != "success" ]; then
-            echo "::error::Post-Merge Complete concluded '$POST_MERGE', expected 'success'"
-            exit 1
-          fi
-
-          echo "Post-merge CI passed on commit $TAG_SHA"
-        env:
-          GH_TOKEN: ${{ github.token }}
-
   release:
     name: Build and Deploy to Internal
-    needs: verify-ci
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Summary
- Removes the `verify-ci` job from `release-android.yml`
- The workflow now trusts the tag and builds immediately
- CI validation is the release script's job (local `validate.sh`), not the workflow's
- This caused android/142 to fail because post-merge CI hadn't finished when the tag was pushed

## Test plan
- [ ] Next release tag triggers build without CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)