### PR TITLE
refactor: AuthViewModel uses Auth UseCases

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -67,9 +67,12 @@ import com.chriscartland.garage.usecase.FetchRecentDoorEventsUseCase
 import com.chriscartland.garage.usecase.FetchSnoozeStatusUseCase
 import com.chriscartland.garage.usecase.LogAppEventUseCase
 import com.chriscartland.garage.usecase.ObserveAppLogCountUseCase
+import com.chriscartland.garage.usecase.ObserveAuthStateUseCase
 import com.chriscartland.garage.usecase.ObserveSnoozeStateUseCase
 import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
 import com.chriscartland.garage.usecase.RegisterFcmUseCase
+import com.chriscartland.garage.usecase.SignInWithGoogleUseCase
+import com.chriscartland.garage.usecase.SignOutUseCase
 import com.chriscartland.garage.usecase.SnoozeNotificationsUseCase
 import com.chriscartland.garage.version.AppVersion
 import io.ktor.client.HttpClient
@@ -93,10 +96,21 @@ abstract class AppComponent(
     // ViewModels
     val authViewModel: DefaultAuthViewModel
         @Provides get() = DefaultAuthViewModel(
-            provideAuthRepository(),
-            provideAppLoggerRepository(),
+            provideObserveAuthStateUseCase(),
+            provideSignInWithGoogleUseCase(),
+            provideSignOutUseCase(),
+            provideLogAppEventUseCase(),
             provideDispatcherProvider(),
         )
+
+    @Provides
+    fun provideObserveAuthStateUseCase(): ObserveAuthStateUseCase = ObserveAuthStateUseCase(provideAuthRepository())
+
+    @Provides
+    fun provideSignInWithGoogleUseCase(): SignInWithGoogleUseCase = SignInWithGoogleUseCase(provideAuthRepository())
+
+    @Provides
+    fun provideSignOutUseCase(): SignOutUseCase = SignOutUseCase(provideAuthRepository())
 
     val appLoggerViewModel: DefaultAppLoggerViewModel
         @Provides get() = DefaultAppLoggerViewModel(

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AuthViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AuthViewModel.kt
@@ -24,8 +24,6 @@ import com.chriscartland.garage.domain.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.GoogleIdToken
-import com.chriscartland.garage.domain.repository.AppLoggerRepository
-import com.chriscartland.garage.domain.repository.AuthRepository
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
@@ -38,24 +36,26 @@ interface AuthViewModel {
 }
 
 class DefaultAuthViewModel(
-    private val authRepository: AuthRepository,
-    private val appLoggerRepository: AppLoggerRepository,
+    observeAuthState: ObserveAuthStateUseCase,
+    private val signInWithGoogleUseCase: SignInWithGoogleUseCase,
+    private val signOutUseCase: SignOutUseCase,
+    private val logAppEvent: LogAppEventUseCase,
     private val dispatchers: DispatcherProvider,
 ) : ViewModel(),
     AuthViewModel {
-    override val authState: StateFlow<AuthState> = authRepository.authState
+    override val authState: StateFlow<AuthState> = observeAuthState()
 
     override fun signInWithGoogle(idToken: GoogleIdToken) {
         viewModelScope.launch(dispatchers.io) {
-            appLoggerRepository.log(AppLoggerKeys.BEGIN_GOOGLE_SIGN_IN)
+            logAppEvent(AppLoggerKeys.BEGIN_GOOGLE_SIGN_IN)
             Logger.d { "signInWithGoogle" }
-            authRepository.signInWithGoogle(idToken)
+            signInWithGoogleUseCase(idToken)
         }
     }
 
     override fun signOut() {
         viewModelScope.launch(dispatchers.io) {
-            authRepository.signOut()
+            signOutUseCase()
         }
     }
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveAuthStateUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveAuthStateUseCase.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.repository.AuthRepository
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Observes the current authentication state.
+ *
+ * Wraps [AuthRepository.authState] so ViewModels can depend on this
+ * UseCase instead of the repository directly.
+ */
+class ObserveAuthStateUseCase(
+    private val authRepository: AuthRepository,
+) {
+    operator fun invoke(): StateFlow<AuthState> = authRepository.authState
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SignInWithGoogleUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SignInWithGoogleUseCase.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.GoogleIdToken
+import com.chriscartland.garage.domain.repository.AuthRepository
+
+/**
+ * Signs the user in with a Google ID token.
+ *
+ * Wraps [AuthRepository.signInWithGoogle] so ViewModels can depend on this
+ * UseCase instead of the repository directly.
+ */
+class SignInWithGoogleUseCase(
+    private val authRepository: AuthRepository,
+) {
+    suspend operator fun invoke(idToken: GoogleIdToken) {
+        authRepository.signInWithGoogle(idToken)
+    }
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SignOutUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SignOutUseCase.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.repository.AuthRepository
+
+/**
+ * Signs the user out.
+ *
+ * Wraps [AuthRepository.signOut] so ViewModels can depend on this
+ * UseCase instead of the repository directly.
+ */
+class SignOutUseCase(
+    private val authRepository: AuthRepository,
+) {
+    suspend operator fun invoke() {
+        authRepository.signOut()
+    }
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAuthViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAuthViewModelTest.kt
@@ -22,7 +22,13 @@ class DefaultAuthViewModelTest {
     private val authRepo = FakeAuthRepository()
     private val logger = FakeAppLoggerRepository()
     private val dispatchers = TestDispatcherProvider(testDispatcher)
-    private val viewModel = DefaultAuthViewModel(authRepo, logger, dispatchers)
+    private val viewModel = DefaultAuthViewModel(
+        observeAuthState = ObserveAuthStateUseCase(authRepo),
+        signInWithGoogleUseCase = SignInWithGoogleUseCase(authRepo),
+        signOutUseCase = SignOutUseCase(authRepo),
+        logAppEvent = LogAppEventUseCase(logger),
+        dispatchers = dispatchers,
+    )
 
     @Test
     fun initialAuthStateIsUnknown() {


### PR DESCRIPTION
## Summary
Phase 43, third ViewModel migrated. \`AuthViewModel\` no longer depends on \`AuthRepository\` or \`AppLoggerRepository\`.

### New use cases
- \`ObserveAuthStateUseCase\` wraps \`authRepository.authState\`
- \`SignInWithGoogleUseCase\` wraps \`authRepository.signInWithGoogle\`
- \`SignOutUseCase\` wraps \`authRepository.signOut\`

Plus reuses \`LogAppEventUseCase\` from #240.

### Conflict potential with #242
Both touch \`AppComponent.kt\` imports + ViewModel constructors. Should merge cleanly since the edits are at different positions.

## Test plan
- [ ] AuthViewModel tests pass
- [ ] \`./scripts/validate.sh\` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)