### PR TITLE
fix: Inject real app version into button ack token (was AppVersionTODO)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -160,7 +160,13 @@ abstract class AppComponent(
             provideSnoozeNotificationsUseCase(),
             provideFetchSnoozeStatusUseCase(),
             provideObserveSnoozeStateUseCase(),
+            provideAppVersionName(),
         )
+
+    /** App version name used in button ack tokens (server logs correlate by version). */
+    @Provides
+    @Singleton
+    fun provideAppVersionName(): String = application.applicationContext.AppVersion().versionName
 
     // Configuration
     @Provides

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
@@ -57,6 +57,7 @@ class DefaultRemoteButtonViewModel(
     private val snoozeNotificationsUseCase: SnoozeNotificationsUseCase,
     private val fetchSnoozeStatusUseCase: FetchSnoozeStatusUseCase,
     private val observeSnoozeStateUseCase: ObserveSnoozeStateUseCase,
+    private val appVersion: String,
 ) : ViewModel(),
     RemoteButtonViewModel {
     private val stateMachine = ButtonStateMachine(
@@ -108,6 +109,7 @@ class DefaultRemoteButtonViewModel(
                 val result = pushRemoteButtonUseCase(
                     buttonAckToken = createButtonAckToken(
                         currentTimeMillis = System.currentTimeMillis(),
+                        appVersion = appVersion,
                     ),
                 )
             ) {
@@ -186,14 +188,19 @@ class DefaultRemoteButtonViewModel(
 }
 
 /**
- * Create a button ack token from the current time.
+ * Create a button ack token from the current time and app version.
  *
  * This token is created by the client so the server can acknowledge the remote button push.
  * The client can send the same token to the server multiple times and the server is
  * responsible for only processing the token once.
+ *
+ * The app version is included so server logs can correlate button activity with client
+ * versions (e.g., when diagnosing version-specific bugs).
  */
-fun createButtonAckToken(currentTimeMillis: Long): String {
-    val appVersion = "AppVersionTODO"
+fun createButtonAckToken(
+    currentTimeMillis: Long,
+    appVersion: String,
+): String {
     val buttonAckTokenData = "android-$appVersion-$currentTimeMillis"
     val re = Regex("[^a-zA-Z0-9-_.]")
     val filtered = re.replace(buttonAckTokenData, ".")

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModelTest.kt
@@ -89,6 +89,7 @@ class RemoteButtonViewModelTest {
             snoozeNotificationsUseCase = SnoozeNotificationsUseCase(ensureFreshIdToken, authRepository, snoozeRepository),
             fetchSnoozeStatusUseCase = FetchSnoozeStatusUseCase(snoozeRepository),
             observeSnoozeStateUseCase = ObserveSnoozeStateUseCase(snoozeRepository),
+            appVersion = "test-version",
         )
         testDispatcher.scheduler.runCurrent()
         return vm


### PR DESCRIPTION
## Summary
The button ack token sent to the server contained a hardcoded `"AppVersionTODO"` string instead of the actual app version. Server logs couldn't correlate button activity with client versions.

- Add `appVersion: String` parameter to `DefaultRemoteButtonViewModel` and `createButtonAckToken()`
- AppComponent provides `provideAppVersionName()` reading from `Context.AppVersion().versionName`
- Test passes literal "test-version"

## Why
This TODO was masking a real observability gap. Server logs record button activity, but the version field was useless (`"AppVersionTODO"` for every press). Now version-correlated debugging is possible.

## Test plan
- [x] `:usecase:testDebugUnitTest` passes (RemoteButtonViewModelTest updated)
- [x] `:androidApp:testDebugUnitTest` passes (DI compiles)
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)