### PR TITLE
feat: YAML-driven screenshot collections

### DIFF
--- a/AndroidGarage/android-screenshot-tests/collections/button-states-dark.md
+++ b/AndroidGarage/android-screenshot-tests/collections/button-states-dark.md
@@ -1,0 +1,17 @@
+<!-- GENERATED FILE — DO NOT EDIT -->
+<!-- Source: android-screenshot-tests/collections/button-states-dark.yaml -->
+
+# Garage Door Button States (Dark)
+
+1. Ready
+2. Preparing
+3. Confirm?
+4. Sending
+5. Waiting
+6. Done!
+7. Cancelled
+8. Server Failed
+9. Door Failed
+
+<img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/GarageDoorButtonReadyPreviewTest_Dark_77106447_0.png" alt="Ready" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/GarageDoorButtonPreparingPreviewTest_Dark_77106447_0.png" alt="Preparing" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/GarageDoorButtonAwaitingConfirmationPreviewTest_Dark_77106447_0.png" alt="Confirm?" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/GarageDoorButtonSendingToServerPreviewTest_Dark_77106447_0.png" alt="Sending" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/GarageDoorButtonSendingToDoorPreviewTest_Dark_77106447_0.png" alt="Waiting" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/GarageDoorButtonSucceededPreviewTest_Dark_77106447_0.png" alt="Done!" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/GarageDoorButtonCancelledPreviewTest_Dark_77106447_0.png" alt="Cancelled" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/GarageDoorButtonServerFailedPreviewTest_Dark_77106447_0.png" alt="Server Failed" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/GarageDoorButtonDoorFailedPreviewTest_Dark_77106447_0.png" alt="Door Failed" width="200" /> 
+

--- a/AndroidGarage/android-screenshot-tests/collections/button-states-dark.yaml
+++ b/AndroidGarage/android-screenshot-tests/collections/button-states-dark.yaml
@@ -1,0 +1,21 @@
+title: "Garage Door Button States (Dark)"
+test_class: ComponentsScreenshotTestKt
+screenshots:
+  - test: GarageDoorButtonReadyPreviewTest_Dark
+    description: "Ready"
+  - test: GarageDoorButtonPreparingPreviewTest_Dark
+    description: "Preparing"
+  - test: GarageDoorButtonAwaitingConfirmationPreviewTest_Dark
+    description: "Confirm?"
+  - test: GarageDoorButtonSendingToServerPreviewTest_Dark
+    description: "Sending"
+  - test: GarageDoorButtonSendingToDoorPreviewTest_Dark
+    description: "Waiting"
+  - test: GarageDoorButtonSucceededPreviewTest_Dark
+    description: "Done!"
+  - test: GarageDoorButtonCancelledPreviewTest_Dark
+    description: "Cancelled"
+  - test: GarageDoorButtonServerFailedPreviewTest_Dark
+    description: "Server Failed"
+  - test: GarageDoorButtonDoorFailedPreviewTest_Dark
+    description: "Door Failed"

--- a/AndroidGarage/android-screenshot-tests/collections/button-states.md
+++ b/AndroidGarage/android-screenshot-tests/collections/button-states.md
@@ -1,0 +1,17 @@
+<!-- GENERATED FILE — DO NOT EDIT -->
+<!-- Source: android-screenshot-tests/collections/button-states.yaml -->
+
+# Garage Door Button States
+
+1. Ready
+2. Preparing
+3. Confirm?
+4. Sending
+5. Waiting
+6. Done!
+7. Cancelled
+8. Server Failed
+9. Door Failed
+
+<img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/GarageDoorButtonReadyPreviewTest_Light_fc5b723e_0.png" alt="Ready" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/GarageDoorButtonPreparingPreviewTest_Light_fc5b723e_0.png" alt="Preparing" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/GarageDoorButtonAwaitingConfirmationPreviewTest_Light_fc5b723e_0.png" alt="Confirm?" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/GarageDoorButtonSendingToServerPreviewTest_Light_fc5b723e_0.png" alt="Sending" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/GarageDoorButtonSendingToDoorPreviewTest_Light_fc5b723e_0.png" alt="Waiting" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/GarageDoorButtonSucceededPreviewTest_Light_fc5b723e_0.png" alt="Done!" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/GarageDoorButtonCancelledPreviewTest_Light_fc5b723e_0.png" alt="Cancelled" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/GarageDoorButtonServerFailedPreviewTest_Light_fc5b723e_0.png" alt="Server Failed" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/GarageDoorButtonDoorFailedPreviewTest_Light_fc5b723e_0.png" alt="Door Failed" width="200" /> 
+

--- a/AndroidGarage/android-screenshot-tests/collections/button-states.yaml
+++ b/AndroidGarage/android-screenshot-tests/collections/button-states.yaml
@@ -1,0 +1,22 @@
+title: "Garage Door Button States"
+# Test class that contains these screenshots.
+test_class: ComponentsScreenshotTestKt
+screenshots:
+  - test: GarageDoorButtonReadyPreviewTest_Light
+    description: "Ready"
+  - test: GarageDoorButtonPreparingPreviewTest_Light
+    description: "Preparing"
+  - test: GarageDoorButtonAwaitingConfirmationPreviewTest_Light
+    description: "Confirm?"
+  - test: GarageDoorButtonSendingToServerPreviewTest_Light
+    description: "Sending"
+  - test: GarageDoorButtonSendingToDoorPreviewTest_Light
+    description: "Waiting"
+  - test: GarageDoorButtonSucceededPreviewTest_Light
+    description: "Done!"
+  - test: GarageDoorButtonCancelledPreviewTest_Light
+    description: "Cancelled"
+  - test: GarageDoorButtonServerFailedPreviewTest_Light
+    description: "Server Failed"
+  - test: GarageDoorButtonDoorFailedPreviewTest_Light
+    description: "Door Failed"

--- a/AndroidGarage/android-screenshot-tests/collections/garage-door-icon.md
+++ b/AndroidGarage/android-screenshot-tests/collections/garage-door-icon.md
@@ -1,0 +1,14 @@
+<!-- GENERATED FILE — DO NOT EDIT -->
+<!-- Source: android-screenshot-tests/collections/garage-door-icon.yaml -->
+
+# Garage Door Icon
+
+1. Closed
+2. Open
+3. Opening
+4. Closing
+5. Midway
+6. Icon
+
+<img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/GarageDoorScreenshotTestKt/GarageDoorClosedPreviewTest_Light_fc5b723e_0.png" alt="Closed" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/GarageDoorScreenshotTestKt/GarageDoorOpenPreviewTest_Light_fc5b723e_0.png" alt="Open" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/GarageDoorScreenshotTestKt/GarageDoorOpeningPreviewTest_Light_fc5b723e_0.png" alt="Opening" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/GarageDoorScreenshotTestKt/GarageDoorClosingPreviewTest_Light_fc5b723e_0.png" alt="Closing" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/GarageDoorScreenshotTestKt/GarageDoorMidwayPreviewTest_Light_fc5b723e_0.png" alt="Midway" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/GarageDoorScreenshotTestKt/GarageIconPreviewTest_Light_fc5b723e_0.png" alt="Icon" width="200" /> 
+

--- a/AndroidGarage/android-screenshot-tests/collections/garage-door-icon.yaml
+++ b/AndroidGarage/android-screenshot-tests/collections/garage-door-icon.yaml
@@ -1,0 +1,15 @@
+title: "Garage Door Icon"
+test_class: GarageDoorScreenshotTestKt
+screenshots:
+  - test: GarageDoorClosedPreviewTest_Light
+    description: "Closed"
+  - test: GarageDoorOpenPreviewTest_Light
+    description: "Open"
+  - test: GarageDoorOpeningPreviewTest_Light
+    description: "Opening"
+  - test: GarageDoorClosingPreviewTest_Light
+    description: "Closing"
+  - test: GarageDoorMidwayPreviewTest_Light
+    description: "Midway"
+  - test: GarageIconPreviewTest_Light
+    description: "Icon"

--- a/AndroidGarage/android-screenshot-tests/collections/history-screen.md
+++ b/AndroidGarage/android-screenshot-tests/collections/history-screen.md
@@ -1,0 +1,10 @@
+<!-- GENERATED FILE — DO NOT EDIT -->
+<!-- Source: android-screenshot-tests/collections/history-screen.yaml -->
+
+# History Screen
+
+1. Light
+2. Dark
+
+<img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ScreensScreenshotTestKt/DoorHistoryScreenPreviewTest_Light_fc5b723e_0.png" alt="Light" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ScreensScreenshotTestKt/DoorHistoryScreenPreviewTest_Dark_77106447_0.png" alt="Dark" width="200" /> 
+

--- a/AndroidGarage/android-screenshot-tests/collections/history-screen.yaml
+++ b/AndroidGarage/android-screenshot-tests/collections/history-screen.yaml
@@ -1,0 +1,7 @@
+title: "History Screen"
+test_class: ScreensScreenshotTestKt
+screenshots:
+  - test: DoorHistoryScreenPreviewTest_Light
+    description: "Light"
+  - test: DoorHistoryScreenPreviewTest_Dark
+    description: "Dark"

--- a/AndroidGarage/android-screenshot-tests/collections/network-diagram.md
+++ b/AndroidGarage/android-screenshot-tests/collections/network-diagram.md
@@ -1,0 +1,14 @@
+<!-- GENERATED FILE — DO NOT EDIT -->
+<!-- Source: android-screenshot-tests/collections/network-diagram.yaml -->
+
+# Network Progress Diagram
+
+1. Idle
+2. Sending to Server
+3. Sending to Door
+4. Succeeded
+5. Server Failed
+6. Door Failed
+
+<img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/NetworkDiagramIdlePreviewTest_Light_fc5b723e_0.png" alt="Idle" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/NetworkDiagramSendingToServerPreviewTest_Light_fc5b723e_0.png" alt="Sending to Server" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/NetworkDiagramSendingToDoorPreviewTest_Light_fc5b723e_0.png" alt="Sending to Door" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/NetworkDiagramSucceededPreviewTest_Light_fc5b723e_0.png" alt="Succeeded" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/NetworkDiagramServerFailedPreviewTest_Light_fc5b723e_0.png" alt="Server Failed" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/NetworkDiagramDoorFailedPreviewTest_Light_fc5b723e_0.png" alt="Door Failed" width="200" /> 
+

--- a/AndroidGarage/android-screenshot-tests/collections/network-diagram.yaml
+++ b/AndroidGarage/android-screenshot-tests/collections/network-diagram.yaml
@@ -1,0 +1,15 @@
+title: "Network Progress Diagram"
+test_class: ComponentsScreenshotTestKt
+screenshots:
+  - test: NetworkDiagramIdlePreviewTest_Light
+    description: "Idle"
+  - test: NetworkDiagramSendingToServerPreviewTest_Light
+    description: "Sending to Server"
+  - test: NetworkDiagramSendingToDoorPreviewTest_Light
+    description: "Sending to Door"
+  - test: NetworkDiagramSucceededPreviewTest_Light
+    description: "Succeeded"
+  - test: NetworkDiagramServerFailedPreviewTest_Light
+    description: "Server Failed"
+  - test: NetworkDiagramDoorFailedPreviewTest_Light
+    description: "Door Failed"

--- a/AndroidGarage/android-screenshot-tests/collections/remote-button-composed.md
+++ b/AndroidGarage/android-screenshot-tests/collections/remote-button-composed.md
@@ -1,0 +1,17 @@
+<!-- GENERATED FILE — DO NOT EDIT -->
+<!-- Source: android-screenshot-tests/collections/remote-button-composed.yaml -->
+
+# Remote Button (Button + Diagram)
+
+1. Ready
+2. Preparing
+3. Confirm?
+4. Sending to Server
+5. Sending to Door
+6. Succeeded
+7. Cancelled
+8. Server Failed
+9. Door Failed
+
+<img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentPreviewTest_Light_fc5b723e_0.png" alt="Ready" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentPreparingPreviewTest_Light_fc5b723e_0.png" alt="Preparing" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentAwaitingConfirmationPreviewTest_Light_fc5b723e_0.png" alt="Confirm?" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentSendingToServerPreviewTest_Light_fc5b723e_0.png" alt="Sending to Server" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentSendingToDoorPreviewTest_Light_fc5b723e_0.png" alt="Sending to Door" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentSucceededPreviewTest_Light_fc5b723e_0.png" alt="Succeeded" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentCancelledPreviewTest_Light_fc5b723e_0.png" alt="Cancelled" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentServerFailedPreviewTest_Light_fc5b723e_0.png" alt="Server Failed" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentDoorFailedPreviewTest_Light_fc5b723e_0.png" alt="Door Failed" width="200" /> 
+

--- a/AndroidGarage/android-screenshot-tests/collections/remote-button-composed.yaml
+++ b/AndroidGarage/android-screenshot-tests/collections/remote-button-composed.yaml
@@ -1,0 +1,21 @@
+title: "Remote Button (Button + Diagram)"
+test_class: ComponentsScreenshotTestKt
+screenshots:
+  - test: RemoteButtonContentPreviewTest_Light
+    description: "Ready"
+  - test: RemoteButtonContentPreparingPreviewTest_Light
+    description: "Preparing"
+  - test: RemoteButtonContentAwaitingConfirmationPreviewTest_Light
+    description: "Confirm?"
+  - test: RemoteButtonContentSendingToServerPreviewTest_Light
+    description: "Sending to Server"
+  - test: RemoteButtonContentSendingToDoorPreviewTest_Light
+    description: "Sending to Door"
+  - test: RemoteButtonContentSucceededPreviewTest_Light
+    description: "Succeeded"
+  - test: RemoteButtonContentCancelledPreviewTest_Light
+    description: "Cancelled"
+  - test: RemoteButtonContentServerFailedPreviewTest_Light
+    description: "Server Failed"
+  - test: RemoteButtonContentDoorFailedPreviewTest_Light
+    description: "Door Failed"

--- a/AndroidGarage/android-screenshot-tests/collections/snooze-card.md
+++ b/AndroidGarage/android-screenshot-tests/collections/snooze-card.md
@@ -1,0 +1,14 @@
+<!-- GENERATED FILE — DO NOT EDIT -->
+<!-- Source: android-screenshot-tests/collections/snooze-card.yaml -->
+
+# Snooze Notification Card
+
+1. Default
+2. Loading
+3. Sending
+4. Succeeded
+5. Cleared
+6. Error
+
+<img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/SnoozeNotificationCardPreviewTest_Light_fc5b723e_0.png" alt="Default" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/SnoozeNotificationCardLoadingPreviewTest_Light_fc5b723e_0.png" alt="Loading" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/SnoozeNotificationCardSendingPreviewTest_Light_fc5b723e_0.png" alt="Sending" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/SnoozeNotificationCardSucceededPreviewTest_Light_fc5b723e_0.png" alt="Succeeded" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/SnoozeNotificationCardClearedPreviewTest_Light_fc5b723e_0.png" alt="Cleared" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/SnoozeNotificationCardErrorPreviewTest_Light_fc5b723e_0.png" alt="Error" width="200" /> 
+

--- a/AndroidGarage/android-screenshot-tests/collections/snooze-card.yaml
+++ b/AndroidGarage/android-screenshot-tests/collections/snooze-card.yaml
@@ -1,0 +1,15 @@
+title: "Snooze Notification Card"
+test_class: ComponentsScreenshotTestKt
+screenshots:
+  - test: SnoozeNotificationCardPreviewTest_Light
+    description: "Default"
+  - test: SnoozeNotificationCardLoadingPreviewTest_Light
+    description: "Loading"
+  - test: SnoozeNotificationCardSendingPreviewTest_Light
+    description: "Sending"
+  - test: SnoozeNotificationCardSucceededPreviewTest_Light
+    description: "Succeeded"
+  - test: SnoozeNotificationCardClearedPreviewTest_Light
+    description: "Cleared"
+  - test: SnoozeNotificationCardErrorPreviewTest_Light
+    description: "Error"

--- a/scripts/generate-android-screenshots.sh
+++ b/scripts/generate-android-screenshots.sh
@@ -25,4 +25,7 @@ done
 echo "Generating screenshot gallery..."
 ./scripts/generate-android-screenshot-gallery.sh
 
+echo "Generating screenshot collections..."
+./scripts/generate-screenshot-collections.sh
+
 echo "All screenshot tests completed."

--- a/scripts/generate-screenshot-collections.sh
+++ b/scripts/generate-screenshot-collections.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Generates Markdown files from YAML screenshot collection declarations.
+#
+# For each .yaml file in android-screenshot-tests/collections/, this script:
+# 1. Deletes the corresponding .md file (clean slate)
+# 2. Reads the YAML to extract title, test_class, and screenshot entries
+# 3. Finds matching reference PNGs (by stable test name prefix)
+# 4. Generates a Markdown file with metadata, descriptions, and inline images
+#
+# Usage: ./scripts/generate-screenshot-collections.sh
+#
+# Requires: No external YAML parser — uses grep/sed since the format is simple.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+COLLECTIONS_DIR="$REPO_ROOT/AndroidGarage/android-screenshot-tests/collections"
+REFERENCE_DIR="$REPO_ROOT/AndroidGarage/android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests"
+
+if [ ! -d "$COLLECTIONS_DIR" ]; then
+    echo "No collections directory found at $COLLECTIONS_DIR"
+    exit 0
+fi
+
+# Delete all generated .md files in collections/
+find "$COLLECTIONS_DIR" -name "*.md" -delete
+
+yaml_count=0
+error_count=0
+
+for yaml_file in "$COLLECTIONS_DIR"/*.yaml; do
+    [ -f "$yaml_file" ] || continue
+    yaml_count=$((yaml_count + 1))
+
+    yaml_basename="$(basename "$yaml_file" .yaml)"
+    md_file="$COLLECTIONS_DIR/$yaml_basename.md"
+    yaml_relpath="android-screenshot-tests/collections/$(basename "$yaml_file")"
+
+    # Parse title
+    title="$(grep '^title:' "$yaml_file" | sed 's/^title: *"\{0,1\}\(.*\)"\{0,1\}$/\1/' | sed 's/"$//')"
+
+    # Parse test_class
+    test_class="$(grep '^test_class:' "$yaml_file" | sed 's/^test_class: *//')"
+
+    if [ -z "$title" ] || [ -z "$test_class" ]; then
+        echo "ERROR: $yaml_file missing title or test_class"
+        error_count=$((error_count + 1))
+        continue
+    fi
+
+    class_dir="$REFERENCE_DIR/$test_class"
+    if [ ! -d "$class_dir" ]; then
+        echo "WARNING: Reference directory not found: $class_dir"
+    fi
+
+    # Extract screenshot entries (test + description pairs)
+    # Simple line-by-line parser for the flat YAML structure
+    tests=()
+    descriptions=()
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^[[:space:]]*-[[:space:]]*test:[[:space:]]*(.*) ]]; then
+            tests+=("${BASH_REMATCH[1]}")
+        elif [[ "$line" =~ ^[[:space:]]*description:[[:space:]]*\"(.*)\" ]]; then
+            descriptions+=("${BASH_REMATCH[1]}")
+        elif [[ "$line" =~ ^[[:space:]]*description:[[:space:]]*(.*) ]]; then
+            descriptions+=("${BASH_REMATCH[1]}")
+        fi
+    done < "$yaml_file"
+
+    if [ "${#tests[@]}" -ne "${#descriptions[@]}" ]; then
+        echo "ERROR: $yaml_file has ${#tests[@]} tests but ${#descriptions[@]} descriptions"
+        error_count=$((error_count + 1))
+        continue
+    fi
+
+    # Find matching PNG for each test name
+    image_paths=()
+    missing=0
+    for test_name in "${tests[@]}"; do
+        # Glob for {test_name}_*_0.png (the hash varies)
+        matches=("$class_dir"/${test_name}_*_0.png)
+        if [ -f "${matches[0]}" ]; then
+            # Store path relative to collections/ dir for Markdown links
+            rel_path="$(python3 -c "import os.path; print(os.path.relpath('${matches[0]}', '$COLLECTIONS_DIR'))")"
+            image_paths+=("$rel_path")
+        else
+            echo "WARNING: No image found for $test_name in $class_dir"
+            image_paths+=("")
+            missing=$((missing + 1))
+        fi
+    done
+
+    # Generate Markdown
+    {
+        echo "<!-- GENERATED FILE — DO NOT EDIT -->"
+        echo "<!-- Source: $yaml_relpath -->"
+        echo ""
+        echo "# $title"
+        echo ""
+
+        # Numbered description list
+        for i in "${!descriptions[@]}"; do
+            echo "$((i + 1)). ${descriptions[$i]}"
+        done
+        echo ""
+
+        # Images in a single paragraph so they flow/wrap naturally
+        img_line=""
+        for i in "${!image_paths[@]}"; do
+            path="${image_paths[$i]}"
+            desc="${descriptions[$i]}"
+            if [ -n "$path" ]; then
+                img_line+="<img src=\"$path\" alt=\"$desc\" width=\"200\" /> "
+            fi
+        done
+        echo "$img_line"
+        echo ""
+    } > "$md_file"
+
+    echo "Generated $md_file (${#tests[@]} images, $missing missing)"
+done
+
+if [ "$error_count" -gt 0 ]; then
+    echo ""
+    echo "ERRORS: $error_count collection(s) failed"
+    exit 1
+fi
+
+echo ""
+echo "Screenshot collections generated: $yaml_count collection(s)"


### PR DESCRIPTION
## Summary

- New YAML format for declaring curated screenshot galleries
- `generate-screenshot-collections.sh` reads YAML, finds PNGs, generates Markdown
- Script deletes all `.md` before regenerating (clean slate for removed screenshots)
- Auto-runs as part of `generate-android-screenshots.sh`
- 7 initial collections: button states (light/dark), network diagram, composed button, garage door icon, snooze card, history

## YAML format

```yaml
title: "Garage Door Button States"
test_class: ComponentsScreenshotTestKt
screenshots:
  - test: GarageDoorButtonReadyPreviewTest_Light
    description: "Ready"
```

## Test plan

- [x] Script generates all 7 collections with 0 missing images
- [x] Generated Markdown has correct metadata, descriptions, and image paths
- [x] Images display inline (flow/wrap based on browser width)

🤖 Generated with [Claude Code](https://claude.com/claude-code)