### PR TITLE
fix: Button timeout regression — start timer from HTTP request

### DIFF
--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ButtonStateMachine.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ButtonStateMachine.kt
@@ -149,9 +149,11 @@ class ButtonStateMachine(
             }
             RemoteButtonState.Armed -> {
                 // Confirm — trigger the network request and optimistically transition to Sending.
+                // Do NOT start the network timeout here. The timeout starts when
+                // PushStatus.SENDING arrives, which is when the HTTP request actually begins.
+                // Starting it here would include token refresh + config fetch in the budget.
                 onSubmit()
                 transitionTo(RemoteButtonState.Sending)
-                scheduleTimer(networkTimeoutMillis, Event.NetworkTimedOut)
             }
             // Tap ignored in all other states — Arming, NotConfirmed,
             // Sending, Sent, Received, *Timeout
@@ -165,11 +167,11 @@ class ButtonStateMachine(
     ) {
         when (status) {
             PushStatus.SENDING -> {
-                // Idempotent — we already optimistically transitioned to Sending on confirm.
-                if (current != RemoteButtonState.Sending) {
-                    transitionTo(RemoteButtonState.Sending)
-                    scheduleTimer(networkTimeoutMillis, Event.NetworkTimedOut)
-                }
+                // The HTTP request has actually started. Transition to Sending if not
+                // already there (we optimistically moved on confirm tap), and start/restart
+                // the network timeout. This is the true start of the network clock.
+                transitionTo(RemoteButtonState.Sending)
+                scheduleTimer(networkTimeoutMillis, Event.NetworkTimedOut)
             }
             PushStatus.IDLE -> {
                 if (current == RemoteButtonState.Sending) {

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ButtonStateMachineTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ButtonStateMachineTest.kt
@@ -212,6 +212,11 @@ class ButtonStateMachineTest {
     fun sendingTimesOutToSendingTimeoutThenReady() =
         runTest {
             val sm = armAndConfirm()
+
+            // Network timeout starts when PushStatus.SENDING arrives, not on confirm tap.
+            pushStatus.value = PushStatus.SENDING
+            testScheduler.runCurrent()
+
             advanceTimeBy(NETWORK_TIMEOUT + 1)
             testScheduler.runCurrent()
             assertEquals(RemoteButtonState.SendingTimeout, sm.state.value)
@@ -219,6 +224,19 @@ class ButtonStateMachineTest {
             advanceTimeBy(DISPLAY + 1)
             testScheduler.runCurrent()
             assertEquals(RemoteButtonState.Ready, sm.state.value)
+        }
+
+    @Test
+    fun sendingDoesNotTimeOutBeforePushStatusSending() =
+        runTest {
+            val sm = armAndConfirm()
+            assertEquals(RemoteButtonState.Sending, sm.state.value)
+
+            // No PushStatus.SENDING yet — timeout timer hasn't started.
+            // Even well past the network timeout, state stays Sending.
+            advanceTimeBy(NETWORK_TIMEOUT * 3)
+            testScheduler.runCurrent()
+            assertEquals(RemoteButtonState.Sending, sm.state.value)
         }
 
     @Test
@@ -332,9 +350,11 @@ class ButtonStateMachineTest {
         }
 
     @Test
-    fun pushStatusSendingArrivingAfterOptimisticIsIdempotent() =
+    fun pushStatusSendingArrivingAfterOptimisticStaysInSending() =
         runTest {
             val sm = armAndConfirm()
+            // Already in Sending from optimistic transition. PushStatus.SENDING
+            // keeps us there but starts the network timeout timer.
             pushStatus.value = PushStatus.SENDING
             testScheduler.runCurrent()
             assertEquals(RemoteButtonState.Sending, sm.state.value)
@@ -344,6 +364,8 @@ class ButtonStateMachineTest {
     fun doorMovementInSendingTimeoutTransitionsToReceived() =
         runTest {
             val sm = armAndConfirm()
+            pushStatus.value = PushStatus.SENDING
+            testScheduler.runCurrent()
             advanceTimeBy(NETWORK_TIMEOUT + 1)
             testScheduler.runCurrent()
             assertEquals(RemoteButtonState.SendingTimeout, sm.state.value)
@@ -428,6 +450,9 @@ class ButtonStateMachineTest {
     fun displayTimeoutFromSendingTimeoutReturnsToReady() =
         runTest {
             val sm = armAndConfirm()
+            pushStatus.value = PushStatus.SENDING
+            testScheduler.runCurrent()
+
             advanceTimeBy(NETWORK_TIMEOUT + 1)
             testScheduler.runCurrent()
             assertEquals(RemoteButtonState.SendingTimeout, sm.state.value)


### PR DESCRIPTION
## Summary

- The `ButtonStateMachine` was starting the 10s network timeout on confirm tap, but the HTTP request doesn't begin until after token refresh + config fetch. This caused false `SendingTimeout` while the server actually received the request and the door opened.
- Moved timeout start to when `PushStatus.SENDING` arrives (actual HTTP start), matching the old state machine's behavior.
- Added test verifying the state machine stays in `Sending` indefinitely before `PushStatus.SENDING` arrives.

## Test plan

- [x] `ButtonStateMachineTest` — all 23 tests pass (1 new)
- [x] `validate.sh` passes
- [ ] Manual: confirm button press on device with slow network — should not show timeout if server responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)