### PR TITLE
test: Add setMain to DefaultAppLoggerViewModelTest (ADR-017 Rule 1)

### DIFF
--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAppLoggerViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAppLoggerViewModelTest.kt
@@ -3,21 +3,39 @@ package com.chriscartland.garage.usecase
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
 import com.chriscartland.garage.testcommon.TestDispatcherProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class DefaultAppLoggerViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
     private val logger = FakeAppLoggerRepository()
     private val dispatchers = TestDispatcherProvider(testDispatcher)
-    private val viewModel = DefaultAppLoggerViewModel(
-        logAppEvent = LogAppEventUseCase(logger),
-        observeAppLogCount = ObserveAppLogCountUseCase(logger),
-        dispatchers = dispatchers,
-    )
+    private lateinit var viewModel: DefaultAppLoggerViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = DefaultAppLoggerViewModel(
+            logAppEvent = LogAppEventUseCase(logger),
+            observeAppLogCount = ObserveAppLogCountUseCase(logger),
+            dispatchers = dispatchers,
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
 
     @Test
     fun logDelegatesToRepository() =


### PR DESCRIPTION
## Summary

Adds \`Dispatchers.setMain\`/\`resetMain\` setup to \`DefaultAppLoggerViewModelTest\` per ADR-017 Rule 1.

\`DefaultAppLoggerViewModel\` extends \`ViewModel\` and uses \`viewModelScope\`, so its tests need this setup. The tests previously worked by accident (no code path actually hit Main during the test) — adding the setup makes the test robust against future ViewModel changes that might.

## Test plan

- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)