### PR TITLE
refactor: AppLoggerViewModel uses LogAppEventUseCase + ObserveAppLogCountUseCase

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -65,6 +65,8 @@ import com.chriscartland.garage.usecase.FetchCurrentDoorEventUseCase
 import com.chriscartland.garage.usecase.FetchFcmStatusUseCase
 import com.chriscartland.garage.usecase.FetchRecentDoorEventsUseCase
 import com.chriscartland.garage.usecase.FetchSnoozeStatusUseCase
+import com.chriscartland.garage.usecase.LogAppEventUseCase
+import com.chriscartland.garage.usecase.ObserveAppLogCountUseCase
 import com.chriscartland.garage.usecase.ObserveSnoozeStateUseCase
 import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
 import com.chriscartland.garage.usecase.RegisterFcmUseCase
@@ -98,9 +100,16 @@ abstract class AppComponent(
 
     val appLoggerViewModel: DefaultAppLoggerViewModel
         @Provides get() = DefaultAppLoggerViewModel(
-            provideAppLoggerRepository(),
+            provideLogAppEventUseCase(),
+            provideObserveAppLogCountUseCase(),
             provideDispatcherProvider(),
         )
+
+    @Provides
+    fun provideLogAppEventUseCase(): LogAppEventUseCase = LogAppEventUseCase(provideAppLoggerRepository())
+
+    @Provides
+    fun provideObserveAppLogCountUseCase(): ObserveAppLogCountUseCase = ObserveAppLogCountUseCase(provideAppLoggerRepository())
 
     val appSettingsViewModel: DefaultAppSettingsViewModel
         @Provides get() = DefaultAppSettingsViewModel(provideAppSettings())

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppLoggerViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppLoggerViewModel.kt
@@ -21,7 +21,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.AppLoggerKeys
-import com.chriscartland.garage.domain.repository.AppLoggerRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -40,7 +39,8 @@ interface AppLoggerViewModel {
 }
 
 class DefaultAppLoggerViewModel(
-    private val appLoggerRepository: AppLoggerRepository,
+    private val logAppEvent: LogAppEventUseCase,
+    private val observeAppLogCount: ObserveAppLogCountUseCase,
     private val dispatchers: DispatcherProvider,
 ) : ViewModel(),
     AppLoggerViewModel {
@@ -69,51 +69,28 @@ class DefaultAppLoggerViewModel(
     override val timeWithoutFcmInExpectedRangeCount = _timeWithoutFcmInExpectedRangeCount
 
     init {
+        observeCount(AppLoggerKeys.INIT_CURRENT_DOOR, _initCurrentDoorCount)
+        observeCount(AppLoggerKeys.INIT_RECENT_DOOR, _initRecentDoorCount)
+        observeCount(AppLoggerKeys.USER_FETCH_CURRENT_DOOR, _userFetchCurrentDoorCount)
+        observeCount(AppLoggerKeys.USER_FETCH_RECENT_DOOR, _userFetchRecentDoorCount)
+        observeCount(AppLoggerKeys.FCM_DOOR_RECEIVED, _fcmReceivedDoorCount)
+        observeCount(AppLoggerKeys.FCM_SUBSCRIBE_TOPIC, _fcmSubscribeTopicCount)
+        observeCount(AppLoggerKeys.EXCEEDED_EXPECTED_TIME_WITHOUT_FCM, _exceededExpectedTimeWithoutFcmCount)
+        observeCount(AppLoggerKeys.TIME_WITHOUT_FCM_IN_EXPECTED_RANGE, _timeWithoutFcmInExpectedRangeCount)
+    }
+
+    private fun observeCount(
+        key: String,
+        target: MutableStateFlow<Long>,
+    ) {
         viewModelScope.launch(dispatchers.io) {
-            appLoggerRepository.countKey(AppLoggerKeys.INIT_CURRENT_DOOR).collect {
-                _initCurrentDoorCount.value = it
-            }
-        }
-        viewModelScope.launch(dispatchers.io) {
-            appLoggerRepository.countKey(AppLoggerKeys.INIT_RECENT_DOOR).collect {
-                _initRecentDoorCount.value = it
-            }
-        }
-        viewModelScope.launch(dispatchers.io) {
-            appLoggerRepository.countKey(AppLoggerKeys.USER_FETCH_CURRENT_DOOR).collect {
-                _userFetchCurrentDoorCount.value = it
-            }
-        }
-        viewModelScope.launch(dispatchers.io) {
-            appLoggerRepository.countKey(AppLoggerKeys.USER_FETCH_RECENT_DOOR).collect {
-                _userFetchRecentDoorCount.value = it
-            }
-        }
-        viewModelScope.launch(dispatchers.io) {
-            appLoggerRepository.countKey(AppLoggerKeys.FCM_DOOR_RECEIVED).collect {
-                _fcmReceivedDoorCount.value = it
-            }
-        }
-        viewModelScope.launch(dispatchers.io) {
-            appLoggerRepository.countKey(AppLoggerKeys.FCM_SUBSCRIBE_TOPIC).collect {
-                _fcmSubscribeTopicCount.value = it
-            }
-        }
-        viewModelScope.launch(dispatchers.io) {
-            appLoggerRepository.countKey(AppLoggerKeys.EXCEEDED_EXPECTED_TIME_WITHOUT_FCM).collect {
-                _exceededExpectedTimeWithoutFcmCount.value = it
-            }
-        }
-        viewModelScope.launch(dispatchers.io) {
-            appLoggerRepository.countKey(AppLoggerKeys.TIME_WITHOUT_FCM_IN_EXPECTED_RANGE).collect {
-                _timeWithoutFcmInExpectedRangeCount.value = it
-            }
+            observeAppLogCount(key).collect { target.value = it }
         }
     }
 
     override fun log(key: String) {
         viewModelScope.launch(dispatchers.io) {
-            appLoggerRepository.log(key)
+            logAppEvent(key)
         }
     }
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/LogAppEventUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/LogAppEventUseCase.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.repository.AppLoggerRepository
+
+/**
+ * Logs an app event by key.
+ *
+ * Wraps [AppLoggerRepository.log] so ViewModels can depend on this UseCase
+ * instead of the repository directly.
+ */
+class LogAppEventUseCase(
+    private val appLoggerRepository: AppLoggerRepository,
+) {
+    suspend operator fun invoke(key: String) {
+        appLoggerRepository.log(key)
+    }
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveAppLogCountUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveAppLogCountUseCase.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.repository.AppLoggerRepository
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Observes the count of logged events for a given key.
+ *
+ * Wraps [AppLoggerRepository.countKey] so ViewModels can depend on this UseCase
+ * instead of the repository directly.
+ */
+class ObserveAppLogCountUseCase(
+    private val appLoggerRepository: AppLoggerRepository,
+) {
+    operator fun invoke(key: String): Flow<Long> = appLoggerRepository.countKey(key)
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAppLoggerViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAppLoggerViewModelTest.kt
@@ -13,7 +13,11 @@ class DefaultAppLoggerViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
     private val logger = FakeAppLoggerRepository()
     private val dispatchers = TestDispatcherProvider(testDispatcher)
-    private val viewModel = DefaultAppLoggerViewModel(logger, dispatchers)
+    private val viewModel = DefaultAppLoggerViewModel(
+        logAppEvent = LogAppEventUseCase(logger),
+        observeAppLogCount = ObserveAppLogCountUseCase(logger),
+        dispatchers = dispatchers,
+    )
 
     @Test
     fun logDelegatesToRepository() =


### PR DESCRIPTION
## Summary
First step of Phase 43 (ViewModel→UseCase enforcement). \`AppLoggerViewModel\` no longer depends on \`AppLoggerRepository\` directly.

### New use cases
- \`LogAppEventUseCase\` wraps \`appLoggerRepository.log(key)\`
- \`ObserveAppLogCountUseCase\` wraps \`appLoggerRepository.countKey(key)\`

Both are thin wrappers — intentional. Per architecture decision, all repository access from ViewModels must go through a UseCase even when the wrapper is trivial.

### Doesn't conflict with #238
This PR touches \`AppLoggerViewModel\`, \`AppLoggerViewModelTest\`, \`AppComponent.kt\`. PR #238 touches \`RemoteButtonViewModel\` and related Composables — disjoint files.

## Test plan
- [ ] AppLoggerViewModel tests pass
- [ ] \`./scripts/validate.sh\` passed

## Follow-ups
Other ViewModels (DoorViewModel, AuthViewModel, AppSettingsViewModel, RemoteButtonViewModel) still need similar refactor. Will land in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)