### PR TITLE
refactor: Replace SnoozeRepository StateFlow with observeSnoozeState() Flow

### DIFF
--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepository.kt
@@ -24,8 +24,8 @@ import com.chriscartland.garage.domain.model.SnoozeState
 import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import com.chriscartland.garage.domain.repository.SnoozeRepository
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 
 class NetworkSnoozeRepository(
     private val networkButtonDataSource: NetworkButtonDataSource,
@@ -33,8 +33,9 @@ class NetworkSnoozeRepository(
     private val snoozeNotificationsOption: Boolean,
     private val currentTimeSeconds: () -> Long,
 ) : SnoozeRepository {
-    private val _snoozeState = MutableStateFlow<SnoozeState>(SnoozeState.Loading)
-    override val snoozeState: StateFlow<SnoozeState> = _snoozeState
+    private val snoozeStateFlow = MutableStateFlow<SnoozeState>(SnoozeState.Loading)
+
+    override fun observeSnoozeState(): Flow<SnoozeState> = snoozeStateFlow
 
     override suspend fun fetchSnoozeStatus() {
         val serverConfig = serverConfigRepository.getServerConfigCached()
@@ -55,7 +56,7 @@ class NetworkSnoozeRepository(
             )
         ) {
             is NetworkResult.Success -> {
-                _snoozeState.value = snoozeStateFromEndTime(result.data)
+                snoozeStateFlow.value = snoozeStateFromEndTime(result.data)
             }
             is NetworkResult.HttpError -> {
                 Logger.e { "Snooze fetch HTTP ${result.code}" }
@@ -106,8 +107,8 @@ class NetworkSnoozeRepository(
 
     /** If still Loading (first fetch), fall back to NotSnoozing so the UI doesn't show "Loading..." forever. */
     private fun clearLoadingState() {
-        if (_snoozeState.value is SnoozeState.Loading) {
-            _snoozeState.value = SnoozeState.NotSnoozing
+        if (snoozeStateFlow.value is SnoozeState.Loading) {
+            snoozeStateFlow.value = SnoozeState.NotSnoozing
         }
     }
 

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/SnoozeRepository.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/SnoozeRepository.kt
@@ -1,7 +1,7 @@
 package com.chriscartland.garage.domain.repository
 
 import com.chriscartland.garage.domain.model.SnoozeState
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Manages snooze-notification state for the garage door.
@@ -10,7 +10,8 @@ import kotlinx.coroutines.flow.StateFlow
  * The snooze end time is persisted server-side and fetched on demand.
  */
 interface SnoozeRepository {
-    val snoozeState: StateFlow<SnoozeState>
+    /** Observation: snooze state changes over time. */
+    fun observeSnoozeState(): Flow<SnoozeState>
 
     suspend fun fetchSnoozeStatus()
 

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeSnoozeRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeSnoozeRepository.kt
@@ -2,12 +2,11 @@ package com.chriscartland.garage.testcommon
 
 import com.chriscartland.garage.domain.model.SnoozeState
 import com.chriscartland.garage.domain.repository.SnoozeRepository
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 
 class FakeSnoozeRepository : SnoozeRepository {
-    private val _snoozeState = MutableStateFlow<SnoozeState>(SnoozeState.Loading)
-    override val snoozeState: StateFlow<SnoozeState> = _snoozeState
+    private val snoozeStateFlow = MutableStateFlow<SnoozeState>(SnoozeState.Loading)
 
     var snoozeCount = 0
         private set
@@ -19,8 +18,10 @@ class FakeSnoozeRepository : SnoozeRepository {
     var snoozeResult: Boolean = true
 
     fun setSnoozeState(state: SnoozeState) {
-        _snoozeState.value = state
+        snoozeStateFlow.value = state
     }
+
+    override fun observeSnoozeState(): Flow<SnoozeState> = snoozeStateFlow
 
     override suspend fun fetchSnoozeStatus() {
         fetchCount++

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/FetchSnoozeStatusUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/FetchSnoozeStatusUseCase.kt
@@ -22,7 +22,7 @@ import com.chriscartland.garage.domain.repository.SnoozeRepository
 /**
  * Fetches the current snooze status from the server.
  *
- * Updates [SnoozeRepository.snoozeState] as a side effect.
+ * Updates the snooze state observable via [SnoozeRepository.observeSnoozeState].
  */
 class FetchSnoozeStatusUseCase(
     private val snoozeRepository: SnoozeRepository,

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveSnoozeStateUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveSnoozeStateUseCase.kt
@@ -19,15 +19,15 @@ package com.chriscartland.garage.usecase
 
 import com.chriscartland.garage.domain.model.SnoozeState
 import com.chriscartland.garage.domain.repository.SnoozeRepository
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.Flow
 
 /**
- * Observes the current snooze state as a [StateFlow].
+ * Observes the current snooze state as a [Flow].
  *
- * Provides the reactive snooze status without exposing the repository directly.
+ * The ViewModel converts to StateFlow for the UI.
  */
 class ObserveSnoozeStateUseCase(
     private val snoozeRepository: SnoozeRepository,
 ) {
-    operator fun invoke(): StateFlow<SnoozeState> = snoozeRepository.snoozeState
+    operator fun invoke(): Flow<SnoozeState> = snoozeRepository.observeSnoozeState()
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
@@ -31,7 +31,9 @@ import com.chriscartland.garage.domain.model.SnoozeState
 import com.chriscartland.garage.domain.model.toServer
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 private const val SNOOZE_ACTION_RESET_DELAY_MS = 10_000L
@@ -69,6 +71,7 @@ class DefaultRemoteButtonViewModel(
     override val buttonState: StateFlow<RemoteButtonState> = stateMachine.state
 
     override val snoozeState: StateFlow<SnoozeState> = observeSnoozeStateUseCase()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, SnoozeState.Loading)
 
     private val _snoozeAction = MutableStateFlow<SnoozeAction>(SnoozeAction.Idle)
     override val snoozeAction: StateFlow<SnoozeAction> = _snoozeAction

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ObserveSnoozeStateUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ObserveSnoozeStateUseCaseTest.kt
@@ -19,25 +19,29 @@ package com.chriscartland.garage.usecase
 
 import com.chriscartland.garage.domain.model.SnoozeState
 import com.chriscartland.garage.testcommon.FakeSnoozeRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class ObserveSnoozeStateUseCaseTest {
     @Test
-    fun invokeReturnsRepositoryState() {
-        val repo = FakeSnoozeRepository()
-        val useCase = ObserveSnoozeStateUseCase(repo)
+    fun invokeReturnsRepositoryState() =
+        runTest {
+            val repo = FakeSnoozeRepository()
+            val useCase = ObserveSnoozeStateUseCase(repo)
 
-        assertEquals(SnoozeState.Loading, useCase().value)
-    }
+            assertEquals(SnoozeState.Loading, useCase().first())
+        }
 
     @Test
-    fun invokeReflectsRepositoryUpdates() {
-        val repo = FakeSnoozeRepository()
-        val useCase = ObserveSnoozeStateUseCase(repo)
+    fun invokeReflectsRepositoryUpdates() =
+        runTest {
+            val repo = FakeSnoozeRepository()
+            val useCase = ObserveSnoozeStateUseCase(repo)
 
-        repo.setSnoozeState(SnoozeState.Snoozing(12345L))
+            repo.setSnoozeState(SnoozeState.Snoozing(12345L))
 
-        assertEquals(SnoozeState.Snoozing(12345L), useCase().value)
-    }
+            assertEquals(SnoozeState.Snoozing(12345L), useCase().first())
+        }
 }


### PR DESCRIPTION
## Summary

Last ADR-013 violation. `SnoozeRepository.snoozeState: StateFlow<SnoozeState>` → `fun observeSnoozeState(): Flow<SnoozeState>`.

ViewModel converts to StateFlow via `stateIn(Eagerly, SnoozeState.Loading)`.

After this + PR #282 + PR #283, zero StateFlow below ViewModel layer.

## Test plan

- [x] All UseCase tests pass
- [x] All ViewModel tests pass
- [x] `validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)