### PR TITLE
refactor: Split AuthRepository StateFlow into getAuthState() + observeAuthState()

### DIFF
--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepository.kt
@@ -28,8 +28,8 @@ import com.chriscartland.garage.domain.model.User
 import com.chriscartland.garage.domain.repository.AppLoggerRepository
 import com.chriscartland.garage.domain.repository.AuthRepository
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
@@ -45,7 +45,10 @@ class FirebaseAuthRepository(
     externalScope: CoroutineScope,
 ) : AuthRepository {
     private val _authState = MutableStateFlow<AuthState>(AuthState.Unknown)
-    override val authState: StateFlow<AuthState> = _authState.asStateFlow()
+
+    override suspend fun getAuthState(): AuthState = _authState.value
+
+    override fun observeAuthState(): Flow<AuthState> = _authState.asStateFlow()
 
     init {
         externalScope.launch {

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepositoryTest.kt
@@ -131,7 +131,7 @@ class FirebaseAuthRepositoryTest {
             repo.signOut()
 
             assertEquals(1, authBridge.signOutCount)
-            assertEquals(AuthState.Unauthenticated, repo.authState.value)
+            assertEquals(AuthState.Unauthenticated, repo.getAuthState())
         }
 
     // --- authState flow ---
@@ -150,7 +150,7 @@ class FirebaseAuthRepositoryTest {
             authBridge.refreshTokenResult = FirebaseIdToken(idToken = "fresh", exp = Long.MAX_VALUE)
             repo.refreshFirebaseAuthState()
 
-            val state = repo.authState.value
+            val state = repo.getAuthState()
             assertTrue(state is AuthState.Authenticated)
             assertEquals("New User", (state as AuthState.Authenticated).user.name.asString())
         }

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/AuthRepository.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/AuthRepository.kt
@@ -2,10 +2,14 @@ package com.chriscartland.garage.domain.repository
 
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.GoogleIdToken
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.Flow
 
 interface AuthRepository {
-    val authState: StateFlow<AuthState>
+    /** One-shot: current auth state right now. */
+    suspend fun getAuthState(): AuthState
+
+    /** Observation: auth state changes over time. */
+    fun observeAuthState(): Flow<AuthState>
 
     suspend fun signInWithGoogle(idToken: GoogleIdToken): AuthState
 

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAuthRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAuthRepository.kt
@@ -20,12 +20,11 @@ package com.chriscartland.garage.testcommon
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.GoogleIdToken
 import com.chriscartland.garage.domain.repository.AuthRepository
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 
 class FakeAuthRepository : AuthRepository {
     private val _authState = MutableStateFlow<AuthState>(AuthState.Unknown)
-    override val authState: StateFlow<AuthState> = _authState
 
     var signInCount = 0
         private set
@@ -40,6 +39,10 @@ class FakeAuthRepository : AuthRepository {
     fun setAuthState(state: AuthState) {
         _authState.value = state
     }
+
+    override suspend fun getAuthState(): AuthState = _authState.value
+
+    override fun observeAuthState(): Flow<AuthState> = _authState
 
     override suspend fun signInWithGoogle(idToken: GoogleIdToken): AuthState {
         signInCount++

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AuthViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AuthViewModel.kt
@@ -24,7 +24,9 @@ import com.chriscartland.garage.domain.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.GoogleIdToken
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 interface AuthViewModel {
@@ -44,6 +46,7 @@ class DefaultAuthViewModel(
 ) : ViewModel(),
     AuthViewModel {
     override val authState: StateFlow<AuthState> = observeAuthState()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, AuthState.Unknown)
 
     override fun signInWithGoogle(idToken: GoogleIdToken) {
         viewModelScope.launch(dispatchers.io) {

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveAuthStateUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveAuthStateUseCase.kt
@@ -19,16 +19,15 @@ package com.chriscartland.garage.usecase
 
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.repository.AuthRepository
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Observes the current authentication state.
  *
- * Wraps [AuthRepository.authState] so ViewModels can depend on this
- * UseCase instead of the repository directly.
+ * Returns a [Flow] — the ViewModel converts to StateFlow for the UI.
  */
 class ObserveAuthStateUseCase(
     private val authRepository: AuthRepository,
 ) {
-    operator fun invoke(): StateFlow<AuthState> = authRepository.authState
+    operator fun invoke(): Flow<AuthState> = authRepository.observeAuthState()
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/PushRemoteButtonUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/PushRemoteButtonUseCase.kt
@@ -35,7 +35,7 @@ class PushRemoteButtonUseCase(
     private val remoteButtonRepository: RemoteButtonRepository,
 ) {
     suspend operator fun invoke(buttonAckToken: String): AppResult<Unit, ActionError> {
-        val authState = authRepository.authState.value
+        val authState = authRepository.getAuthState()
         if (authState !is AuthState.Authenticated) {
             return AppResult.Error(ActionError.NotAuthenticated)
         }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SnoozeNotificationsUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SnoozeNotificationsUseCase.kt
@@ -38,7 +38,7 @@ class SnoozeNotificationsUseCase(
         snoozeDurationHours: String,
         lastChangeTimeSeconds: Long?,
     ): AppResult<Unit, ActionError> {
-        val authState = authRepository.authState.value
+        val authState = authRepository.getAuthState()
         if (authState !is AuthState.Authenticated) {
             return AppResult.Error(ActionError.NotAuthenticated)
         }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAuthViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAuthViewModelTest.kt
@@ -9,26 +9,45 @@ import com.chriscartland.garage.domain.model.User
 import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
 import com.chriscartland.garage.testcommon.FakeAuthRepository
 import com.chriscartland.garage.testcommon.TestDispatcherProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class DefaultAuthViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
-    private val authRepo = FakeAuthRepository()
-    private val logger = FakeAppLoggerRepository()
-    private val dispatchers = TestDispatcherProvider(testDispatcher)
-    private val viewModel = DefaultAuthViewModel(
-        observeAuthState = ObserveAuthStateUseCase(authRepo),
-        signInWithGoogleUseCase = SignInWithGoogleUseCase(authRepo),
-        signOutUseCase = SignOutUseCase(authRepo),
-        logAppEvent = LogAppEventUseCase(logger),
-        dispatchers = dispatchers,
-    )
+    private lateinit var authRepo: FakeAuthRepository
+    private lateinit var logger: FakeAppLoggerRepository
+    private lateinit var viewModel: DefaultAuthViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        authRepo = FakeAuthRepository()
+        logger = FakeAppLoggerRepository()
+        viewModel = DefaultAuthViewModel(
+            observeAuthState = ObserveAuthStateUseCase(authRepo),
+            signInWithGoogleUseCase = SignInWithGoogleUseCase(authRepo),
+            signOutUseCase = SignOutUseCase(authRepo),
+            logAppEvent = LogAppEventUseCase(logger),
+            dispatchers = TestDispatcherProvider(testDispatcher),
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
 
     @Test
     fun initialAuthStateIsUnknown() {

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ObserveAuthStateUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ObserveAuthStateUseCaseTest.kt
@@ -19,26 +19,30 @@ package com.chriscartland.garage.usecase
 
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.testcommon.FakeAuthRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
 class ObserveAuthStateUseCaseTest {
     @Test
-    fun invokeReturnsRepositoryAuthState() {
-        val repo = FakeAuthRepository()
-        val useCase = ObserveAuthStateUseCase(repo)
+    fun invokeReturnsRepositoryAuthState() =
+        runTest {
+            val repo = FakeAuthRepository()
+            val useCase = ObserveAuthStateUseCase(repo)
 
-        assertIs<AuthState.Unknown>(useCase().value)
-    }
+            assertIs<AuthState.Unknown>(useCase().first())
+        }
 
     @Test
-    fun invokeReflectsRepositoryUpdates() {
-        val repo = FakeAuthRepository()
-        val useCase = ObserveAuthStateUseCase(repo)
+    fun invokeReflectsRepositoryUpdates() =
+        runTest {
+            val repo = FakeAuthRepository()
+            val useCase = ObserveAuthStateUseCase(repo)
 
-        repo.setAuthState(AuthState.Unauthenticated)
+            repo.setAuthState(AuthState.Unauthenticated)
 
-        assertEquals(AuthState.Unauthenticated, useCase().value)
-    }
+            assertEquals(AuthState.Unauthenticated, useCase().first())
+        }
 }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SignInWithGoogleUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SignInWithGoogleUseCaseTest.kt
@@ -56,6 +56,6 @@ class SignInWithGoogleUseCaseTest {
 
             useCase(GoogleIdToken("token"))
 
-            assertIs<AuthState.Authenticated>(repo.authState.value)
+            assertIs<AuthState.Authenticated>(repo.getAuthState())
         }
 }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SignOutUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SignOutUseCaseTest.kt
@@ -44,6 +44,6 @@ class SignOutUseCaseTest {
 
             useCase()
 
-            assertIs<AuthState.Unauthenticated>(repo.authState.value)
+            assertIs<AuthState.Unauthenticated>(repo.getAuthState())
         }
 }


### PR DESCRIPTION
## Summary

Resolves ADR-013 violation: `AuthRepository.authState: StateFlow<AuthState>`.

Split into two APIs matching two distinct needs:
- `suspend fun getAuthState(): AuthState` — one-shot snapshot (for UseCases)
- `fun observeAuthState(): Flow<AuthState>` — observation (for ViewModel)

ViewModel converts Flow to StateFlow via `stateIn(Eagerly)`. No StateFlow exposed below ViewModel.

## Test plan

- [x] All UseCase tests pass (PushRemoteButton, Snooze, SignIn, SignOut, ObserveAuthState)
- [x] DefaultAuthViewModelTest passes (with proper Dispatchers.setMain setup)
- [x] FirebaseAuthRepositoryTest passes (uses getAuthState() instead of .authState.value)
- [x] `validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)