### PR TITLE
fix: FCM registration retry when NOT_REGISTERED

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FcmRegistration.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FcmRegistration.kt
@@ -17,16 +17,15 @@
 
 package com.chriscartland.garage.fcm
 
-import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.viewmodel.compose.viewModel
-import co.touchlab.kermit.Logger
 import com.chriscartland.garage.di.rememberAppComponent
-import com.chriscartland.garage.domain.model.FcmRegistrationStatus
 import com.chriscartland.garage.usecase.DoorViewModel
+import com.chriscartland.garage.usecase.FcmRegistrationAction
+import com.chriscartland.garage.usecase.toAction
 
 /**
  * Register for FCM updates.
@@ -41,23 +40,12 @@ import com.chriscartland.garage.usecase.DoorViewModel
 fun FCMRegistration() {
     val component = rememberAppComponent()
     val viewModel: DoorViewModel = viewModel { component.doorViewModel }
-    val activity = LocalActivity.current
     val fcmState by viewModel.fcmRegistrationStatus.collectAsState()
     LaunchedEffect(key1 = fcmState) {
-        // Subscribe to FCM updates.
-        when (fcmState) {
-            FcmRegistrationStatus.UNKNOWN -> {
-                Logger.d { "Unknown FCM registration status, fetching..." }
-                viewModel.fetchFcmRegistrationStatus()
-            }
-
-            FcmRegistrationStatus.REGISTERED -> {
-                Logger.d { "FCM registration status is registered" }
-            }
-
-            FcmRegistrationStatus.NOT_REGISTERED -> {
-                Logger.d { "FCM registration status is not registered, registering..." }
-            }
+        when (fcmState.toAction()) {
+            FcmRegistrationAction.FETCH_STATUS -> viewModel.fetchFcmRegistrationStatus()
+            FcmRegistrationAction.REGISTER -> viewModel.registerFcm()
+            FcmRegistrationAction.NONE -> { /* Already registered */ }
         }
     }
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/FcmRegistrationAction.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/FcmRegistrationAction.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.FcmRegistrationStatus
+
+/**
+ * Determines what action to take based on FCM registration status.
+ * Extracted from FcmRegistration composable for testability.
+ */
+enum class FcmRegistrationAction {
+    FETCH_STATUS,
+    REGISTER,
+    NONE,
+}
+
+fun FcmRegistrationStatus.toAction(): FcmRegistrationAction =
+    when (this) {
+        FcmRegistrationStatus.UNKNOWN -> FcmRegistrationAction.FETCH_STATUS
+        FcmRegistrationStatus.NOT_REGISTERED -> FcmRegistrationAction.REGISTER
+        FcmRegistrationStatus.REGISTERED -> FcmRegistrationAction.NONE
+    }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/FcmRegistrationActionTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/FcmRegistrationActionTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.FcmRegistrationStatus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FcmRegistrationActionTest {
+    @Test
+    fun unknownStatusReturnsFetchStatus() {
+        assertEquals(
+            FcmRegistrationAction.FETCH_STATUS,
+            FcmRegistrationStatus.UNKNOWN.toAction(),
+        )
+    }
+
+    @Test
+    fun notRegisteredStatusReturnsRegister() {
+        assertEquals(
+            FcmRegistrationAction.REGISTER,
+            FcmRegistrationStatus.NOT_REGISTERED.toAction(),
+        )
+    }
+
+    @Test
+    fun registeredStatusReturnsNone() {
+        assertEquals(
+            FcmRegistrationAction.NONE,
+            FcmRegistrationStatus.REGISTERED.toAction(),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- `FcmRegistration` composable now actually calls `registerFcm()` when status is NOT_REGISTERED. Previously it only logged "registering..." but took no action.
- Extracted decision logic into `FcmRegistrationStatus.toAction()` for testability
- 3 tests verify correct action for each status

## Test plan

- [x] `FcmRegistrationActionTest` — 3 tests pass
- [x] Spotless passes
- [ ] Full CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)