### PR TITLE
refactor: Extract CheckInStalenessManager (ADR-017 Rule 2 + ADR-015)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/AppStartup.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/AppStartup.kt
@@ -20,6 +20,7 @@ package com.chriscartland.garage
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.usecase.AppLoggerViewModel
+import com.chriscartland.garage.usecase.CheckInStalenessManager
 import com.chriscartland.garage.usecase.FcmRegistrationManager
 
 /**
@@ -30,10 +31,11 @@ import com.chriscartland.garage.usecase.FcmRegistrationManager
  */
 class AppStartup(
     private val fcmRegistrationManager: FcmRegistrationManager,
+    private val checkInStalenessManager: CheckInStalenessManager,
     private val appLoggerViewModel: AppLoggerViewModel,
 ) {
     /**
-     * Performs startup actions: FCM registration and logging.
+     * Performs startup actions: FCM registration, staleness tracking, and logging.
      * Returns the list of actions taken (for testing/logging).
      */
     fun run(): List<String> {
@@ -42,6 +44,10 @@ class AppStartup(
         Logger.d { "AppStartup: Starting FCM registration manager" }
         fcmRegistrationManager.start()
         actions.add("startFcmRegistration")
+
+        Logger.d { "AppStartup: Starting check-in staleness manager" }
+        checkInStalenessManager.start()
+        actions.add("startCheckInStaleness")
 
         appLoggerViewModel.log(AppLoggerKeys.ON_CREATE_FCM_SUBSCRIBE_TOPIC)
         actions.add("logFcmSubscribe")

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -44,6 +44,7 @@ import com.chriscartland.garage.datalocal.DataStoreSettingsFactory
 import com.chriscartland.garage.datalocal.DatabaseFactory
 import com.chriscartland.garage.datalocal.DatabaseLocalDoorDataSource
 import com.chriscartland.garage.datalocal.RoomAppLoggerRepository
+import com.chriscartland.garage.domain.coroutines.AppClock
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.AppConfig
 import com.chriscartland.garage.domain.repository.AppLoggerRepository
@@ -56,6 +57,7 @@ import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import com.chriscartland.garage.domain.repository.SnoozeRepository
 import com.chriscartland.garage.fcm.FirebaseMessagingBridge
 import com.chriscartland.garage.usecase.AppSettingsUseCase
+import com.chriscartland.garage.usecase.CheckInStalenessManager
 import com.chriscartland.garage.usecase.DefaultAppLoggerViewModel
 import com.chriscartland.garage.usecase.DefaultAppSettingsViewModel
 import com.chriscartland.garage.usecase.DefaultAuthViewModel
@@ -147,7 +149,7 @@ abstract class AppComponent(
             provideFetchRecentDoorEventsUseCase(),
             provideDeregisterFcmUseCase(),
             provideFcmRegistrationManager(),
-            scope = provideApplicationScope(),
+            provideCheckInStalenessManager(),
         )
 
     val remoteButtonViewModel: DefaultRemoteButtonViewModel
@@ -269,9 +271,25 @@ abstract class AppComponent(
         )
 
     @Provides
+    @Singleton
+    fun provideAppClock(): AppClock = AppClock { System.currentTimeMillis() / 1000 }
+
+    @Provides
+    @Singleton
+    fun provideCheckInStalenessManager(): CheckInStalenessManager =
+        CheckInStalenessManager(
+            observeDoorEvents = provideObserveDoorEventsUseCase(),
+            logAppEvent = provideLogAppEventUseCase(),
+            scope = provideApplicationScope(),
+            dispatcher = provideDispatcherProvider().io,
+            clock = provideAppClock(),
+        )
+
+    @Provides
     fun provideAppStartup(): AppStartup =
         AppStartup(
             provideFcmRegistrationManager(),
+            provideCheckInStalenessManager(),
             appLoggerViewModel,
         )
 

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/AppStartupTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/AppStartupTest.kt
@@ -17,13 +17,18 @@
 
 package com.chriscartland.garage
 
+import com.chriscartland.garage.domain.coroutines.AppClock
 import com.chriscartland.garage.domain.model.ActionError
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.AppResult
+import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
 import com.chriscartland.garage.testcommon.FakeDoorFcmRepository
 import com.chriscartland.garage.testcommon.FakeDoorRepository
 import com.chriscartland.garage.usecase.AppLoggerViewModel
+import com.chriscartland.garage.usecase.CheckInStalenessManager
 import com.chriscartland.garage.usecase.FcmRegistrationManager
+import com.chriscartland.garage.usecase.LogAppEventUseCase
+import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
 import com.chriscartland.garage.usecase.RegisterFcmUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -34,7 +39,7 @@ import org.junit.Test
 class AppStartupTest {
     private val testDispatcher = StandardTestDispatcher()
 
-    private fun createManager(scope: TestScope): FcmRegistrationManager {
+    private fun createFcmManager(scope: TestScope): FcmRegistrationManager {
         val useCase = object : RegisterFcmUseCase(
             FakeDoorRepository(),
             FakeDoorFcmRepository(),
@@ -47,6 +52,15 @@ class AppStartupTest {
             dispatcher = testDispatcher,
         )
     }
+
+    private fun createStalenessManager(scope: TestScope): CheckInStalenessManager =
+        CheckInStalenessManager(
+            observeDoorEvents = ObserveDoorEventsUseCase(FakeDoorRepository()),
+            logAppEvent = LogAppEventUseCase(FakeAppLoggerRepository()),
+            scope = scope.backgroundScope,
+            dispatcher = testDispatcher,
+            clock = AppClock { 0L },
+        )
 
     private class FakeAppLoggerViewModel : AppLoggerViewModel {
         val loggedKeys = mutableListOf<String>()
@@ -68,9 +82,10 @@ class AppStartupTest {
     @Test
     fun onActivityCreated_logsFcmSubscribe() {
         val scope = TestScope(testDispatcher)
-        val manager = createManager(scope)
+        val fcmManager = createFcmManager(scope)
+        val stalenessManager = createStalenessManager(scope)
         val appLoggerViewModel = FakeAppLoggerViewModel()
-        val actions = AppStartup(manager, appLoggerViewModel)
+        val actions = AppStartup(fcmManager, stalenessManager, appLoggerViewModel)
 
         actions.run()
 
@@ -83,12 +98,16 @@ class AppStartupTest {
     @Test
     fun onActivityCreated_returnsAllActions() {
         val scope = TestScope(testDispatcher)
-        val manager = createManager(scope)
+        val fcmManager = createFcmManager(scope)
+        val stalenessManager = createStalenessManager(scope)
         val appLoggerViewModel = FakeAppLoggerViewModel()
-        val actions = AppStartup(manager, appLoggerViewModel)
+        val actions = AppStartup(fcmManager, stalenessManager, appLoggerViewModel)
 
         val result = actions.run()
 
-        assertEquals(listOf("startFcmRegistration", "logFcmSubscribe"), result)
+        assertEquals(
+            listOf("startFcmRegistration", "startCheckInStaleness", "logFcmSubscribe"),
+            result,
+        )
     }
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/CheckInStalenessManager.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/CheckInStalenessManager.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import co.touchlab.kermit.Logger
+import com.chriscartland.garage.domain.coroutines.AppClock
+import com.chriscartland.garage.domain.model.AppLoggerKeys
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * App-scoped manager for door check-in staleness (ADR-015, ADR-017).
+ *
+ * Computes whether the last door check-in is older than [thresholdSeconds].
+ * Re-evaluates on every door event change (reactive) AND on a fixed
+ * interval (in case clock time passes the threshold without new events).
+ *
+ * Logs transitions: emits [AppLoggerKeys.EXCEEDED_EXPECTED_TIME_WITHOUT_FCM]
+ * when becoming stale, [AppLoggerKeys.TIME_WITHOUT_FCM_IN_EXPECTED_RANGE]
+ * when becoming fresh (skipping the initial fresh emission).
+ *
+ * [start] is idempotent — calling twice doesn't create duplicate jobs.
+ * Status is observable via [isCheckInStale].
+ */
+class CheckInStalenessManager(
+    private val observeDoorEvents: ObserveDoorEventsUseCase,
+    private val logAppEvent: LogAppEventUseCase,
+    private val scope: CoroutineScope,
+    private val dispatcher: CoroutineDispatcher,
+    private val clock: AppClock,
+    private val thresholdSeconds: Long = CHECK_IN_STALE_THRESHOLD_SECONDS,
+    private val intervalMillis: Long = STALE_CHECK_INTERVAL_MS,
+) {
+    private val staleFlow = MutableStateFlow(false)
+
+    /** Observable staleness. ViewModel collects this. */
+    val isCheckInStale: Flow<Boolean> = staleFlow
+
+    /** Last-known check-in time, kept up-to-date by the reactive collector. */
+    private val lastCheckInTime = MutableStateFlow<Long?>(null)
+
+    private val jobs = mutableListOf<Job>()
+
+    /**
+     * Start staleness evaluation. Idempotent — if already running, this is a no-op.
+     */
+    fun start() {
+        if (jobs.any { it.isActive }) {
+            Logger.d { "CheckInStalenessManager: already running" }
+            return
+        }
+        // Reactive: re-evaluate when door event changes.
+        jobs += scope.launch(dispatcher) {
+            observeDoorEvents.current().collect { event ->
+                lastCheckInTime.value = event?.lastCheckInTimeSeconds
+                staleFlow.value = computeStale(lastCheckInTime.value)
+            }
+        }
+        // Periodic: re-evaluate even if no new event arrives (catches clock drift).
+        jobs += scope.launch(dispatcher) {
+            while (true) {
+                delay(intervalMillis)
+                staleFlow.value = computeStale(lastCheckInTime.value)
+            }
+        }
+        // Log transitions (skip initial fresh emission).
+        jobs += scope.launch(dispatcher) {
+            var isFirstEmission = true
+            staleFlow.collect { stale ->
+                if (stale) {
+                    logAppEvent(AppLoggerKeys.EXCEEDED_EXPECTED_TIME_WITHOUT_FCM)
+                } else if (!isFirstEmission) {
+                    logAppEvent(AppLoggerKeys.TIME_WITHOUT_FCM_IN_EXPECTED_RANGE)
+                }
+                isFirstEmission = false
+            }
+        }
+    }
+
+    private fun computeStale(checkInTimeSeconds: Long?): Boolean {
+        if (checkInTimeSeconds == null) return false
+        val age = clock.nowEpochSeconds() - checkInTimeSeconds
+        return age > thresholdSeconds
+    }
+
+    companion object {
+        /** 11 minutes — matches the previous OldLastCheckInBanner threshold. */
+        const val CHECK_IN_STALE_THRESHOLD_SECONDS = 11L * 60
+
+        /** Re-evaluate staleness every 30 seconds (catches clock drift past threshold). */
+        const val STALE_CHECK_INTERVAL_MS = 30_000L
+    }
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorViewModel.kt
@@ -20,7 +20,6 @@ package com.chriscartland.garage.usecase
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
-import com.chriscartland.garage.domain.coroutines.AppClock
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.AppResult
@@ -28,9 +27,6 @@ import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.FcmRegistrationStatus
 import com.chriscartland.garage.domain.model.FetchError
 import com.chriscartland.garage.domain.model.LoadingResult
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -58,13 +54,11 @@ class DefaultDoorViewModel(
     private val fetchRecentDoorEventsUseCase: FetchRecentDoorEventsUseCase,
     private val deregisterFcmUseCase: DeregisterFcmUseCase,
     private val fcmRegistrationManager: FcmRegistrationManager,
-    private val scope: CoroutineScope,
-    private val clock: AppClock = AppClock { System.currentTimeMillis() / 1000 },
+    private val checkInStalenessManager: CheckInStalenessManager,
     private val fetchOnInit: Boolean = true,
 ) : ViewModel(),
     DoorViewModel {
-    // Observe FCM status from the app-scoped manager (ADR-014, ADR-015).
-    // Uses explicit MutableStateFlow + collect (ADR-017 Rule 6).
+    // ADR-017 Rule 6: explicit MutableStateFlow + collect, no stateIn in ViewModels.
     private val _fcmRegistrationStatus = MutableStateFlow(FcmRegistrationStatus.UNKNOWN)
     override val fcmRegistrationStatus: StateFlow<FcmRegistrationStatus> = _fcmRegistrationStatus
 
@@ -79,14 +73,16 @@ class DefaultDoorViewModel(
     private val _isCheckInStale = MutableStateFlow(false)
     override val isCheckInStale: StateFlow<Boolean> = _isCheckInStale
 
-    /** Staleness coroutines — cancelled in [onCleared] to avoid leaking past ViewModel lifetime. */
-    private val stalenessJobs = mutableListOf<Job>()
-
     init {
         Logger.d { "init" }
         viewModelScope.launch(dispatchers.io) {
             fcmRegistrationManager.registrationStatus.collect {
                 _fcmRegistrationStatus.value = it
+            }
+        }
+        viewModelScope.launch(dispatchers.io) {
+            checkInStalenessManager.isCheckInStale.collect {
+                _isCheckInStale.value = it
             }
         }
         viewModelScope.launch(dispatchers.io) {
@@ -109,37 +105,6 @@ class DefaultDoorViewModel(
             fetchCurrentDoorEvent()
             fetchRecentDoorEvents()
         }
-        // Staleness: re-evaluate on data change and periodically.
-        // Uses injected scope (not viewModelScope) so tests control the lifecycle.
-        // Jobs are tracked and cancelled in onCleared() to avoid leaking past ViewModel lifetime.
-        stalenessJobs += scope.launch(dispatchers.io) {
-            _currentDoorEvent.collect { event ->
-                _isCheckInStale.value = computeStale(event)
-            }
-        }
-        stalenessJobs += scope.launch(dispatchers.io) {
-            while (true) {
-                delay(STALE_CHECK_INTERVAL_MS)
-                _isCheckInStale.value = computeStale(_currentDoorEvent.value)
-            }
-        }
-        // Log staleness transitions (moved from Main.kt composable).
-        stalenessJobs += scope.launch(dispatchers.io) {
-            var isFirstEmission = true
-            isCheckInStale.collect { stale ->
-                if (stale) {
-                    logAppEvent(AppLoggerKeys.EXCEEDED_EXPECTED_TIME_WITHOUT_FCM)
-                } else if (!isFirstEmission) {
-                    logAppEvent(AppLoggerKeys.TIME_WITHOUT_FCM_IN_EXPECTED_RANGE)
-                }
-                isFirstEmission = false
-            }
-        }
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        stalenessJobs.forEach { it.cancel() }
     }
 
     override fun deregisterFcm() {
@@ -187,19 +152,5 @@ class DefaultDoorViewModel(
                 }
             }
         }
-    }
-
-    private fun computeStale(event: LoadingResult<DoorEvent?>): Boolean {
-        val checkInTime = event.data?.lastCheckInTimeSeconds ?: return false
-        val age = clock.nowEpochSeconds() - checkInTime
-        return age > CHECK_IN_STALE_THRESHOLD_SECONDS
-    }
-
-    companion object {
-        /** 11 minutes — matches the old OldLastCheckInBanner threshold. */
-        const val CHECK_IN_STALE_THRESHOLD_SECONDS = 11L * 60
-
-        /** Re-evaluate staleness every 30 seconds. */
-        const val STALE_CHECK_INTERVAL_MS = 30_000L
     }
 }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/CheckInStalenessManagerTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/CheckInStalenessManagerTest.kt
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.AppLoggerKeys
+import com.chriscartland.garage.domain.model.DoorEvent
+import com.chriscartland.garage.domain.model.DoorPosition
+import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
+import com.chriscartland.garage.testcommon.FakeClock
+import com.chriscartland.garage.testcommon.FakeDoorRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private val THRESHOLD = CheckInStalenessManager.CHECK_IN_STALE_THRESHOLD_SECONDS
+private val INTERVAL = CheckInStalenessManager.STALE_CHECK_INTERVAL_MS
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CheckInStalenessManagerTest {
+    private lateinit var doorRepository: FakeDoorRepository
+    private lateinit var logger: FakeAppLoggerRepository
+
+    @BeforeTest
+    fun setup() {
+        doorRepository = FakeDoorRepository()
+        logger = FakeAppLoggerRepository()
+    }
+
+    /**
+     * Build the manager wired to the same scheduler as the test scope.
+     * Following the FcmRegistrationManagerTest pattern: dispatcher is built
+     * from `testScheduler` so it shares the scheduler with `backgroundScope`.
+     */
+    private fun TestScope.createManager(clock: FakeClock): CheckInStalenessManager =
+        CheckInStalenessManager(
+            observeDoorEvents = ObserveDoorEventsUseCase(doorRepository),
+            logAppEvent = LogAppEventUseCase(logger),
+            scope = backgroundScope,
+            dispatcher = StandardTestDispatcher(testScheduler),
+            clock = clock,
+        )
+
+    private fun makeEvent(checkInTime: Long): DoorEvent =
+        DoorEvent(
+            doorPosition = DoorPosition.CLOSED,
+            lastCheckInTimeSeconds = checkInTime,
+            lastChangeTimeSeconds = checkInTime,
+        )
+
+    @Test
+    fun isCheckInStale_isFalse_whenCheckInIsRecent() =
+        runTest {
+            val clock = FakeClock(nowSeconds = 1000L)
+            doorRepository.setCurrentDoorEvent(makeEvent(checkInTime = 1000L))
+            val manager = createManager(clock = clock)
+
+            manager.start()
+            testScheduler.runCurrent()
+
+            assertFalse(manager.isCheckInStale.first())
+        }
+
+    @Test
+    fun isCheckInStale_isTrue_whenStaleEventArrives() =
+        runTest {
+            // Start with a fresh check-in.
+            val clock = FakeClock(nowSeconds = 1000L)
+            doorRepository.setCurrentDoorEvent(makeEvent(checkInTime = 1000L))
+            val manager = createManager(clock = clock)
+            manager.start()
+            testScheduler.runCurrent()
+            assertFalse(manager.isCheckInStale.first())
+
+            // New event with old check-in — reactive path (no ticker advance needed).
+            doorRepository.setCurrentDoorEvent(
+                makeEvent(checkInTime = clock.nowEpochSeconds() - THRESHOLD - 1),
+            )
+            testScheduler.runCurrent()
+
+            assertTrue(manager.isCheckInStale.first())
+        }
+
+    @Test
+    fun isCheckInStale_becomesTrue_afterClockAdvances_viaTicker() =
+        runTest {
+            val checkInTime = 1000L
+            val clock = FakeClock(nowSeconds = checkInTime)
+            doorRepository.setCurrentDoorEvent(makeEvent(checkInTime = checkInTime))
+            val manager = createManager(clock = clock)
+            manager.start()
+            testScheduler.runCurrent()
+            assertFalse(manager.isCheckInStale.first())
+
+            // Wall clock moves past threshold, but no new door event arrives.
+            clock.advanceSeconds(THRESHOLD + 1)
+            // Periodic ticker fires.
+            advanceTimeBy(INTERVAL + 1)
+            testScheduler.runCurrent()
+
+            assertTrue(manager.isCheckInStale.first())
+        }
+
+    @Test
+    fun isCheckInStale_becomesFresh_whenNewEventArrives() =
+        runTest {
+            val checkInTime = 1000L
+            val clock = FakeClock(nowSeconds = checkInTime + THRESHOLD + 1)
+            doorRepository.setCurrentDoorEvent(makeEvent(checkInTime = checkInTime))
+            val manager = createManager(clock = clock)
+            manager.start()
+            testScheduler.runCurrent()
+            assertTrue(manager.isCheckInStale.first())
+
+            // New fresh event arrives.
+            doorRepository.setCurrentDoorEvent(makeEvent(checkInTime = clock.nowEpochSeconds()))
+            testScheduler.runCurrent()
+
+            assertFalse(manager.isCheckInStale.first())
+        }
+
+    @Test
+    fun logsStaleEvent_whenCheckInBecomesStale() =
+        runTest {
+            val checkInTime = 1000L
+            val clock = FakeClock(nowSeconds = checkInTime)
+            doorRepository.setCurrentDoorEvent(makeEvent(checkInTime = checkInTime))
+            val manager = createManager(clock = clock)
+            manager.start()
+            testScheduler.runCurrent()
+
+            // Advance clock + ticker to trigger stale.
+            clock.advanceSeconds(THRESHOLD + 1)
+            advanceTimeBy(INTERVAL + 1)
+            testScheduler.runCurrent()
+
+            assertTrue(
+                logger.loggedKeys.contains(AppLoggerKeys.EXCEEDED_EXPECTED_TIME_WITHOUT_FCM),
+                "Expected staleness log, got: ${logger.loggedKeys}",
+            )
+        }
+
+    @Test
+    fun doesNotLogFresh_onFirstEmission() =
+        runTest {
+            val clock = FakeClock(nowSeconds = 1000L)
+            doorRepository.setCurrentDoorEvent(makeEvent(checkInTime = 1000L))
+            val manager = createManager(clock = clock)
+
+            manager.start()
+            testScheduler.runCurrent()
+
+            // First emission is false (fresh) — should NOT log "in range".
+            val freshLogs = logger.loggedKeys.filter {
+                it == AppLoggerKeys.TIME_WITHOUT_FCM_IN_EXPECTED_RANGE
+            }
+            assertTrue(
+                freshLogs.isEmpty(),
+                "Should not log fresh on first emission, got: ${logger.loggedKeys}",
+            )
+        }
+
+    @Test
+    fun start_isIdempotent() =
+        runTest {
+            val clock = FakeClock(nowSeconds = 1000L)
+            doorRepository.setCurrentDoorEvent(makeEvent(checkInTime = 1000L))
+            val manager = createManager(clock = clock)
+
+            manager.start()
+            manager.start() // second call should be a no-op
+            testScheduler.runCurrent()
+
+            // Move forward, expect single transition log (not duplicates).
+            clock.advanceSeconds(THRESHOLD + 1)
+            advanceTimeBy(INTERVAL + 1)
+            testScheduler.runCurrent()
+
+            val staleCount = logger.loggedKeys.count {
+                it == AppLoggerKeys.EXCEEDED_EXPECTED_TIME_WITHOUT_FCM
+            }
+            assertEquals(1, staleCount, "Expected single stale log, got: ${logger.loggedKeys}")
+        }
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DoorViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DoorViewModelTest.kt
@@ -18,13 +18,11 @@
 package com.chriscartland.garage.usecase
 
 import com.chriscartland.garage.domain.coroutines.AppClock
-import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.model.FcmRegistrationStatus
 import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
-import com.chriscartland.garage.testcommon.FakeClock
 import com.chriscartland.garage.testcommon.FakeDoorFcmRepository
 import com.chriscartland.garage.testcommon.FakeDoorRepository
 import com.chriscartland.garage.testcommon.TestDispatcherProvider
@@ -73,18 +71,25 @@ class DoorViewModelTest {
     }
 
     /**
-     * Pass the [scope] from `runTest { this }` so staleness coroutines
-     * are cancelled when the test completes (same pattern as FcmRegistrationManagerTest).
+     * [scope] is used for the FcmRegistrationManager and CheckInStalenessManager
+     * (which contain infinite loops). Tests pass `backgroundScope` from `runTest`
+     * so those loops are cancelled when the test completes.
      */
     private fun createViewModel(
         scope: CoroutineScope,
-        clock: AppClock = AppClock { 0L },
         fetchOnInit: Boolean = true,
     ): DefaultDoorViewModel {
         val fcmManager = FcmRegistrationManager(
             registerFcmUseCase = RegisterFcmUseCase(doorRepository, doorFcmRepository),
             scope = scope,
             dispatcher = testDispatcher,
+        )
+        val stalenessManager = CheckInStalenessManager(
+            observeDoorEvents = ObserveDoorEventsUseCase(doorRepository),
+            logAppEvent = LogAppEventUseCase(appLoggerRepository),
+            scope = scope,
+            dispatcher = testDispatcher,
+            clock = AppClock { 0L },
         )
         val vm = DefaultDoorViewModel(
             observeDoorEvents = ObserveDoorEventsUseCase(doorRepository),
@@ -94,8 +99,7 @@ class DoorViewModelTest {
             fetchRecentDoorEventsUseCase = FetchRecentDoorEventsUseCase(doorRepository),
             deregisterFcmUseCase = DeregisterFcmUseCase(doorFcmRepository),
             fcmRegistrationManager = fcmManager,
-            clock = clock,
-            scope = scope,
+            checkInStalenessManager = stalenessManager,
             fetchOnInit = fetchOnInit,
         )
         testDispatcher.scheduler.runCurrent()
@@ -199,172 +203,5 @@ class DoorViewModelTest {
             // Flow collection still runs (shows repo data), but network fetch was NOT triggered
             assertEquals(0, doorRepository.fetchCurrentDoorEventCount)
             assertEquals(0, doorRepository.fetchRecentDoorEventsCount)
-        }
-
-    // --- Staleness tests ---
-
-    private val staleCheckInterval = DefaultDoorViewModel.STALE_CHECK_INTERVAL_MS
-
-    @Test
-    fun isCheckInStale_isFalse_whenCheckInIsRecent() =
-        runTest {
-            val clock = FakeClock(nowSeconds = 1000L)
-            doorRepository.setCurrentDoorEvent(
-                testDoorEvent.copy(lastCheckInTimeSeconds = 1000L),
-            )
-            val viewModel = createViewModel(
-                scope = backgroundScope,
-                clock = clock,
-            )
-
-            assertEquals(false, viewModel.isCheckInStale.value)
-        }
-
-    @Test
-    fun isCheckInStale_isTrue_whenStaleEventArrives() =
-        runTest {
-            // Start with fresh check-in.
-            val clock = FakeClock(nowSeconds = 1000L)
-            doorRepository.setCurrentDoorEvent(
-                testDoorEvent.copy(lastCheckInTimeSeconds = 1000L),
-            )
-            val viewModel = createViewModel(
-                scope = backgroundScope,
-                clock = clock,
-            )
-            assertEquals(false, viewModel.isCheckInStale.value)
-
-            // Emit a new event with old check-in — reactive path (no ticker needed).
-            val staleCheckInTime = clock.nowEpochSeconds() -
-                DefaultDoorViewModel.CHECK_IN_STALE_THRESHOLD_SECONDS - 1
-            doorRepository.setCurrentDoorEvent(
-                testDoorEvent.copy(lastCheckInTimeSeconds = staleCheckInTime),
-            )
-            testDispatcher.scheduler.runCurrent()
-
-            assertEquals(true, viewModel.isCheckInStale.value)
-        }
-
-    @Test
-    fun isCheckInStale_isTrue_whenCheckInIsOld_viaTicker() =
-        runTest {
-            val checkInTime = 1000L
-            val clock = FakeClock(
-                nowSeconds = checkInTime + DefaultDoorViewModel.CHECK_IN_STALE_THRESHOLD_SECONDS + 1,
-            )
-            doorRepository.setCurrentDoorEvent(
-                testDoorEvent.copy(lastCheckInTimeSeconds = checkInTime),
-            )
-            val viewModel = createViewModel(
-                scope = backgroundScope,
-                clock = clock,
-            )
-
-            // Advance past the ticker interval so the periodic check fires.
-            testDispatcher.scheduler.advanceTimeBy(staleCheckInterval + 1)
-            testDispatcher.scheduler.runCurrent()
-
-            assertEquals(true, viewModel.isCheckInStale.value)
-        }
-
-    @Test
-    fun isCheckInStale_becomesTrue_afterClockAdvances() =
-        runTest {
-            val checkInTime = 1000L
-            val clock = FakeClock(nowSeconds = checkInTime)
-            doorRepository.setCurrentDoorEvent(
-                testDoorEvent.copy(lastCheckInTimeSeconds = checkInTime),
-            )
-            val viewModel = createViewModel(
-                scope = backgroundScope,
-                clock = clock,
-            )
-
-            assertEquals(false, viewModel.isCheckInStale.value)
-
-            // Advance the fake clock past threshold.
-            clock.advanceSeconds(DefaultDoorViewModel.CHECK_IN_STALE_THRESHOLD_SECONDS + 1)
-            // Advance coroutine time so the ticker fires.
-            testDispatcher.scheduler.advanceTimeBy(staleCheckInterval + 1)
-            testDispatcher.scheduler.runCurrent()
-
-            assertEquals(true, viewModel.isCheckInStale.value)
-        }
-
-    @Test
-    fun isCheckInStale_becomesFresh_whenNewEventArrives() =
-        runTest {
-            val checkInTime = 1000L
-            val clock = FakeClock(
-                nowSeconds = checkInTime + DefaultDoorViewModel.CHECK_IN_STALE_THRESHOLD_SECONDS + 1,
-            )
-            doorRepository.setCurrentDoorEvent(
-                testDoorEvent.copy(lastCheckInTimeSeconds = checkInTime),
-            )
-            val viewModel = createViewModel(
-                scope = backgroundScope,
-                clock = clock,
-            )
-
-            // Becomes stale via ticker.
-            testDispatcher.scheduler.advanceTimeBy(staleCheckInterval + 1)
-            testDispatcher.scheduler.runCurrent()
-            assertEquals(true, viewModel.isCheckInStale.value)
-
-            // New event arrives with fresh check-in time — triggers collect, not ticker.
-            doorRepository.setCurrentDoorEvent(
-                testDoorEvent.copy(lastCheckInTimeSeconds = clock.nowEpochSeconds()),
-            )
-            testDispatcher.scheduler.runCurrent()
-
-            assertEquals(false, viewModel.isCheckInStale.value)
-        }
-
-    @Test
-    fun logsStaleEvent_whenCheckInBecomesStale() =
-        runTest {
-            val checkInTime = 1000L
-            val clock = FakeClock(nowSeconds = checkInTime)
-            doorRepository.setCurrentDoorEvent(
-                testDoorEvent.copy(lastCheckInTimeSeconds = checkInTime),
-            )
-            createViewModel(
-                scope = backgroundScope,
-                clock = clock,
-            )
-
-            // Advance past threshold.
-            clock.advanceSeconds(DefaultDoorViewModel.CHECK_IN_STALE_THRESHOLD_SECONDS + 1)
-            testDispatcher.scheduler.advanceTimeBy(staleCheckInterval + 1)
-            testDispatcher.scheduler.runCurrent()
-
-            assertTrue(
-                appLoggerRepository.loggedKeys.contains(
-                    AppLoggerKeys.EXCEEDED_EXPECTED_TIME_WITHOUT_FCM,
-                ),
-                "Expected staleness log, got: ${appLoggerRepository.loggedKeys}",
-            )
-        }
-
-    @Test
-    fun doesNotLogFresh_onFirstEmission() =
-        runTest {
-            val clock = FakeClock(nowSeconds = 1000L)
-            doorRepository.setCurrentDoorEvent(
-                testDoorEvent.copy(lastCheckInTimeSeconds = 1000L),
-            )
-            createViewModel(
-                scope = backgroundScope,
-                clock = clock,
-            )
-
-            // The first emission is false (fresh) — should NOT log "in range".
-            val freshLogs = appLoggerRepository.loggedKeys.filter {
-                it == AppLoggerKeys.TIME_WITHOUT_FCM_IN_EXPECTED_RANGE
-            }
-            assertTrue(
-                freshLogs.isEmpty(),
-                "Should not log fresh on first emission, got: ${appLoggerRepository.loggedKeys}",
-            )
         }
 }


### PR DESCRIPTION
## Summary

Move staleness ticker out of \`DoorViewModel\` into an app-scoped Manager following the \`FcmRegistrationManager\` pattern. Per ADR-017 Rule 2, app-scoped state lives in Manager classes, not ViewModels.

## Changes

- **New** \`CheckInStalenessManager\` (usecase module): owns the reactive collector + 30s ticker + transition logging. App-scoped (\`applicationScope\` in production). \`start()\` is idempotent.
- \`DoorViewModel\` loses: \`scope\` param, \`clock\` param, \`computeStale\`, \`stalenessJobs\`, \`onCleared\`, the 3 staleness coroutines. Now just observes \`manager.isCheckInStale\`.
- \`AppStartup.run()\` calls \`manager.start()\` (added after FCM)
- \`AppComponent\` wires \`CheckInStalenessManager\` + \`AppClock\` singleton
- **New** \`CheckInStalenessManagerTest\`: reactive path, ticker path, fresh-after-stale, transition logging, idempotency
- \`DoorViewModelTest\` simplified — staleness tests moved to manager test

## Test plan

- [x] \`validate.sh\` passes
- [x] All existing tests pass + 7 new manager tests
- [ ] Device verification ideal — staleness banner should still appear/disappear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)