### PR TITLE
docs: Update stale state references in ARCHITECTURE and TESTING

### DIFF
--- a/AndroidGarage/docs/ARCHITECTURE.md
+++ b/AndroidGarage/docs/ARCHITECTURE.md
@@ -87,12 +87,13 @@ Root files: `GarageApplication.kt` (@HiltAndroidApp), `MainActivity.kt` (Compose
 
 ### Remote Button Press
 
-1. UI → `RemoteButtonViewModel.pushRemoteButton(authRepository)`
-2. Checks auth, refreshes token if expired
-3. Creates `buttonAckToken` (android-version-timestamp-millis)
+1. UI → `RemoteButtonViewModel.onButtonTap()` → `ButtonStateMachine.onTap()`
+2. State machine: Ready → Arming (500ms) → Armed (5s timeout) → tap → Sending
+3. On confirm: `onSubmit` callback → `PushRemoteButtonUseCase` checks auth, refreshes token if expired
 4. `PushRepository.push(idToken, buttonAckToken)` → POST `/addRemoteButtonCommand`
-5. State machine: NONE → SENDING → SENT (server ack) → RECEIVED (door moves)
-6. 10-second timeouts at each state → SENDING_TIMEOUT / SENT_TIMEOUT → NONE
+5. State machine observes `pushButtonStatus`: Sending → Sent (server ack) → Received (door moves)
+6. Failure paths: SendingTimeout / SentTimeout → Ready after display delay
+7. All transitions atomic via single Channel consumer; testable with virtual time
 
 ### Authentication
 

--- a/AndroidGarage/docs/TESTING.md
+++ b/AndroidGarage/docs/TESTING.md
@@ -95,7 +95,7 @@ The highest-risk untested area. The app has ~15 null-check branches in network c
 - Push with HTTP 500 response → verify `pushButtonStatus` reflects error (not IDLE)
 - Push with null server config → verify status is not stuck in SENDING
 - Push with `remoteButtonPushEnabled = false` → verify no network call made
-- Snooze with error response body → verify `snoozeRequestStatus` is ERROR
+- Snooze with error response body → verify `snoozeAction` becomes `Failed.NetworkError`
 
 **Files:** New `PushRepositoryTest.kt`
 


### PR DESCRIPTION
## Summary
Update stale references after the button state machine refactor (#237-#241):
- ARCHITECTURE.md "Remote Button Press" data flow now describes the unified \`ButtonStateMachine\`
- TESTING.md snooze test note references \`snoozeAction.Failed.NetworkError\` instead of removed \`snoozeRequestStatus\`

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)