### PR TITLE
feat: Enforce ViewModel→UseCase only via LayerImportCheck (Phase 43 complete)

### DIFF
--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -84,6 +84,15 @@ tasks.register<architecture.LayerImportCheckTask>("checkLayerImports") {
             "com.chriscartland.garage.data.Local,com.chriscartland.garage.data.Network,com.chriscartland.garage.data.ktor.,com.chriscartland.garage.data.repository.,com.chriscartland.garage.datalocal.",
             "ViewModels must depend on UseCases and domain interfaces, not data layer implementations.",
         ),
+        // ViewModels must not import domain repository interfaces — only UseCases.
+        // Phase 43: ViewModels orchestrate UI state via UseCases, never reach into the
+        // repository layer directly. This keeps the dependency graph clean and
+        // enables future module separation (battery-butler pattern).
+        listOf(
+            ".*ViewModel\\.kt",
+            "com.chriscartland.garage.domain.repository.",
+            "ViewModels must depend on UseCases, not domain repository interfaces. Wrap repository access in a UseCase.",
+        ),
         // UseCases must not import DataSource or concrete implementations
         listOf(
             ".*UseCase\\.kt",

--- a/AndroidGarage/docs/TESTING.md
+++ b/AndroidGarage/docs/TESTING.md
@@ -26,7 +26,7 @@
 - **Safety guardrails:** git hooks warn on Room entity changes, block push to main, enforce squash merge, block direct screenshot Gradle tasks, block absolute paths to gradlew, block push to branches with auto-merge enabled
 - **DI system:** kotlin-inject (Hilt fully removed as of Phase 3), Ktor HTTP (Retrofit fully removed as of Phase 4)
 - **Navigation:** Navigation 3 (Nav2 fully removed, enforcement check blocks re-introduction)
-- **Architecture enforcement:** ArchitectureCheckTask (module deps), SingletonGuardTask (DB/Settings/HTTP scoping), LayerImportCheckTask (ViewModel→UseCase, UseCase→domain boundaries), RememberSaveableGuardTask (blocks unsafe rememberSaveable without saver). **Gap:** LayerImportCheckTask blocks data *implementation* imports but not `domain.repository.*` imports in ViewModels — Phase 43 will close this gap
+- **Architecture enforcement:** ArchitectureCheckTask (module deps), SingletonGuardTask (DB/Settings/HTTP scoping), LayerImportCheckTask (ViewModel→UseCase strict, UseCase→domain boundaries), RememberSaveableGuardTask (blocks unsafe rememberSaveable without saver). ViewModels are blocked from importing both data layer implementations AND `domain.repository.*` interfaces — must go through a UseCase
 - **Test coverage:** No exemptions remaining (RoomAppLoggerRepository moved to data-local KMP module)
 - **Test pattern:** usecase tests fake at repository interface; data tests use real repos with fake data sources
 - **Completed:** Phase 1 (CI hardening), Phase 2 (network error tests), Phase 3 (auth token fix + UseCase tests + AuthBridge extraction), Phase 4 (state machine completeness), Phase 5.2-5.3 (release safety), Phase 6.1 (ESLint migration), Phase 7 (instrumented tests)


### PR DESCRIPTION
## Summary
**Phase 43 complete!** All 5 ViewModels are now migrated, so the lint rule that enforces ViewModel→UseCase dependencies can be added without breaking the build.

### Change
Add \`com.chriscartland.garage.domain.repository.\` to \`LayerImportCheckTask\` forbidden imports for files matching \`.*ViewModel\\.kt\`.

Any future ViewModel that tries to import a domain repository interface will fail \`checkLayerImports\` with this message:
> ViewModels must depend on UseCases, not domain repository interfaces. Wrap repository access in a UseCase.

### Why
This matches battery-butler's pattern: ViewModels orchestrate UI state via UseCases, never reach into the repository layer directly. This:
1. Keeps the dependency graph clean
2. Forces business logic into UseCases (not ViewModels)
3. Enables future module separation where ViewModels live in a \`:viewmodel\` module that doesn't depend on \`:domain.repository\`

### Verification
\`./scripts/validate.sh\` passes — all 5 ViewModels are clean.

Update TESTING.md to remove the gap note (it's no longer a gap).

## Test plan
- [ ] \`./scripts/validate.sh\` passes (validates the lint check itself)
- [ ] No ViewModel import violations remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)