### PR TITLE
docs: Require validation before release, ask user before skipping

### DIFF
--- a/.claude/skills/release-android/SKILL.md
+++ b/.claude/skills/release-android/SKILL.md
@@ -16,35 +16,40 @@ git checkout main && git pull
 git status  # Must be clean
 ```
 
-Verify CI is green on latest main:
+### 2. Run validation
+
+**Always run validation before releasing.** Do not skip this step.
+
 ```bash
-gh run list --branch main --limit 1 --json conclusion,headSha --jq '.[0]'
+./scripts/validate.sh
 ```
 
-### 2. Check release state
+If validation fails, fix the issue before releasing. Do NOT use `--skip-validation` unless the user explicitly confirms they want to release without validation (e.g., emergency rollback).
+
+### 3. Check release state
 
 ```bash
 scripts/release-android.sh --check
 ```
 
-This prints the latest tag and the computed next tag (`android/<N+1>`).
+This prints the latest tag and the computed next tag (`android/<N+1>`). Verify validation shows "passed".
 
-### 3. Cut the release
+### 4. Cut the release
 
 ```bash
 scripts/release-android.sh --confirm-tag android/N
 ```
 
-Where `N` is the next tag number from step 2. The `--confirm-tag` is a safety check — it must match the computed tag exactly (cannot override).
+Where `N` is the next tag number from step 3. The `--confirm-tag` is a safety check — it must match the computed tag exactly (cannot override).
 
 The script will:
 - Verify clean git state
 - Verify on main branch
-- Verify CI passed on HEAD
+- Verify validate.sh passed on HEAD
 - Create and push the tag
 - The tag triggers `.github/workflows/release-android.yml`
 
-### 4. Verify deployment
+### 5. Verify deployment
 
 Watch the release workflow:
 ```bash
@@ -57,4 +62,5 @@ gh run watch <run-id>
 - **Never push tags directly** — hooks block `git tag` (except `git tag -l`). Only the release script can create tags.
 - **Never deploy to production** — internal track only.
 - **Tag version = versionCode** — `android/120` → `versionCode=120`.
-- **Don't skip CI** — the script verifies CI passed before tagging.
+- **Always validate first** — run `./scripts/validate.sh` before every release.
+- **Never use `--skip-validation` without asking the user.** It exists for emergencies only (rollbacks, hotfixes). If validation hasn't passed, tell the user and ask whether to run validation or skip it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,11 +163,12 @@ Use `./scripts/release-android.sh` — never create or push tags directly (hooks
 ./scripts/release-android.sh --check      # Print latest + next tag
 ./scripts/release-android.sh --confirm-tag android/N  # Non-interactive
 ./scripts/release-android.sh --confirm-tag android/N --confirm-hash android/M  # Rollback to old tag
-./scripts/release-android.sh --confirm-tag android/N --skip-validation  # Skip validation gate
 ./scripts/release-android.sh --dry-run    # Preview without releasing
 ```
 
 The script computes the next tag as `android/<highest + 1>`. The `--confirm-tag` flag is a safety check — it must match the computed tag, it cannot override it. Deploys to Play Store internal track only — never production.
+
+**Validation is required by default.** Run `./scripts/validate.sh` before releasing. If validation hasn't passed on the commit, the release script will block. `--skip-validation` exists for emergencies (e.g., rollbacks to old tags) but should NOT be used routinely. Always ask the user before using `--skip-validation`.
 
 ### Releasing Firebase Server
 Use `./scripts/release-firebase.sh` — same pattern as Android releases.

--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -242,8 +242,12 @@ if [ -n "$CONFIRM_HASH" ]; then
 fi
 
 # === Gate 3: Must have passed validate.sh — override with --skip-validation ===
+# --skip-validation is for emergencies only (e.g., rollbacks to old tags).
+# Normal releases should ALWAYS pass validate.sh first.
 if [ "$SKIP_VALIDATION" = true ]; then
-    echo -e "${YELLOW}Warning: Validation check skipped (--skip-validation).${RESET}"
+    echo -e "${RED}WARNING: Validation check skipped (--skip-validation).${RESET}"
+    echo "  This should only be used for emergencies (rollbacks, hotfixes)."
+    echo "  Normal releases should always run ./scripts/validate.sh first."
     echo ""
 elif check_validation; then
     echo -e "${GREEN}Validation passed for this commit.${RESET}"


### PR DESCRIPTION
## Summary
- Release skill: always run `validate.sh` before releasing, never skip without user confirmation
- CLAUDE.md: document that `--skip-validation` is for emergencies only
- Release script: stronger warning when `--skip-validation` is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)