### PR TITLE
refactor: Extract FcmMessageHandler for testable FCM processing

### DIFF
--- a/AndroidGarage/androidApp/build.gradle.kts
+++ b/AndroidGarage/androidApp/build.gradle.kts
@@ -255,6 +255,7 @@ dependencies {
     // Testing
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(project(":test-common"))
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
@@ -19,10 +19,6 @@ package com.chriscartland.garage.fcm
 
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.GarageApplication
-import com.chriscartland.garage.data.FcmPayloadParser
-import com.chriscartland.garage.domain.model.AppLoggerKeys
-import com.chriscartland.garage.domain.repository.AppLoggerRepository
-import com.chriscartland.garage.domain.repository.DoorRepository
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import kotlinx.coroutines.CoroutineScope
@@ -31,12 +27,12 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
 class FCMService : FirebaseMessagingService() {
-    private val doorRepository: DoorRepository by lazy {
-        (application as GarageApplication).component.provideDoorRepository()
-    }
-
-    private val appLoggerRepository: AppLoggerRepository by lazy {
-        (application as GarageApplication).component.provideAppLoggerRepository()
+    private val handler: FcmMessageHandler by lazy {
+        val component = (application as GarageApplication).component
+        FcmMessageHandler(
+            doorRepository = component.provideDoorRepository(),
+            appLoggerRepository = component.provideAppLoggerRepository(),
+        )
     }
 
     private val serviceJob = SupervisorJob()
@@ -48,28 +44,14 @@ class FCMService : FirebaseMessagingService() {
 
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
         Logger.d { "onMessageReceived, from: ${remoteMessage.from}" }
-
-        if (remoteMessage.data.isEmpty()) {
-            Logger.d { "Message data payload is empty" }
-            return
-        }
-
         Logger.d { "Message data payload: ${remoteMessage.data}" }
-        val doorEvent = FcmPayloadParser.parseDoorEvent(remoteMessage.data)
-        if (doorEvent == null) {
-            Logger.e { "Failed to parse FCM payload: ${remoteMessage.data.entries.joinToString()}" }
-            return
-        }
 
-        Logger.d { "DoorData: $doorEvent" }
         serviceScope.launch(Dispatchers.IO) {
-            appLoggerRepository.log(AppLoggerKeys.FCM_DOOR_RECEIVED)
-        }
-
-        try {
-            doorRepository.insertDoorEvent(doorEvent)
-        } catch (e: IllegalStateException) {
-            Logger.e { "Failed to insert door event: $e" }
+            try {
+                handler.handleDoorMessage(remoteMessage.data)
+            } catch (e: IllegalStateException) {
+                Logger.e { "Failed to handle door message: $e" }
+            }
         }
 
         remoteMessage.notification?.let {

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FcmMessageHandler.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FcmMessageHandler.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.fcm
+
+import co.touchlab.kermit.Logger
+import com.chriscartland.garage.data.FcmPayloadParser
+import com.chriscartland.garage.domain.model.AppLoggerKeys
+import com.chriscartland.garage.domain.repository.AppLoggerRepository
+import com.chriscartland.garage.domain.repository.DoorRepository
+
+/**
+ * Handles FCM door event messages. Extracted from FCMService for testability.
+ *
+ * Parses the FCM data payload and inserts the resulting DoorEvent into the repository.
+ * Returns true if the event was successfully parsed and inserted.
+ */
+class FcmMessageHandler(
+    private val doorRepository: DoorRepository,
+    private val appLoggerRepository: AppLoggerRepository,
+) {
+    /**
+     * Process an FCM data message. Returns true if a DoorEvent was parsed and inserted.
+     */
+    suspend fun handleDoorMessage(data: Map<String, String>): Boolean {
+        if (data.isEmpty()) {
+            Logger.d { "Message data payload is empty" }
+            return false
+        }
+        val doorEvent = FcmPayloadParser.parseDoorEvent(data) ?: run {
+            Logger.e { "Failed to parse FCM payload: ${data.entries.joinToString()}" }
+            return false
+        }
+        Logger.d { "DoorData: $doorEvent" }
+        doorRepository.insertDoorEvent(doorEvent)
+        appLoggerRepository.log(AppLoggerKeys.FCM_DOOR_RECEIVED)
+        return true
+    }
+}

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/fcm/FcmMessageHandlerTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/fcm/FcmMessageHandlerTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.fcm
+
+import com.chriscartland.garage.domain.model.AppLoggerKeys
+import com.chriscartland.garage.domain.model.DoorPosition
+import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
+import com.chriscartland.garage.testcommon.FakeDoorRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FcmMessageHandlerTest {
+    private val doorRepository = FakeDoorRepository()
+    private val appLoggerRepository = FakeAppLoggerRepository()
+    private val handler = FcmMessageHandler(doorRepository, appLoggerRepository)
+
+    private fun makePayload(
+        type: String? = "CLOSED",
+        message: String? = "The door is closed.",
+        timestampSeconds: String? = "1000",
+        checkInTimestampSeconds: String? = "1100",
+    ): Map<String, String> =
+        buildMap {
+            type?.let { put("type", it) }
+            message?.let { put("message", it) }
+            timestampSeconds?.let { put("timestampSeconds", it) }
+            checkInTimestampSeconds?.let { put("checkInTimestampSeconds", it) }
+        }
+
+    @Test
+    fun handleDoorMessage_emptyData_returnsFalse() =
+        runTest {
+            val result = handler.handleDoorMessage(emptyMap())
+
+            assertFalse(result)
+            // No event should have been inserted — currentDoorEvent should still be default.
+            val event = doorRepository.currentDoorEvent.first()
+            assertNull(event?.doorPosition)
+        }
+
+    @Test
+    fun handleDoorMessage_invalidPayload_returnsFalse() =
+        runTest {
+            // Missing required "type" field.
+            val result = handler.handleDoorMessage(mapOf("message" to "hello"))
+
+            assertFalse(result)
+            val event = doorRepository.currentDoorEvent.first()
+            assertNull(event?.doorPosition)
+        }
+
+    @Test
+    fun handleDoorMessage_validPayload_insertsAndReturnsTrue() =
+        runTest {
+            val result = handler.handleDoorMessage(makePayload())
+
+            assertTrue(result)
+            val event = doorRepository.currentDoorEvent.first()
+            assertEquals(DoorPosition.CLOSED, event?.doorPosition)
+            assertEquals("The door is closed.", event?.message)
+            assertEquals(1000L, event?.lastChangeTimeSeconds)
+            assertEquals(1100L, event?.lastCheckInTimeSeconds)
+        }
+
+    @Test
+    fun handleDoorMessage_validPayload_logsEvent() =
+        runTest {
+            handler.handleDoorMessage(makePayload())
+
+            assertTrue(
+                "Expected FCM_DOOR_RECEIVED to be logged",
+                appLoggerRepository.loggedKeys.contains(AppLoggerKeys.FCM_DOOR_RECEIVED),
+            )
+        }
+}


### PR DESCRIPTION
## Summary

- Extracts parse + insert logic from `FCMService.onMessageReceived()` into `FcmMessageHandler`
- Plain Kotlin class testable with fakes — no Android framework dependency
- 4 tests: empty data, invalid payload, valid insert, logging

## Test plan

- [x] 4 FcmMessageHandler tests pass
- [x] Full `validate.sh` passes (55 unit tests, 0 failures)
- [ ] CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)