### PR TITLE
test: Add FetchFcmStatusUseCase + DeregisterFcmUseCase coverage

### DIFF
--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DeregisterFcmUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DeregisterFcmUseCaseTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.DoorFcmState
+import com.chriscartland.garage.domain.model.FcmRegistrationStatus
+import com.chriscartland.garage.testcommon.FakeDoorFcmRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DeregisterFcmUseCaseTest {
+    @Test
+    fun deregisterReturnsNotRegisteredOnSuccess() =
+        runTest {
+            val repo = FakeDoorFcmRepository()
+            repo.deregisterResult = DoorFcmState.NotRegistered
+            val useCase = DeregisterFcmUseCase(repo)
+
+            assertEquals(FcmRegistrationStatus.NOT_REGISTERED, useCase())
+        }
+
+    @Test
+    fun deregisterReturnsUnknownOnFailure() =
+        runTest {
+            val repo = FakeDoorFcmRepository()
+            repo.deregisterResult = DoorFcmState.Unknown
+            val useCase = DeregisterFcmUseCase(repo)
+
+            assertEquals(FcmRegistrationStatus.UNKNOWN, useCase())
+        }
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/FetchFcmStatusUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/FetchFcmStatusUseCaseTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.DoorFcmState
+import com.chriscartland.garage.domain.model.DoorFcmTopic
+import com.chriscartland.garage.domain.model.FcmRegistrationStatus
+import com.chriscartland.garage.testcommon.FakeDoorFcmRepository
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FetchFcmStatusUseCaseTest {
+    @Test
+    fun returnsRegisteredWhenRepoReturnsRegistered() =
+        runTest {
+            val repo = FakeDoorFcmRepository()
+            repo.fetchStatusResult = DoorFcmState.Registered(DoorFcmTopic("test"))
+            val useCase = FetchFcmStatusUseCase(repo)
+
+            assertEquals(FcmRegistrationStatus.REGISTERED, useCase())
+        }
+
+    @Test
+    fun returnsNotRegisteredWhenRepoReturnsNotRegistered() =
+        runTest {
+            val repo = FakeDoorFcmRepository()
+            repo.fetchStatusResult = DoorFcmState.NotRegistered
+            val useCase = FetchFcmStatusUseCase(repo)
+
+            assertEquals(FcmRegistrationStatus.NOT_REGISTERED, useCase())
+        }
+
+    @Test
+    fun returnsUnknownWhenRepoReturnsUnknown() =
+        runTest {
+            val repo = FakeDoorFcmRepository()
+            repo.fetchStatusResult = DoorFcmState.Unknown
+            val useCase = FetchFcmStatusUseCase(repo)
+
+            assertEquals(FcmRegistrationStatus.UNKNOWN, useCase())
+        }
+}


### PR DESCRIPTION
## Summary
Test coverage for FCM use cases that didn't have tests yet:
- \`FetchFcmStatusUseCaseTest\` (3 tests — registered, not registered, unknown)
- \`DeregisterFcmUseCaseTest\` (2 tests)

\`RegisterFcmUseCaseTest\` already covers the third FCM use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)