### PR TITLE
refactor: DoorViewModel uses ObserveDoorEventsUseCase

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -69,6 +69,7 @@ import com.chriscartland.garage.usecase.FetchSnoozeStatusUseCase
 import com.chriscartland.garage.usecase.LogAppEventUseCase
 import com.chriscartland.garage.usecase.ObserveAppLogCountUseCase
 import com.chriscartland.garage.usecase.ObserveAuthStateUseCase
+import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
 import com.chriscartland.garage.usecase.ObserveSnoozeStateUseCase
 import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
 import com.chriscartland.garage.usecase.RegisterFcmUseCase
@@ -126,6 +127,9 @@ abstract class AppComponent(
     @Provides
     fun provideObserveAppLogCountUseCase(): ObserveAppLogCountUseCase = ObserveAppLogCountUseCase(provideAppLoggerRepository())
 
+    @Provides
+    fun provideObserveDoorEventsUseCase(): ObserveDoorEventsUseCase = ObserveDoorEventsUseCase(provideDoorRepository())
+
     val appSettingsViewModel: DefaultAppSettingsViewModel
         @Provides get() = DefaultAppSettingsViewModel(provideAppSettingsUseCase())
 
@@ -134,8 +138,8 @@ abstract class AppComponent(
 
     val doorViewModel: DefaultDoorViewModel
         @Provides get() = DefaultDoorViewModel(
-            provideAppLoggerRepository(),
-            provideDoorRepository(),
+            provideObserveDoorEventsUseCase(),
+            provideLogAppEventUseCase(),
             provideDispatcherProvider(),
             provideFetchCurrentDoorEventUseCase(),
             provideFetchRecentDoorEventsUseCase(),

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorViewModel.kt
@@ -27,8 +27,6 @@ import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.FcmRegistrationStatus
 import com.chriscartland.garage.domain.model.FetchError
 import com.chriscartland.garage.domain.model.LoadingResult
-import com.chriscartland.garage.domain.repository.AppLoggerRepository
-import com.chriscartland.garage.domain.repository.DoorRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -50,8 +48,8 @@ interface DoorViewModel {
 }
 
 class DefaultDoorViewModel(
-    private val appLoggerRepository: AppLoggerRepository,
-    private val doorRepository: DoorRepository,
+    observeDoorEvents: ObserveDoorEventsUseCase,
+    private val logAppEvent: LogAppEventUseCase,
     private val dispatchers: DispatcherProvider,
     private val fetchCurrentDoorEventUseCase: FetchCurrentDoorEventUseCase,
     private val fetchRecentDoorEventsUseCase: FetchRecentDoorEventsUseCase,
@@ -76,21 +74,21 @@ class DefaultDoorViewModel(
     init {
         Logger.d { "init" }
         viewModelScope.launch(dispatchers.io) {
-            doorRepository.currentDoorEvent.collect {
+            observeDoorEvents.current().collect {
                 Logger.d { "currentDoorEvent collect: $it" }
                 _currentDoorEvent.value = LoadingResult.Complete(it)
             }
         }
         viewModelScope.launch(dispatchers.io) {
-            doorRepository.recentDoorEvents.collect {
+            observeDoorEvents.recent().collect {
                 Logger.d { "recentDoorEvents collect: $it" }
                 _recentDoorEvents.value = LoadingResult.Complete(it)
             }
         }
         if (fetchOnInit) {
             viewModelScope.launch(dispatchers.io) {
-                appLoggerRepository.log(AppLoggerKeys.INIT_CURRENT_DOOR)
-                appLoggerRepository.log(AppLoggerKeys.INIT_RECENT_DOOR)
+                logAppEvent(AppLoggerKeys.INIT_CURRENT_DOOR)
+                logAppEvent(AppLoggerKeys.INIT_RECENT_DOOR)
             }
             fetchCurrentDoorEvent()
             fetchRecentDoorEvents()

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveDoorEventsUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveDoorEventsUseCase.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.DoorEvent
+import com.chriscartland.garage.domain.repository.DoorRepository
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Observes the current and recent door events from the repository.
+ *
+ * Wraps [DoorRepository] flows so ViewModels can depend on this UseCase
+ * instead of the repository directly.
+ */
+class ObserveDoorEventsUseCase(
+    private val doorRepository: DoorRepository,
+) {
+    fun current(): Flow<DoorEvent?> = doorRepository.currentDoorEvent
+
+    fun recent(): Flow<List<DoorEvent>> = doorRepository.recentDoorEvents
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DoorViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DoorViewModelTest.kt
@@ -72,14 +72,14 @@ class DoorViewModelTest {
 
     private fun createViewModel(fetchOnInit: Boolean = true): DefaultDoorViewModel {
         val vm = DefaultDoorViewModel(
-            appLoggerRepository,
-            doorRepository,
-            TestDispatcherProvider(testDispatcher),
-            FetchCurrentDoorEventUseCase(doorRepository),
-            FetchRecentDoorEventsUseCase(doorRepository),
-            FetchFcmStatusUseCase(doorFcmRepository),
-            RegisterFcmUseCase(doorRepository, doorFcmRepository),
-            DeregisterFcmUseCase(doorFcmRepository),
+            observeDoorEvents = ObserveDoorEventsUseCase(doorRepository),
+            logAppEvent = LogAppEventUseCase(appLoggerRepository),
+            dispatchers = TestDispatcherProvider(testDispatcher),
+            fetchCurrentDoorEventUseCase = FetchCurrentDoorEventUseCase(doorRepository),
+            fetchRecentDoorEventsUseCase = FetchRecentDoorEventsUseCase(doorRepository),
+            fetchFcmStatusUseCase = FetchFcmStatusUseCase(doorFcmRepository),
+            registerFcmUseCase = RegisterFcmUseCase(doorRepository, doorFcmRepository),
+            deregisterFcmUseCase = DeregisterFcmUseCase(doorFcmRepository),
             fetchOnInit = fetchOnInit,
         )
         testDispatcher.scheduler.runCurrent()


### PR DESCRIPTION
## Summary
Phase 43, fourth ViewModel migrated. \`DoorViewModel\` no longer depends on \`DoorRepository\` or \`AppLoggerRepository\` directly.

### New
- \`ObserveDoorEventsUseCase\` wraps \`currentDoorEvent\` and \`recentDoorEvents\` flows

### Reused
- \`LogAppEventUseCase\` from #240 for init log events

The existing fetch use cases (\`FetchCurrentDoorEventUseCase\`, \`FetchRecentDoorEventsUseCase\`, \`FetchFcmStatusUseCase\`, \`RegisterFcmUseCase\`, \`DeregisterFcmUseCase\`) were already in place — only the direct repository imports needed removal.

After this PR, only \`RemoteButtonViewModel\` still imports a repository directly (\`RemoteButtonRepository\` for \`pushButtonStatus\` flow).

## Test plan
- [ ] DoorViewModel tests pass
- [ ] \`./scripts/validate.sh\` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)