### PR TITLE
refactor: FakeRemoteButtonRepository — call-list pattern (ADR-017 Rule 5)

### DIFF
--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeRemoteButtonRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeRemoteButtonRepository.kt
@@ -5,13 +5,20 @@ import com.chriscartland.garage.domain.repository.RemoteButtonRepository
 /**
  * Fake [RemoteButtonRepository] for unit testing.
  *
- * Configure responses with `setX()` methods. ADR-017 Rule 5.
+ * Tracks each call via [pushCalls] (call-list pattern, ADR-017 Rule 5) so tests
+ * can assert on the exact arguments passed, not just call counts. `pushCount` is
+ * a convenience accessor backed by the call list.
  */
 class FakeRemoteButtonRepository : RemoteButtonRepository {
-    var pushCount = 0
-        private set
-    var lastIdToken: String? = null
-        private set
+    data class PushCall(
+        val idToken: String,
+        val buttonAckToken: String,
+    )
+
+    private val _pushCalls = mutableListOf<PushCall>()
+    val pushCalls: List<PushCall> get() = _pushCalls
+    val pushCount: Int get() = _pushCalls.size
+    val lastIdToken: String? get() = _pushCalls.lastOrNull()?.idToken
 
     /** Set to false to simulate network failure. */
     private var pushSucceeds = true
@@ -24,8 +31,7 @@ class FakeRemoteButtonRepository : RemoteButtonRepository {
         idToken: String,
         buttonAckToken: String,
     ): Boolean {
-        pushCount++
-        lastIdToken = idToken
+        _pushCalls.add(PushCall(idToken = idToken, buttonAckToken = buttonAckToken))
         return pushSucceeds
     }
 }


### PR DESCRIPTION
## Summary
Opportunistic Rule 5 task #6: convert counter-style fields to a backing call list so future tests can assert on call arguments.

- Add `data class PushCall(idToken, buttonAckToken)`
- `pushCalls: List<PushCall>` (read-only)
- Keep `pushCount` / `lastIdToken` as backing-list accessors — no test changes needed.

## Test plan
- [x] `:usecase:testDebugUnitTest` passes (no test changes; existing assertions backed by accessors)
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)