### PR TITLE
refactor: 3 Fake Network DataSources — convert public var to setX() (ADR-017 Rule 5)

### DIFF
--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepositoryTest.kt
@@ -48,7 +48,7 @@ class CachedServerConfigRepositoryTest {
                 remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
                 remoteButtonPushKey = "key",
             )
-            configDataSource.serverConfigResult = NetworkResult.Success(config)
+            configDataSource.setServerConfigResult(NetworkResult.Success(config))
 
             val repo = createRepository()
             val result = repo.getServerConfigCached()
@@ -65,7 +65,7 @@ class CachedServerConfigRepositoryTest {
                 remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
                 remoteButtonPushKey = "key",
             )
-            configDataSource.serverConfigResult = NetworkResult.Success(config)
+            configDataSource.setServerConfigResult(NetworkResult.Success(config))
 
             val repo = createRepository()
             repo.getServerConfigCached()
@@ -77,7 +77,7 @@ class CachedServerConfigRepositoryTest {
     @Test
     fun getServerConfigCachedReturnsNullWhenNetworkFails() =
         runTest {
-            configDataSource.serverConfigResult = NetworkResult.ConnectionFailed
+            configDataSource.setServerConfigResult(NetworkResult.ConnectionFailed)
 
             val repo = createRepository()
             assertNull(repo.getServerConfigCached())
@@ -87,7 +87,7 @@ class CachedServerConfigRepositoryTest {
     @Test
     fun getServerConfigCachedRetriesAfterNullResponse() =
         runTest {
-            configDataSource.serverConfigResult = NetworkResult.ConnectionFailed
+            configDataSource.setServerConfigResult(NetworkResult.ConnectionFailed)
 
             val repo = createRepository()
             assertNull(repo.getServerConfigCached())
@@ -98,7 +98,7 @@ class CachedServerConfigRepositoryTest {
                 remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
                 remoteButtonPushKey = "key",
             )
-            configDataSource.serverConfigResult = NetworkResult.Success(config)
+            configDataSource.setServerConfigResult(NetworkResult.Success(config))
             assertEquals(config, repo.getServerConfigCached())
             assertEquals(2, configDataSource.fetchCount)
         }
@@ -111,7 +111,7 @@ class CachedServerConfigRepositoryTest {
                 remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
                 remoteButtonPushKey = "key1",
             )
-            configDataSource.serverConfigResult = NetworkResult.Success(config1)
+            configDataSource.setServerConfigResult(NetworkResult.Success(config1))
 
             val repo = createRepository()
             repo.getServerConfigCached()
@@ -122,7 +122,7 @@ class CachedServerConfigRepositoryTest {
                 remoteButtonBuildTimestamp = "2024-01-16T00:00:00Z",
                 remoteButtonPushKey = "key2",
             )
-            configDataSource.serverConfigResult = NetworkResult.Success(config2)
+            configDataSource.setServerConfigResult(NetworkResult.Success(config2))
             repo.fetchServerConfig()
 
             // Cached value should now be updated
@@ -139,13 +139,13 @@ class CachedServerConfigRepositoryTest {
                 remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
                 remoteButtonPushKey = "key",
             )
-            configDataSource.serverConfigResult = NetworkResult.Success(config)
+            configDataSource.setServerConfigResult(NetworkResult.Success(config))
 
             val repo = createRepository()
             repo.getServerConfigCached()
 
             // Network now returns null
-            configDataSource.serverConfigResult = NetworkResult.ConnectionFailed
+            configDataSource.setServerConfigResult(NetworkResult.ConnectionFailed)
             repo.fetchServerConfig()
 
             // Cache should retain the old value

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepositoryIntegrationTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepositoryIntegrationTest.kt
@@ -57,25 +57,28 @@ class NetworkDoorRepositoryIntegrationTest {
         )
     }
 
+    private fun successConfig() =
+        NetworkResult.Success(
+            ServerConfig(
+                buildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonPushKey = "key",
+            ),
+        )
+
     // --- fetchCurrentDoorEvent ---
 
     @Test
     fun fetchCurrentDoorEventStoresInLocal() =
         runTest {
-            configDataSource.serverConfigResult = NetworkResult.Success(
-                ServerConfig(
-                    buildTimestamp = "2024-01-15T00:00:00Z",
-                    remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
-                    remoteButtonPushKey = "key",
-                ),
-            )
+            configDataSource.setServerConfigResult(successConfig())
             val event = DoorEvent(
                 doorPosition = DoorPosition.OPEN,
                 message = "Door is open",
                 lastCheckInTimeSeconds = 1000L,
                 lastChangeTimeSeconds = 900L,
             )
-            networkDataSource.currentDoorEventResult = NetworkResult.Success(event)
+            networkDataSource.setCurrentDoorEventResult(NetworkResult.Success(event))
 
             val repo = createRepository()
             val result = repo.fetchCurrentDoorEvent()
@@ -90,18 +93,12 @@ class NetworkDoorRepositoryIntegrationTest {
     @Test
     fun fetchCurrentDoorEventExposedViaFlow() =
         runTest {
-            configDataSource.serverConfigResult = NetworkResult.Success(
-                ServerConfig(
-                    buildTimestamp = "2024-01-15T00:00:00Z",
-                    remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
-                    remoteButtonPushKey = "key",
-                ),
-            )
+            configDataSource.setServerConfigResult(successConfig())
             val event = DoorEvent(
                 doorPosition = DoorPosition.CLOSED,
                 message = "Door is closed",
             )
-            networkDataSource.currentDoorEventResult = NetworkResult.Success(event)
+            networkDataSource.setCurrentDoorEventResult(NetworkResult.Success(event))
 
             val repo = createRepository()
             repo.fetchCurrentDoorEvent()
@@ -113,7 +110,7 @@ class NetworkDoorRepositoryIntegrationTest {
     @Test
     fun fetchCurrentDoorEventWithNullServerConfigReturnsNotReady() =
         runTest {
-            configDataSource.serverConfigResult = NetworkResult.ConnectionFailed
+            configDataSource.setServerConfigResult(NetworkResult.ConnectionFailed)
 
             val repo = createRepository()
             val result = repo.fetchCurrentDoorEvent()
@@ -127,14 +124,8 @@ class NetworkDoorRepositoryIntegrationTest {
     @Test
     fun fetchCurrentDoorEventWithNullNetworkResponseReturnsNetworkFailed() =
         runTest {
-            configDataSource.serverConfigResult = NetworkResult.Success(
-                ServerConfig(
-                    buildTimestamp = "2024-01-15T00:00:00Z",
-                    remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
-                    remoteButtonPushKey = "key",
-                ),
-            )
-            networkDataSource.currentDoorEventResult = NetworkResult.ConnectionFailed
+            configDataSource.setServerConfigResult(successConfig())
+            networkDataSource.setCurrentDoorEventResult(NetworkResult.ConnectionFailed)
 
             val repo = createRepository()
             val result = repo.fetchCurrentDoorEvent()
@@ -151,19 +142,13 @@ class NetworkDoorRepositoryIntegrationTest {
     @Test
     fun fetchRecentDoorEventsStoresInLocal() =
         runTest {
-            configDataSource.serverConfigResult = NetworkResult.Success(
-                ServerConfig(
-                    buildTimestamp = "2024-01-15T00:00:00Z",
-                    remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
-                    remoteButtonPushKey = "key",
-                ),
-            )
+            configDataSource.setServerConfigResult(successConfig())
             val events = listOf(
                 DoorEvent(doorPosition = DoorPosition.OPEN, lastChangeTimeSeconds = 300L),
                 DoorEvent(doorPosition = DoorPosition.CLOSED, lastChangeTimeSeconds = 200L),
                 DoorEvent(doorPosition = DoorPosition.OPENING, lastChangeTimeSeconds = 100L),
             )
-            networkDataSource.recentDoorEventsResult = NetworkResult.Success(events)
+            networkDataSource.setRecentDoorEventsResult(NetworkResult.Success(events))
 
             val repo = createRepository()
             val result = repo.fetchRecentDoorEvents()
@@ -176,7 +161,7 @@ class NetworkDoorRepositoryIntegrationTest {
     @Test
     fun fetchRecentDoorEventsWithNullServerConfigReturnsNotReady() =
         runTest {
-            configDataSource.serverConfigResult = NetworkResult.ConnectionFailed
+            configDataSource.setServerConfigResult(NetworkResult.ConnectionFailed)
 
             val repo = createRepository()
             val result = repo.fetchRecentDoorEvents()
@@ -190,14 +175,8 @@ class NetworkDoorRepositoryIntegrationTest {
     @Test
     fun fetchRecentDoorEventsWithNullNetworkResponseReturnsNetworkFailed() =
         runTest {
-            configDataSource.serverConfigResult = NetworkResult.Success(
-                ServerConfig(
-                    buildTimestamp = "2024-01-15T00:00:00Z",
-                    remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
-                    remoteButtonPushKey = "key",
-                ),
-            )
-            networkDataSource.recentDoorEventsResult = NetworkResult.ConnectionFailed
+            configDataSource.setServerConfigResult(successConfig())
+            networkDataSource.setRecentDoorEventsResult(NetworkResult.ConnectionFailed)
 
             val repo = createRepository()
             val result = repo.fetchRecentDoorEvents()
@@ -251,13 +230,7 @@ class NetworkDoorRepositoryIntegrationTest {
     @Test
     fun fetchBuildTimestampCachedReturnsFromServerConfig() =
         runTest {
-            configDataSource.serverConfigResult = NetworkResult.Success(
-                ServerConfig(
-                    buildTimestamp = "2024-01-15T00:00:00Z",
-                    remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
-                    remoteButtonPushKey = "key",
-                ),
-            )
+            configDataSource.setServerConfigResult(successConfig())
 
             val repo = createRepository()
             assertEquals("2024-01-15T00:00:00Z", repo.fetchBuildTimestampCached())
@@ -266,7 +239,7 @@ class NetworkDoorRepositoryIntegrationTest {
     @Test
     fun fetchBuildTimestampCachedReturnsNullWhenNoConfig() =
         runTest {
-            configDataSource.serverConfigResult = NetworkResult.ConnectionFailed
+            configDataSource.setServerConfigResult(NetworkResult.ConnectionFailed)
 
             val repo = createRepository()
             assertNull(repo.fetchBuildTimestampCached())

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/RemoteButtonRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/RemoteButtonRepositoryTest.kt
@@ -32,7 +32,7 @@ class RemoteButtonRepositoryTest {
     @Test
     fun pushReturnsFalseWhenServerConfigFetchFails() =
         runTest {
-            networkConfigDataSource.serverConfigResult = NetworkResult.ConnectionFailed
+            networkConfigDataSource.setServerConfigResult(NetworkResult.ConnectionFailed)
             val result = repo.pushButton("token", "ack-token")
             assertEquals(false, result)
             assertEquals(0, networkButtonDataSource.pushCount)
@@ -41,8 +41,10 @@ class RemoteButtonRepositoryTest {
     @Test
     fun pushReturnsTrueWhenServerConfigAvailable() =
         runTest {
-            networkConfigDataSource.serverConfigResult = NetworkResult.Success(
-                ServerConfig(buildTimestamp = "test", remoteButtonBuildTimestamp = "test", remoteButtonPushKey = "key"),
+            networkConfigDataSource.setServerConfigResult(
+                NetworkResult.Success(
+                    ServerConfig(buildTimestamp = "test", remoteButtonBuildTimestamp = "test", remoteButtonPushKey = "key"),
+                ),
             )
             val result = repo.pushButton("token", "ack-token")
             assertEquals(true, result)
@@ -52,10 +54,12 @@ class RemoteButtonRepositoryTest {
     @Test
     fun pushReturnsFalseAfterHttpError() =
         runTest {
-            networkConfigDataSource.serverConfigResult = NetworkResult.Success(
-                ServerConfig(buildTimestamp = "test", remoteButtonBuildTimestamp = "test", remoteButtonPushKey = "key"),
+            networkConfigDataSource.setServerConfigResult(
+                NetworkResult.Success(
+                    ServerConfig(buildTimestamp = "test", remoteButtonBuildTimestamp = "test", remoteButtonPushKey = "key"),
+                ),
             )
-            networkButtonDataSource.pushResult = NetworkResult.HttpError(500)
+            networkButtonDataSource.setPushResult(NetworkResult.HttpError(500))
             val result = repo.pushButton("token", "ack-token")
             assertEquals(false, result)
             assertEquals(1, networkButtonDataSource.pushCount)
@@ -64,10 +68,12 @@ class RemoteButtonRepositoryTest {
     @Test
     fun pushReturnsFalseAfterConnectionFailure() =
         runTest {
-            networkConfigDataSource.serverConfigResult = NetworkResult.Success(
-                ServerConfig(buildTimestamp = "test", remoteButtonBuildTimestamp = "test", remoteButtonPushKey = "key"),
+            networkConfigDataSource.setServerConfigResult(
+                NetworkResult.Success(
+                    ServerConfig(buildTimestamp = "test", remoteButtonBuildTimestamp = "test", remoteButtonPushKey = "key"),
+                ),
             )
-            networkButtonDataSource.pushResult = NetworkResult.ConnectionFailed
+            networkButtonDataSource.setPushResult(NetworkResult.ConnectionFailed)
             val result = repo.pushButton("token", "ack-token")
             assertEquals(false, result)
         }
@@ -80,8 +86,10 @@ class RemoteButtonRepositoryTest {
                 CachedServerConfigRepository(networkConfigDataSource, "test-key"),
                 remoteButtonPushEnabled = false,
             )
-            networkConfigDataSource.serverConfigResult = NetworkResult.Success(
-                ServerConfig(buildTimestamp = "test", remoteButtonBuildTimestamp = "test", remoteButtonPushKey = "key"),
+            networkConfigDataSource.setServerConfigResult(
+                NetworkResult.Success(
+                    ServerConfig(buildTimestamp = "test", remoteButtonBuildTimestamp = "test", remoteButtonPushKey = "key"),
+                ),
             )
             val result = disabledRepo.pushButton("token", "ack-token")
             assertEquals(false, result)

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeNetworkButtonDataSource.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeNetworkButtonDataSource.kt
@@ -3,10 +3,15 @@ package com.chriscartland.garage.testcommon
 import com.chriscartland.garage.data.NetworkButtonDataSource
 import com.chriscartland.garage.data.NetworkResult
 
+/**
+ * Fake [NetworkButtonDataSource] for unit testing.
+ *
+ * Configure responses with `setX()` methods. ADR-017 Rule 5.
+ */
 class FakeNetworkButtonDataSource : NetworkButtonDataSource {
-    var pushResult: NetworkResult<Unit> = NetworkResult.Success(Unit)
-    var snoozeResult: NetworkResult<Unit> = NetworkResult.Success(Unit)
-    var fetchSnoozeResult: NetworkResult<Long> = NetworkResult.Success(0L)
+    private var pushResult: NetworkResult<Unit> = NetworkResult.Success(Unit)
+    private var snoozeResult: NetworkResult<Unit> = NetworkResult.Success(Unit)
+    private var fetchSnoozeResult: NetworkResult<Long> = NetworkResult.Success(0L)
 
     var pushCount = 0
         private set
@@ -14,6 +19,18 @@ class FakeNetworkButtonDataSource : NetworkButtonDataSource {
         private set
     var fetchSnoozeCount = 0
         private set
+
+    fun setPushResult(value: NetworkResult<Unit>) {
+        pushResult = value
+    }
+
+    fun setSnoozeResult(value: NetworkResult<Unit>) {
+        snoozeResult = value
+    }
+
+    fun setFetchSnoozeResult(value: NetworkResult<Long>) {
+        fetchSnoozeResult = value
+    }
 
     override suspend fun pushButton(
         remoteButtonBuildTimestamp: String,

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeNetworkConfigDataSource.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeNetworkConfigDataSource.kt
@@ -21,11 +21,20 @@ import com.chriscartland.garage.data.NetworkConfigDataSource
 import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.domain.model.ServerConfig
 
+/**
+ * Fake [NetworkConfigDataSource] for unit testing.
+ *
+ * Configure responses with `setX()` methods. ADR-017 Rule 5.
+ */
 class FakeNetworkConfigDataSource : NetworkConfigDataSource {
-    var serverConfigResult: NetworkResult<ServerConfig> = NetworkResult.ConnectionFailed
+    private var serverConfigResult: NetworkResult<ServerConfig> = NetworkResult.ConnectionFailed
 
     var fetchCount = 0
         private set
+
+    fun setServerConfigResult(value: NetworkResult<ServerConfig>) {
+        serverConfigResult = value
+    }
 
     override suspend fun fetchServerConfig(serverConfigKey: String): NetworkResult<ServerConfig> {
         fetchCount++

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeNetworkDoorDataSource.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeNetworkDoorDataSource.kt
@@ -21,14 +21,27 @@ import com.chriscartland.garage.data.NetworkDoorDataSource
 import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.domain.model.DoorEvent
 
+/**
+ * Fake [NetworkDoorDataSource] for unit testing.
+ *
+ * Configure responses with `setX()` methods. ADR-017 Rule 5.
+ */
 class FakeNetworkDoorDataSource : NetworkDoorDataSource {
-    var currentDoorEventResult: NetworkResult<DoorEvent> = NetworkResult.ConnectionFailed
-    var recentDoorEventsResult: NetworkResult<List<DoorEvent>> = NetworkResult.ConnectionFailed
+    private var currentDoorEventResult: NetworkResult<DoorEvent> = NetworkResult.ConnectionFailed
+    private var recentDoorEventsResult: NetworkResult<List<DoorEvent>> = NetworkResult.ConnectionFailed
 
     var fetchCurrentCount = 0
         private set
     var fetchRecentCount = 0
         private set
+
+    fun setCurrentDoorEventResult(value: NetworkResult<DoorEvent>) {
+        currentDoorEventResult = value
+    }
+
+    fun setRecentDoorEventsResult(value: NetworkResult<List<DoorEvent>>) {
+        recentDoorEventsResult = value
+    }
 
     override suspend fun fetchCurrentDoorEvent(buildTimestamp: String): NetworkResult<DoorEvent> {
         fetchCurrentCount++


### PR DESCRIPTION
## Summary
Combined refactor of `FakeNetworkConfigDataSource`, `FakeNetworkButtonDataSource`, `FakeNetworkDoorDataSource`. They share callers (`RemoteButtonRepositoryTest`, `NetworkDoorRepositoryIntegrationTest`, `CachedServerConfigRepositoryTest`), so doing them in one PR avoids merge conflicts.

- All public `var` result fields → `private var` + `setX()` methods (ADR-017 Rule 5).
- Counters already had `private set`.
- Updated 3 test files; extracted `successConfig()` helper in `NetworkDoorRepositoryIntegrationTest` to reduce repetition.

## Test plan
- [x] `:data:testDebugUnitTest` passes
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)