### PR TITLE
refactor: FakeMessagingBridge — convert public var to setX() (ADR-017 Rule 5)

### DIFF
--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/FirebaseDoorFcmRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/FirebaseDoorFcmRepositoryTest.kt
@@ -79,7 +79,7 @@ class FirebaseDoorFcmRepositoryTest {
     @Test
     fun registerDoorReturnsNotRegisteredOnSubscribeFailure() =
         runTest {
-            bridge.subscribeResult = false
+            bridge.setSubscribeResult(false)
             val state = repo.registerDoor(DoorFcmTopic("topic"))
 
             assertIs<DoorFcmState.NotRegistered>(state)
@@ -88,7 +88,7 @@ class FirebaseDoorFcmRepositoryTest {
     @Test
     fun registerDoorReturnsNotRegisteredWhenNoToken() =
         runTest {
-            bridge.token = null
+            bridge.setToken(null)
             val state = repo.registerDoor(DoorFcmTopic("topic"))
 
             assertIs<DoorFcmState.NotRegistered>(state)

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeMessagingBridge.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeMessagingBridge.kt
@@ -2,11 +2,24 @@ package com.chriscartland.garage.testcommon
 
 import com.chriscartland.garage.data.MessagingBridge
 
+/**
+ * Fake [MessagingBridge] for unit testing.
+ *
+ * Configure responses with `setX()` methods. ADR-017 Rule 5.
+ */
 class FakeMessagingBridge : MessagingBridge {
-    var subscribeResult = true
-    var token: String? = "fake-token"
+    private var subscribeResult = true
+    private var token: String? = "fake-token"
     val subscribedTopics = mutableListOf<String>()
     val unsubscribedTopics = mutableListOf<String>()
+
+    fun setSubscribeResult(value: Boolean) {
+        subscribeResult = value
+    }
+
+    fun setToken(value: String?) {
+        token = value
+    }
 
     override suspend fun subscribeToTopic(topic: String): Boolean {
         subscribedTopics.add(topic)


### PR DESCRIPTION
## Summary
- Convert `FakeMessagingBridge` public `var subscribeResult` and `var token` to `private var` + `setSubscribeResult()` / `setToken()`.
- Update `FirebaseDoorFcmRepositoryTest` call sites.
- Mutable list fields (`subscribedTopics`, `unsubscribedTopics`) untouched — left for opportunistic call-list migration (ADR-017 Rule 5 task #6).

## Test plan
- [x] `:data:testDebugUnitTest --tests *FirebaseDoorFcmRepositoryTest*` passes
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)