### PR TITLE
refactor: Convert FakeMessagingBridge + FakeAppLoggerRepository to call-list pattern

### DIFF
--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAppLoggerRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAppLoggerRepository.kt
@@ -5,12 +5,20 @@ import com.chriscartland.garage.domain.repository.AppLoggerRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
+/**
+ * Fake [AppLoggerRepository] for unit testing.
+ *
+ * Tracks calls via read-only `loggedKeys` list so tests cannot reset or reorder
+ * them mid-test (ADR-017 Rule 5 — call-list pattern).
+ */
 class FakeAppLoggerRepository : AppLoggerRepository {
-    val loggedKeys = mutableListOf<String>()
+    private val _loggedKeys = mutableListOf<String>()
+    val loggedKeys: List<String> get() = _loggedKeys
+
     private val counts = mutableMapOf<String, MutableStateFlow<Long>>()
 
     override suspend fun log(key: String) {
-        loggedKeys.add(key)
+        _loggedKeys.add(key)
         counts.getOrPut(key) { MutableStateFlow(0L) }.let { it.value++ }
     }
 

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeMessagingBridge.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeMessagingBridge.kt
@@ -5,13 +5,18 @@ import com.chriscartland.garage.data.MessagingBridge
 /**
  * Fake [MessagingBridge] for unit testing.
  *
- * Configure responses with `setX()` methods. ADR-017 Rule 5.
+ * Configure responses with `setX()` methods. Tracks calls via read-only lists
+ * so tests cannot reset or reorder them mid-test (ADR-017 Rule 5 — call-list pattern).
  */
 class FakeMessagingBridge : MessagingBridge {
     private var subscribeResult = true
     private var token: String? = "fake-token"
-    val subscribedTopics = mutableListOf<String>()
-    val unsubscribedTopics = mutableListOf<String>()
+
+    private val _subscribedTopics = mutableListOf<String>()
+    val subscribedTopics: List<String> get() = _subscribedTopics
+
+    private val _unsubscribedTopics = mutableListOf<String>()
+    val unsubscribedTopics: List<String> get() = _unsubscribedTopics
 
     fun setSubscribeResult(value: Boolean) {
         subscribeResult = value
@@ -22,12 +27,12 @@ class FakeMessagingBridge : MessagingBridge {
     }
 
     override suspend fun subscribeToTopic(topic: String): Boolean {
-        subscribedTopics.add(topic)
+        _subscribedTopics.add(topic)
         return subscribeResult
     }
 
     override suspend fun unsubscribeFromTopic(topic: String) {
-        unsubscribedTopics.add(topic)
+        _unsubscribedTopics.add(topic)
     }
 
     override suspend fun getToken(): String? = token


### PR DESCRIPTION
## Summary
ADR-017 Rule 5 task #6 (opportunistic call-list migration). Two fakes were exposing `mutableListOf` directly — tests could clear/reorder mid-test. Convert to read-only `List<T>` views backed by private mutable lists.

- `FakeMessagingBridge`: `subscribedTopics`, `unsubscribedTopics`
- `FakeAppLoggerRepository`: `loggedKeys`

## Test plan
- [x] `:data:testDebugUnitTest` and `:usecase:testDebugUnitTest` pass — no test changes needed (assertions use only read-only operations)
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)