### PR TITLE
fix: Add yield() after PushStatus.SENDING in production repository

### DIFF
--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkRemoteButtonRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkRemoteButtonRepository.kt
@@ -26,6 +26,7 @@ import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.yield
 
 class NetworkRemoteButtonRepository(
     private val networkButtonDataSource: NetworkButtonDataSource,
@@ -40,6 +41,11 @@ class NetworkRemoteButtonRepository(
         buttonAckToken: String,
     ) {
         _pushButtonStatus.value = PushStatus.SENDING
+        // Yield so StateFlow collectors observe SENDING before any subsequent
+        // state change. Without this, if getServerConfigCached() returns
+        // synchronously (cached hit) and the HTTP call is fast, StateFlow
+        // conflation can swallow SENDING — the state machine never sees it.
+        yield()
         val serverConfig = serverConfigRepository.getServerConfigCached()
         if (serverConfig == null) {
             Logger.e { "Server config is null" }


### PR DESCRIPTION
## Summary

Same StateFlow conflation fix as PR #279 (fake), but for the production `NetworkRemoteButtonRepository`. 

Without `yield()`, if `getServerConfigCached()` returns from cache and the HTTP call is fast, `SENDING` can be conflated before the state machine sees it. This means no network timeout starts and the UI skips `SendingToDoor`.

One line: `yield()` after `_pushButtonStatus.value = PushStatus.SENDING`.

## Test plan

- [x] `validate.sh` passes
- [x] Existing repository tests pass
- [ ] Manual: verify button shows Sending → Waiting → Done sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)