### PR TITLE
refactor: FakeDoorRepository.buildTimestamp — convert var to setter (ADR-017 Rule 5)

### DIFF
--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeDoorRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeDoorRepository.kt
@@ -38,7 +38,11 @@ class FakeDoorRepository : DoorRepository {
         private set
     var fetchRecentDoorEventsCount = 0
         private set
-    var buildTimestamp: String? = "2024-01-15T00:00:00Z"
+    private var buildTimestamp: String? = "2024-01-15T00:00:00Z"
+
+    fun setBuildTimestamp(value: String?) {
+        buildTimestamp = value
+    }
 
     fun setCurrentDoorEvent(event: DoorEvent) {
         _currentDoorEvent.value = event

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RegisterFcmUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RegisterFcmUseCaseTest.kt
@@ -66,7 +66,7 @@ class RegisterFcmUseCaseTest {
     @Test
     fun registerSucceedsWithBuildTimestamp() =
         runTest {
-            fakeDoor.buildTimestamp = "Sat Mar 13 14:45:00 2021"
+            fakeDoor.setBuildTimestamp("Sat Mar 13 14:45:00 2021")
             fakeFcm.setRegisterResult(
                 DoorFcmState.Registered(DoorFcmTopic("door_open-Sat.Mar.13.14.45.00.2021")),
             )
@@ -80,7 +80,7 @@ class RegisterFcmUseCaseTest {
     @Test
     fun registerFailsWithNullBuildTimestamp() =
         runTest {
-            fakeDoor.buildTimestamp = null
+            fakeDoor.setBuildTimestamp(null)
             val result = useCase()
 
             assertIs<AppResult.Error<ActionError>>(result)
@@ -91,7 +91,7 @@ class RegisterFcmUseCaseTest {
     @Test
     fun registerConvertsTimestampToTopic() =
         runTest {
-            fakeDoor.buildTimestamp = "Sat Mar 13 14:45:00 2021"
+            fakeDoor.setBuildTimestamp("Sat Mar 13 14:45:00 2021")
             fakeFcm.setRegisterResult(DoorFcmState.Registered(DoorFcmTopic("test")))
 
             useCase()
@@ -102,7 +102,7 @@ class RegisterFcmUseCaseTest {
     @Test
     fun registerReturnsNetworkFailedOnSubscribeFailure() =
         runTest {
-            fakeDoor.buildTimestamp = "timestamp"
+            fakeDoor.setBuildTimestamp("timestamp")
             fakeFcm.setRegisterResult(DoorFcmState.NotRegistered)
 
             val result = useCase()


### PR DESCRIPTION
## Summary
Missed in the earlier Rule 5 sweep — `var buildTimestamp: String?` was the only remaining public-mutable result configuration in the test fakes. Convert to `private var` + `setBuildTimestamp()` and update `RegisterFcmUseCaseTest` call sites (4 sites).

## Test plan
- [x] `:usecase:testDebugUnitTest --tests *RegisterFcmUseCaseTest*` passes
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)