### PR TITLE
test: Add UseCase coverage — LogAppEvent, ObserveAppLogCount, AppSettings

### DIFF
--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/AppSettingsUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/AppSettingsUseCaseTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.testcommon.FakeAppSettingsRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AppSettingsUseCaseTest {
+    @Test
+    fun observeAndSetFcmDoorTopicRoundTrip() =
+        runTest {
+            val repo = FakeAppSettingsRepository()
+            val useCase = AppSettingsUseCase(repo)
+
+            useCase.setFcmDoorTopic("topic-123")
+
+            assertEquals("topic-123", useCase.observeFcmDoorTopic().first())
+        }
+
+    @Test
+    fun observeAndSetProfileUserCardExpandedRoundTrip() =
+        runTest {
+            val repo = FakeAppSettingsRepository()
+            val useCase = AppSettingsUseCase(repo)
+
+            useCase.setProfileUserCardExpanded(false)
+
+            assertEquals(false, useCase.observeProfileUserCardExpanded().first())
+        }
+
+    @Test
+    fun observeAndSetProfileLogCardExpandedRoundTrip() =
+        runTest {
+            val repo = FakeAppSettingsRepository()
+            val useCase = AppSettingsUseCase(repo)
+
+            useCase.setProfileLogCardExpanded(true)
+
+            assertEquals(true, useCase.observeProfileLogCardExpanded().first())
+        }
+
+    @Test
+    fun observeAndSetProfileAppCardExpandedRoundTrip() =
+        runTest {
+            val repo = FakeAppSettingsRepository()
+            val useCase = AppSettingsUseCase(repo)
+
+            useCase.setProfileAppCardExpanded(false)
+
+            assertEquals(false, useCase.observeProfileAppCardExpanded().first())
+        }
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/LogAppEventUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/LogAppEventUseCaseTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class LogAppEventUseCaseTest {
+    @Test
+    fun invokeDelegatesToRepository() =
+        runTest {
+            val repo = FakeAppLoggerRepository()
+            val useCase = LogAppEventUseCase(repo)
+
+            useCase("test_key")
+
+            assertTrue(repo.loggedKeys.contains("test_key"))
+        }
+
+    @Test
+    fun multipleCallsAccumulate() =
+        runTest {
+            val repo = FakeAppLoggerRepository()
+            val useCase = LogAppEventUseCase(repo)
+
+            useCase("a")
+            useCase("b")
+            useCase("c")
+
+            assertEquals(listOf("a", "b", "c"), repo.loggedKeys)
+        }
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ObserveAppLogCountUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ObserveAppLogCountUseCaseTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ObserveAppLogCountUseCaseTest {
+    @Test
+    fun invokeReturnsCountForKey() =
+        runTest {
+            val repo = FakeAppLoggerRepository()
+            val useCase = ObserveAppLogCountUseCase(repo)
+
+            repo.log("a")
+            repo.log("a")
+            repo.log("b")
+
+            assertEquals(2L, useCase("a").first())
+            assertEquals(1L, useCase("b").first())
+            assertEquals(0L, useCase("c").first())
+        }
+}


### PR DESCRIPTION
## Summary
Test coverage for the new UseCases from Phase 43:
- \`LogAppEventUseCaseTest\` (2 tests)
- \`ObserveAppLogCountUseCaseTest\` (1 test)
- \`AppSettingsUseCaseTest\` (4 tests, one per setting)

All use existing fakes from \`test-common\`. No conflicts with #243, #244, #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)