### PR TITLE
refactor: AppSettingsViewModel uses AppSettingsUseCase

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -54,6 +54,7 @@ import com.chriscartland.garage.domain.repository.RemoteButtonRepository
 import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import com.chriscartland.garage.domain.repository.SnoozeRepository
 import com.chriscartland.garage.fcm.FirebaseMessagingBridge
+import com.chriscartland.garage.usecase.AppSettingsUseCase
 import com.chriscartland.garage.usecase.DefaultAppLoggerViewModel
 import com.chriscartland.garage.usecase.DefaultAppSettingsViewModel
 import com.chriscartland.garage.usecase.DefaultAuthViewModel
@@ -103,7 +104,10 @@ abstract class AppComponent(
         )
 
     val appSettingsViewModel: DefaultAppSettingsViewModel
-        @Provides get() = DefaultAppSettingsViewModel(provideAppSettings())
+        @Provides get() = DefaultAppSettingsViewModel(provideAppSettingsUseCase())
+
+    @Provides
+    fun provideAppSettingsUseCase(): AppSettingsUseCase = AppSettingsUseCase(provideAppSettings())
 
     val doorViewModel: DefaultDoorViewModel
         @Provides get() = DefaultDoorViewModel(

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppSettingsUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppSettingsUseCase.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.repository.AppSettingsRepository
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Façade over [AppSettingsRepository] so ViewModels never depend on the
+ * repository interface directly. Per-setting observe/update methods.
+ */
+class AppSettingsUseCase(
+    private val settings: AppSettingsRepository,
+) {
+    fun observeFcmDoorTopic(): Flow<String> = settings.fcmDoorTopic.flow
+
+    suspend fun setFcmDoorTopic(value: String) = settings.fcmDoorTopic.set(value)
+
+    fun observeProfileUserCardExpanded(): Flow<Boolean> = settings.profileUserCardExpanded.flow
+
+    suspend fun setProfileUserCardExpanded(value: Boolean) = settings.profileUserCardExpanded.set(value)
+
+    fun observeProfileLogCardExpanded(): Flow<Boolean> = settings.profileLogCardExpanded.flow
+
+    suspend fun setProfileLogCardExpanded(value: Boolean) = settings.profileLogCardExpanded.set(value)
+
+    fun observeProfileAppCardExpanded(): Flow<Boolean> = settings.profileAppCardExpanded.flow
+
+    suspend fun setProfileAppCardExpanded(value: Boolean) = settings.profileAppCardExpanded.set(value)
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppSettingsViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppSettingsViewModel.kt
@@ -19,7 +19,6 @@ package com.chriscartland.garage.usecase
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.chriscartland.garage.domain.repository.AppSettingsRepository
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
@@ -47,34 +46,38 @@ interface AppSettingsViewModel {
 }
 
 class DefaultAppSettingsViewModel(
-    private val settings: AppSettingsRepository,
+    private val settings: AppSettingsUseCase,
 ) : ViewModel(),
     AppSettingsViewModel {
-    override val fcmDoorTopic: StateFlow<String> = settings.fcmDoorTopic.flow
+    override val fcmDoorTopic: StateFlow<String> = settings
+        .observeFcmDoorTopic()
         .stateIn(viewModelScope, SharingStarted.Eagerly, "")
 
-    override val profileUserCardExpanded: StateFlow<Boolean?> = settings.profileUserCardExpanded.flow
+    override val profileUserCardExpanded: StateFlow<Boolean?> = settings
+        .observeProfileUserCardExpanded()
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-    override val profileLogCardExpanded: StateFlow<Boolean?> = settings.profileLogCardExpanded.flow
+    override val profileLogCardExpanded: StateFlow<Boolean?> = settings
+        .observeProfileLogCardExpanded()
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-    override val profileAppCardExpanded: StateFlow<Boolean?> = settings.profileAppCardExpanded.flow
+    override val profileAppCardExpanded: StateFlow<Boolean?> = settings
+        .observeProfileAppCardExpanded()
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     override fun setFcmDoorTopic(topic: String) {
-        viewModelScope.launch { settings.fcmDoorTopic.set(topic) }
+        viewModelScope.launch { settings.setFcmDoorTopic(topic) }
     }
 
     override fun setProfileUserCardExpanded(expanded: Boolean) {
-        viewModelScope.launch { settings.profileUserCardExpanded.set(expanded) }
+        viewModelScope.launch { settings.setProfileUserCardExpanded(expanded) }
     }
 
     override fun setProfileLogCardExpanded(expanded: Boolean) {
-        viewModelScope.launch { settings.profileLogCardExpanded.set(expanded) }
+        viewModelScope.launch { settings.setProfileLogCardExpanded(expanded) }
     }
 
     override fun setProfileAppCardExpanded(expanded: Boolean) {
-        viewModelScope.launch { settings.profileAppCardExpanded.set(expanded) }
+        viewModelScope.launch { settings.setProfileAppCardExpanded(expanded) }
     }
 }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAppSettingsViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAppSettingsViewModelTest.kt
@@ -32,7 +32,7 @@ class DefaultAppSettingsViewModelTest {
     @Test
     fun initialStateReflectsSettings() =
         runTest(testDispatcher) {
-            val viewModel = DefaultAppSettingsViewModel(settings)
+            val viewModel = DefaultAppSettingsViewModel(AppSettingsUseCase(settings))
             advanceUntilIdle()
 
             assertEquals("", viewModel.fcmDoorTopic.value)
@@ -44,7 +44,7 @@ class DefaultAppSettingsViewModelTest {
     @Test
     fun setFcmDoorTopicUpdatesFlowAndSetting() =
         runTest(testDispatcher) {
-            val viewModel = DefaultAppSettingsViewModel(settings)
+            val viewModel = DefaultAppSettingsViewModel(AppSettingsUseCase(settings))
             advanceUntilIdle()
 
             viewModel.setFcmDoorTopic("new-topic")
@@ -57,7 +57,7 @@ class DefaultAppSettingsViewModelTest {
     @Test
     fun setProfileUserCardExpandedUpdatesFlowAndSetting() =
         runTest(testDispatcher) {
-            val viewModel = DefaultAppSettingsViewModel(settings)
+            val viewModel = DefaultAppSettingsViewModel(AppSettingsUseCase(settings))
             advanceUntilIdle()
 
             viewModel.setProfileUserCardExpanded(false)
@@ -70,7 +70,7 @@ class DefaultAppSettingsViewModelTest {
     @Test
     fun setProfileLogCardExpandedUpdatesFlowAndSetting() =
         runTest(testDispatcher) {
-            val viewModel = DefaultAppSettingsViewModel(settings)
+            val viewModel = DefaultAppSettingsViewModel(AppSettingsUseCase(settings))
             advanceUntilIdle()
 
             viewModel.setProfileLogCardExpanded(true)
@@ -83,7 +83,7 @@ class DefaultAppSettingsViewModelTest {
     @Test
     fun setProfileAppCardExpandedUpdatesFlowAndSetting() =
         runTest(testDispatcher) {
-            val viewModel = DefaultAppSettingsViewModel(settings)
+            val viewModel = DefaultAppSettingsViewModel(AppSettingsUseCase(settings))
             advanceUntilIdle()
 
             viewModel.setProfileAppCardExpanded(false)
@@ -99,7 +99,7 @@ class DefaultAppSettingsViewModelTest {
             settings.fcmDoorTopic.set("pre-existing")
             settings.profileLogCardExpanded.set(true)
 
-            val vm = DefaultAppSettingsViewModel(settings)
+            val vm = DefaultAppSettingsViewModel(AppSettingsUseCase(settings))
             advanceUntilIdle()
 
             assertEquals("pre-existing", vm.fcmDoorTopic.value)


### PR DESCRIPTION
## Summary
Phase 43 (ViewModel→UseCase enforcement), second step. \`AppSettingsViewModel\` no longer depends on \`AppSettingsRepository\` directly.

### New: AppSettingsUseCase
Façade with per-setting observe/update methods:
- \`observeFcmDoorTopic()\` / \`setFcmDoorTopic()\`
- \`observeProfileUserCardExpanded()\` / \`setProfileUserCardExpanded()\`
- \`observeProfileLogCardExpanded()\` / \`setProfileLogCardExpanded()\`
- \`observeProfileAppCardExpanded()\` / \`setProfileAppCardExpanded()\`

One UseCase with 8 methods is cleaner than 8 separate single-method UseCases for this case.

### Doesn't conflict with #240, #241
Touches AppSettingsViewModel + AppComponent. May lightly touch the same imports section in AppComponent as #240; should merge cleanly since edits are at different positions.

## Test plan
- [ ] AppSettingsViewModel tests pass
- [ ] \`./scripts/validate.sh\` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)