### PR TITLE
feat: Target SDK 36 with predictive back fade transitions

### DIFF
--- a/AndroidGarage/androidApp/build.gradle.kts
+++ b/AndroidGarage/androidApp/build.gradle.kts
@@ -57,7 +57,7 @@ android {
     defaultConfig {
         applicationId = "com.chriscartland.garage"
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
         // versionCode comes from android/N tag via -PVERSION_CODE=N
         // Falls back to 1 for local development builds
         val tagVersionCode = (project.findProperty("VERSION_CODE") as? String)?.toIntOrNull()

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -17,6 +17,11 @@
 
 package com.chriscartland.garage.ui
 
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -75,6 +80,11 @@ fun GarageApp(
         )
     }
 }
+
+private const val NAV_ANIM_DURATION = 300
+
+/** Reusable tween with FastOutSlowIn easing for all nav animations. */
+private inline fun <reified T> navTween() = tween<T>(NAV_ANIM_DURATION, easing = FastOutSlowInEasing)
 
 /**
  * Type-safe navigation routes.
@@ -179,6 +189,9 @@ fun AppNavigation(
         NavDisplay(
             backStack = backStack,
             onBack = { if (backStack.size > 1) backStack.removeAt(backStack.lastIndex) },
+            transitionSpec = { fadeIn(navTween()) togetherWith fadeOut(navTween()) },
+            popTransitionSpec = { fadeIn(navTween()) togetherWith fadeOut(navTween()) },
+            predictivePopTransitionSpec = { fadeIn(navTween()) togetherWith fadeOut(navTween()) },
             entryDecorators = listOf(
                 rememberSaveableStateHolderNavEntryDecorator<Screen>(),
                 rememberViewModelStoreNavEntryDecorator<Screen>(),

--- a/AndroidGarage/docs/MIGRATION.md
+++ b/AndroidGarage/docs/MIGRATION.md
@@ -498,6 +498,59 @@ Moved pure math formatting to shared domain module:
 - Data tests use real repos with fake data sources (#219)
 - Deleted `AndroidAppLoggerRepository` wrapper — replaced with `exportAppLogCsvToUri()` function (#217)
 
+### Phase 40: SDK 36 + Predictive Back
+
+**Goal:** Target Android 16 (SDK 36) and add predictive back fade transitions.
+
+**Changes:**
+- Bump `targetSdk` from 35 to 36 in androidApp and macrobenchmark
+- Add `transitionSpec`, `popTransitionSpec`, `predictivePopTransitionSpec` with fade animations to NavDisplay
+- Extract `navTween()` helper for consistent animation timing (300ms, FastOutSlowIn)
+- App exit (back-to-home) uses default system predictive back animation
+
+### Phase 41: Adaptive Layout (Level 3)
+
+**Goal:** Optimize UI for tablets, foldables, and large screens (600dp+). SDK 36 ignores fixed orientation constraints on large screens, so the app must look good at any size.
+
+**Changes:**
+
+#### 41.1 WindowSizeClass Detection
+- Add `material3-window-size-class` dependency
+- Call `calculateWindowSizeClass()` in MainActivity
+- Pass size class down via CompositionLocal or parameter
+
+#### 41.2 Adaptive Navigation
+- **Compact** (< 600dp): Bottom NavigationBar (current)
+- **Medium** (600-840dp): NavigationRail on the left
+- **Expanded** (840dp+): Persistent NavigationDrawer
+
+Use `material3-adaptive-navigation-suite` (`NavigationSuiteScaffold`) to handle this automatically.
+
+#### 41.3 Home Screen Adaptive Layout
+- **Compact**: Vertical stack — door status card on top, remote button below (current)
+- **Medium/Expanded**: Side-by-side — door status on left, remote button on right
+- Remove `widthIn(max = 192.dp)` cap on remote button; use `fillMaxWidth(0.5f)` on expanded
+
+#### 41.4 History Screen Two-Column Grid
+- **Compact**: Single-column LazyColumn (current)
+- **Medium/Expanded**: Two-column LazyVerticalGrid with `GridCells.Fixed(2)`
+
+#### 41.5 Settings Screen Adaptive Width
+- **Compact**: Full-width cards (current)
+- **Expanded**: Constrain content to `maxWidth = 600.dp` centered, avoiding overly wide cards
+
+#### 41.6 Foldable Support
+- Add `material3-adaptive` dependency for `FoldingFeature` awareness
+- Avoid placing interactive elements on the fold hinge
+- Test with foldable emulator profiles
+
+**Dependencies:** `material3-window-size-class`, `material3-adaptive-navigation-suite`
+
+**Testing:**
+- Preview composables at Compact, Medium, Expanded widths
+- Screenshot tests for each size class
+- Manual testing on tablet emulator (Pixel Tablet, 10.1")
+
 ### Phase 38: iOS target (SwiftUI)
 
 **Goal:** Add iOS app consuming shared KMP modules via SwiftUI.

--- a/AndroidGarage/macrobenchmark/build.gradle.kts
+++ b/AndroidGarage/macrobenchmark/build.gradle.kts
@@ -35,7 +35,7 @@ android {
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
## Summary
- Bump `targetSdk` from 35 to 36 (Android 16) in androidApp and macrobenchmark
- Add fade transitions between tabs via `NavDisplay` `transitionSpec`/`popTransitionSpec`/`predictivePopTransitionSpec`
- Extract `navTween()` helper (300ms, FastOutSlowIn) matching battery-butler's animation architecture
- App exit (back-to-home) uses default system predictive back animation
- Document Phase 41 (adaptive layout) plan in MIGRATION.md

## Test plan
- [ ] Verify fade transition between tabs on device
- [ ] Verify predictive back gesture shows fade animation
- [ ] Verify back-to-home uses system default animation
- [ ] Run `./scripts/validate.sh` — passed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)