### PR TITLE
fix: Single staleness source, thread-safety doc, reactive-path test

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorStatusCard.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorStatusCard.kt
@@ -53,20 +53,20 @@ import com.chriscartland.garage.ui.theme.DoorStatusColorScheme
 import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
 import com.chriscartland.garage.ui.theme.doorColorSet
 import com.chriscartland.garage.ui.theme.doorColorState
-import com.chriscartland.garage.ui.theme.isStale
 import java.time.Instant
 
 @Composable
 fun DoorStatusCard(
     doorEvent: DoorEvent?,
     modifier: Modifier = Modifier,
+    isCheckInStale: Boolean = false,
 ) {
     val doorPosition = doorEvent?.doorPosition ?: DoorPosition.UNKNOWN
     val lastChangeTimeSeconds = doorEvent?.lastChangeTimeSeconds
     val date = lastChangeTimeSeconds?.toFriendlyDate()
     val time = lastChangeTimeSeconds?.toFriendlyTime()
     // Select the door color based on the door state.
-    val color = doorEvent.color(LocalDoorStatusColorScheme.current)
+    val color = doorEvent.color(LocalDoorStatusColorScheme.current, isStale = isCheckInStale)
     // Blend the door color into the color of the text on background.
     val contentColor = blendColors(color, MaterialTheme.colorScheme.onBackground, 0.5f)
     CompositionLocalProvider(LocalContentColor provides contentColor) {
@@ -156,8 +156,10 @@ fun DoorStatusCard(
     }
 }
 
-fun DoorEvent?.color(scheme: DoorStatusColorScheme): Color {
-    val isStale = isStale(maxAge = OLD_DURATION_FOR_DOOR_CHECK_IN)
+fun DoorEvent?.color(
+    scheme: DoorStatusColorScheme,
+    isStale: Boolean,
+): Color {
     val colorSet = scheme.doorColorSet(isStale = isStale)
     return when (doorColorState()) {
         DoorColorState.OPEN -> colorSet.open
@@ -166,8 +168,10 @@ fun DoorEvent?.color(scheme: DoorStatusColorScheme): Color {
     }
 }
 
-fun DoorEvent?.onColor(scheme: DoorStatusColorScheme): Color {
-    val isStale = isStale(maxAge = OLD_DURATION_FOR_DOOR_CHECK_IN)
+fun DoorEvent?.onColor(
+    scheme: DoorStatusColorScheme,
+    isStale: Boolean,
+): Color {
     val colorSet = scheme.doorColorSet(isStale = isStale)
     return when (doorColorState()) {
         DoorColorState.OPEN -> colorSet.onOpen

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -186,6 +186,7 @@ fun HomeContent(
                 modifier = Modifier
                     .fillMaxSize()
                     .clickable { onFetchCurrentDoorEvent() },
+                isCheckInStale = isCheckInStale,
             )
             // If the current event is loading, show a loading indicator.
             if (currentDoorEvent is LoadingResult.Loading) {

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -124,9 +124,9 @@ fun AppNavigation(
     val lastCheckInTime = currentDoorEvent.data?.lastCheckInTimeSeconds?.let {
         Instant.ofEpochSecond(it)
     }
-    val doorColor = currentDoorEvent.data.color(LocalDoorStatusColorScheme.current)
-    val onDoorColor = currentDoorEvent.data.onColor(LocalDoorStatusColorScheme.current)
     val isCheckInStale by doorViewModel.isCheckInStale.collectAsState()
+    val doorColor = currentDoorEvent.data.color(LocalDoorStatusColorScheme.current, isStale = isCheckInStale)
+    val onDoorColor = currentDoorEvent.data.onColor(LocalDoorStatusColorScheme.current, isStale = isCheckInStale)
     // Nav3: back stack is a simple mutable list of Screen objects.
     // Using remember (not rememberSaveable) because Screen objects aren't Bundle-saveable.
     // For tab navigation this is fine — process death just restarts on Home tab.

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/OldLastCheckInBanner.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/OldLastCheckInBanner.kt
@@ -41,10 +41,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.chriscartland.garage.R
 import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
-import java.time.Duration
 import java.time.Instant
-
-val OLD_DURATION_FOR_DOOR_CHECK_IN = Duration.ofMinutes(11)
 
 data class PillColors(
     val backgroundColor: Color,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/theme/DoorStatusColorScheme.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/theme/DoorStatusColorScheme.kt
@@ -20,10 +20,6 @@ package com.chriscartland.garage.ui.theme
 import androidx.compose.ui.graphics.Color
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
-import com.chriscartland.garage.domain.model.Staleness
-import java.time.Duration
-import java.time.Instant
-import kotlin.time.toKotlinDuration
 
 /**
  * Color scheme selected by the app theme.
@@ -123,13 +119,3 @@ fun DoorEvent?.doorColorState(): DoorColorState =
         DoorPosition.CLOSED -> DoorColorState.CLOSED
         else -> DoorColorState.OPEN
     }
-
-fun DoorEvent?.isStale(
-    maxAge: Duration,
-    now: Instant = Instant.now(),
-): Boolean =
-    Staleness.isStale(
-        lastCheckInTimeSeconds = this?.lastCheckInTimeSeconds,
-        maxAge = maxAge.toKotlinDuration(),
-        nowEpochSeconds = now.epochSecond,
-    )

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeClock.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeClock.kt
@@ -21,6 +21,9 @@ import com.chriscartland.garage.domain.coroutines.AppClock
 
 /**
  * Test clock with controllable time. Advance with [advanceSeconds].
+ *
+ * Not thread-safe — use only with single-threaded test dispatchers
+ * (e.g., [kotlinx.coroutines.test.StandardTestDispatcher]).
  */
 class FakeClock(
     private var nowSeconds: Long = 0L,

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DoorViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DoorViewModelTest.kt
@@ -221,7 +221,32 @@ class DoorViewModelTest {
         }
 
     @Test
-    fun isCheckInStale_isTrue_whenCheckInIsOld() =
+    fun isCheckInStale_isTrue_whenStaleEventArrives() =
+        runTest {
+            // Start with fresh check-in.
+            val clock = FakeClock(nowSeconds = 1000L)
+            doorRepository.setCurrentDoorEvent(
+                testDoorEvent.copy(lastCheckInTimeSeconds = 1000L),
+            )
+            val viewModel = createViewModel(
+                scope = backgroundScope,
+                clock = clock,
+            )
+            assertEquals(false, viewModel.isCheckInStale.value)
+
+            // Emit a new event with old check-in — reactive path (no ticker needed).
+            val staleCheckInTime = clock.nowEpochSeconds() -
+                DefaultDoorViewModel.CHECK_IN_STALE_THRESHOLD_SECONDS - 1
+            doorRepository.setCurrentDoorEvent(
+                testDoorEvent.copy(lastCheckInTimeSeconds = staleCheckInTime),
+            )
+            testDispatcher.scheduler.runCurrent()
+
+            assertEquals(true, viewModel.isCheckInStale.value)
+        }
+
+    @Test
+    fun isCheckInStale_isTrue_whenCheckInIsOld_viaTicker() =
         runTest {
             val checkInTime = 1000L
             val clock = FakeClock(


### PR DESCRIPTION
## Summary

Follow-up to #291. Addresses review findings:

- **Single staleness source**: `color()`/`onColor()` now accept `isStale: Boolean` instead of computing internally via `System.currentTimeMillis()`. Deletes `OLD_DURATION_FOR_DOOR_CHECK_IN` and `DoorEvent?.isStale()` extension — eliminates dual computation that could momentarily disagree with ViewModel
- **Thread-safety doc**: `FakeClock` KDoc warns about single-threaded usage
- **Reactive-path test**: `isCheckInStale_isTrue_whenStaleEventArrives` verifies data-change triggers staleness without ticker. Existing ticker test renamed for clarity

## Test plan

- [x] `validate.sh` passes
- [x] All DoorViewModel tests pass (13 tests, <1s)
- [x] No test hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)