### PR TITLE
feat: Tab back stack with testable navigateToTab()

### DIFF
--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/BackStackTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/BackStackTest.kt
@@ -1,0 +1,96 @@
+package com.chriscartland.garage.ui
+
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.espresso.Espresso
+import com.chriscartland.garage.MainActivity
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Instrumented tests for tab back stack behavior.
+ *
+ * Verifies that:
+ * - Non-Home tabs stack on Home (Back reveals Home)
+ * - Non-Home tabs replace each other (Back goes to Home, not previous tab)
+ * - Home tab is always the root
+ */
+class BackStackTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun backFromHistoryReturnsToHome() {
+        // Navigate to History
+        composeTestRule.onNodeWithText("History").performClick()
+        composeTestRule.waitForIdle()
+
+        // Press system Back
+        Espresso.pressBack()
+        composeTestRule.waitForIdle()
+
+        // Should be on Home, not exited
+        composeTestRule.onNodeWithText("Home").assertIsSelected()
+    }
+
+    @Test
+    fun backFromSettingsReturnsToHome() {
+        // Navigate to Settings
+        composeTestRule.onNodeWithText("Settings").performClick()
+        composeTestRule.waitForIdle()
+
+        // Press system Back
+        Espresso.pressBack()
+        composeTestRule.waitForIdle()
+
+        // Should be on Home
+        composeTestRule.onNodeWithText("Home").assertIsSelected()
+    }
+
+    @Test
+    fun settingsReplacesHistoryOnBackStack() {
+        // Navigate: Home → History → Settings
+        composeTestRule.onNodeWithText("History").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Settings").performClick()
+        composeTestRule.waitForIdle()
+
+        // Press Back — should go to Home, NOT History
+        Espresso.pressBack()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("Home").assertIsSelected()
+    }
+
+    @Test
+    fun tappingCurrentTabIsNoOp() {
+        // Navigate to History
+        composeTestRule.onNodeWithText("History").performClick()
+        composeTestRule.waitForIdle()
+
+        // Tap History again
+        composeTestRule.onNodeWithText("History").performClick()
+        composeTestRule.waitForIdle()
+
+        // Still on History, Back still goes to Home
+        Espresso.pressBack()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Home").assertIsSelected()
+    }
+
+    @Test
+    fun tappingHomePopsToHome() {
+        // Navigate to Settings
+        composeTestRule.onNodeWithText("Settings").performClick()
+        composeTestRule.waitForIdle()
+
+        // Tap Home
+        composeTestRule.onNodeWithText("Home").performClick()
+        composeTestRule.waitForIdle()
+
+        // Should be on Home
+        composeTestRule.onNodeWithText("Home").assertIsSelected()
+    }
+}

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -172,11 +172,7 @@ fun AppNavigation(
         bottomBar = {
             BottomNavigationBar(
                 currentScreen = backStack.lastOrNull(),
-                onTabSelected = { screen ->
-                    // Replace the back stack with a single tab screen.
-                    backStack.clear()
-                    backStack.add(screen)
-                },
+                onTabSelected = { screen -> navigateToTab(backStack, screen) },
             )
         },
     ) { innerPadding ->
@@ -243,6 +239,36 @@ fun BottomNavigationBar(
                 selected = currentScreen == tab.screen,
                 onClick = { onTabSelected(tab.screen) },
             )
+        }
+    }
+}
+
+/**
+ * Navigate to a tab screen.
+ *
+ * Home is always at the bottom of the stack. Non-Home tabs replace each other
+ * on top of Home. The stack is always `[Home]` or `[Home, <tab>]` (max depth 2).
+ *
+ * - Tap Home → pop to Home
+ * - Tap current tab → no-op
+ * - Tap different tab → replace non-Home tab on top
+ * - Back from non-Home → reveals Home
+ * - Back from Home → exits app
+ */
+fun navigateToTab(
+    backStack: MutableList<Screen>,
+    screen: Screen,
+) {
+    when {
+        screen is Screen.Home -> {
+            while (backStack.size > 1) backStack.removeAt(backStack.lastIndex)
+        }
+        backStack.lastOrNull() == screen -> {
+            // Already on this tab, no-op.
+        }
+        else -> {
+            while (backStack.size > 1) backStack.removeAt(backStack.lastIndex)
+            backStack.add(screen)
         }
     }
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -178,7 +178,7 @@ fun AppNavigation(
     ) { innerPadding ->
         NavDisplay(
             backStack = backStack,
-            onBack = { backStack.removeLastOrNull() },
+            onBack = { if (backStack.size > 1) backStack.removeAt(backStack.lastIndex) },
             entryDecorators = listOf(
                 rememberSaveableStateHolderNavEntryDecorator<Screen>(),
                 rememberViewModelStoreNavEntryDecorator<Screen>(),

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/NavigateToTabTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/NavigateToTabTest.kt
@@ -105,14 +105,14 @@ class NavigateToTabTest {
     @Test
     fun backFromHistoryRevealsHome() {
         val stack = backStack(Screen.Home, Screen.History)
-        stack.removeLast() // simulate system back
+        stack.removeAt(stack.lastIndex) // simulate system back
         assertEquals(listOf(Screen.Home), stack.toList())
     }
 
     @Test
     fun backFromSettingsRevealsHome() {
         val stack = backStack(Screen.Home, Screen.Profile)
-        stack.removeLast() // simulate system back
+        stack.removeAt(stack.lastIndex) // simulate system back
         assertEquals(listOf(Screen.Home), stack.toList())
     }
 
@@ -136,7 +136,7 @@ class NavigateToTabTest {
 
         // Home → Settings → Back → Home
         navigateToTab(stack, Screen.Profile)
-        stack.removeLast()
+        stack.removeAt(stack.lastIndex)
         assertEquals(listOf(Screen.Home), stack.toList())
     }
 }

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/NavigateToTabTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/NavigateToTabTest.kt
@@ -1,0 +1,142 @@
+package com.chriscartland.garage.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests for [navigateToTab] back stack management.
+ *
+ * The back stack rule: Home is always at the bottom, non-Home tabs replace
+ * each other on top. Stack is always [Home] or [Home, <tab>]. Max depth 2.
+ */
+class NavigateToTabTest {
+    private fun backStack(vararg screens: Screen): MutableList<Screen> = mutableListOf(*screens)
+
+    @Test
+    fun initialStateIsHome() {
+        val stack = backStack(Screen.Home)
+        assertEquals(listOf(Screen.Home), stack.toList())
+    }
+
+    @Test
+    fun tapHistoryFromHome() {
+        val stack = backStack(Screen.Home)
+        navigateToTab(stack, Screen.History)
+        assertEquals(listOf(Screen.Home, Screen.History), stack.toList())
+    }
+
+    @Test
+    fun tapSettingsFromHome() {
+        val stack = backStack(Screen.Home)
+        navigateToTab(stack, Screen.Profile)
+        assertEquals(listOf(Screen.Home, Screen.Profile), stack.toList())
+    }
+
+    @Test
+    fun tapSettingsReplacesHistory() {
+        val stack = backStack(Screen.Home, Screen.History)
+        navigateToTab(stack, Screen.Profile)
+        assertEquals(listOf(Screen.Home, Screen.Profile), stack.toList())
+    }
+
+    @Test
+    fun tapHistoryReplacesSettings() {
+        val stack = backStack(Screen.Home, Screen.Profile)
+        navigateToTab(stack, Screen.History)
+        assertEquals(listOf(Screen.Home, Screen.History), stack.toList())
+    }
+
+    @Test
+    fun tapHomeFromHistoryPopsToHome() {
+        val stack = backStack(Screen.Home, Screen.History)
+        navigateToTab(stack, Screen.Home)
+        assertEquals(listOf(Screen.Home), stack.toList())
+    }
+
+    @Test
+    fun tapHomeFromSettingsPopsToHome() {
+        val stack = backStack(Screen.Home, Screen.Profile)
+        navigateToTab(stack, Screen.Home)
+        assertEquals(listOf(Screen.Home), stack.toList())
+    }
+
+    @Test
+    fun tapHomeWhenAlreadyOnHomeIsNoOp() {
+        val stack = backStack(Screen.Home)
+        navigateToTab(stack, Screen.Home)
+        assertEquals(listOf(Screen.Home), stack.toList())
+    }
+
+    @Test
+    fun tapHistoryWhenAlreadyOnHistoryIsNoOp() {
+        val stack = backStack(Screen.Home, Screen.History)
+        navigateToTab(stack, Screen.History)
+        assertEquals(listOf(Screen.Home, Screen.History), stack.toList())
+    }
+
+    @Test
+    fun tapSettingsWhenAlreadyOnSettingsIsNoOp() {
+        val stack = backStack(Screen.Home, Screen.Profile)
+        navigateToTab(stack, Screen.Profile)
+        assertEquals(listOf(Screen.Home, Screen.Profile), stack.toList())
+    }
+
+    @Test
+    fun stackNeverExceedsDepthTwo() {
+        val stack = backStack(Screen.Home)
+        navigateToTab(stack, Screen.History)
+        navigateToTab(stack, Screen.Profile)
+        navigateToTab(stack, Screen.History)
+        navigateToTab(stack, Screen.Profile)
+        assert(stack.size <= 2) { "Stack depth ${stack.size} exceeds max 2" }
+    }
+
+    @Test
+    fun homeAlwaysAtBottom() {
+        val stack = backStack(Screen.Home)
+        navigateToTab(stack, Screen.History)
+        assertEquals(Screen.Home, stack.first())
+        navigateToTab(stack, Screen.Profile)
+        assertEquals(Screen.Home, stack.first())
+        navigateToTab(stack, Screen.Home)
+        assertEquals(Screen.Home, stack.first())
+    }
+
+    @Test
+    fun backFromHistoryRevealsHome() {
+        val stack = backStack(Screen.Home, Screen.History)
+        stack.removeLast() // simulate system back
+        assertEquals(listOf(Screen.Home), stack.toList())
+    }
+
+    @Test
+    fun backFromSettingsRevealsHome() {
+        val stack = backStack(Screen.Home, Screen.Profile)
+        stack.removeLast() // simulate system back
+        assertEquals(listOf(Screen.Home), stack.toList())
+    }
+
+    @Test
+    fun fullNavigationSequence() {
+        val stack = backStack(Screen.Home)
+
+        // Home → History
+        navigateToTab(stack, Screen.History)
+        assertEquals(Screen.History, stack.last())
+
+        // History → Settings (replaces, doesn't stack)
+        navigateToTab(stack, Screen.Profile)
+        assertEquals(Screen.Profile, stack.last())
+        assertEquals(2, stack.size)
+
+        // Settings → Home (pop)
+        navigateToTab(stack, Screen.Home)
+        assertEquals(Screen.Home, stack.last())
+        assertEquals(1, stack.size)
+
+        // Home → Settings → Back → Home
+        navigateToTab(stack, Screen.Profile)
+        stack.removeLast()
+        assertEquals(listOf(Screen.Home), stack.toList())
+    }
+}


### PR DESCRIPTION
## Summary
- Home is always the root of the back stack
- Non-Home tabs replace each other on top (never stack on each other)
- Back from non-Home reveals Home, Back from Home exits app
- Extracted `navigateToTab()` function for unit testability

## Tests
- **14 unit tests** (`NavigateToTabTest`): all navigation rules, depth invariants, full sequences
- **5 instrumented tests** (`BackStackTest`): real back button with Espresso, tab replacement, no-op taps

## Test plan
- [ ] Tap History → Back → Home (not exit)
- [ ] Tap History → Tap Settings → Back → Home (not History)
- [ ] Tap Home when on Home → no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)