### PR TITLE
build: Add FakePublicVarCheckTask (ADR-017 Rule 5 enforcement)

### DIFF
--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -129,6 +129,12 @@ tasks.register<architecture.ViewModelStateFlowCheckTask>("checkViewModelStateFlo
     )
 }
 
+tasks.register<architecture.FakePublicVarCheckTask>("checkFakePublicVar") {
+    sourceDirs = listOf(
+        "$rootDir/test-common/src/commonMain/kotlin",
+    )
+}
+
 tasks.register<testcoverage.TestCoverageCheckTask>("checkTestCoverage") {
     sourceDir = "$rootDir/androidApp/src/main/java/com/chriscartland/garage"
     testDir = "$rootDir/androidApp/src/test/java/com/chriscartland/garage"

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/FakePublicVarCheckTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/FakePublicVarCheckTask.kt
@@ -1,0 +1,71 @@
+package architecture
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Bans public `var` properties on `Fake*` test doubles (ADR-017 Rule 5).
+ *
+ * Public mutable state on fakes lets tests write whenever, gives no single
+ * call site to grep for mutations, and makes test ordering load-bearing.
+ *
+ * Allowed patterns inside `Fake*.kt`:
+ * - `private var x = ...` (mutated only by the fake itself)
+ * - `var x = ...` followed on the next line by `private set` (counters / last-call)
+ * - `val x = ...` (immutable)
+ *
+ * Forbidden:
+ * - `var x: T = ...` (no `private`, no `private set`)
+ *
+ * Configure result responses with `setX()` methods backed by `private var` instead.
+ */
+abstract class FakePublicVarCheckTask : DefaultTask() {
+    @get:Input
+    var sourceDirs: List<String> = emptyList()
+
+    private val fileNameRegex = Regex("Fake.*\\.kt")
+
+    /** Matches a property declaration `    var name...` (4-space indent, class-level). */
+    private val varPattern = Regex("""^\s{4}var\s+\w+""")
+
+    @TaskAction
+    fun check() {
+        val violations = mutableListOf<String>()
+
+        for (dirPath in sourceDirs) {
+            val dir = File(dirPath)
+            if (!dir.exists()) continue
+
+            dir
+                .walkTopDown()
+                .filter { it.extension == "kt" && fileNameRegex.matches(it.name) }
+                .forEach { file ->
+                    val lines = file.readLines()
+                    lines.forEachIndexed { index, line ->
+                        if (!varPattern.containsMatchIn(line)) return@forEachIndexed
+                        if (line.contains("private")) return@forEachIndexed
+                        // Allow `var x = 0` followed by `        private set` on next line.
+                        val nextLine = lines.getOrNull(index + 1)?.trim()
+                        if (nextLine == "private set") return@forEachIndexed
+                        violations.add(
+                            "${file.relativeTo(dir).path}:${index + 1}: " +
+                                "public `var` on a Fake* class is banned (ADR-017 Rule 5). " +
+                                "Use `private var` + `setX()` method, or add `private set`. " +
+                                "Line: ${line.trim()}",
+                        )
+                    }
+                }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                "Fake Public Var Check Failed (${violations.size} violation(s)):\n" +
+                    violations.joinToString("\n\n") { "  $it" },
+            )
+        }
+        logger.lifecycle("Fake public var check passed: no unguarded public `var` on Fake* classes.")
+    }
+}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -49,6 +49,9 @@ $GRADLE checkHardcodedColors && pass "hardcoded colors" || fail "hardcoded color
 step "ViewModel StateFlow (no stateIn(viewModelScope, ...))"
 $GRADLE checkViewModelStateFlow && pass "viewmodel stateflow" || fail "viewmodel stateflow"
 
+step "Fake public var (no unguarded public var on Fake* classes)"
+$GRADLE checkFakePublicVar && pass "fake public var" || fail "fake public var"
+
 step "Detekt (static analysis)"
 $GRADLE :androidApp:detekt && pass "detekt" || fail "detekt"
 


### PR DESCRIPTION
## Summary
Adds a Gradle lint check banning public `var` properties on `Fake*` test doubles. Prevents regression of the ADR-017 Rule 5 migration completed in PRs #301–#308.

- New `architecture.FakePublicVarCheckTask` scans `Fake*.kt` in `test-common/src/commonMain`
- Allowed: `private var`, `var` with `private set`, `val`
- Forbidden: bare public `var`
- Registered as `checkFakePublicVar` Gradle task
- Added to `scripts/validate.sh`

## Stacking
Stacked on #308 (base branch) — without that fix, this lint would fail on `FakeDoorRepository.buildTimestamp`. Auto-merge will wait for #308.

## Test plan
- [x] `./gradlew checkFakePublicVar` passes (with #308 changes)
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)