### PR TITLE
fix: Auth state UI regression — replace stateIn(Eagerly) with explicit collect

### DIFF
--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AuthViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AuthViewModel.kt
@@ -24,9 +24,8 @@ import com.chriscartland.garage.domain.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.GoogleIdToken
-import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 interface AuthViewModel {
@@ -45,8 +44,18 @@ class DefaultAuthViewModel(
     private val dispatchers: DispatcherProvider,
 ) : ViewModel(),
     AuthViewModel {
-    override val authState: StateFlow<AuthState> = observeAuthState()
-        .stateIn(viewModelScope, SharingStarted.Eagerly, AuthState.Unknown)
+    // Explicit MutableStateFlow + collect pattern (matches DoorViewModel).
+    // Previously used stateIn(Eagerly) but that caused UI to not reflect
+    // auth state changes on real devices — Compose collectAsState would see
+    // only the initial Unknown value.
+    private val _authState = MutableStateFlow<AuthState>(AuthState.Unknown)
+    override val authState: StateFlow<AuthState> = _authState
+
+    init {
+        viewModelScope.launch(dispatchers.io) {
+            observeAuthState().collect { _authState.value = it }
+        }
+    }
 
     override fun signInWithGoogle(idToken: GoogleIdToken) {
         viewModelScope.launch(dispatchers.io) {

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAuthViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAuthViewModelTest.kt
@@ -103,4 +103,36 @@ class DefaultAuthViewModelTest {
             advanceUntilIdle()
             assertIs<AuthState.Unauthenticated>(viewModel.authState.value)
         }
+
+    /**
+     * Verifies that direct repository state changes (not via ViewModel methods)
+     * propagate to the ViewModel's authState StateFlow.
+     *
+     * Previously the ViewModel used stateIn(Eagerly) which had subtle timing
+     * issues causing the Compose UI to not reflect auth state changes.
+     * This test ensures the explicit MutableStateFlow + collect pattern
+     * (matching DoorViewModel) works correctly.
+     */
+    @Test
+    fun authState_reflectsRepositoryChanges() =
+        runTest(testDispatcher) {
+            // Initial state is Unknown.
+            advanceUntilIdle()
+            assertIs<AuthState.Unknown>(viewModel.authState.value)
+
+            // Repository emits Authenticated (simulating Firebase auth update).
+            val user = User(
+                name = DisplayName("Alice"),
+                email = Email("alice@test.com"),
+                idToken = FirebaseIdToken("token", exp = 9999999999L),
+            )
+            authRepo.setAuthState(AuthState.Authenticated(user))
+            advanceUntilIdle()
+            assertIs<AuthState.Authenticated>(viewModel.authState.value)
+
+            // Repository emits Unauthenticated.
+            authRepo.setAuthState(AuthState.Unauthenticated)
+            advanceUntilIdle()
+            assertIs<AuthState.Unauthenticated>(viewModel.authState.value)
+        }
 }


### PR DESCRIPTION
## Summary

UI elements depending on sign-in state were not updating on real devices after sign-in or sign-out.

**Root cause**: `stateIn(viewModelScope, Eagerly, Unknown)` in `DefaultAuthViewModel` had subtle timing issues where the internal collector did not reliably propagate upstream `AuthState` changes to Compose's `collectAsState`.

**Fix**: Switch to the explicit `MutableStateFlow` + `viewModelScope.launch.collect` pattern — matches `DoorViewModel.currentDoorEvent` which works reliably. Predictable, well-tested across the codebase.

## Change

```kotlin
// Before
override val authState: StateFlow<AuthState> = observeAuthState()
    .stateIn(viewModelScope, SharingStarted.Eagerly, AuthState.Unknown)

// After
private val _authState = MutableStateFlow<AuthState>(AuthState.Unknown)
override val authState: StateFlow<AuthState> = _authState

init {
    viewModelScope.launch(dispatchers.io) {
        observeAuthState().collect { _authState.value = it }
    }
}
```

## Test plan

- [x] New `authState_reflectsRepositoryChanges` test verifies repository state changes propagate to ViewModel
- [x] All existing DefaultAuthViewModelTest tests pass
- [x] `validate.sh` passes
- [ ] **Device verification needed**: sign-in/sign-out now updates UI in `HomeContent` button area and `ProfileContent` user card

🤖 Generated with [Claude Code](https://claude.com/claude-code)