### PR TITLE
refactor: FakeAuthBridge — convert public var to setX() (ADR-017 Rule 5)

### DIFF
--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepositoryTest.kt
@@ -66,8 +66,8 @@ class FirebaseAuthRepositoryTest {
     @Test
     fun refreshReturnsAuthenticatedWhenUserAndTokenExist() =
         runTest {
-            authBridge.userInfo = AuthUserInfo(displayName = "Test User", email = "test@test.com")
-            authBridge.refreshTokenResult = FirebaseIdToken(idToken = "token-123", exp = Long.MAX_VALUE)
+            authBridge.setUserInfo(AuthUserInfo(displayName = "Test User", email = "test@test.com"))
+            authBridge.setRefreshTokenResult(FirebaseIdToken(idToken = "token-123", exp = Long.MAX_VALUE))
 
             val repo = createRepository()
             val result = repo.refreshFirebaseAuthState()
@@ -82,7 +82,7 @@ class FirebaseAuthRepositoryTest {
     @Test
     fun refreshReturnsUnauthenticatedWhenNoUser() =
         runTest {
-            authBridge.userInfo = null
+            authBridge.setUserInfo(null)
 
             val repo = createRepository()
             val result = repo.refreshFirebaseAuthState()
@@ -93,8 +93,8 @@ class FirebaseAuthRepositoryTest {
     @Test
     fun refreshReturnsUnauthenticatedWhenTokenRefreshFails() =
         runTest {
-            authBridge.userInfo = AuthUserInfo(displayName = "Test", email = "test@test.com")
-            authBridge.refreshTokenResult = null
+            authBridge.setUserInfo(AuthUserInfo(displayName = "Test", email = "test@test.com"))
+            authBridge.setRefreshTokenResult(null)
 
             val repo = createRepository()
             val result = repo.refreshFirebaseAuthState()
@@ -107,9 +107,9 @@ class FirebaseAuthRepositoryTest {
     @Test
     fun signInDelegatesAndRefreshes() =
         runTest {
-            authBridge.signInResult = true
-            authBridge.userInfo = AuthUserInfo(displayName = "Signed In", email = "user@test.com")
-            authBridge.refreshTokenResult = FirebaseIdToken(idToken = "new-token", exp = Long.MAX_VALUE)
+            authBridge.setSignInResult(true)
+            authBridge.setUserInfo(AuthUserInfo(displayName = "Signed In", email = "user@test.com"))
+            authBridge.setRefreshTokenResult(FirebaseIdToken(idToken = "new-token", exp = Long.MAX_VALUE))
 
             val repo = createRepository()
             val result = repo.signInWithGoogle(GoogleIdToken("google-token"))
@@ -124,8 +124,8 @@ class FirebaseAuthRepositoryTest {
     @Test
     fun signOutDelegatesToBridgeAndUpdatesState() =
         runTest {
-            authBridge.userInfo = AuthUserInfo(displayName = "Test", email = "test@test.com")
-            authBridge.refreshTokenResult = FirebaseIdToken(idToken = "token", exp = Long.MAX_VALUE)
+            authBridge.setUserInfo(AuthUserInfo(displayName = "Test", email = "test@test.com"))
+            authBridge.setRefreshTokenResult(FirebaseIdToken(idToken = "token", exp = Long.MAX_VALUE))
 
             val repo = createRepository()
             repo.signOut()
@@ -140,14 +140,14 @@ class FirebaseAuthRepositoryTest {
     fun authStateUpdatesOnRefresh() =
         runTest {
             // Start with a signed-in user so init refresh produces Authenticated
-            authBridge.userInfo = AuthUserInfo(displayName = "User", email = "user@test.com")
-            authBridge.refreshTokenResult = FirebaseIdToken(idToken = "token", exp = Long.MAX_VALUE)
+            authBridge.setUserInfo(AuthUserInfo(displayName = "User", email = "user@test.com"))
+            authBridge.setRefreshTokenResult(FirebaseIdToken(idToken = "token", exp = Long.MAX_VALUE))
 
             val repo = createRepository()
 
             // Change bridge to return different user
-            authBridge.userInfo = AuthUserInfo(displayName = "New User", email = "new@test.com")
-            authBridge.refreshTokenResult = FirebaseIdToken(idToken = "fresh", exp = Long.MAX_VALUE)
+            authBridge.setUserInfo(AuthUserInfo(displayName = "New User", email = "new@test.com"))
+            authBridge.setRefreshTokenResult(FirebaseIdToken(idToken = "fresh", exp = Long.MAX_VALUE))
             repo.refreshFirebaseAuthState()
 
             val state = repo.getAuthState()

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAuthBridge.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAuthBridge.kt
@@ -25,12 +25,13 @@ import com.chriscartland.garage.domain.model.GoogleIdToken
 /**
  * Fake [AuthBridge] for unit testing.
  *
- * All responses are configurable. Tracks call counts for verification.
+ * Configure responses with `setX()` methods. Tracks call counts for verification.
+ * ADR-017 Rule 5: result configuration uses setters, not public `var`.
  */
 class FakeAuthBridge : AuthBridge {
-    var signInResult: Boolean = true
-    var userInfo: AuthUserInfo? = null
-    var refreshTokenResult: FirebaseIdToken? = null
+    private var signInResult: Boolean = true
+    private var userInfo: AuthUserInfo? = null
+    private var refreshTokenResult: FirebaseIdToken? = null
 
     var signInCount = 0
         private set
@@ -38,6 +39,18 @@ class FakeAuthBridge : AuthBridge {
         private set
     var signOutCount = 0
         private set
+
+    fun setSignInResult(value: Boolean) {
+        signInResult = value
+    }
+
+    fun setUserInfo(value: AuthUserInfo?) {
+        userInfo = value
+    }
+
+    fun setRefreshTokenResult(value: FirebaseIdToken?) {
+        refreshTokenResult = value
+    }
 
     override suspend fun signInWithGoogleToken(idToken: GoogleIdToken): Boolean {
         signInCount++


### PR DESCRIPTION
## Summary
- Convert `FakeAuthBridge` public `var` config fields (`signInResult`, `userInfo`, `refreshTokenResult`) to `private var` + `setX()` methods (ADR-017 Rule 5).
- Update `FirebaseAuthRepositoryTest` call sites to use the new setters.
- Counters already use `private set`.

## Why
Public `var` for fake configuration lets tests write whenever, gives no single call site to grep, and makes test ordering load-bearing. Setters give a clear mutation API.

## Test plan
- [x] `:data:testDebugUnitTest --tests *FirebaseAuthRepositoryTest*` passes
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)