### PR TITLE
refactor: RemoteButtonViewModel uses UseCases (Phase 43 complete)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -70,6 +70,7 @@ import com.chriscartland.garage.usecase.LogAppEventUseCase
 import com.chriscartland.garage.usecase.ObserveAppLogCountUseCase
 import com.chriscartland.garage.usecase.ObserveAuthStateUseCase
 import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
+import com.chriscartland.garage.usecase.ObservePushButtonStatusUseCase
 import com.chriscartland.garage.usecase.ObserveSnoozeStateUseCase
 import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
 import com.chriscartland.garage.usecase.RegisterFcmUseCase
@@ -150,14 +151,18 @@ abstract class AppComponent(
 
     val remoteButtonViewModel: DefaultRemoteButtonViewModel
         @Provides get() = DefaultRemoteButtonViewModel(
-            provideRemoteButtonRepository(),
-            provideDoorRepository(),
+            provideObservePushButtonStatusUseCase(),
+            provideObserveDoorEventsUseCase(),
             provideDispatcherProvider(),
             providePushRemoteButtonUseCase(),
             provideSnoozeNotificationsUseCase(),
             provideFetchSnoozeStatusUseCase(),
             provideObserveSnoozeStateUseCase(),
         )
+
+    @Provides
+    fun provideObservePushButtonStatusUseCase(): ObservePushButtonStatusUseCase =
+        ObservePushButtonStatusUseCase(provideRemoteButtonRepository())
 
     // Configuration
     @Provides

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveDoorEventsUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveDoorEventsUseCase.kt
@@ -18,6 +18,7 @@
 package com.chriscartland.garage.usecase
 
 import com.chriscartland.garage.domain.model.DoorEvent
+import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.repository.DoorRepository
 import kotlinx.coroutines.flow.Flow
 
@@ -33,4 +34,7 @@ class ObserveDoorEventsUseCase(
     fun current(): Flow<DoorEvent?> = doorRepository.currentDoorEvent
 
     fun recent(): Flow<List<DoorEvent>> = doorRepository.recentDoorEvents
+
+    /** Stream of door position changes — needed by ButtonStateMachine. */
+    fun position(): Flow<DoorPosition> = doorRepository.currentDoorPosition
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObservePushButtonStatusUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObservePushButtonStatusUseCase.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.PushStatus
+import com.chriscartland.garage.domain.repository.RemoteButtonRepository
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Observes the push-button network status from the repository.
+ *
+ * Wraps [RemoteButtonRepository.pushButtonStatus] so ViewModels can depend
+ * on this UseCase instead of the repository directly.
+ *
+ * Used by [ButtonStateMachine] to track the network/door request lifecycle.
+ */
+class ObservePushButtonStatusUseCase(
+    private val remoteButtonRepository: RemoteButtonRepository,
+) {
+    operator fun invoke(): Flow<PushStatus> = remoteButtonRepository.pushButtonStatus
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
@@ -29,8 +29,6 @@ import com.chriscartland.garage.domain.model.SnoozeAction
 import com.chriscartland.garage.domain.model.SnoozeDurationUIOption
 import com.chriscartland.garage.domain.model.SnoozeState
 import com.chriscartland.garage.domain.model.toServer
-import com.chriscartland.garage.domain.repository.DoorRepository
-import com.chriscartland.garage.domain.repository.RemoteButtonRepository
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -53,8 +51,8 @@ interface RemoteButtonViewModel {
 }
 
 class DefaultRemoteButtonViewModel(
-    remoteButtonRepository: RemoteButtonRepository,
-    private val doorRepository: DoorRepository,
+    observePushButtonStatus: ObservePushButtonStatusUseCase,
+    private val observeDoorEvents: ObserveDoorEventsUseCase,
     private val dispatchers: DispatcherProvider,
     private val pushRemoteButtonUseCase: PushRemoteButtonUseCase,
     private val snoozeNotificationsUseCase: SnoozeNotificationsUseCase,
@@ -63,8 +61,8 @@ class DefaultRemoteButtonViewModel(
 ) : ViewModel(),
     RemoteButtonViewModel {
     private val stateMachine = ButtonStateMachine(
-        pushButtonStatus = remoteButtonRepository.pushButtonStatus,
-        doorPosition = doorRepository.currentDoorPosition,
+        pushButtonStatus = observePushButtonStatus(),
+        doorPosition = observeDoorEvents.position(),
         onSubmit = ::submitButtonPress,
         scope = viewModelScope,
         dispatcher = dispatchers.io,
@@ -85,7 +83,7 @@ class DefaultRemoteButtonViewModel(
 
     private fun listenToDoorEvent() {
         viewModelScope.launch(dispatchers.io) {
-            doorRepository.currentDoorEvent.collect {
+            observeDoorEvents.current().collect {
                 currentDoorEvent.value = it
             }
         }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModelTest.kt
@@ -83,13 +83,13 @@ class RemoteButtonViewModelTest {
         authRepository.setAuthState(authState)
         val ensureFreshIdToken = EnsureFreshIdTokenUseCase(authRepository)
         val vm = DefaultRemoteButtonViewModel(
-            remoteButtonRepository,
-            doorRepository,
-            TestDispatcherProvider(testDispatcher),
-            PushRemoteButtonUseCase(ensureFreshIdToken, authRepository, remoteButtonRepository),
-            SnoozeNotificationsUseCase(ensureFreshIdToken, authRepository, snoozeRepository),
-            FetchSnoozeStatusUseCase(snoozeRepository),
-            ObserveSnoozeStateUseCase(snoozeRepository),
+            observePushButtonStatus = ObservePushButtonStatusUseCase(remoteButtonRepository),
+            observeDoorEvents = ObserveDoorEventsUseCase(doorRepository),
+            dispatchers = TestDispatcherProvider(testDispatcher),
+            pushRemoteButtonUseCase = PushRemoteButtonUseCase(ensureFreshIdToken, authRepository, remoteButtonRepository),
+            snoozeNotificationsUseCase = SnoozeNotificationsUseCase(ensureFreshIdToken, authRepository, snoozeRepository),
+            fetchSnoozeStatusUseCase = FetchSnoozeStatusUseCase(snoozeRepository),
+            observeSnoozeStateUseCase = ObserveSnoozeStateUseCase(snoozeRepository),
         )
         testDispatcher.scheduler.runCurrent()
         return vm


### PR DESCRIPTION
## Summary
**Phase 43 complete!** Last ViewModel migrated. \`RemoteButtonViewModel\` no longer imports any repository directly.

### Changes
- New \`ObservePushButtonStatusUseCase\` wraps \`remoteButtonRepository.pushButtonStatus\`
- \`ObserveDoorEventsUseCase\` gains a \`position()\` method exposing \`currentDoorPosition\`
- \`ButtonStateMachine\` is constructed with UseCase flows
- \`listenToDoorEvent\` uses \`observeDoorEvents.current()\` instead of repo

### State after this PR
All 5 ViewModels (AppLogger, AppSettings, Auth, Door, RemoteButton) now depend only on UseCases and domain types. The \`LayerImportCheck\` lint rule can now be added in a follow-up PR to enforce this at build time.

## Test plan
- [ ] All RemoteButtonViewModel tests pass
- [ ] \`./scripts/validate.sh\` passed

## Follow-up
- Add \`domain.repository.\` to \`LayerImportCheck\` forbidden imports for ViewModel files

🤖 Generated with [Claude Code](https://claude.com/claude-code)