### PR TITLE
refactor: Move duration formatting to shared domain (Phase 36)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/TimeFormats.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/TimeFormats.kt
@@ -23,12 +23,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import com.chriscartland.garage.domain.model.FriendlyDuration
 import kotlinx.coroutines.delay
 import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
+import kotlin.time.toKotlinDuration
 
 /**
  * Convert Unix timestamp seconds to a human-readable date string.
@@ -55,37 +57,12 @@ fun Long.toFriendlyTimeShort(): String? =
         .format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT))
 
 /**
- * Convert Unix timestamp seconds to a human-readable duration string.
+ * Convert a [java.time.Duration] to a human-readable string.
  *
- * 0:59
- * 59:59
- * 23:59:59
- * 1 day, 23:59:59
- * 2 days, 23:59:59
+ * Delegates to [FriendlyDuration.format] (shared KMP code) after converting
+ * from java.time.Duration to kotlin.time.Duration.
  */
-fun Duration.toFriendlyDuration(): String {
-    val days = toDays().coerceAtLeast(0L)
-    val hours = (toHours() % 24).coerceAtLeast(0L)
-    val minutes = (toMinutes() % 60).coerceAtLeast(0L)
-    val seconds = (seconds % 60).coerceAtLeast(0L)
-
-    return when {
-        days > 0 -> String.format(
-            "%d day%s, %dh %dm %ds",
-            days,
-            if (days > 1) "s" else "",
-            hours,
-            minutes,
-            seconds,
-        )
-
-        hours > 0 -> String.format("%dh %dm %ds", hours, minutes, seconds)
-
-        minutes > 0 -> String.format("%dm %ds", minutes, seconds)
-
-        else -> String.format("%ds", seconds)
-    }
-}
+fun Duration.toFriendlyDuration(): String = FriendlyDuration.format(this.toKotlinDuration())
 
 /**
  * Composable that updates periodically based on the duration since a specific time.

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/theme/DoorStatusColorScheme.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/theme/DoorStatusColorScheme.kt
@@ -20,8 +20,10 @@ package com.chriscartland.garage.ui.theme
 import androidx.compose.ui.graphics.Color
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
+import com.chriscartland.garage.domain.model.Staleness
 import java.time.Duration
 import java.time.Instant
+import kotlin.time.toKotlinDuration
 
 /**
  * Color scheme selected by the app theme.
@@ -126,7 +128,8 @@ fun DoorEvent?.isStale(
     maxAge: Duration,
     now: Instant = Instant.now(),
 ): Boolean =
-    this?.lastCheckInTimeSeconds?.let { utcSeconds ->
-        val limit = now.minusSeconds(maxAge.seconds)
-        Instant.ofEpochSecond(utcSeconds).isBefore(limit)
-    } == true
+    Staleness.isStale(
+        lastCheckInTimeSeconds = this?.lastCheckInTimeSeconds,
+        maxAge = maxAge.toKotlinDuration(),
+        nowEpochSeconds = now.epochSecond,
+    )

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/FriendlyDuration.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/FriendlyDuration.kt
@@ -1,0 +1,27 @@
+package com.chriscartland.garage.domain.model
+
+import kotlin.time.Duration
+
+/**
+ * Format a [Duration] as a human-readable string.
+ *
+ * Examples: "0s", "45s", "5m 30s", "2h 15m 30s", "1 day, 0h 0m 0s", "3 days, 5h 30m 0s"
+ *
+ * Pure arithmetic — no locale or platform dependencies.
+ */
+object FriendlyDuration {
+    fun format(duration: Duration): String {
+        val totalSeconds = duration.inWholeSeconds.coerceAtLeast(0L)
+        val days = totalSeconds / 86400
+        val hours = (totalSeconds % 86400) / 3600
+        val minutes = (totalSeconds % 3600) / 60
+        val seconds = totalSeconds % 60
+
+        return when {
+            days > 0 -> "$days day${if (days > 1) "s" else ""}, ${hours}h ${minutes}m ${seconds}s"
+            hours > 0 -> "${hours}h ${minutes}m ${seconds}s"
+            minutes > 0 -> "${minutes}m ${seconds}s"
+            else -> "${seconds}s"
+        }
+    }
+}

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/Staleness.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/Staleness.kt
@@ -1,0 +1,23 @@
+package com.chriscartland.garage.domain.model
+
+import kotlin.time.Duration
+
+/**
+ * Check whether a [DoorEvent] is stale (last check-in too long ago).
+ *
+ * Pure arithmetic on Unix timestamps — no platform dependencies.
+ *
+ * @param maxAge Maximum acceptable age before data is considered stale.
+ * @param nowEpochSeconds Current time as Unix epoch seconds.
+ */
+object Staleness {
+    fun isStale(
+        lastCheckInTimeSeconds: Long?,
+        maxAge: Duration,
+        nowEpochSeconds: Long,
+    ): Boolean {
+        if (lastCheckInTimeSeconds == null) return false
+        val limitSeconds = nowEpochSeconds - maxAge.inWholeSeconds
+        return lastCheckInTimeSeconds < limitSeconds
+    }
+}

--- a/AndroidGarage/domain/src/commonTest/kotlin/com/chriscartland/garage/domain/model/FriendlyDurationTest.kt
+++ b/AndroidGarage/domain/src/commonTest/kotlin/com/chriscartland/garage/domain/model/FriendlyDurationTest.kt
@@ -1,0 +1,55 @@
+package com.chriscartland.garage.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+class FriendlyDurationTest {
+    @Test
+    fun zeroDuration() {
+        assertEquals("0s", FriendlyDuration.format(0.seconds))
+    }
+
+    @Test
+    fun secondsOnly() {
+        assertEquals("45s", FriendlyDuration.format(45.seconds))
+    }
+
+    @Test
+    fun minutesAndSeconds() {
+        assertEquals("5m 30s", FriendlyDuration.format(5.minutes + 30.seconds))
+    }
+
+    @Test
+    fun hoursMinutesSeconds() {
+        assertEquals("2h 15m 30s", FriendlyDuration.format(2.hours + 15.minutes + 30.seconds))
+    }
+
+    @Test
+    fun exactlyOneHour() {
+        assertEquals("1h 0m 0s", FriendlyDuration.format(1.hours))
+    }
+
+    @Test
+    fun exactlyOneMinute() {
+        assertEquals("1m 0s", FriendlyDuration.format(1.minutes))
+    }
+
+    @Test
+    fun oneDay() {
+        assertEquals("1 day, 0h 0m 0s", FriendlyDuration.format(1.days))
+    }
+
+    @Test
+    fun multipleDays() {
+        assertEquals("3 days, 5h 30m 0s", FriendlyDuration.format(3.days + 5.hours + 30.minutes))
+    }
+
+    @Test
+    fun negativeDurationTreatedAsZero() {
+        assertEquals("0s", FriendlyDuration.format((-5).seconds))
+    }
+}

--- a/AndroidGarage/domain/src/commonTest/kotlin/com/chriscartland/garage/domain/model/StalenessTest.kt
+++ b/AndroidGarage/domain/src/commonTest/kotlin/com/chriscartland/garage/domain/model/StalenessTest.kt
@@ -1,0 +1,52 @@
+package com.chriscartland.garage.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
+
+class StalenessTest {
+    @Test
+    fun notStaleWhenRecent() {
+        assertFalse(
+            Staleness.isStale(
+                lastCheckInTimeSeconds = 1000L,
+                maxAge = 5.minutes,
+                nowEpochSeconds = 1100L, // 100s ago, under 5min
+            ),
+        )
+    }
+
+    @Test
+    fun staleWhenOld() {
+        assertTrue(
+            Staleness.isStale(
+                lastCheckInTimeSeconds = 1000L,
+                maxAge = 5.minutes,
+                nowEpochSeconds = 1400L, // 400s ago, over 5min
+            ),
+        )
+    }
+
+    @Test
+    fun exactlyAtBoundaryIsNotStale() {
+        assertFalse(
+            Staleness.isStale(
+                lastCheckInTimeSeconds = 1000L,
+                maxAge = 5.minutes,
+                nowEpochSeconds = 1300L, // exactly 5min
+            ),
+        )
+    }
+
+    @Test
+    fun nullTimestampIsNotStale() {
+        assertFalse(
+            Staleness.isStale(
+                lastCheckInTimeSeconds = null,
+                maxAge = 5.minutes,
+                nowEpochSeconds = 9999L,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- `FriendlyDuration.format()` in domain/commonMain — pure `kotlin.time.Duration` formatting, no platform deps
- `Staleness.isStale()` in domain/commonMain — pure `Long` timestamp comparison
- Android callers delegate to shared functions (thin adapter via `toKotlinDuration()`)
- 13 new shared tests (9 duration + 4 staleness)
- Locale-aware formatting (`toFriendlyDate`, `toFriendlyTime`) stays in androidApp

## Phase 36 complete
Pure math formatting is now in the shared domain module, usable from iOS.
Locale-aware formatting stays per-platform as planned.

## Test plan
- [x] All existing TimeFormatsTest pass (delegate to shared)
- [x] 13 new domain tests pass
- [x] Full validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)