### PR TITLE
refactor: FakeDoorFcmRepository — convert public var to setX() (ADR-017 Rule 5)

### DIFF
--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeDoorFcmRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeDoorFcmRepository.kt
@@ -21,12 +21,32 @@ import com.chriscartland.garage.domain.model.DoorFcmState
 import com.chriscartland.garage.domain.model.DoorFcmTopic
 import com.chriscartland.garage.domain.repository.DoorFcmRepository
 
+/**
+ * Fake [DoorFcmRepository] for unit testing.
+ *
+ * Configure responses with `setX()` methods. ADR-017 Rule 5.
+ */
 class FakeDoorFcmRepository : DoorFcmRepository {
-    var fetchStatusResult: DoorFcmState = DoorFcmState.Unknown
-    var registerResult: DoorFcmState = DoorFcmState.NotRegistered
-    var deregisterResult: DoorFcmState = DoorFcmState.NotRegistered
+    private var fetchStatusResult: DoorFcmState = DoorFcmState.Unknown
+    private var registerResult: DoorFcmState = DoorFcmState.NotRegistered
+    private var deregisterResult: DoorFcmState = DoorFcmState.NotRegistered
+
     var registerCount = 0
+        private set
     var lastRegisteredTopic: DoorFcmTopic? = null
+        private set
+
+    fun setFetchStatusResult(value: DoorFcmState) {
+        fetchStatusResult = value
+    }
+
+    fun setRegisterResult(value: DoorFcmState) {
+        registerResult = value
+    }
+
+    fun setDeregisterResult(value: DoorFcmState) {
+        deregisterResult = value
+    }
 
     override suspend fun fetchStatus(): DoorFcmState = fetchStatusResult
 

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DeregisterFcmUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DeregisterFcmUseCaseTest.kt
@@ -29,7 +29,7 @@ class DeregisterFcmUseCaseTest {
     fun deregisterReturnsNotRegisteredOnSuccess() =
         runTest {
             val repo = FakeDoorFcmRepository()
-            repo.deregisterResult = DoorFcmState.NotRegistered
+            repo.setDeregisterResult(DoorFcmState.NotRegistered)
             val useCase = DeregisterFcmUseCase(repo)
 
             assertEquals(FcmRegistrationStatus.NOT_REGISTERED, useCase())
@@ -39,7 +39,7 @@ class DeregisterFcmUseCaseTest {
     fun deregisterReturnsUnknownOnFailure() =
         runTest {
             val repo = FakeDoorFcmRepository()
-            repo.deregisterResult = DoorFcmState.Unknown
+            repo.setDeregisterResult(DoorFcmState.Unknown)
             val useCase = DeregisterFcmUseCase(repo)
 
             assertEquals(FcmRegistrationStatus.UNKNOWN, useCase())

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/FetchFcmStatusUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/FetchFcmStatusUseCaseTest.kt
@@ -30,7 +30,7 @@ class FetchFcmStatusUseCaseTest {
     fun returnsRegisteredWhenRepoReturnsRegistered() =
         runTest {
             val repo = FakeDoorFcmRepository()
-            repo.fetchStatusResult = DoorFcmState.Registered(DoorFcmTopic("test"))
+            repo.setFetchStatusResult(DoorFcmState.Registered(DoorFcmTopic("test")))
             val useCase = FetchFcmStatusUseCase(repo)
 
             assertEquals(FcmRegistrationStatus.REGISTERED, useCase())
@@ -40,7 +40,7 @@ class FetchFcmStatusUseCaseTest {
     fun returnsNotRegisteredWhenRepoReturnsNotRegistered() =
         runTest {
             val repo = FakeDoorFcmRepository()
-            repo.fetchStatusResult = DoorFcmState.NotRegistered
+            repo.setFetchStatusResult(DoorFcmState.NotRegistered)
             val useCase = FetchFcmStatusUseCase(repo)
 
             assertEquals(FcmRegistrationStatus.NOT_REGISTERED, useCase())
@@ -50,7 +50,7 @@ class FetchFcmStatusUseCaseTest {
     fun returnsUnknownWhenRepoReturnsUnknown() =
         runTest {
             val repo = FakeDoorFcmRepository()
-            repo.fetchStatusResult = DoorFcmState.Unknown
+            repo.setFetchStatusResult(DoorFcmState.Unknown)
             val useCase = FetchFcmStatusUseCase(repo)
 
             assertEquals(FcmRegistrationStatus.UNKNOWN, useCase())

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RegisterFcmUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RegisterFcmUseCaseTest.kt
@@ -67,8 +67,9 @@ class RegisterFcmUseCaseTest {
     fun registerSucceedsWithBuildTimestamp() =
         runTest {
             fakeDoor.buildTimestamp = "Sat Mar 13 14:45:00 2021"
-            fakeFcm.registerResult =
-                DoorFcmState.Registered(DoorFcmTopic("door_open-Sat.Mar.13.14.45.00.2021"))
+            fakeFcm.setRegisterResult(
+                DoorFcmState.Registered(DoorFcmTopic("door_open-Sat.Mar.13.14.45.00.2021")),
+            )
 
             val result = useCase()
 
@@ -91,7 +92,7 @@ class RegisterFcmUseCaseTest {
     fun registerConvertsTimestampToTopic() =
         runTest {
             fakeDoor.buildTimestamp = "Sat Mar 13 14:45:00 2021"
-            fakeFcm.registerResult = DoorFcmState.Registered(DoorFcmTopic("test"))
+            fakeFcm.setRegisterResult(DoorFcmState.Registered(DoorFcmTopic("test")))
 
             useCase()
 
@@ -102,7 +103,7 @@ class RegisterFcmUseCaseTest {
     fun registerReturnsNetworkFailedOnSubscribeFailure() =
         runTest {
             fakeDoor.buildTimestamp = "timestamp"
-            fakeFcm.registerResult = DoorFcmState.NotRegistered
+            fakeFcm.setRegisterResult(DoorFcmState.NotRegistered)
 
             val result = useCase()
 


### PR DESCRIPTION
## Summary
- Convert `FakeDoorFcmRepository` public `var` config fields (`fetchStatusResult`, `registerResult`, `deregisterResult`) to `private var` + `setX()` methods.
- Add `private set` to `registerCount` and `lastRegisteredTopic` (mutated only internally by the fake).
- Update `FetchFcmStatusUseCaseTest`, `RegisterFcmUseCaseTest`, `DeregisterFcmUseCaseTest` call sites.

## Test plan
- [x] `:usecase:testDebugUnitTest` for affected tests passes
- [x] `./scripts/validate.sh` passes (covers DoorViewModelTest, FcmRegistrationManagerTest, AppStartupTest which only construct the fake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)