### PR TITLE
fix: Snooze network errors actually propagate to the UI

### DIFF
--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepository.kt
@@ -72,35 +72,34 @@ class NetworkSnoozeRepository(
         snoozeDurationHours: String,
         idToken: String,
         snoozeEventTimestampSeconds: Long,
-    ) {
+    ): Boolean {
         val serverConfig = serverConfigRepository.getServerConfigCached()
         if (serverConfig == null) {
             Logger.e { "Server config is null" }
-            return
+            return false
         }
         if (!snoozeNotificationsOption) {
             Logger.w { "Snooze notifications disabled" }
             delay(500)
+            return true // Treat as success in feature-disabled mode
         }
-        if (snoozeNotificationsOption) {
-            when (
-                val result = networkButtonDataSource.snoozeNotifications(
-                    buildTimestamp = serverConfig.buildTimestamp,
-                    remoteButtonPushKey = serverConfig.remoteButtonPushKey,
-                    idToken = idToken,
-                    snoozeDurationHours = snoozeDurationHours,
-                    snoozeEventTimestampSeconds = snoozeEventTimestampSeconds,
-                )
-            ) {
-                is NetworkResult.Success -> return
-                is NetworkResult.HttpError -> {
-                    Logger.e { "Snooze HTTP ${result.code}" }
-                    return
-                }
-                NetworkResult.ConnectionFailed -> {
-                    Logger.e { "Snooze connection failed" }
-                    return
-                }
+        return when (
+            val result = networkButtonDataSource.snoozeNotifications(
+                buildTimestamp = serverConfig.buildTimestamp,
+                remoteButtonPushKey = serverConfig.remoteButtonPushKey,
+                idToken = idToken,
+                snoozeDurationHours = snoozeDurationHours,
+                snoozeEventTimestampSeconds = snoozeEventTimestampSeconds,
+            )
+        ) {
+            is NetworkResult.Success -> true
+            is NetworkResult.HttpError -> {
+                Logger.e { "Snooze HTTP ${result.code}" }
+                false
+            }
+            NetworkResult.ConnectionFailed -> {
+                Logger.e { "Snooze connection failed" }
+                false
             }
         }
     }

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/PushRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/PushRepositoryTest.kt
@@ -96,16 +96,62 @@ class SnoozeRepositoryTest {
     }
 
     @Test
-    fun snoozeDoesNotCrashWhenServerConfigFetchFails() =
+    fun snoozeReturnsFalseWhenServerConfigFetchFails() =
         runTest {
             networkConfigDataSource.serverConfigResult = NetworkResult.ConnectionFailed
-            repo.snoozeNotifications(
+            val success = repo.snoozeNotifications(
                 snoozeDurationHours = "1h",
                 idToken = "token",
                 snoozeEventTimestampSeconds = 1000L,
             )
-            // State remains Loading — no crash, no error propagation
+            assertEquals(false, success)
+            // State unchanged (still Loading from initial)
             assertEquals(SnoozeState.Loading, repo.snoozeState.value)
+        }
+
+    @Test
+    fun snoozeReturnsTrueOnSuccess() =
+        runTest {
+            networkConfigDataSource.serverConfigResult = NetworkResult.Success(
+                ServerConfig(buildTimestamp = "test", remoteButtonBuildTimestamp = "test", remoteButtonPushKey = "key"),
+            )
+            networkButtonDataSource.snoozeResult = NetworkResult.Success(Unit)
+            val success = repo.snoozeNotifications(
+                snoozeDurationHours = "1h",
+                idToken = "token",
+                snoozeEventTimestampSeconds = 1000L,
+            )
+            assertEquals(true, success)
+        }
+
+    @Test
+    fun snoozeReturnsFalseOnHttpError() =
+        runTest {
+            networkConfigDataSource.serverConfigResult = NetworkResult.Success(
+                ServerConfig(buildTimestamp = "test", remoteButtonBuildTimestamp = "test", remoteButtonPushKey = "key"),
+            )
+            networkButtonDataSource.snoozeResult = NetworkResult.HttpError(500)
+            val success = repo.snoozeNotifications(
+                snoozeDurationHours = "1h",
+                idToken = "token",
+                snoozeEventTimestampSeconds = 1000L,
+            )
+            assertEquals(false, success)
+        }
+
+    @Test
+    fun snoozeReturnsFalseOnConnectionFailure() =
+        runTest {
+            networkConfigDataSource.serverConfigResult = NetworkResult.Success(
+                ServerConfig(buildTimestamp = "test", remoteButtonBuildTimestamp = "test", remoteButtonPushKey = "key"),
+            )
+            networkButtonDataSource.snoozeResult = NetworkResult.ConnectionFailed
+            val success = repo.snoozeNotifications(
+                snoozeDurationHours = "1h",
+                idToken = "token",
+                snoozeEventTimestampSeconds = 1000L,
+            )
+            assertEquals(false, success)
         }
 
     @Test

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/ActionError.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/ActionError.kt
@@ -17,4 +17,9 @@ sealed interface ActionError : AppError {
     data object MissingData : ActionError {
         override val message: String = "Required data not available"
     }
+
+    /** Network call failed (HTTP error or connection failure). */
+    data object NetworkFailed : ActionError {
+        override val message: String = "Network request failed"
+    }
 }

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/SnoozeRepository.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/SnoozeRepository.kt
@@ -14,9 +14,13 @@ interface SnoozeRepository {
 
     suspend fun fetchSnoozeStatus()
 
+    /**
+     * Send a snooze request. Returns true on success, false on any failure
+     * (server config missing, HTTP error, connection failure).
+     */
     suspend fun snoozeNotifications(
         snoozeDurationHours: String,
         idToken: String,
         snoozeEventTimestampSeconds: Long,
-    )
+    ): Boolean
 }

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeSnoozeRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeSnoozeRepository.kt
@@ -15,6 +15,9 @@ class FakeSnoozeRepository : SnoozeRepository {
     var fetchCount = 0
         private set
 
+    /** Set this to false to make snoozeNotifications() return false (network failure). */
+    var snoozeResult: Boolean = true
+
     fun setSnoozeState(state: SnoozeState) {
         _snoozeState.value = state
     }
@@ -27,7 +30,8 @@ class FakeSnoozeRepository : SnoozeRepository {
         snoozeDurationHours: String,
         idToken: String,
         snoozeEventTimestampSeconds: Long,
-    ) {
+    ): Boolean {
         snoozeCount++
+        return snoozeResult
     }
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
@@ -111,6 +111,7 @@ class DefaultRemoteButtonViewModel(
                 is AppResult.Error -> when (result.error) {
                     ActionError.NotAuthenticated -> Logger.w { "Push failed — not authenticated" }
                     ActionError.MissingData -> Logger.w { "Push failed — missing data" }
+                    ActionError.NetworkFailed -> Logger.w { "Push failed — network error" }
                 }
             }
         }
@@ -142,6 +143,7 @@ class DefaultRemoteButtonViewModel(
                     _snoozeAction.value = when (result.error) {
                         ActionError.NotAuthenticated -> SnoozeAction.Failed.NotAuthenticated
                         ActionError.MissingData -> SnoozeAction.Failed.MissingData
+                        ActionError.NetworkFailed -> SnoozeAction.Failed.NetworkError
                     }
                     scheduleActionReset()
                 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SnoozeNotificationsUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SnoozeNotificationsUseCase.kt
@@ -46,11 +46,15 @@ class SnoozeNotificationsUseCase(
             return AppResult.Error(ActionError.MissingData)
         }
         val idToken = ensureFreshIdToken(authState)
-        snoozeRepository.snoozeNotifications(
+        val success = snoozeRepository.snoozeNotifications(
             snoozeDurationHours = snoozeDurationHours,
             idToken = idToken.asString(),
             snoozeEventTimestampSeconds = lastChangeTimeSeconds,
         )
-        return AppResult.Success(Unit)
+        return if (success) {
+            AppResult.Success(Unit)
+        } else {
+            AppResult.Error(ActionError.NetworkFailed)
+        }
     }
 }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModelTest.kt
@@ -257,6 +257,20 @@ class RemoteButtonViewModelTest {
         }
 
     @Test
+    fun snoozeActionFailedNetworkErrorWhenRepositoryReturnsFalse() =
+        runTest {
+            val viewModel = createAuthenticatedViewModel()
+            doorRepository.setCurrentDoorEvent(DoorEvent(lastChangeTimeSeconds = 1000L))
+            snoozeRepository.snoozeResult = false
+            testDispatcher.scheduler.runCurrent()
+
+            viewModel.snoozeOpenDoorsNotifications(SnoozeDurationUIOption.OneHour)
+            testDispatcher.scheduler.runCurrent()
+
+            assertEquals(SnoozeAction.Failed.NetworkError, viewModel.snoozeAction.value)
+        }
+
+    @Test
     fun snoozeActionWithNoneDurationDoesNotShowSnoozingTime() =
         runTest {
             val viewModel = createAuthenticatedViewModel()


### PR DESCRIPTION
## Summary
**Bug:** \`SnoozeAction.Failed.NetworkError\` was dead code. The repository swallowed all network errors and returned Unit, so the UseCase always returned \`AppResult.Success\` and the UI never saw the network error state.

## Fix
- \`SnoozeRepository.snoozeNotifications\` now returns \`Boolean\` (true=success)
- \`NetworkSnoozeRepository\` propagates HTTP errors and connection failures as \`false\`
- \`SnoozeNotificationsUseCase\` translates \`false\` to \`AppResult.Error(NetworkFailed)\`
- New \`ActionError.NetworkFailed\` variant
- ViewModel maps \`NetworkFailed\` → \`SnoozeAction.Failed.NetworkError\`
- \`PushRemoteButton\` handler updated for exhaustive \`when\`

## Tests added
- \`snoozeActionFailedNetworkErrorWhenRepositoryReturnsFalse\` (ViewModel)
- \`snoozeReturnsTrueOnSuccess\` (data layer)
- \`snoozeReturnsFalseOnHttpError\` (data layer)
- \`snoozeReturnsFalseOnConnectionFailure\` (data layer)

## Test plan
- [ ] Existing snooze tests pass
- [ ] New tests pass
- [ ] \`./scripts/validate.sh\` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)