### PR TITLE
build: Add ViewModelStateFlowCheckTask (ADR-017 Rule 6 enforcement)

### DIFF
--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -122,6 +122,13 @@ tasks.register<codestyle.RememberSaveableGuardTask>("checkRememberSaveable") {
     )
 }
 
+tasks.register<architecture.ViewModelStateFlowCheckTask>("checkViewModelStateFlow") {
+    sourceDirs = listOf(
+        "$rootDir/usecase/src/commonMain/kotlin",
+        "$rootDir/androidApp/src/main/java",
+    )
+}
+
 tasks.register<testcoverage.TestCoverageCheckTask>("checkTestCoverage") {
     sourceDir = "$rootDir/androidApp/src/main/java/com/chriscartland/garage"
     testDir = "$rootDir/androidApp/src/test/java/com/chriscartland/garage"

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/ViewModelStateFlowCheckTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/ViewModelStateFlowCheckTask.kt
@@ -1,0 +1,60 @@
+package architecture
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Bans `.stateIn(viewModelScope, ...)` in ViewModel files (ADR-017 Rule 6).
+ *
+ * The `stateIn(Eagerly)` pattern caused a real production bug where
+ * Compose collectors did not observe upstream state changes (see PR #295,
+ * AuthViewModel auth state UI regression). The required pattern is
+ * explicit `MutableStateFlow + init.collect`.
+ *
+ * Only literal `viewModelScope` is banned — `stateIn(applicationScope, ...)`
+ * in a Manager class is legitimate.
+ */
+abstract class ViewModelStateFlowCheckTask : DefaultTask() {
+    @get:Input
+    var sourceDirs: List<String> = emptyList()
+
+    private val pattern = Regex("""\.stateIn\s*\(\s*viewModelScope""")
+    private val fileNameRegex = Regex(".*ViewModel\\.kt")
+
+    @TaskAction
+    fun check() {
+        val violations = mutableListOf<String>()
+
+        for (dirPath in sourceDirs) {
+            val dir = File(dirPath)
+            if (!dir.exists()) continue
+
+            dir
+                .walkTopDown()
+                .filter { it.extension == "kt" && fileNameRegex.matches(it.name) }
+                .forEach { file ->
+                    file.readLines().forEachIndexed { index, line ->
+                        if (pattern.containsMatchIn(line)) {
+                            violations.add(
+                                "${file.relativeTo(dir).path}:${index + 1}: " +
+                                    "stateIn(viewModelScope, ...) is banned in ViewModels (ADR-017 Rule 6). " +
+                                    "Use explicit MutableStateFlow + init.collect instead. " +
+                                    "Line: ${line.trim()}",
+                            )
+                        }
+                    }
+                }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                "ViewModel StateFlow Check Failed (${violations.size} violation(s)):\n" +
+                    violations.joinToString("\n\n") { "  $it" },
+            )
+        }
+        logger.lifecycle("ViewModel StateFlow check passed: no stateIn(viewModelScope, ...) usages.")
+    }
+}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -46,6 +46,9 @@ $GRADLE checkLayerImports && pass "layer imports" || fail "layer imports"
 step "Hardcoded colors (must use theme)"
 $GRADLE checkHardcodedColors && pass "hardcoded colors" || fail "hardcoded colors"
 
+step "ViewModel StateFlow (no stateIn(viewModelScope, ...))"
+$GRADLE checkViewModelStateFlow && pass "viewmodel stateflow" || fail "viewmodel stateflow"
+
 step "Detekt (static analysis)"
 $GRADLE :androidApp:detekt && pass "detekt" || fail "detekt"
 


### PR DESCRIPTION
## Summary

New Gradle task scans \`*ViewModel.kt\` files for \`.stateIn(viewModelScope, ...)\` and fails the build with a violation message pointing to ADR-017 Rule 6.

Only literal \`viewModelScope\` is banned — \`stateIn(applicationScope, ...)\` in a Manager class is legitimate.

## Why

The \`stateIn(viewModelScope, Eagerly, ...)\` pattern caused a real production bug where Compose collectors did not observe upstream state changes (PR #295, AuthViewModel auth state UI regression). The required pattern per ADR-017 Rule 6 is explicit \`MutableStateFlow + init.collect\`.

## Test plan

- [x] Task runs on current main — zero violations (PR #295/#298 already removed all usages)
- [x] \`validate.sh\` passes with new check wired in
- [x] Matches existing architecture task style (\`SingletonGuardTask\`, \`HardcodedColorCheckTask\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)