### PR TITLE
fix: Show neutral text instead of Loading snooze status

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/SnoozeNotificationCard.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/SnoozeNotificationCard.kt
@@ -145,10 +145,9 @@ fun SnoozeNotificationCard(
 @Composable
 private fun SnoozeStatusText(snoozeState: SnoozeState) {
     when (snoozeState) {
-        SnoozeState.Loading -> {
-            Text("Loading snooze status...")
-        }
-        SnoozeState.NotSnoozing -> {
+        SnoozeState.Loading,
+        SnoozeState.NotSnoozing,
+        -> {
             Text("Snooze notifications")
         }
         is SnoozeState.Snoozing -> {


### PR DESCRIPTION
## Summary

- `SnoozeState.Loading` is the default before any fetch, not an active loading indicator
- Changed to show "Snooze notifications" (same as NotSnoozing) instead of "Loading snooze status..."
- If snooze is active, it updates to "Snoozing until..." when the fetch completes

## Test plan

- [x] `validate.sh` passes
- [ ] Manual: open app, verify no "Loading snooze status..." flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)