### PR TITLE
test: Auth UseCase coverage

### DIFF
--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ObserveAuthStateUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ObserveAuthStateUseCaseTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.testcommon.FakeAuthRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class ObserveAuthStateUseCaseTest {
+    @Test
+    fun invokeReturnsRepositoryAuthState() {
+        val repo = FakeAuthRepository()
+        val useCase = ObserveAuthStateUseCase(repo)
+
+        assertIs<AuthState.Unknown>(useCase().value)
+    }
+
+    @Test
+    fun invokeReflectsRepositoryUpdates() {
+        val repo = FakeAuthRepository()
+        val useCase = ObserveAuthStateUseCase(repo)
+
+        repo.setAuthState(AuthState.Unauthenticated)
+
+        assertEquals(AuthState.Unauthenticated, useCase().value)
+    }
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SignInWithGoogleUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SignInWithGoogleUseCaseTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.DisplayName
+import com.chriscartland.garage.domain.model.Email
+import com.chriscartland.garage.domain.model.FirebaseIdToken
+import com.chriscartland.garage.domain.model.GoogleIdToken
+import com.chriscartland.garage.domain.model.User
+import com.chriscartland.garage.testcommon.FakeAuthRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class SignInWithGoogleUseCaseTest {
+    @Test
+    fun invokeDelegatesToRepository() =
+        runTest {
+            val repo = FakeAuthRepository()
+            val useCase = SignInWithGoogleUseCase(repo)
+
+            useCase(GoogleIdToken("test-token"))
+
+            assertEquals(1, repo.signInCount)
+        }
+
+    @Test
+    fun invokeUpdatesAuthStateOnSuccess() =
+        runTest {
+            val repo = FakeAuthRepository()
+            repo.signInResult = AuthState.Authenticated(
+                user = User(
+                    name = DisplayName("Alice"),
+                    email = Email("alice@test.com"),
+                    idToken = FirebaseIdToken("token", exp = Long.MAX_VALUE),
+                ),
+            )
+            val useCase = SignInWithGoogleUseCase(repo)
+
+            useCase(GoogleIdToken("token"))
+
+            assertIs<AuthState.Authenticated>(repo.authState.value)
+        }
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SignOutUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SignOutUseCaseTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.testcommon.FakeAuthRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class SignOutUseCaseTest {
+    @Test
+    fun invokeDelegatesToRepository() =
+        runTest {
+            val repo = FakeAuthRepository()
+            val useCase = SignOutUseCase(repo)
+
+            useCase()
+
+            assertEquals(1, repo.signOutCount)
+        }
+
+    @Test
+    fun invokeUpdatesAuthStateToUnauthenticated() =
+        runTest {
+            val repo = FakeAuthRepository()
+            val useCase = SignOutUseCase(repo)
+
+            useCase()
+
+            assertIs<AuthState.Unauthenticated>(repo.authState.value)
+        }
+}


### PR DESCRIPTION
## Summary
Test coverage for the auth UseCases from PR #243:
- \`SignInWithGoogleUseCaseTest\` (2 tests)
- \`SignOutUseCaseTest\` (2 tests)
- \`ObserveAuthStateUseCaseTest\` (2 tests)

All use \`FakeAuthRepository\` from test-common. No conflicts with #247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)