### PR TITLE
test: Add snooze fetch coverage — ViewModel and repository

### DIFF
--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/PushRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/PushRepositoryTest.kt
@@ -132,4 +132,45 @@ class SnoozeRepositoryTest {
             // Must not stay Loading — user would see "Loading..." forever
             assertNotEquals(SnoozeState.Loading, repo.snoozeState.value)
         }
+
+    @Test
+    fun fetchSnoozeStatusReturnsSnoozingWhenEndTimeInFuture() =
+        runTest {
+            networkConfigDataSource.serverConfigResult = NetworkResult.Success(
+                ServerConfig(buildTimestamp = "test", remoteButtonBuildTimestamp = "test", remoteButtonPushKey = "key"),
+            )
+            // currentTimeSeconds returns 1000L (from setup), so 2000L is in the future
+            networkButtonDataSource.fetchSnoozeResult = NetworkResult.Success(2000L)
+            repo.fetchSnoozeStatus()
+            assertEquals(SnoozeState.Snoozing(2000L), repo.snoozeState.value)
+        }
+
+    @Test
+    fun fetchSnoozeStatusReturnsNotSnoozingWhenEndTimeInPast() =
+        runTest {
+            networkConfigDataSource.serverConfigResult = NetworkResult.Success(
+                ServerConfig(buildTimestamp = "test", remoteButtonBuildTimestamp = "test", remoteButtonPushKey = "key"),
+            )
+            // currentTimeSeconds returns 1000L (from setup), so 500L is in the past
+            networkButtonDataSource.fetchSnoozeResult = NetworkResult.Success(500L)
+            repo.fetchSnoozeStatus()
+            assertEquals(SnoozeState.NotSnoozing, repo.snoozeState.value)
+        }
+
+    @Test
+    fun subsequentFetchFailureKeepsLastKnownState() =
+        runTest {
+            networkConfigDataSource.serverConfigResult = NetworkResult.Success(
+                ServerConfig(buildTimestamp = "test", remoteButtonBuildTimestamp = "test", remoteButtonPushKey = "key"),
+            )
+            // First fetch succeeds — snoozing
+            networkButtonDataSource.fetchSnoozeResult = NetworkResult.Success(2000L)
+            repo.fetchSnoozeStatus()
+            assertEquals(SnoozeState.Snoozing(2000L), repo.snoozeState.value)
+
+            // Second fetch fails — should keep Snoozing, not revert to NotSnoozing
+            networkButtonDataSource.fetchSnoozeResult = NetworkResult.ConnectionFailed
+            repo.fetchSnoozeStatus()
+            assertEquals(SnoozeState.Snoozing(2000L), repo.snoozeState.value)
+        }
 }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModelTest.kt
@@ -102,6 +102,18 @@ class RemoteButtonViewModelTest {
     }
 
     @Test
+    fun fetchSnoozeStatusCallsThroughToRepository() =
+        runTest {
+            val viewModel = createViewModel()
+            assertEquals(0, snoozeRepository.fetchCount)
+
+            viewModel.fetchSnoozeStatus()
+            testDispatcher.scheduler.runCurrent()
+
+            assertEquals(1, snoozeRepository.fetchCount)
+        }
+
+    @Test
     fun snoozeStateFollowsRepository() =
         runTest {
             val viewModel = createViewModel()


### PR DESCRIPTION
## Summary
- **ViewModel test:** `fetchSnoozeStatus()` calls through to repository (checks `fetchCount`)
- **Data tests (real repo + fake data source):**
  - Future end time → `Snoozing(2000L)`
  - Past end time → `NotSnoozing`
  - Subsequent fetch failure keeps last known state (doesn't revert Snoozing → NotSnoozing)

## Test plan
- [ ] All new tests pass locally
- [ ] `./scripts/validate.sh` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)