### PR TITLE
refactor: 3 Fake Repositories — convert public var to setX() (ADR-017 Rule 5)

### DIFF
--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAuthRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAuthRepository.kt
@@ -23,6 +23,11 @@ import com.chriscartland.garage.domain.repository.AuthRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
+/**
+ * Fake [AuthRepository] for unit testing.
+ *
+ * Configure responses with `setX()` methods. ADR-017 Rule 5.
+ */
 class FakeAuthRepository : AuthRepository {
     private val _authState = MutableStateFlow<AuthState>(AuthState.Unknown)
 
@@ -33,11 +38,19 @@ class FakeAuthRepository : AuthRepository {
     var refreshCount = 0
         private set
 
-    var signInResult: AuthState? = null
-    var refreshResult: AuthState? = null
+    private var signInResult: AuthState? = null
+    private var refreshResult: AuthState? = null
 
     fun setAuthState(state: AuthState) {
         _authState.value = state
+    }
+
+    fun setSignInResult(value: AuthState?) {
+        signInResult = value
+    }
+
+    fun setRefreshResult(value: AuthState?) {
+        refreshResult = value
     }
 
     override suspend fun getAuthState(): AuthState = _authState.value

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeRemoteButtonRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeRemoteButtonRepository.kt
@@ -2,6 +2,11 @@ package com.chriscartland.garage.testcommon
 
 import com.chriscartland.garage.domain.repository.RemoteButtonRepository
 
+/**
+ * Fake [RemoteButtonRepository] for unit testing.
+ *
+ * Configure responses with `setX()` methods. ADR-017 Rule 5.
+ */
 class FakeRemoteButtonRepository : RemoteButtonRepository {
     var pushCount = 0
         private set
@@ -9,7 +14,11 @@ class FakeRemoteButtonRepository : RemoteButtonRepository {
         private set
 
     /** Set to false to simulate network failure. */
-    var pushSucceeds = true
+    private var pushSucceeds = true
+
+    fun setPushSucceeds(value: Boolean) {
+        pushSucceeds = value
+    }
 
     override suspend fun pushButton(
         idToken: String,

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeSnoozeRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeSnoozeRepository.kt
@@ -5,6 +5,11 @@ import com.chriscartland.garage.domain.repository.SnoozeRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
+/**
+ * Fake [SnoozeRepository] for unit testing.
+ *
+ * Configure responses with `setX()` methods. ADR-017 Rule 5.
+ */
 class FakeSnoozeRepository : SnoozeRepository {
     private val snoozeStateFlow = MutableStateFlow<SnoozeState>(SnoozeState.Loading)
 
@@ -15,10 +20,14 @@ class FakeSnoozeRepository : SnoozeRepository {
         private set
 
     /** Set this to false to make snoozeNotifications() return false (network failure). */
-    var snoozeResult: Boolean = true
+    private var snoozeResult: Boolean = true
 
     fun setSnoozeState(state: SnoozeState) {
         snoozeStateFlow.value = state
+    }
+
+    fun setSnoozeResult(value: Boolean) {
+        snoozeResult = value
     }
 
     override fun observeSnoozeState(): Flow<SnoozeState> = snoozeStateFlow

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAuthViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAuthViewModelTest.kt
@@ -62,7 +62,7 @@ class DefaultAuthViewModelTest {
                 email = Email("alice@test.com"),
                 idToken = FirebaseIdToken("token", exp = 9999999999L),
             )
-            authRepo.signInResult = AuthState.Authenticated(user)
+            authRepo.setSignInResult(AuthState.Authenticated(user))
 
             viewModel.signInWithGoogle(GoogleIdToken("test-token"))
             advanceUntilIdle()
@@ -87,11 +87,13 @@ class DefaultAuthViewModelTest {
     fun signOutUpdatesAuthState() =
         runTest(testDispatcher) {
             // First sign in
-            authRepo.signInResult = AuthState.Authenticated(
-                user = User(
-                    name = DisplayName("Test"),
-                    email = Email("test@test.com"),
-                    idToken = FirebaseIdToken("token", exp = 9999999999L),
+            authRepo.setSignInResult(
+                AuthState.Authenticated(
+                    user = User(
+                        name = DisplayName("Test"),
+                        email = Email("test@test.com"),
+                        idToken = FirebaseIdToken("token", exp = 9999999999L),
+                    ),
                 ),
             )
             viewModel.signInWithGoogle(GoogleIdToken("token"))

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/EnsureFreshIdTokenUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/EnsureFreshIdTokenUseCaseTest.kt
@@ -65,7 +65,7 @@ class EnsureFreshIdTokenUseCaseTest {
         runTest {
             val auth = makeAuth(token = "old-token", exp = 1000L)
             val refreshedAuth = makeAuth(token = "new-token", exp = 9000L)
-            fakeAuth.refreshResult = refreshedAuth
+            fakeAuth.setRefreshResult(refreshedAuth)
 
             val result = useCase(auth, currentTimeMillis = 2000L)
 
@@ -78,7 +78,7 @@ class EnsureFreshIdTokenUseCaseTest {
         runTest {
             val auth = makeAuth(token = "old-token", exp = 1000L)
             val refreshedAuth = makeAuth(token = "new-token", exp = 9000L)
-            fakeAuth.refreshResult = refreshedAuth
+            fakeAuth.setRefreshResult(refreshedAuth)
 
             val result = useCase(auth, currentTimeMillis = 1000L)
 
@@ -90,7 +90,7 @@ class EnsureFreshIdTokenUseCaseTest {
     fun fallsBackToCachedTokenWhenRefreshFailsWithUnauthenticated() =
         runTest {
             val auth = makeAuth(token = "old-token", exp = 1000L)
-            fakeAuth.refreshResult = AuthState.Unauthenticated
+            fakeAuth.setRefreshResult(AuthState.Unauthenticated)
 
             val result = useCase(auth, currentTimeMillis = 2000L)
 
@@ -102,7 +102,7 @@ class EnsureFreshIdTokenUseCaseTest {
     fun fallsBackToCachedTokenWhenRefreshFailsWithUnknown() =
         runTest {
             val auth = makeAuth(token = "old-token", exp = 1000L)
-            fakeAuth.refreshResult = AuthState.Unknown
+            fakeAuth.setRefreshResult(AuthState.Unknown)
 
             val result = useCase(auth, currentTimeMillis = 2000L)
 

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/PushRemoteButtonUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/PushRemoteButtonUseCaseTest.kt
@@ -114,7 +114,7 @@ class PushRemoteButtonUseCaseTest {
                     idToken = FirebaseIdToken(idToken = "new-token", exp = Long.MAX_VALUE),
                 ),
             )
-            fakeAuth.refreshResult = refreshedAuth
+            fakeAuth.setRefreshResult(refreshedAuth)
 
             useCase("ack-123")
 

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModelTest.kt
@@ -156,7 +156,7 @@ class RemoteButtonViewModelTest {
     @Test
     fun confirmWhenNetworkFailsShowsServerFailed() =
         runTest {
-            remoteButtonRepository.pushSucceeds = false
+            remoteButtonRepository.setPushSucceeds(false)
             val viewModel = createAuthenticatedViewModel()
 
             viewModel.onButtonTap()
@@ -278,7 +278,7 @@ class RemoteButtonViewModelTest {
         runTest {
             val viewModel = createAuthenticatedViewModel()
             doorRepository.setCurrentDoorEvent(DoorEvent(lastChangeTimeSeconds = 1000L))
-            snoozeRepository.snoozeResult = false
+            snoozeRepository.setSnoozeResult(false)
             testDispatcher.scheduler.runCurrent()
 
             viewModel.snoozeOpenDoorsNotifications(SnoozeDurationUIOption.OneHour)

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SignInWithGoogleUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SignInWithGoogleUseCaseTest.kt
@@ -45,11 +45,13 @@ class SignInWithGoogleUseCaseTest {
     fun invokeUpdatesAuthStateOnSuccess() =
         runTest {
             val repo = FakeAuthRepository()
-            repo.signInResult = AuthState.Authenticated(
-                user = User(
-                    name = DisplayName("Alice"),
-                    email = Email("alice@test.com"),
-                    idToken = FirebaseIdToken("token", exp = Long.MAX_VALUE),
+            repo.setSignInResult(
+                AuthState.Authenticated(
+                    user = User(
+                        name = DisplayName("Alice"),
+                        email = Email("alice@test.com"),
+                        idToken = FirebaseIdToken("token", exp = Long.MAX_VALUE),
+                    ),
                 ),
             )
             val useCase = SignInWithGoogleUseCase(repo)

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SnoozeNotificationsUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SnoozeNotificationsUseCaseTest.kt
@@ -110,11 +110,13 @@ class SnoozeNotificationsUseCaseTest {
     fun snoozeRefreshesExpiredToken() =
         runTest {
             authenticateUser(token = "old", exp = 1000L)
-            fakeAuth.refreshResult = AuthState.Authenticated(
-                user = User(
-                    name = DisplayName("Test"),
-                    email = Email("test@test.com"),
-                    idToken = FirebaseIdToken(idToken = "fresh", exp = Long.MAX_VALUE),
+            fakeAuth.setRefreshResult(
+                AuthState.Authenticated(
+                    user = User(
+                        name = DisplayName("Test"),
+                        email = Email("test@test.com"),
+                        idToken = FirebaseIdToken(idToken = "fresh", exp = Long.MAX_VALUE),
+                    ),
                 ),
             )
             useCase("4h", 2000L)
@@ -125,7 +127,7 @@ class SnoozeNotificationsUseCaseTest {
     fun snoozeReturnsNetworkFailedWhenRepositoryReturnsFalse() =
         runTest {
             authenticateUser()
-            fakeSnooze.snoozeResult = false
+            fakeSnooze.setSnoozeResult(false)
 
             val result = useCase("1h", 1000L)
 


### PR DESCRIPTION
## Summary
Combined refactor of `FakeAuthRepository`, `FakeRemoteButtonRepository`, `FakeSnoozeRepository`. They share test files (`RemoteButtonViewModelTest`, `PushRemoteButtonUseCaseTest`, `SnoozeNotificationsUseCaseTest`), so doing them in one PR avoids merge conflicts.

- `var signInResult` / `refreshResult` (FakeAuthRepository) → `private var` + setters
- `var pushSucceeds` (FakeRemoteButtonRepository) → `private var` + setter
- `var snoozeResult` (FakeSnoozeRepository) → `private var` + setter
- Counters and last-call fields already use `private set`.

Updated 6 callers across usecase tests.

## Test plan
- [x] `:usecase:testDebugUnitTest` passes
- [x] `./scripts/validate.sh` passes

## ADR-017 Rule 5 status
This completes migration task #5 from ADR-017 — all fake `var` configuration has been converted to setter methods across the test-common module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)