### PR TITLE
feat: YAML-driven screenshot collections

### DIFF
--- a/AndroidGarage/android-screenshot-tests/collections/app-overview.md
+++ b/AndroidGarage/android-screenshot-tests/collections/app-overview.md
@@ -1,0 +1,22 @@
+<!-- GENERATED FILE — DO NOT EDIT -->
+<!-- Source: android-screenshot-tests/collections/app-overview.yaml -->
+
+# Smart Garage Door — App Overview
+
+1. Home: garage door button (ready)
+2. Home: confirm door action
+3. Home: sending command to server
+4. Home: door moved successfully
+5. Home: server request failed
+6. Door status card
+7. History: recent door events
+8. History: single event card
+9. Settings: signed-in user
+10. Settings: snooze notifications
+11. Settings: snooze active
+12. Door: closed
+13. Door: open
+14. Door: opening
+
+<img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentPreviewTest_Light_fc5b723e_0.png" alt="Home: garage door button (ready)" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentAwaitingConfirmationPreviewTest_Light_fc5b723e_0.png" alt="Home: confirm door action" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentSendingToServerPreviewTest_Light_fc5b723e_0.png" alt="Home: sending command to server" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentSucceededPreviewTest_Light_fc5b723e_0.png" alt="Home: door moved successfully" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentServerFailedPreviewTest_Light_fc5b723e_0.png" alt="Home: server request failed" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/DoorStatusCardPreviewTest_Light_fc5b723e_0.png" alt="Door status card" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ScreensScreenshotTestKt/DoorHistoryScreenPreviewTest_Light_fc5b723e_0.png" alt="History: recent door events" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RecentDoorEventListItemPreviewTest_Light_fc5b723e_0.png" alt="History: single event card" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/UserInfoCardPreviewTest_Light_fc5b723e_0.png" alt="Settings: signed-in user" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/SnoozeNotificationCardPreviewTest_Light_fc5b723e_0.png" alt="Settings: snooze notifications" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/SnoozeNotificationCardSucceededPreviewTest_Light_fc5b723e_0.png" alt="Settings: snooze active" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/GarageDoorScreenshotTestKt/GarageDoorClosedPreviewTest_Light_fc5b723e_0.png" alt="Door: closed" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/GarageDoorScreenshotTestKt/GarageDoorOpenPreviewTest_Light_fc5b723e_0.png" alt="Door: open" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/GarageDoorScreenshotTestKt/GarageDoorOpeningPreviewTest_Light_fc5b723e_0.png" alt="Door: opening" width="200" /> 
+

--- a/AndroidGarage/android-screenshot-tests/collections/app-overview.yaml
+++ b/AndroidGarage/android-screenshot-tests/collections/app-overview.yaml
@@ -1,0 +1,63 @@
+title: "Smart Garage Door — App Overview"
+# Goal: Full-screen screenshots showing each tab with the navigation bar,
+# illustrating the main features of the app at a glance. Each screenshot
+# should be a complete screen (Scaffold + tabs + content) with demo data.
+#
+# TODO: Replace component-only screenshots with full-screen tab previews.
+#   Requires stateless overloads for HomeContent and ProfileContent that
+#   accept demo data as parameters (DoorHistoryContent already works).
+#   Each full-screen preview wraps content in Scaffold + AppNavigationBar.
+# TODO: Add full Home screen with door closed + button ready
+# TODO: Add full Home screen with door open + button ready
+# TODO: Add full Settings/Profile screen with signed-in user + snooze options
+# TODO: Add error banner screenshot (e.g., network error, stale data)
+#
+# Current: component-level screenshots as placeholders until full-screen previews exist.
+screenshots:
+  # Home tab — the door button
+  - test_class: ComponentsScreenshotTestKt
+    test: RemoteButtonContentPreviewTest_Light
+    description: "Home: garage door button (ready)"
+  - test_class: ComponentsScreenshotTestKt
+    test: RemoteButtonContentAwaitingConfirmationPreviewTest_Light
+    description: "Home: confirm door action"
+  - test_class: ComponentsScreenshotTestKt
+    test: RemoteButtonContentSendingToServerPreviewTest_Light
+    description: "Home: sending command to server"
+  - test_class: ComponentsScreenshotTestKt
+    test: RemoteButtonContentSucceededPreviewTest_Light
+    description: "Home: door moved successfully"
+  - test_class: ComponentsScreenshotTestKt
+    test: RemoteButtonContentServerFailedPreviewTest_Light
+    description: "Home: server request failed"
+  # Home tab — door status
+  - test_class: ComponentsScreenshotTestKt
+    test: DoorStatusCardPreviewTest_Light
+    description: "Door status card"
+  # History tab
+  - test_class: ScreensScreenshotTestKt
+    test: DoorHistoryScreenPreviewTest_Light
+    description: "History: recent door events"
+  - test_class: ComponentsScreenshotTestKt
+    test: RecentDoorEventListItemPreviewTest_Light
+    description: "History: single event card"
+  # Settings tab
+  - test_class: ComponentsScreenshotTestKt
+    test: UserInfoCardPreviewTest_Light
+    description: "Settings: signed-in user"
+  - test_class: ComponentsScreenshotTestKt
+    test: SnoozeNotificationCardPreviewTest_Light
+    description: "Settings: snooze notifications"
+  - test_class: ComponentsScreenshotTestKt
+    test: SnoozeNotificationCardSucceededPreviewTest_Light
+    description: "Settings: snooze active"
+  # Door icon states
+  - test_class: GarageDoorScreenshotTestKt
+    test: GarageDoorClosedPreviewTest_Light
+    description: "Door: closed"
+  - test_class: GarageDoorScreenshotTestKt
+    test: GarageDoorOpenPreviewTest_Light
+    description: "Door: open"
+  - test_class: GarageDoorScreenshotTestKt
+    test: GarageDoorOpeningPreviewTest_Light
+    description: "Door: opening"

--- a/AndroidGarage/android-screenshot-tests/collections/button-flow.md
+++ b/AndroidGarage/android-screenshot-tests/collections/button-flow.md
@@ -1,0 +1,13 @@
+<!-- GENERATED FILE — DO NOT EDIT -->
+<!-- Source: android-screenshot-tests/collections/button-flow.yaml -->
+
+# Button Press Flow
+
+1. 1. Ready — tap to start
+2. 2. Confirm — tap again
+3. 3. Sending to server
+4. 4. Server forwarding to door
+5. 5. Door moved
+
+<img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentPreviewTest_Light_fc5b723e_0.png" alt="1. Ready — tap to start" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentAwaitingConfirmationPreviewTest_Light_fc5b723e_0.png" alt="2. Confirm — tap again" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentSendingToServerPreviewTest_Light_fc5b723e_0.png" alt="3. Sending to server" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentSendingToDoorPreviewTest_Light_fc5b723e_0.png" alt="4. Server forwarding to door" width="200" /> <img src="../src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentSucceededPreviewTest_Light_fc5b723e_0.png" alt="5. Door moved" width="200" /> 
+

--- a/AndroidGarage/android-screenshot-tests/collections/button-flow.yaml
+++ b/AndroidGarage/android-screenshot-tests/collections/button-flow.yaml
@@ -1,0 +1,18 @@
+title: "Button Press Flow"
+# TODO: Add dark mode variant collection once full-screen Home preview works
+screenshots:
+  - test_class: ComponentsScreenshotTestKt
+    test: RemoteButtonContentPreviewTest_Light
+    description: "1. Ready — tap to start"
+  - test_class: ComponentsScreenshotTestKt
+    test: RemoteButtonContentAwaitingConfirmationPreviewTest_Light
+    description: "2. Confirm — tap again"
+  - test_class: ComponentsScreenshotTestKt
+    test: RemoteButtonContentSendingToServerPreviewTest_Light
+    description: "3. Sending to server"
+  - test_class: ComponentsScreenshotTestKt
+    test: RemoteButtonContentSendingToDoorPreviewTest_Light
+    description: "4. Server forwarding to door"
+  - test_class: ComponentsScreenshotTestKt
+    test: RemoteButtonContentSucceededPreviewTest_Light
+    description: "5. Door moved"

--- a/scripts/generate-android-screenshots.sh
+++ b/scripts/generate-android-screenshots.sh
@@ -25,4 +25,7 @@ done
 echo "Generating screenshot gallery..."
 ./scripts/generate-android-screenshot-gallery.sh
 
+echo "Generating screenshot collections..."
+./scripts/generate-screenshot-collections.sh
+
 echo "All screenshot tests completed."

--- a/scripts/generate-screenshot-collections.sh
+++ b/scripts/generate-screenshot-collections.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# Generates Markdown files from YAML screenshot collection declarations.
+#
+# For each .yaml file in android-screenshot-tests/collections/, this script:
+# 1. Deletes all .md files in the directory (clean slate)
+# 2. Reads each YAML to extract title and screenshot entries
+# 3. Finds matching reference PNGs (by stable test name prefix)
+# 4. Generates a Markdown file with metadata, descriptions, and inline images
+#
+# YAML format:
+#   title: "Collection Title"
+#   screenshots:
+#     - test_class: ComponentsScreenshotTestKt
+#       test: TestFunctionName_Light
+#       description: "What this shows"
+#
+# Usage: ./scripts/generate-screenshot-collections.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+COLLECTIONS_DIR="$REPO_ROOT/AndroidGarage/android-screenshot-tests/collections"
+REFERENCE_DIR="$REPO_ROOT/AndroidGarage/android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests"
+
+if [ ! -d "$COLLECTIONS_DIR" ]; then
+    echo "No collections directory found at $COLLECTIONS_DIR"
+    exit 0
+fi
+
+# Delete all generated .md files in collections/
+find "$COLLECTIONS_DIR" -name "*.md" -delete
+
+yaml_count=0
+error_count=0
+
+for yaml_file in "$COLLECTIONS_DIR"/*.yaml; do
+    [ -f "$yaml_file" ] || continue
+    yaml_count=$((yaml_count + 1))
+
+    yaml_basename="$(basename "$yaml_file" .yaml)"
+    md_file="$COLLECTIONS_DIR/$yaml_basename.md"
+    yaml_relpath="android-screenshot-tests/collections/$(basename "$yaml_file")"
+
+    # Parse title
+    title="$(grep '^title:' "$yaml_file" | sed 's/^title: *"\{0,1\}\(.*\)"\{0,1\}$/\1/' | sed 's/"$//')"
+
+    if [ -z "$title" ]; then
+        echo "ERROR: $yaml_file missing title"
+        error_count=$((error_count + 1))
+        continue
+    fi
+
+    # Extract screenshot entries (test_class, test, description)
+    test_classes=()
+    tests=()
+    descriptions=()
+    current_class=""
+    while IFS= read -r line; do
+        if [[ "$line" =~ test_class:[[:space:]]*(.*) ]]; then
+            current_class="${BASH_REMATCH[1]}"
+        elif [[ "$line" =~ ^[[:space:]]*-?[[:space:]]*test:[[:space:]]*(.*) ]]; then
+            tests+=("${BASH_REMATCH[1]}")
+            test_classes+=("$current_class")
+        elif [[ "$line" =~ ^[[:space:]]*description:[[:space:]]*\"(.*)\" ]]; then
+            descriptions+=("${BASH_REMATCH[1]}")
+        elif [[ "$line" =~ ^[[:space:]]*description:[[:space:]]*(.*) ]]; then
+            descriptions+=("${BASH_REMATCH[1]}")
+        fi
+    done < "$yaml_file"
+
+    if [ "${#tests[@]}" -ne "${#descriptions[@]}" ]; then
+        echo "ERROR: $yaml_file has ${#tests[@]} tests but ${#descriptions[@]} descriptions"
+        error_count=$((error_count + 1))
+        continue
+    fi
+
+    # Find matching PNG for each test name
+    image_paths=()
+    missing=0
+    for i in "${!tests[@]}"; do
+        test_name="${tests[$i]}"
+        class="${test_classes[$i]}"
+        class_dir="$REFERENCE_DIR/$class"
+
+        if [ ! -d "$class_dir" ]; then
+            echo "WARNING: Reference directory not found: $class_dir"
+            image_paths+=("")
+            missing=$((missing + 1))
+            continue
+        fi
+
+        # Glob for {test_name}_*_0.png (the hash varies across generations)
+        matches=("$class_dir"/${test_name}_*_0.png)
+        if [ -f "${matches[0]}" ]; then
+            rel_path="$(python3 -c "import os.path; print(os.path.relpath('${matches[0]}', '$COLLECTIONS_DIR'))")"
+            image_paths+=("$rel_path")
+        else
+            echo "WARNING: No image found for $test_name in $class_dir"
+            image_paths+=("")
+            missing=$((missing + 1))
+        fi
+    done
+
+    # Generate Markdown
+    {
+        echo "<!-- GENERATED FILE — DO NOT EDIT -->"
+        echo "<!-- Source: $yaml_relpath -->"
+        echo ""
+        echo "# $title"
+        echo ""
+
+        # Numbered description list
+        for i in "${!descriptions[@]}"; do
+            echo "$((i + 1)). ${descriptions[$i]}"
+        done
+        echo ""
+
+        # Images in a single paragraph so they flow/wrap naturally
+        img_line=""
+        for i in "${!image_paths[@]}"; do
+            path="${image_paths[$i]}"
+            desc="${descriptions[$i]}"
+            if [ -n "$path" ]; then
+                img_line+="<img src=\"$path\" alt=\"$desc\" width=\"200\" /> "
+            fi
+        done
+        echo "$img_line"
+        echo ""
+    } > "$md_file"
+
+    echo "Generated $md_file (${#tests[@]} images, $missing missing)"
+done
+
+if [ "$error_count" -gt 0 ]; then
+    echo ""
+    echo "ERRORS: $error_count collection(s) failed"
+    exit 1
+fi
+
+echo ""
+echo "Screenshot collections generated: $yaml_count collection(s)"


### PR DESCRIPTION
## Summary

Curated screenshot galleries declared in YAML, generated as Markdown.

- **app-overview.yaml**: 14 screenshots across all tabs — button flow, door status, history, settings, door icons
- **button-flow.yaml**: 5-step happy path from ready → confirm → sending → forwarding → done
- **generate-screenshot-collections.sh**: reads YAML, finds PNGs by stable test name, generates Markdown with inline wrapping images
- Wired into `generate-android-screenshots.sh`

TODOs in YAML for missing screenshots (Home/Profile full-screen previews need stateless overloads).

## Review

Check the generated Markdown:
- `android-screenshot-tests/collections/app-overview.md`
- `android-screenshot-tests/collections/button-flow.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)