### PR TITLE
fix: Fake repository StateFlow conflation — yield between SENDING and IDLE

### DIFF
--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeRemoteButtonRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeRemoteButtonRepository.kt
@@ -4,6 +4,7 @@ import com.chriscartland.garage.domain.model.PushStatus
 import com.chriscartland.garage.domain.repository.RemoteButtonRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.yield
 
 class FakeRemoteButtonRepository : RemoteButtonRepository {
     private val _pushButtonStatus = MutableStateFlow(PushStatus.IDLE)
@@ -25,6 +26,12 @@ class FakeRemoteButtonRepository : RemoteButtonRepository {
         pushCount++
         lastIdToken = idToken
         _pushButtonStatus.value = PushStatus.SENDING
+        // Yield to let StateFlow collectors observe SENDING before it changes
+        // to IDLE. Without this, StateFlow conflation can swallow SENDING
+        // entirely — the collector never sees it, so the state machine never
+        // starts the network timeout or transitions to SendingToDoor.
+        // The real repository has an HTTP call here which naturally yields.
+        yield()
         _pushButtonStatus.value = PushStatus.IDLE
     }
 }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModelTest.kt
@@ -115,24 +115,25 @@ class RemoteButtonViewModelTest {
         }
 
     @Test
-    fun confirmTriggersPushUseCaseAndIncrementsRepoCounter() =
+    fun confirmTriggersPushAndTransitionsToSendingToDoor() =
         runTest {
             val viewModel = createAuthenticatedViewModel()
             assertEquals(0, remoteButtonRepository.pushCount)
 
-            // Tap to arm
+            // Prepare and confirm
             viewModel.onButtonTap()
             testDispatcher.scheduler.runCurrent()
-            // Wait for preparing delay (500ms default)
             advanceTimeBy(ButtonStateMachine.DEFAULT_PREPARING_DELAY + 1)
             testDispatcher.scheduler.runCurrent()
             assertEquals(RemoteButtonState.AwaitingConfirmation, viewModel.buttonState.value)
 
-            // Confirm
+            // Confirm — triggers UseCase → repository sets SENDING→yield→IDLE
             viewModel.onButtonTap()
             testDispatcher.scheduler.runCurrent()
 
-            assertEquals(RemoteButtonState.SendingToServer, viewModel.buttonState.value)
+            // After the fake repository completes (SENDING → yield → IDLE),
+            // the state machine transitions: SendingToServer → SendingToDoor.
+            assertEquals(RemoteButtonState.SendingToDoor, viewModel.buttonState.value)
             assertEquals(1, remoteButtonRepository.pushCount)
         }
 


### PR DESCRIPTION
## Summary

- `FakeRemoteButtonRepository.pushButton()` set `SENDING` then `IDLE` synchronously — StateFlow conflated `SENDING` away, collectors never saw it
- Added `yield()` between the two assignments to match real repository behavior (HTTP call yields)
- Updated ViewModel test: now verifies the button reaches `SendingToDoor` after network completes (previously only checked `SendingToServer`)

This explains why the UI jumped from Sending straight to door moved — the state machine never observed `PushStatus.SENDING`, so it never transitioned to `SendingToDoor`.

## Test plan

- [x] `confirmTriggersPushAndTransitionsToSendingToDoor` — new test passes
- [x] All 14 ViewModel tests pass
- [x] All 23 ButtonStateMachine tests pass
- [x] `validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)