### PR TITLE
refactor: Convert ViewModel stateIn to explicit MutableStateFlow (ADR-017 Rule 6)

### DIFF
--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppSettingsViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppSettingsViewModel.kt
@@ -19,9 +19,8 @@ package com.chriscartland.garage.usecase
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 interface AppSettingsViewModel {
@@ -49,21 +48,33 @@ class DefaultAppSettingsViewModel(
     private val settings: AppSettingsUseCase,
 ) : ViewModel(),
     AppSettingsViewModel {
-    override val fcmDoorTopic: StateFlow<String> = settings
-        .observeFcmDoorTopic()
-        .stateIn(viewModelScope, SharingStarted.Eagerly, "")
+    // ADR-017 Rule 6: explicit MutableStateFlow + collect, no stateIn in ViewModels.
+    private val _fcmDoorTopic = MutableStateFlow("")
+    override val fcmDoorTopic: StateFlow<String> = _fcmDoorTopic
 
-    override val profileUserCardExpanded: StateFlow<Boolean?> = settings
-        .observeProfileUserCardExpanded()
-        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+    private val _profileUserCardExpanded = MutableStateFlow<Boolean?>(null)
+    override val profileUserCardExpanded: StateFlow<Boolean?> = _profileUserCardExpanded
 
-    override val profileLogCardExpanded: StateFlow<Boolean?> = settings
-        .observeProfileLogCardExpanded()
-        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+    private val _profileLogCardExpanded = MutableStateFlow<Boolean?>(null)
+    override val profileLogCardExpanded: StateFlow<Boolean?> = _profileLogCardExpanded
 
-    override val profileAppCardExpanded: StateFlow<Boolean?> = settings
-        .observeProfileAppCardExpanded()
-        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+    private val _profileAppCardExpanded = MutableStateFlow<Boolean?>(null)
+    override val profileAppCardExpanded: StateFlow<Boolean?> = _profileAppCardExpanded
+
+    init {
+        viewModelScope.launch {
+            settings.observeFcmDoorTopic().collect { _fcmDoorTopic.value = it }
+        }
+        viewModelScope.launch {
+            settings.observeProfileUserCardExpanded().collect { _profileUserCardExpanded.value = it }
+        }
+        viewModelScope.launch {
+            settings.observeProfileLogCardExpanded().collect { _profileLogCardExpanded.value = it }
+        }
+        viewModelScope.launch {
+            settings.observeProfileAppCardExpanded().collect { _profileAppCardExpanded.value = it }
+        }
+    }
 
     override fun setFcmDoorTopic(topic: String) {
         viewModelScope.launch { settings.setFcmDoorTopic(topic) }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorViewModel.kt
@@ -32,9 +32,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 interface DoorViewModel {
@@ -59,16 +57,16 @@ class DefaultDoorViewModel(
     private val fetchCurrentDoorEventUseCase: FetchCurrentDoorEventUseCase,
     private val fetchRecentDoorEventsUseCase: FetchRecentDoorEventsUseCase,
     private val deregisterFcmUseCase: DeregisterFcmUseCase,
-    fcmRegistrationManager: FcmRegistrationManager,
+    private val fcmRegistrationManager: FcmRegistrationManager,
     private val scope: CoroutineScope,
     private val clock: AppClock = AppClock { System.currentTimeMillis() / 1000 },
     private val fetchOnInit: Boolean = true,
 ) : ViewModel(),
     DoorViewModel {
     // Observe FCM status from the app-scoped manager (ADR-014, ADR-015).
-    override val fcmRegistrationStatus: StateFlow<FcmRegistrationStatus> =
-        fcmRegistrationManager.registrationStatus
-            .stateIn(viewModelScope, SharingStarted.Eagerly, FcmRegistrationStatus.UNKNOWN)
+    // Uses explicit MutableStateFlow + collect (ADR-017 Rule 6).
+    private val _fcmRegistrationStatus = MutableStateFlow(FcmRegistrationStatus.UNKNOWN)
+    override val fcmRegistrationStatus: StateFlow<FcmRegistrationStatus> = _fcmRegistrationStatus
 
     private val _currentDoorEvent =
         MutableStateFlow<LoadingResult<DoorEvent?>>(LoadingResult.Loading(null))
@@ -86,6 +84,11 @@ class DefaultDoorViewModel(
 
     init {
         Logger.d { "init" }
+        viewModelScope.launch(dispatchers.io) {
+            fcmRegistrationManager.registrationStatus.collect {
+                _fcmRegistrationStatus.value = it
+            }
+        }
         viewModelScope.launch(dispatchers.io) {
             observeDoorEvents.current().collect {
                 Logger.d { "currentDoorEvent collect: $it" }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
@@ -31,9 +31,7 @@ import com.chriscartland.garage.domain.model.SnoozeState
 import com.chriscartland.garage.domain.model.toServer
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 private const val SNOOZE_ACTION_RESET_DELAY_MS = 10_000L
@@ -70,8 +68,9 @@ class DefaultRemoteButtonViewModel(
 
     override val buttonState: StateFlow<RemoteButtonState> = stateMachine.state
 
-    override val snoozeState: StateFlow<SnoozeState> = observeSnoozeStateUseCase()
-        .stateIn(viewModelScope, SharingStarted.Eagerly, SnoozeState.Loading)
+    // ADR-017 Rule 6: explicit MutableStateFlow + collect, no stateIn in ViewModels.
+    private val _snoozeState = MutableStateFlow<SnoozeState>(SnoozeState.Loading)
+    override val snoozeState: StateFlow<SnoozeState> = _snoozeState
 
     private val _snoozeAction = MutableStateFlow<SnoozeAction>(SnoozeAction.Idle)
     override val snoozeAction: StateFlow<SnoozeAction> = _snoozeAction
@@ -80,6 +79,9 @@ class DefaultRemoteButtonViewModel(
 
     init {
         listenToDoorEvent()
+        viewModelScope.launch(dispatchers.io) {
+            observeSnoozeStateUseCase().collect { _snoozeState.value = it }
+        }
     }
 
     private fun listenToDoorEvent() {


### PR DESCRIPTION
## Summary

Removes \`stateIn(viewModelScope, ...)\` from 3 ViewModels per ADR-017 Rule 6.

| ViewModel | Field | Before | After |
|-----------|-------|--------|-------|
| DoorViewModel | fcmRegistrationStatus | stateIn upstream | \_fcmRegistrationStatus + collect in init |
| RemoteButtonViewModel | snoozeState | stateIn upstream | \_snoozeState + collect in init |
| AppSettingsViewModel | fcmDoorTopic + 3 expansion booleans | 4× stateIn | 4× MutableStateFlow + collect |

This is the pattern that \`DoorViewModel.currentDoorEvent\` already uses successfully — predictable, matches \`MutableStateFlow\` semantics directly, no subscription path that can fail silently (the bug PR #295 fixes for AuthViewModel).

## What this enables

After PR #295 merges, **zero ViewModels will use \`stateIn(viewModelScope, ...)\`**. A follow-up PR will add a lint check (\`ViewModelStateFlowCheckTask\`) banning the pattern going forward.

## Test plan

- [x] All existing usecase module tests pass
- [x] \`validate.sh\` passes
- [ ] Device verification ideal but not required (pattern proven in DoorViewModel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)