### PR TITLE
fix: Ensure network request reliability for garage door button confirm

### DIFF
--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkRemoteButtonRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkRemoteButtonRepository.kt
@@ -39,13 +39,15 @@ class NetworkRemoteButtonRepository(
         idToken: String,
         buttonAckToken: String,
     ) {
-        _pushButtonStatus.value = PushStatus.SENDING
+        // Resolve server config BEFORE setting SENDING. This ensures that
+        // PushStatus.SENDING means the HTTP request is imminent, so the state
+        // machine's network timeout accurately reflects the actual request.
         val serverConfig = serverConfigRepository.getServerConfigCached()
         if (serverConfig == null) {
-            Logger.e { "Server config is null" }
-            _pushButtonStatus.value = PushStatus.IDLE
-            return
+            Logger.e { "Server config is null — cannot send button press" }
+            throw IllegalStateException("Server config not available")
         }
+        _pushButtonStatus.value = PushStatus.SENDING
         if (!remoteButtonPushEnabled) {
             Logger.w { "Remote button push is disabled" }
             delay(500)

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAuthRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAuthRepository.kt
@@ -37,6 +37,9 @@ class FakeAuthRepository : AuthRepository {
     var signInResult: AuthState? = null
     var refreshResult: AuthState? = null
 
+    /** When non-null, [refreshFirebaseAuthState] throws this exception. */
+    var refreshException: Exception? = null
+
     fun setAuthState(state: AuthState) {
         _authState.value = state
     }
@@ -50,6 +53,7 @@ class FakeAuthRepository : AuthRepository {
 
     override suspend fun refreshFirebaseAuthState(): AuthState {
         refreshCount++
+        refreshException?.let { throw it }
         return refreshResult ?: _authState.value
     }
 

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeRemoteButtonRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeRemoteButtonRepository.kt
@@ -14,6 +14,9 @@ class FakeRemoteButtonRepository : RemoteButtonRepository {
     var lastIdToken: String? = null
         private set
 
+    /** When non-null, [pushButton] throws this exception instead of succeeding. */
+    var pushException: Exception? = null
+
     fun setPushStatus(status: PushStatus) {
         _pushButtonStatus.value = status
     }
@@ -24,6 +27,7 @@ class FakeRemoteButtonRepository : RemoteButtonRepository {
     ) {
         pushCount++
         lastIdToken = idToken
+        pushException?.let { throw it }
         _pushButtonStatus.value = PushStatus.SENDING
         _pushButtonStatus.value = PushStatus.IDLE
     }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/PushRemoteButtonUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/PushRemoteButtonUseCase.kt
@@ -17,11 +17,13 @@
 
 package com.chriscartland.garage.usecase
 
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.domain.model.ActionError
 import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.repository.AuthRepository
 import com.chriscartland.garage.domain.repository.RemoteButtonRepository
+import kotlinx.coroutines.CancellationException
 
 /**
  * Pushes the remote garage button.
@@ -39,11 +41,18 @@ class PushRemoteButtonUseCase(
         if (authState !is AuthState.Authenticated) {
             return AppResult.Error(ActionError.NotAuthenticated)
         }
-        val idToken = ensureFreshIdToken(authState)
-        remoteButtonRepository.pushButton(
-            idToken = idToken.asString(),
-            buttonAckToken = buttonAckToken,
-        )
-        return AppResult.Success(Unit)
+        return try {
+            val idToken = ensureFreshIdToken(authState)
+            remoteButtonRepository.pushButton(
+                idToken = idToken.asString(),
+                buttonAckToken = buttonAckToken,
+            )
+            AppResult.Success(Unit)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Logger.e(e) { "Push failed — unexpected error" }
+            AppResult.Error(ActionError.NetworkFailed)
+        }
     }
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
@@ -29,6 +29,7 @@ import com.chriscartland.garage.domain.model.SnoozeAction
 import com.chriscartland.garage.domain.model.SnoozeDurationUIOption
 import com.chriscartland.garage.domain.model.SnoozeState
 import com.chriscartland.garage.domain.model.toServer
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -100,25 +101,35 @@ class DefaultRemoteButtonViewModel(
     private fun submitButtonPress() {
         Logger.d { "submitButtonPress" }
         viewModelScope.launch(dispatchers.io) {
-            when (
-                val result = pushRemoteButtonUseCase(
-                    buttonAckToken = createButtonAckToken(
-                        currentTimeMillis = System.currentTimeMillis(),
-                    ),
-                )
-            ) {
-                is AppResult.Success -> { /* State machine tracks via pushButtonStatus flow */ }
-                is AppResult.Error -> {
-                    // The state machine is in SendingToServer but PushStatus.SENDING
-                    // will never arrive because the UseCase failed before calling the
-                    // repository. Reset to avoid being stuck forever.
-                    stateMachine.reset()
-                    when (result.error) {
-                        ActionError.NotAuthenticated -> Logger.w { "Push failed — not authenticated" }
-                        ActionError.MissingData -> Logger.w { "Push failed — missing data" }
-                        ActionError.NetworkFailed -> Logger.w { "Push failed — network error" }
+            try {
+                when (
+                    val result = pushRemoteButtonUseCase(
+                        buttonAckToken = createButtonAckToken(
+                            currentTimeMillis = System.currentTimeMillis(),
+                        ),
+                    )
+                ) {
+                    is AppResult.Success -> { /* State machine tracks via pushButtonStatus flow */ }
+                    is AppResult.Error -> {
+                        // The state machine is in SendingToServer but PushStatus.SENDING
+                        // will never arrive because the UseCase failed before calling the
+                        // repository. Reset to avoid being stuck forever.
+                        stateMachine.reset()
+                        when (result.error) {
+                            ActionError.NotAuthenticated -> Logger.w { "Push failed — not authenticated" }
+                            ActionError.MissingData -> Logger.w { "Push failed — missing data" }
+                            ActionError.NetworkFailed -> Logger.w { "Push failed — network error" }
+                        }
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // Safety net: if an unexpected exception escapes the UseCase,
+                // reset the state machine so the UI doesn't get stuck in
+                // SendingToServer indefinitely.
+                Logger.e(e) { "submitButtonPress: unexpected error" }
+                stateMachine.reset()
             }
         }
     }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/PushRemoteButtonUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/PushRemoteButtonUseCaseTest.kt
@@ -121,4 +121,29 @@ class PushRemoteButtonUseCaseTest {
             assertEquals("new-token", fakePush.lastIdToken)
             assertEquals(1, fakeAuth.refreshCount)
         }
+
+    @Test
+    fun pushReturnsNetworkFailedWhenRepositoryThrows() =
+        runTest {
+            authenticateUser()
+            fakePush.pushException = IllegalStateException("Server config not available")
+
+            val result = useCase("ack-123")
+
+            assertTrue(result is AppResult.Error, "Should be NetworkFailed error")
+            assertEquals(ActionError.NetworkFailed, (result as AppResult.Error).error)
+        }
+
+    @Test
+    fun pushReturnsNetworkFailedWhenTokenRefreshThrows() =
+        runTest {
+            authenticateUser(token = "old-token", exp = 1000L)
+            fakeAuth.refreshException = RuntimeException("Network error during refresh")
+
+            val result = useCase("ack-123")
+
+            assertTrue(result is AppResult.Error, "Should be NetworkFailed error")
+            assertEquals(ActionError.NetworkFailed, (result as AppResult.Error).error)
+            assertEquals(0, fakePush.pushCount)
+        }
 }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModelTest.kt
@@ -154,6 +154,29 @@ class RemoteButtonViewModelTest {
         }
 
     @Test
+    fun confirmWhenRepositoryThrowsResetsToReady() =
+        runTest {
+            val viewModel = createAuthenticatedViewModel()
+            remoteButtonRepository.pushException =
+                IllegalStateException("Server config not available")
+
+            // Tap to arm
+            viewModel.onButtonTap()
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(ButtonStateMachine.DEFAULT_PREPARING_DELAY + 1)
+            testDispatcher.scheduler.runCurrent()
+            assertEquals(RemoteButtonState.AwaitingConfirmation, viewModel.buttonState.value)
+
+            // Confirm — repository throws, UseCase catches and returns Error,
+            // ViewModel resets state machine.
+            viewModel.onButtonTap()
+            testDispatcher.scheduler.runCurrent()
+
+            assertEquals(RemoteButtonState.Ready, viewModel.buttonState.value)
+            assertEquals(1, remoteButtonRepository.pushCount)
+        }
+
+    @Test
     fun resetButtonReturnsToReady() =
         runTest {
             val viewModel = createViewModel()


### PR DESCRIPTION
Three reliability gaps existed between the confirm tap and the actual
HTTP request:

1. PushRemoteButtonUseCase could throw uncaught exceptions (from token
   refresh or repository errors) that crashed the coroutine silently,
   leaving the state machine stuck in SendingToServer forever — the
   network timeout never started because PushStatus.SENDING was never set.

2. NetworkRemoteButtonRepository set PushStatus.SENDING before checking
   server config. If config was null, SENDING→IDLE caused the state
   machine to misleadingly transition to SendingToDoor when no request
   was ever sent.

3. The ViewModel had no safety net for unexpected exceptions escaping
   the UseCase.

Fixes:
- UseCase: wrap token refresh + pushButton in try-catch, return
  AppResult.Error(NetworkFailed) instead of propagating exceptions
- Repository: move SENDING after server config check; throw if config
  is null so the UseCase can catch and report the error
- ViewModel: add belt-and-suspenders try-catch that resets the state
  machine on any unexpected exception
- Tests: add cases for repository-throws and token-refresh-throws paths
- Fakes: add pushException/refreshException flags for error simulation

https://claude.ai/code/session_017F3EWx5NQezn5R3ihrwGMj