### PR TITLE
refactor: Replace DurationSince with rememberDurationSince + ViewModel staleness

### DIFF
--- a/AndroidGarage/android-screenshot-tests/SCREENSHOT_GALLERY.md
+++ b/AndroidGarage/android-screenshot-tests/SCREENSHOT_GALLERY.md
@@ -2,7 +2,7 @@
 
 # Screenshot Gallery
 
-Generated on Wed Apr 15 09:01:20 PDT 2026
+Generated on Wed Apr 15 13:22:57 PDT 2026
 
 ## Table of Contents
 - [ComponentsScreenshotTestKt](#componentsscreenshottestkt)

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -147,6 +147,7 @@ abstract class AppComponent(
             provideFetchRecentDoorEventsUseCase(),
             provideDeregisterFcmUseCase(),
             provideFcmRegistrationManager(),
+            scope = provideApplicationScope(),
         )
 
     val remoteButtonViewModel: DefaultRemoteButtonViewModel

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
@@ -42,7 +42,6 @@ import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.presentation.demoDoorEvents
 import com.chriscartland.garage.usecase.AppLoggerViewModel
 import com.chriscartland.garage.usecase.DoorViewModel
-import java.time.Instant
 
 @Composable
 fun DoorHistoryContent(
@@ -54,8 +53,10 @@ fun DoorHistoryContent(
     val resolvedDoorViewModel = doorViewModel ?: viewModel { component.doorViewModel }
     val resolvedAppLoggerViewModel = appLoggerViewModel ?: viewModel { component.appLoggerViewModel }
     val recentDoorEvents by resolvedDoorViewModel.recentDoorEvents.collectAsState()
+    val isCheckInStale by resolvedDoorViewModel.isCheckInStale.collectAsState()
     DoorHistoryContent(
         recentDoorEvents = recentDoorEvents,
+        isCheckInStale = isCheckInStale,
         modifier = modifier,
         onFetchRecentDoorEvents = {
             resolvedAppLoggerViewModel.log(AppLoggerKeys.USER_FETCH_RECENT_DOOR)
@@ -71,58 +72,55 @@ fun DoorHistoryContent(
 fun DoorHistoryContent(
     modifier: Modifier = Modifier,
     recentDoorEvents: LoadingResult<List<DoorEvent>?>,
+    isCheckInStale: Boolean = false,
     onFetchRecentDoorEvents: () -> Unit = {},
     onResetFcm: () -> Unit = {},
 ) {
-    val lastCheckInTime = recentDoorEvents.data?.firstOrNull()?.lastCheckInTimeSeconds
-    DurationSince(lastCheckInTime?.let { Instant.ofEpochSecond(it) }) { duration ->
-        val isOld = lastCheckInTime != null && duration > OLD_DURATION_FOR_DOOR_CHECK_IN
-        LazyColumn(
-            modifier = modifier,
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            if (isOld) {
-                item {
-                    OldLastCheckInBanner(
-                        modifier = Modifier.fillMaxWidth(),
-                        action = {
-                            Logger.e { "Trying to fix outdated info. Resetting FCM, and fetching data." }
-                            onResetFcm()
-                            onFetchRecentDoorEvents()
-                        },
-                    )
-                }
-            }
-            // If the recent events are loading, show a loading indicator.
-            if (recentDoorEvents is LoadingResult.Loading) {
-                item {
-                    Text(text = "Loading...")
-                }
-            }
-            // If the recent events had an error, show an error card.
-            if (recentDoorEvents is LoadingResult.Error) {
-                item {
-                    ErrorCard(
-                        text = "Error fetching recent door events:" +
-                            recentDoorEvents.exception.toString().take(500),
-                        buttonText = "Retry",
-                        onClick = { onFetchRecentDoorEvents() },
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                }
-            }
-            // Show the recent door events.
-            items(recentDoorEvents.data ?: emptyList()) { item ->
-                RecentDoorEventListItem(
-                    doorEvent = item,
-                    modifier = Modifier
-                        .clickable { onFetchRecentDoorEvents() }, // Fetch on click.
+    LazyColumn(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        if (isCheckInStale) {
+            item {
+                OldLastCheckInBanner(
+                    modifier = Modifier.fillMaxWidth(),
+                    action = {
+                        Logger.e { "Trying to fix outdated info. Resetting FCM, and fetching data." }
+                        onResetFcm()
+                        onFetchRecentDoorEvents()
+                    },
                 )
             }
+        }
+        // If the recent events are loading, show a loading indicator.
+        if (recentDoorEvents is LoadingResult.Loading) {
             item {
-                Spacer(modifier = Modifier.height(8.dp))
+                Text(text = "Loading...")
             }
+        }
+        // If the recent events had an error, show an error card.
+        if (recentDoorEvents is LoadingResult.Error) {
+            item {
+                ErrorCard(
+                    text = "Error fetching recent door events:" +
+                        recentDoorEvents.exception.toString().take(500),
+                    buttonText = "Retry",
+                    onClick = { onFetchRecentDoorEvents() },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+        // Show the recent door events.
+        items(recentDoorEvents.data ?: emptyList()) { item ->
+            RecentDoorEventListItem(
+                doorEvent = item,
+                modifier = Modifier
+                    .clickable { onFetchRecentDoorEvents() }, // Fetch on click.
+            )
+        }
+        item {
+            Spacer(modifier = Modifier.height(8.dp))
         }
     }
     ReportDrawnWhen { recentDoorEvents is LoadingResult.Complete }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorStatusCard.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorStatusCard.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -82,33 +83,34 @@ fun DoorStatusCard(
                     text = doorPosition.toFriendlyName(),
                     style = MaterialTheme.typography.titleLarge,
                 )
-                DurationSince(lastChangeTimeSeconds?.let { Instant.ofEpochSecond(it) }) { duration ->
-                    Row(
-                        modifier = Modifier,
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.Center,
-                    ) {
-                        Image(
-                            painter = painterResource(id = R.drawable.clock_icon),
-                            contentDescription = "Date icon",
-                            modifier = Modifier
-                                .size(32.dp)
-                                .padding(start = 8.dp, end = 8.dp),
-                            colorFilter = ColorFilter.tint(contentColor),
-                        )
-                        Text(
-                            text = duration.toFriendlyDuration(),
-                            style = MaterialTheme.typography.labelSmall,
-                        )
-                    }
-                    GarageIcon(
-                        doorPosition = doorPosition,
+                val lastChangeDuration by rememberDurationSince(
+                    lastChangeTimeSeconds?.let { Instant.ofEpochSecond(it) },
+                )
+                Row(
+                    modifier = Modifier,
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    Image(
+                        painter = painterResource(id = R.drawable.clock_icon),
+                        contentDescription = "Date icon",
                         modifier = Modifier
-                            .weight(1f),
-                        static = false,
-                        color = color,
+                            .size(32.dp)
+                            .padding(start = 8.dp, end = 8.dp),
+                        colorFilter = ColorFilter.tint(contentColor),
+                    )
+                    Text(
+                        text = lastChangeDuration.toFriendlyDuration(),
+                        style = MaterialTheme.typography.labelSmall,
                     )
                 }
+                GarageIcon(
+                    doorPosition = doorPosition,
+                    modifier = Modifier
+                        .weight(1f),
+                    static = false,
+                    color = color,
+                )
                 Row(
                     modifier = Modifier,
                     verticalAlignment = Alignment.CenterVertically,
@@ -240,13 +242,14 @@ fun RecentDoorEventListItem(
                     textAlign = TextAlign.Center,
                     style = MaterialTheme.typography.labelSmall,
                 )
-                DurationSince(eventTimeSeconds?.let { Instant.ofEpochSecond(it) }) { duration ->
-                    Text(
-                        text = "${duration.toFriendlyDuration()} ago",
-                        textAlign = TextAlign.Center,
-                        style = MaterialTheme.typography.labelSmall,
-                    )
-                }
+                val eventDuration by rememberDurationSince(
+                    eventTimeSeconds?.let { Instant.ofEpochSecond(it) },
+                )
+                Text(
+                    text = "${eventDuration.toFriendlyDuration()} ago",
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.labelSmall,
+                )
             }
         }
     }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -64,7 +64,6 @@ import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionState
 import com.google.accompanist.permissions.PermissionStatus
 import com.google.accompanist.permissions.isGranted
-import java.time.Instant
 
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
@@ -85,9 +84,11 @@ fun HomeContent(
     val currentDoorEvent by resolvedDoorViewModel.currentDoorEvent.collectAsState()
     val buttonState by buttonViewModel.buttonState.collectAsState()
     val authState by resolvedAuthViewModel.authState.collectAsState()
+    val isCheckInStale by resolvedDoorViewModel.isCheckInStale.collectAsState()
     HomeContent(
         currentDoorEvent = currentDoorEvent,
         remoteButtonState = buttonState,
+        isCheckInStale = isCheckInStale,
         modifier = modifier,
         onFetchCurrentDoorEvent = {
             resolvedAppLoggerViewModel.log(AppLoggerKeys.USER_FETCH_CURRENT_DOOR)
@@ -126,6 +127,7 @@ fun HomeContent(
     currentDoorEvent: LoadingResult<DoorEvent?>,
     modifier: Modifier = Modifier,
     remoteButtonState: RemoteButtonState = RemoteButtonState.Ready,
+    isCheckInStale: Boolean = false,
     onFetchCurrentDoorEvent: () -> Unit = {},
     onRemoteButtonTap: () -> Unit = {},
     authState: AuthState = AuthState.Unauthenticated,
@@ -138,91 +140,87 @@ fun HomeContent(
     // Show the current door event.
     val doorEvent = currentDoorEvent.data
 
-    val lastCheckInTime = doorEvent?.lastCheckInTimeSeconds
-    DurationSince(lastCheckInTime?.let { Instant.ofEpochSecond(it) }) { duration ->
-        val isOld = lastCheckInTime != null && duration > OLD_DURATION_FOR_DOOR_CHECK_IN
-        Column(
-            modifier = modifier,
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        if (isCheckInStale) {
+            OldLastCheckInBanner(
+                action = {
+                    Logger.e { "Trying to fix outdated info. Resetting FCM, and fetching data." }
+                    onResetFcm()
+                    onFetchCurrentDoorEvent()
+                },
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        // Add a card at the top if the notification permission is not granted.
+        if (!notificationPermissionState.status.isGranted) {
+            ErrorCard(
+                text = notificationJustificationText(permissionRequestCount),
+                buttonText = "Allow",
+                onClick = {
+                    permissionRequestCount++
+                    notificationPermissionState.launchPermissionRequest()
+                    onLogNotificationPermissionRequested()
+                },
+            )
+        }
+
+        // If the current event had an error, show an error card.
+        if (currentDoorEvent is LoadingResult.Error) {
+            ErrorCard(
+                text = "Error fetching current door event: " +
+                    currentDoorEvent.exception.toString().take(500),
+                buttonText = "Retry",
+                onClick = { onFetchCurrentDoorEvent() },
+            )
+        }
+
+        Box(
+            modifier = Modifier.weight(1f),
         ) {
-            if (isOld) {
-                OldLastCheckInBanner(
-                    action = {
-                        Logger.e { "Trying to fix outdated info. Resetting FCM, and fetching data." }
-                        onResetFcm()
-                        onFetchCurrentDoorEvent()
-                    },
-                    modifier = Modifier.fillMaxWidth(),
+            DoorStatusCard(
+                doorEvent = doorEvent,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clickable { onFetchCurrentDoorEvent() },
+            )
+            // If the current event is loading, show a loading indicator.
+            if (currentDoorEvent is LoadingResult.Loading) {
+                Text(
+                    text = "Loading...",
+                    modifier = Modifier.padding(8.dp),
+                    style = MaterialTheme.typography.titleMedium,
                 )
             }
-            // Add a card at the top if the notification permission is not granted.
-            if (!notificationPermissionState.status.isGranted) {
-                ErrorCard(
-                    text = notificationJustificationText(permissionRequestCount),
-                    buttonText = "Allow",
-                    onClick = {
-                        permissionRequestCount++
-                        notificationPermissionState.launchPermissionRequest()
-                        onLogNotificationPermissionRequested()
-                    },
-                )
-            }
+        }
 
-            // If the current event had an error, show an error card.
-            if (currentDoorEvent is LoadingResult.Error) {
-                ErrorCard(
-                    text = "Error fetching current door event: " +
-                        currentDoorEvent.exception.toString().take(500),
-                    buttonText = "Retry",
-                    onClick = { onFetchCurrentDoorEvent() },
-                )
-            }
+        Spacer(modifier = Modifier.height(8.dp))
 
-            Box(
-                modifier = Modifier.weight(1f),
-            ) {
-                DoorStatusCard(
-                    doorEvent = doorEvent,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .clickable { onFetchCurrentDoorEvent() },
-                )
-                // If the current event is loading, show a loading indicator.
-                if (currentDoorEvent is LoadingResult.Loading) {
-                    Text(
-                        text = "Loading...",
-                        modifier = Modifier.padding(8.dp),
-                        style = MaterialTheme.typography.titleMedium,
-                    )
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            when (authState) {
+                AuthState.Unknown -> {
+                    Text(text = "Checking authentication...")
                 }
-            }
 
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Box(
-                modifier = Modifier.weight(1f),
-                contentAlignment = Alignment.Center,
-            ) {
-                when (authState) {
-                    AuthState.Unknown -> {
-                        Text(text = "Checking authentication...")
+                AuthState.Unauthenticated -> {
+                    Button(onClick = { onSignIn() }) {
+                        Text("Sign to access garage remote button")
                     }
+                }
 
-                    AuthState.Unauthenticated -> {
-                        Button(onClick = { onSignIn() }) {
-                            Text("Sign to access garage remote button")
-                        }
-                    }
-
-                    is AuthState.Authenticated -> {
-                        RemoteButtonContent(
-                            modifier = Modifier
-                                .fillMaxSize(),
-                            state = remoteButtonState,
-                            onTap = onRemoteButtonTap,
-                        )
-                    }
+                is AuthState.Authenticated -> {
+                    RemoteButtonContent(
+                        modifier = Modifier
+                            .fillMaxSize(),
+                        state = remoteButtonState,
+                        onTap = onRemoteButtonTap,
+                    )
                 }
             }
         }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -38,13 +38,10 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
@@ -54,7 +51,6 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import com.chriscartland.garage.di.rememberAppComponent
-import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.ui.theme.AppTheme
 import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
 import com.chriscartland.garage.usecase.AppLoggerViewModel
@@ -124,30 +120,12 @@ fun AppNavigation(
 ) {
     val component = rememberAppComponent()
     val buttonViewModel: RemoteButtonViewModel = viewModel { component.remoteButtonViewModel }
-    var isOld by remember { mutableStateOf(false) }
     val currentDoorEvent by doorViewModel.currentDoorEvent.collectAsState()
     val lastCheckInTime = currentDoorEvent.data?.lastCheckInTimeSeconds?.let {
         Instant.ofEpochSecond(it)
     }
     val doorColor = currentDoorEvent.data.color(LocalDoorStatusColorScheme.current)
     val onDoorColor = currentDoorEvent.data.onColor(LocalDoorStatusColorScheme.current)
-    var isTimeWithoutFcmTooLong by remember { mutableStateOf(false) }
-    var isFirstValue by remember { mutableStateOf(true) }
-    DurationSince(lastCheckInTime) { duration ->
-        isOld = lastCheckInTime != null && duration > OLD_DURATION_FOR_DOOR_CHECK_IN
-        LaunchedEffect(isOld) {
-            isTimeWithoutFcmTooLong = isOld
-        }
-    }
-    LaunchedEffect(isTimeWithoutFcmTooLong) {
-        if (isTimeWithoutFcmTooLong) {
-            appLoggerViewModel.log(AppLoggerKeys.EXCEEDED_EXPECTED_TIME_WITHOUT_FCM)
-        } else if (!isFirstValue) {
-            // Do not log the first time if everything is ok.
-            appLoggerViewModel.log(AppLoggerKeys.TIME_WITHOUT_FCM_IN_EXPECTED_RANGE)
-        }
-        isFirstValue = false
-    }
     // Nav3: back stack is a simple mutable list of Screen objects.
     // Using remember (not rememberSaveable) because Screen objects aren't Bundle-saveable.
     // For tab navigation this is fine — process death just restarts on Home tab.

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -126,6 +126,7 @@ fun AppNavigation(
     }
     val doorColor = currentDoorEvent.data.color(LocalDoorStatusColorScheme.current)
     val onDoorColor = currentDoorEvent.data.onColor(LocalDoorStatusColorScheme.current)
+    val isCheckInStale by doorViewModel.isCheckInStale.collectAsState()
     // Nav3: back stack is a simple mutable list of Screen objects.
     // Using remember (not rememberSaveable) because Screen objects aren't Bundle-saveable.
     // For tab navigation this is fine — process death just restarts on Home tab.
@@ -140,6 +141,7 @@ fun AppNavigation(
                 actions = {
                     CheckInRow(
                         lastCheckIn = lastCheckInTime,
+                        isCheckInStale = isCheckInStale,
                         pillColors = PillColors(
                             // Match the door color
                             backgroundColor = doorColor,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/OldLastCheckInBanner.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/OldLastCheckInBanner.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
@@ -61,38 +62,37 @@ fun CheckInRow(
 ) {
     // This is called in a RowScope in TopAppBar.
     val pillShape = RoundedCornerShape(50)
-    DurationSince(lastCheckIn) { duration ->
-        val isOld = lastCheckIn != null && duration > OLD_DURATION_FOR_DOOR_CHECK_IN
-        CompositionLocalProvider(LocalContentColor provides pillColors.contentColor) {
-            Box(
-                modifier = Modifier
-                    .background(
-                        color = pillColors.backgroundColor,
-                        shape = pillShape,
-                    ).padding(start = 8.dp, end = 4.dp),
+    val duration by rememberDurationSince(lastCheckIn)
+    val isOld = lastCheckIn != null && duration > OLD_DURATION_FOR_DOOR_CHECK_IN
+    CompositionLocalProvider(LocalContentColor provides pillColors.contentColor) {
+        Box(
+            modifier = Modifier
+                .background(
+                    color = pillColors.backgroundColor,
+                    shape = pillShape,
+                ).padding(start = 8.dp, end = 4.dp),
+        ) {
+            Row(
+                modifier = modifier,
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Row(
-                    modifier = modifier,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    if (lastCheckIn != null) {
-                        Text(
-                            text = ("${duration.toFriendlyDuration()} ago"),
-                            style = MaterialTheme.typography.labelSmall,
-                        )
-                        Spacer(modifier = Modifier.width(4.dp))
-                    }
-                    Image(
-                        modifier = Modifier.scale(0.7f),
-                        painter = if (isOld) {
-                            painterResource(id = R.drawable.outline_signal_disconnected_24)
-                        } else {
-                            painterResource(id = R.drawable.baseline_cell_tower_24)
-                        },
-                        colorFilter = ColorFilter.tint(LocalContentColor.current),
-                        contentDescription = "Door Broadcast Icon",
+                if (lastCheckIn != null) {
+                    Text(
+                        text = ("${duration.toFriendlyDuration()} ago"),
+                        style = MaterialTheme.typography.labelSmall,
                     )
+                    Spacer(modifier = Modifier.width(4.dp))
                 }
+                Image(
+                    modifier = Modifier.scale(0.7f),
+                    painter = if (isOld) {
+                        painterResource(id = R.drawable.outline_signal_disconnected_24)
+                    } else {
+                        painterResource(id = R.drawable.baseline_cell_tower_24)
+                    },
+                    colorFilter = ColorFilter.tint(LocalContentColor.current),
+                    contentDescription = "Door Broadcast Icon",
+                )
             }
         }
     }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/OldLastCheckInBanner.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/OldLastCheckInBanner.kt
@@ -54,6 +54,7 @@ data class PillColors(
 @Composable
 fun CheckInRow(
     lastCheckIn: Instant?,
+    isCheckInStale: Boolean,
     modifier: Modifier = Modifier,
     pillColors: PillColors = PillColors(
         backgroundColor = LocalDoorStatusColorScheme.current.unknownFresh,
@@ -63,7 +64,6 @@ fun CheckInRow(
     // This is called in a RowScope in TopAppBar.
     val pillShape = RoundedCornerShape(50)
     val duration by rememberDurationSince(lastCheckIn)
-    val isOld = lastCheckIn != null && duration > OLD_DURATION_FOR_DOOR_CHECK_IN
     CompositionLocalProvider(LocalContentColor provides pillColors.contentColor) {
         Box(
             modifier = Modifier
@@ -85,7 +85,7 @@ fun CheckInRow(
                 }
                 Image(
                     modifier = Modifier.scale(0.7f),
-                    painter = if (isOld) {
+                    painter = if (isCheckInStale) {
                         painterResource(id = R.drawable.outline_signal_disconnected_24)
                     } else {
                         painterResource(id = R.drawable.baseline_cell_tower_24)
@@ -126,7 +126,7 @@ fun LastCheckInRowPreview() {
         verticalAlignment = Alignment.CenterVertically,
     ) {
         // This is called in a RowScope by TopAppBar.
-        CheckInRow(Instant.now().minusSeconds(123))
+        CheckInRow(Instant.now().minusSeconds(123), isCheckInStale = false)
     }
 }
 
@@ -137,7 +137,7 @@ fun LastCheckInRowOldPreview() {
         verticalAlignment = Alignment.CenterVertically,
     ) {
         // This is called in a RowScope by TopAppBar.
-        CheckInRow(Instant.now().minusSeconds(1234))
+        CheckInRow(Instant.now().minusSeconds(1234), isCheckInStale = true)
     }
 }
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/TimeFormats.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/TimeFormats.kt
@@ -19,10 +19,9 @@ package com.chriscartland.garage.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import com.chriscartland.garage.domain.model.FriendlyDuration
 import kotlinx.coroutines.delay
 import java.time.Duration
@@ -65,25 +64,24 @@ fun Long.toFriendlyTimeShort(): String? =
 fun Duration.toFriendlyDuration(): String = FriendlyDuration.format(this.toKotlinDuration())
 
 /**
- * Composable that updates periodically based on the duration since a specific time.
+ * Returns a [State] holding the live [Duration] since [time], updated every second.
+ *
+ * Replaces the old `DurationSince` content-lambda composable. Callers read
+ * the value directly instead of being wrapped in a lambda, which fixes blank
+ * screenshots and keeps layout trees flat.
  */
 @Composable
-fun DurationSince(
-    time: Instant?,
-    defaultDuration: Duration = Duration.ZERO,
-    updatePeriod: Duration = Duration.ofSeconds(1),
-    content: @Composable (duration: Duration) -> Unit,
-) {
-    var checkInDuration by remember { mutableStateOf(defaultDuration) }
-    LaunchedEffect(key1 = time) {
+fun rememberDurationSince(time: Instant?): State<Duration> {
+    val duration = remember { mutableStateOf(Duration.ZERO) }
+    LaunchedEffect(time) {
         while (true) {
-            checkInDuration = if (time == null) {
-                defaultDuration
-            } else {
+            duration.value = if (time != null) {
                 Duration.between(time, Instant.now())
+            } else {
+                Duration.ZERO
             }
-            delay(updatePeriod.toMillis())
+            delay(1_000L)
         }
     }
-    content(checkInDuration)
+    return duration
 }

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/coroutines/AppClock.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/coroutines/AppClock.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.domain.coroutines
+
+/**
+ * Abstraction over wall-clock time for testability.
+ *
+ * Production uses [System.currentTimeMillis]; tests use [FakeClock]
+ * to control time without real delays.
+ */
+fun interface AppClock {
+    fun nowEpochSeconds(): Long
+}

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeClock.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeClock.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.testcommon
+
+import com.chriscartland.garage.domain.coroutines.AppClock
+
+/**
+ * Test clock with controllable time. Advance with [advanceSeconds].
+ */
+class FakeClock(
+    private var nowSeconds: Long = 0L,
+) : AppClock {
+    override fun nowEpochSeconds(): Long = nowSeconds
+
+    fun advanceSeconds(seconds: Long) {
+        nowSeconds += seconds
+    }
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorViewModel.kt
@@ -29,6 +29,7 @@ import com.chriscartland.garage.domain.model.FcmRegistrationStatus
 import com.chriscartland.garage.domain.model.FetchError
 import com.chriscartland.garage.domain.model.LoadingResult
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -41,7 +42,7 @@ interface DoorViewModel {
     val currentDoorEvent: StateFlow<LoadingResult<DoorEvent?>>
     val recentDoorEvents: StateFlow<LoadingResult<List<DoorEvent>>>
 
-    /** True when the last check-in is older than [CHECK_IN_STALE_THRESHOLD_SECONDS]. */
+    /** True when the last check-in is older than the staleness threshold (11 min). */
     val isCheckInStale: StateFlow<Boolean>
 
     fun deregisterFcm()
@@ -59,8 +60,8 @@ class DefaultDoorViewModel(
     private val fetchRecentDoorEventsUseCase: FetchRecentDoorEventsUseCase,
     private val deregisterFcmUseCase: DeregisterFcmUseCase,
     fcmRegistrationManager: FcmRegistrationManager,
-    private val clock: AppClock = AppClock { System.currentTimeMillis() / 1000 },
     private val scope: CoroutineScope,
+    private val clock: AppClock = AppClock { System.currentTimeMillis() / 1000 },
     private val fetchOnInit: Boolean = true,
 ) : ViewModel(),
     DoorViewModel {
@@ -79,6 +80,9 @@ class DefaultDoorViewModel(
 
     private val _isCheckInStale = MutableStateFlow(false)
     override val isCheckInStale: StateFlow<Boolean> = _isCheckInStale
+
+    /** Staleness coroutines — cancelled in [onCleared] to avoid leaking past ViewModel lifetime. */
+    private val stalenessJobs = mutableListOf<Job>()
 
     init {
         Logger.d { "init" }
@@ -104,19 +108,20 @@ class DefaultDoorViewModel(
         }
         // Staleness: re-evaluate on data change and periodically.
         // Uses injected scope (not viewModelScope) so tests control the lifecycle.
-        scope.launch(dispatchers.io) {
+        // Jobs are tracked and cancelled in onCleared() to avoid leaking past ViewModel lifetime.
+        stalenessJobs += scope.launch(dispatchers.io) {
             _currentDoorEvent.collect { event ->
                 _isCheckInStale.value = computeStale(event)
             }
         }
-        scope.launch(dispatchers.io) {
+        stalenessJobs += scope.launch(dispatchers.io) {
             while (true) {
                 delay(STALE_CHECK_INTERVAL_MS)
                 _isCheckInStale.value = computeStale(_currentDoorEvent.value)
             }
         }
         // Log staleness transitions (moved from Main.kt composable).
-        scope.launch(dispatchers.io) {
+        stalenessJobs += scope.launch(dispatchers.io) {
             var isFirstEmission = true
             isCheckInStale.collect { stale ->
                 if (stale) {
@@ -127,6 +132,11 @@ class DefaultDoorViewModel(
                 isFirstEmission = false
             }
         }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        stalenessJobs.forEach { it.cancel() }
     }
 
     override fun deregisterFcm() {

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorViewModel.kt
@@ -20,6 +20,7 @@ package com.chriscartland.garage.usecase
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
+import com.chriscartland.garage.domain.coroutines.AppClock
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.AppResult
@@ -27,6 +28,8 @@ import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.FcmRegistrationStatus
 import com.chriscartland.garage.domain.model.FetchError
 import com.chriscartland.garage.domain.model.LoadingResult
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -37,6 +40,9 @@ interface DoorViewModel {
     val fcmRegistrationStatus: StateFlow<FcmRegistrationStatus>
     val currentDoorEvent: StateFlow<LoadingResult<DoorEvent?>>
     val recentDoorEvents: StateFlow<LoadingResult<List<DoorEvent>>>
+
+    /** True when the last check-in is older than [CHECK_IN_STALE_THRESHOLD_SECONDS]. */
+    val isCheckInStale: StateFlow<Boolean>
 
     fun deregisterFcm()
 
@@ -53,6 +59,8 @@ class DefaultDoorViewModel(
     private val fetchRecentDoorEventsUseCase: FetchRecentDoorEventsUseCase,
     private val deregisterFcmUseCase: DeregisterFcmUseCase,
     fcmRegistrationManager: FcmRegistrationManager,
+    private val clock: AppClock = AppClock { System.currentTimeMillis() / 1000 },
+    private val scope: CoroutineScope,
     private val fetchOnInit: Boolean = true,
 ) : ViewModel(),
     DoorViewModel {
@@ -68,6 +76,9 @@ class DefaultDoorViewModel(
     private val _recentDoorEvents =
         MutableStateFlow<LoadingResult<List<DoorEvent>>>(LoadingResult.Loading(listOf()))
     override val recentDoorEvents: StateFlow<LoadingResult<List<DoorEvent>>> = _recentDoorEvents
+
+    private val _isCheckInStale = MutableStateFlow(false)
+    override val isCheckInStale: StateFlow<Boolean> = _isCheckInStale
 
     init {
         Logger.d { "init" }
@@ -90,6 +101,31 @@ class DefaultDoorViewModel(
             }
             fetchCurrentDoorEvent()
             fetchRecentDoorEvents()
+        }
+        // Staleness: re-evaluate on data change and periodically.
+        // Uses injected scope (not viewModelScope) so tests control the lifecycle.
+        scope.launch(dispatchers.io) {
+            _currentDoorEvent.collect { event ->
+                _isCheckInStale.value = computeStale(event)
+            }
+        }
+        scope.launch(dispatchers.io) {
+            while (true) {
+                delay(STALE_CHECK_INTERVAL_MS)
+                _isCheckInStale.value = computeStale(_currentDoorEvent.value)
+            }
+        }
+        // Log staleness transitions (moved from Main.kt composable).
+        scope.launch(dispatchers.io) {
+            var isFirstEmission = true
+            isCheckInStale.collect { stale ->
+                if (stale) {
+                    logAppEvent(AppLoggerKeys.EXCEEDED_EXPECTED_TIME_WITHOUT_FCM)
+                } else if (!isFirstEmission) {
+                    logAppEvent(AppLoggerKeys.TIME_WITHOUT_FCM_IN_EXPECTED_RANGE)
+                }
+                isFirstEmission = false
+            }
         }
     }
 
@@ -138,5 +174,19 @@ class DefaultDoorViewModel(
                 }
             }
         }
+    }
+
+    private fun computeStale(event: LoadingResult<DoorEvent?>): Boolean {
+        val checkInTime = event.data?.lastCheckInTimeSeconds ?: return false
+        val age = clock.nowEpochSeconds() - checkInTime
+        return age > CHECK_IN_STALE_THRESHOLD_SECONDS
+    }
+
+    companion object {
+        /** 11 minutes — matches the old OldLastCheckInBanner threshold. */
+        const val CHECK_IN_STALE_THRESHOLD_SECONDS = 11L * 60
+
+        /** Re-evaluate staleness every 30 seconds. */
+        const val STALE_CHECK_INTERVAL_MS = 30_000L
     }
 }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DoorViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DoorViewModelTest.kt
@@ -17,14 +17,18 @@
 
 package com.chriscartland.garage.usecase
 
+import com.chriscartland.garage.domain.coroutines.AppClock
+import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.model.FcmRegistrationStatus
 import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
+import com.chriscartland.garage.testcommon.FakeClock
 import com.chriscartland.garage.testcommon.FakeDoorFcmRepository
 import com.chriscartland.garage.testcommon.FakeDoorRepository
 import com.chriscartland.garage.testcommon.TestDispatcherProvider
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -68,10 +72,18 @@ class DoorViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel(fetchOnInit: Boolean = true): DefaultDoorViewModel {
+    /**
+     * Pass the [scope] from `runTest { this }` so staleness coroutines
+     * are cancelled when the test completes (same pattern as FcmRegistrationManagerTest).
+     */
+    private fun createViewModel(
+        scope: CoroutineScope,
+        clock: AppClock = AppClock { 0L },
+        fetchOnInit: Boolean = true,
+    ): DefaultDoorViewModel {
         val fcmManager = FcmRegistrationManager(
             registerFcmUseCase = RegisterFcmUseCase(doorRepository, doorFcmRepository),
-            scope = kotlinx.coroutines.CoroutineScope(testDispatcher),
+            scope = scope,
             dispatcher = testDispatcher,
         )
         val vm = DefaultDoorViewModel(
@@ -82,6 +94,8 @@ class DoorViewModelTest {
             fetchRecentDoorEventsUseCase = FetchRecentDoorEventsUseCase(doorRepository),
             deregisterFcmUseCase = DeregisterFcmUseCase(doorFcmRepository),
             fcmRegistrationManager = fcmManager,
+            clock = clock,
+            scope = scope,
             fetchOnInit = fetchOnInit,
         )
         testDispatcher.scheduler.runCurrent()
@@ -91,7 +105,7 @@ class DoorViewModelTest {
     @Test
     fun initialFcmRegistrationStatusIsUnknown() =
         runTest {
-            val viewModel = createViewModel()
+            val viewModel = createViewModel(scope = backgroundScope)
 
             assertEquals(FcmRegistrationStatus.UNKNOWN, viewModel.fcmRegistrationStatus.value)
         }
@@ -99,7 +113,7 @@ class DoorViewModelTest {
     @Test
     fun collectsCurrentDoorEventFromRepository() =
         runTest {
-            val viewModel = createViewModel()
+            val viewModel = createViewModel(scope = backgroundScope)
 
             val updatedEvent =
                 DoorEvent(
@@ -119,7 +133,7 @@ class DoorViewModelTest {
     @Test
     fun collectsUpdatedDoorEventFromRepository() =
         runTest {
-            val viewModel = createViewModel()
+            val viewModel = createViewModel(scope = backgroundScope)
 
             val updatedEvent =
                 DoorEvent(
@@ -139,7 +153,7 @@ class DoorViewModelTest {
     @Test
     fun collectsRecentDoorEventsFromRepository() =
         runTest {
-            val viewModel = createViewModel()
+            val viewModel = createViewModel(scope = backgroundScope)
 
             val events =
                 listOf(
@@ -157,7 +171,7 @@ class DoorViewModelTest {
     @Test
     fun fetchCurrentDoorEventCallsRepository() =
         runTest {
-            val viewModel = createViewModel()
+            val viewModel = createViewModel(scope = backgroundScope)
 
             viewModel.fetchCurrentDoorEvent()
             testDispatcher.scheduler.runCurrent()
@@ -169,7 +183,7 @@ class DoorViewModelTest {
     @Test
     fun fetchRecentDoorEventsCallsRepository() =
         runTest {
-            val viewModel = createViewModel()
+            val viewModel = createViewModel(scope = backgroundScope)
 
             viewModel.fetchRecentDoorEvents()
             testDispatcher.scheduler.runCurrent()
@@ -180,10 +194,152 @@ class DoorViewModelTest {
     @Test
     fun fetchOnInitFalseDoesNotFetchOnCreate() =
         runTest {
-            val viewModel = createViewModel(fetchOnInit = false)
+            val viewModel = createViewModel(scope = backgroundScope, fetchOnInit = false)
 
             // Flow collection still runs (shows repo data), but network fetch was NOT triggered
             assertEquals(0, doorRepository.fetchCurrentDoorEventCount)
             assertEquals(0, doorRepository.fetchRecentDoorEventsCount)
+        }
+
+    // --- Staleness tests ---
+
+    private val staleCheckInterval = DefaultDoorViewModel.STALE_CHECK_INTERVAL_MS
+
+    @Test
+    fun isCheckInStale_isFalse_whenCheckInIsRecent() =
+        runTest {
+            val clock = FakeClock(nowSeconds = 1000L)
+            doorRepository.setCurrentDoorEvent(
+                testDoorEvent.copy(lastCheckInTimeSeconds = 1000L),
+            )
+            val viewModel = createViewModel(
+                scope = backgroundScope,
+                clock = clock,
+            )
+
+            assertEquals(false, viewModel.isCheckInStale.value)
+        }
+
+    @Test
+    fun isCheckInStale_isTrue_whenCheckInIsOld() =
+        runTest {
+            val checkInTime = 1000L
+            val clock = FakeClock(
+                nowSeconds = checkInTime + DefaultDoorViewModel.CHECK_IN_STALE_THRESHOLD_SECONDS + 1,
+            )
+            doorRepository.setCurrentDoorEvent(
+                testDoorEvent.copy(lastCheckInTimeSeconds = checkInTime),
+            )
+            val viewModel = createViewModel(
+                scope = backgroundScope,
+                clock = clock,
+            )
+
+            // Advance past the ticker interval so the periodic check fires.
+            testDispatcher.scheduler.advanceTimeBy(staleCheckInterval + 1)
+            testDispatcher.scheduler.runCurrent()
+
+            assertEquals(true, viewModel.isCheckInStale.value)
+        }
+
+    @Test
+    fun isCheckInStale_becomesTrue_afterClockAdvances() =
+        runTest {
+            val checkInTime = 1000L
+            val clock = FakeClock(nowSeconds = checkInTime)
+            doorRepository.setCurrentDoorEvent(
+                testDoorEvent.copy(lastCheckInTimeSeconds = checkInTime),
+            )
+            val viewModel = createViewModel(
+                scope = backgroundScope,
+                clock = clock,
+            )
+
+            assertEquals(false, viewModel.isCheckInStale.value)
+
+            // Advance the fake clock past threshold.
+            clock.advanceSeconds(DefaultDoorViewModel.CHECK_IN_STALE_THRESHOLD_SECONDS + 1)
+            // Advance coroutine time so the ticker fires.
+            testDispatcher.scheduler.advanceTimeBy(staleCheckInterval + 1)
+            testDispatcher.scheduler.runCurrent()
+
+            assertEquals(true, viewModel.isCheckInStale.value)
+        }
+
+    @Test
+    fun isCheckInStale_becomesFresh_whenNewEventArrives() =
+        runTest {
+            val checkInTime = 1000L
+            val clock = FakeClock(
+                nowSeconds = checkInTime + DefaultDoorViewModel.CHECK_IN_STALE_THRESHOLD_SECONDS + 1,
+            )
+            doorRepository.setCurrentDoorEvent(
+                testDoorEvent.copy(lastCheckInTimeSeconds = checkInTime),
+            )
+            val viewModel = createViewModel(
+                scope = backgroundScope,
+                clock = clock,
+            )
+
+            // Becomes stale via ticker.
+            testDispatcher.scheduler.advanceTimeBy(staleCheckInterval + 1)
+            testDispatcher.scheduler.runCurrent()
+            assertEquals(true, viewModel.isCheckInStale.value)
+
+            // New event arrives with fresh check-in time — triggers collect, not ticker.
+            doorRepository.setCurrentDoorEvent(
+                testDoorEvent.copy(lastCheckInTimeSeconds = clock.nowEpochSeconds()),
+            )
+            testDispatcher.scheduler.runCurrent()
+
+            assertEquals(false, viewModel.isCheckInStale.value)
+        }
+
+    @Test
+    fun logsStaleEvent_whenCheckInBecomesStale() =
+        runTest {
+            val checkInTime = 1000L
+            val clock = FakeClock(nowSeconds = checkInTime)
+            doorRepository.setCurrentDoorEvent(
+                testDoorEvent.copy(lastCheckInTimeSeconds = checkInTime),
+            )
+            createViewModel(
+                scope = backgroundScope,
+                clock = clock,
+            )
+
+            // Advance past threshold.
+            clock.advanceSeconds(DefaultDoorViewModel.CHECK_IN_STALE_THRESHOLD_SECONDS + 1)
+            testDispatcher.scheduler.advanceTimeBy(staleCheckInterval + 1)
+            testDispatcher.scheduler.runCurrent()
+
+            assertTrue(
+                appLoggerRepository.loggedKeys.contains(
+                    AppLoggerKeys.EXCEEDED_EXPECTED_TIME_WITHOUT_FCM,
+                ),
+                "Expected staleness log, got: ${appLoggerRepository.loggedKeys}",
+            )
+        }
+
+    @Test
+    fun doesNotLogFresh_onFirstEmission() =
+        runTest {
+            val clock = FakeClock(nowSeconds = 1000L)
+            doorRepository.setCurrentDoorEvent(
+                testDoorEvent.copy(lastCheckInTimeSeconds = 1000L),
+            )
+            createViewModel(
+                scope = backgroundScope,
+                clock = clock,
+            )
+
+            // The first emission is false (fresh) — should NOT log "in range".
+            val freshLogs = appLoggerRepository.loggedKeys.filter {
+                it == AppLoggerKeys.TIME_WITHOUT_FCM_IN_EXPECTED_RANGE
+            }
+            assertTrue(
+                freshLogs.isEmpty(),
+                "Should not log fresh on first emission, got: ${appLoggerRepository.loggedKeys}",
+            )
         }
 }


### PR DESCRIPTION
## Summary

- **Display layer**: `DurationSince` content-lambda composable → `rememberDurationSince()` returning `State<Duration>`. Flat layout, no wrapping — fixes blank screenshot root cause
- **Business layer**: `DoorViewModel.isCheckInStale: StateFlow<Boolean>` with `AppClock` + 30s periodic ticker. Staleness logging moved from `Main.kt` composable to ViewModel coroutine
- **Scope injection**: `DefaultDoorViewModel` accepts `CoroutineScope` (same pattern as `FcmRegistrationManager`). Tests pass `backgroundScope` — ticker is cancelled when test ends, no hanging
- **New infrastructure**: `AppClock` interface (domain), `FakeClock` (test-common) for time control in tests

## Call site migration

| # | Location | Before | After |
|---|----------|--------|-------|
| 1 | TimeFormats.kt | `DurationSince` composable | `rememberDurationSince()` |
| 2 | Main.kt | DurationSince + LaunchedEffect logging | Deleted (logging in ViewModel) |
| 3 | HomeContent.kt | DurationSince wraps entire screen | `isCheckInStale: Boolean` param |
| 4 | DoorHistoryContent.kt | DurationSince wraps LazyColumn | `isCheckInStale: Boolean` param |
| 5 | DoorStatusCard.kt:85 | DurationSince wraps icon + text | `val d by rememberDurationSince()` |
| 6 | DoorStatusCard.kt:243 | DurationSince wraps "X ago" text | `val d by rememberDurationSince()` |
| 7 | OldLastCheckInBanner.kt | DurationSince wraps entire banner | `val d by rememberDurationSince()` |

## Test plan

- [x] `validate.sh` passes (all checks)
- [x] 6 new staleness tests: fresh, stale, transition, new-event-recovery, logging, skip-first-emission
- [x] All existing DoorViewModel tests pass
- [x] No test hanging (verified with 90s timeout)
- [x] Screenshots regenerated (91 healthy, 5 pre-existing blanks unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)