### PR TITLE
test: Snooze UseCase coverage

### DIFF
--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/FetchSnoozeStatusUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/FetchSnoozeStatusUseCaseTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.testcommon.FakeSnoozeRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FetchSnoozeStatusUseCaseTest {
+    @Test
+    fun invokeDelegatesToRepository() =
+        runTest {
+            val repo = FakeSnoozeRepository()
+            val useCase = FetchSnoozeStatusUseCase(repo)
+
+            useCase()
+
+            assertEquals(1, repo.fetchCount)
+        }
+
+    @Test
+    fun multipleCallsAccumulate() =
+        runTest {
+            val repo = FakeSnoozeRepository()
+            val useCase = FetchSnoozeStatusUseCase(repo)
+
+            useCase()
+            useCase()
+            useCase()
+
+            assertEquals(3, repo.fetchCount)
+        }
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ObserveSnoozeStateUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ObserveSnoozeStateUseCaseTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.SnoozeState
+import com.chriscartland.garage.testcommon.FakeSnoozeRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ObserveSnoozeStateUseCaseTest {
+    @Test
+    fun invokeReturnsRepositoryState() {
+        val repo = FakeSnoozeRepository()
+        val useCase = ObserveSnoozeStateUseCase(repo)
+
+        assertEquals(SnoozeState.Loading, useCase().value)
+    }
+
+    @Test
+    fun invokeReflectsRepositoryUpdates() {
+        val repo = FakeSnoozeRepository()
+        val useCase = ObserveSnoozeStateUseCase(repo)
+
+        repo.setSnoozeState(SnoozeState.Snoozing(12345L))
+
+        assertEquals(SnoozeState.Snoozing(12345L), useCase().value)
+    }
+}


### PR DESCRIPTION
## Summary
Test coverage for snooze UseCases:
- \`FetchSnoozeStatusUseCaseTest\` (2 tests)
- \`ObserveSnoozeStateUseCaseTest\` (2 tests)

No conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)