### PR TITLE
fix: Button stuck in Sending when UseCase fails

### DIFF
--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
@@ -108,10 +108,16 @@ class DefaultRemoteButtonViewModel(
                 )
             ) {
                 is AppResult.Success -> { /* State machine tracks via pushButtonStatus flow */ }
-                is AppResult.Error -> when (result.error) {
-                    ActionError.NotAuthenticated -> Logger.w { "Push failed — not authenticated" }
-                    ActionError.MissingData -> Logger.w { "Push failed — missing data" }
-                    ActionError.NetworkFailed -> Logger.w { "Push failed — network error" }
+                is AppResult.Error -> {
+                    // The state machine is in SendingToServer but PushStatus.SENDING
+                    // will never arrive because the UseCase failed before calling the
+                    // repository. Reset to avoid being stuck forever.
+                    stateMachine.reset()
+                    when (result.error) {
+                        ActionError.NotAuthenticated -> Logger.w { "Push failed — not authenticated" }
+                        ActionError.MissingData -> Logger.w { "Push failed — missing data" }
+                        ActionError.NetworkFailed -> Logger.w { "Push failed — network error" }
+                    }
                 }
             }
         }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModelTest.kt
@@ -137,7 +137,7 @@ class RemoteButtonViewModelTest {
         }
 
     @Test
-    fun confirmWhenNotAuthenticatedDoesNotIncrementPushButPushFailsSilently() =
+    fun confirmWhenNotAuthenticatedResetsToReady() =
         runTest {
             val viewModel = createViewModel(authState = AuthState.Unauthenticated)
 
@@ -148,9 +148,8 @@ class RemoteButtonViewModelTest {
             viewModel.onButtonTap()
             testDispatcher.scheduler.runCurrent()
 
-            // The state machine still optimistically transitions to SendingToServer,
-            // but the use case fails the auth check and never calls pushButton.
-            assertEquals(RemoteButtonState.SendingToServer, viewModel.buttonState.value)
+            // UseCase fails auth check, ViewModel resets state machine.
+            assertEquals(RemoteButtonState.Ready, viewModel.buttonState.value)
             assertEquals(0, remoteButtonRepository.pushCount)
         }
 


### PR DESCRIPTION
## Summary

When PushRemoteButtonUseCase fails (auth, config, network), `PushStatus.SENDING` never arrives from the repository. The state machine stays in `SendingToServer` forever — no timeout fires because the timeout was moved to start on `PushStatus.SENDING` (PR #265).

Fix: ViewModel resets the state machine on UseCase error.

## Test plan

- [x] `confirmWhenNotAuthenticatedResetsToReady` test passes
- [x] All 23 ButtonStateMachine tests pass
- [x] All 12 RemoteButtonViewModel tests pass
- [x] `validate.sh` passes
- [ ] Manual: verify button resets when not authenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)