### PR TITLE
fix: Snooze Loading state stuck forever on fetch failure

### DIFF
--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepository.kt
@@ -55,8 +55,14 @@ class NetworkSnoozeRepository(
                 is NetworkResult.Success -> {
                     _snoozeState.value = snoozeStateFromEndTime(result.data)
                 }
-                is NetworkResult.HttpError -> Logger.e { "Snooze fetch HTTP ${result.code}" }
-                NetworkResult.ConnectionFailed -> Logger.e { "Snooze fetch connection failed" }
+                is NetworkResult.HttpError -> {
+                    Logger.e { "Snooze fetch HTTP ${result.code}" }
+                    clearLoadingState()
+                }
+                NetworkResult.ConnectionFailed -> {
+                    Logger.e { "Snooze fetch connection failed" }
+                    clearLoadingState()
+                }
             }
         }
     }
@@ -95,6 +101,13 @@ class NetworkSnoozeRepository(
                     return
                 }
             }
+        }
+    }
+
+    /** If still Loading (first fetch), fall back to NotSnoozing so the UI doesn't show "Loading..." forever. */
+    private fun clearLoadingState() {
+        if (_snoozeState.value is SnoozeState.Loading) {
+            _snoozeState.value = SnoozeState.NotSnoozing
         }
     }
 

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/PushRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/PushRepositoryTest.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 
 /**
  * Tests use real [CachedServerConfigRepository] with [FakeNetworkConfigDataSource],
@@ -105,5 +106,30 @@ class SnoozeRepositoryTest {
             )
             // State remains Loading — no crash, no error propagation
             assertEquals(SnoozeState.Loading, repo.snoozeState.value)
+        }
+
+    @Test
+    fun fetchSnoozeStatusTransitionsFromLoadingToNotSnoozing() =
+        runTest {
+            assertEquals(SnoozeState.Loading, repo.snoozeState.value)
+            networkConfigDataSource.serverConfigResult = NetworkResult.Success(
+                ServerConfig(buildTimestamp = "test", remoteButtonBuildTimestamp = "test", remoteButtonPushKey = "key"),
+            )
+            networkButtonDataSource.fetchSnoozeResult = NetworkResult.Success(0L)
+            repo.fetchSnoozeStatus()
+            assertEquals(SnoozeState.NotSnoozing, repo.snoozeState.value)
+        }
+
+    @Test
+    fun fetchSnoozeStatusTransitionsFromLoadingEvenOnFailure() =
+        runTest {
+            assertEquals(SnoozeState.Loading, repo.snoozeState.value)
+            networkConfigDataSource.serverConfigResult = NetworkResult.Success(
+                ServerConfig(buildTimestamp = "test", remoteButtonBuildTimestamp = "test", remoteButtonPushKey = "key"),
+            )
+            networkButtonDataSource.fetchSnoozeResult = NetworkResult.ConnectionFailed
+            repo.fetchSnoozeStatus()
+            // Must not stay Loading — user would see "Loading..." forever
+            assertNotEquals(SnoozeState.Loading, repo.snoozeState.value)
         }
 }


### PR DESCRIPTION
## Summary
- Bug: if first snooze fetch failed, `SnoozeState.Loading` persisted forever — UI showed "Loading snooze status..." indefinitely
- Fix: `clearLoadingState()` transitions to `NotSnoozing` on failure, but only if still `Loading` (subsequent poll failures keep last known state)
- Two new tests: success fetch clears Loading, failed fetch also clears Loading

## Test plan
- [ ] `SnoozeRepositoryTest.fetchSnoozeStatusTransitionsFromLoadingToNotSnoozing` — passes
- [ ] `SnoozeRepositoryTest.fetchSnoozeStatusTransitionsFromLoadingEvenOnFailure` — passes (was failing before fix)
- [ ] `./scripts/validate.sh` — passed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)