### PR TITLE
test: SnoozeNotificationsUseCase NetworkFailed coverage

### DIFF
--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SnoozeNotificationsUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SnoozeNotificationsUseCaseTest.kt
@@ -120,4 +120,16 @@ class SnoozeNotificationsUseCaseTest {
             useCase("4h", 2000L)
             assertEquals(1, fakeAuth.refreshCount)
         }
+
+    @Test
+    fun snoozeReturnsNetworkFailedWhenRepositoryReturnsFalse() =
+        runTest {
+            authenticateUser()
+            fakeSnooze.snoozeResult = false
+
+            val result = useCase("1h", 1000L)
+
+            assertTrue(result is AppResult.Error, "Should be error")
+            assertEquals(ActionError.NetworkFailed, (result as AppResult.Error).error)
+        }
 }


### PR DESCRIPTION
## Summary
Add a use case test for the \`NetworkFailed\` path that #256 made reachable.

Companion to #256 — verifies that when \`snoozeRepository.snoozeNotifications()\` returns false, the use case correctly translates that to \`AppResult.Error(ActionError.NetworkFailed)\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)