### PR TITLE
docs: Capture memory-only conventions in repo

### DIFF
--- a/AndroidGarage/docs/DECISIONS.md
+++ b/AndroidGarage/docs/DECISIONS.md
@@ -483,7 +483,11 @@ The `FCMService` correctly inserts door events into the repository (data layer),
 
 - **Display**: `rememberDurationSince()` returns `State<Duration>`, updated every 1s via `LaunchedEffect`. Lives in `androidApp` UI layer.
 - **Business**: `DoorViewModel.isCheckInStale: StateFlow<Boolean>` computed from `AppClock` + periodic 30s ticker + reactive data-change collect. Staleness logging moved from composable to ViewModel.
-- **Scope injection**: `DefaultDoorViewModel` accepts `CoroutineScope` for staleness coroutines (same pattern as `FcmRegistrationManager`, ADR-015). Production passes `applicationScope`; tests pass `backgroundScope` from `runTest`. Jobs tracked and cancelled in `onCleared()`.
+- **Scope injection**: `DefaultDoorViewModel` accepts `CoroutineScope` for staleness coroutines (same pattern as `FcmRegistrationManager`, ADR-015). Production passes `applicationScope`. Jobs tracked and cancelled in `onCleared()`.
+
+**Test scope choice — `this` vs `backgroundScope`:**
+- `runTest { scope = this }` — use when the injected coroutine has a natural end (e.g., retry loop stops on success). `FcmRegistrationManagerTest` does this. `runTest` blocks until all children of `this` complete, so infinite loops would hang.
+- `runTest { scope = backgroundScope }` — use when the coroutine never ends (e.g., periodic ticker). `DoorViewModelTest` does this. `backgroundScope` is cancelled at test completion without blocking — the right choice for `while(true)` timer loops.
 - **Clock injection**: `AppClock` interface in domain module. Tests use `FakeClock` to control wall-clock time independently from coroutine virtual time.
 
 **Rules:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,6 +282,7 @@ Push notifications are the hardest feature to verify in production. If topic nam
 - No bare top-level functions — group in a named `object {}` for discoverability (Composables exempt). See ADR-009
 - No extension functions on generic types (e.g., `FcmPayloadParser.parse(data)` not `Map.asDoorEvent()`)
 - No `*Impl` suffix on implementations — use descriptive prefixes (`Network*`, `Cached*`, `Firebase*`, `Default*`). See ADR-008
+- Generic naming over platform-specific terms for app-scoped classes: `AppStartup.run()` not `AppStartupActions.onActivityCreated()`. App-scoped code should be platform-agnostic (KMP target). Only call sites in Activities know about Android lifecycles
 
 ## Known Limitations
 


### PR DESCRIPTION
## Summary

Two pieces of knowledge were only in Claude's memory, not in the repo:

1. **CLAUDE.md**: Generic naming convention — `AppStartup.run()` over `onActivityCreated()` for app-scoped classes. KMP/platform-agnostic rationale.
2. **ADR-016**: Test scope choice nuance — `this` scope for terminating loops (FcmRegistrationManager retry), `backgroundScope` for infinite timers (DoorViewModel ticker).

If memory is cleared, this knowledge is now preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)