### PR TITLE
refactor: FakeNetworkButtonDataSource — call-list pattern (ADR-017 Rule 5)

### DIFF
--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeNetworkButtonDataSource.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeNetworkButtonDataSource.kt
@@ -6,19 +6,43 @@ import com.chriscartland.garage.data.NetworkResult
 /**
  * Fake [NetworkButtonDataSource] for unit testing.
  *
- * Configure responses with `setX()` methods. ADR-017 Rule 5.
+ * Configure responses with `setX()` methods. Tracks each call via `*Calls`
+ * lists (ADR-017 Rule 5 — call-list pattern), so tests can assert on the
+ * exact arguments passed (idTokens, ack tokens, snooze durations) without
+ * relying on call ordering. The `*Count` accessors are convenience reads
+ * backed by the lists.
  */
 class FakeNetworkButtonDataSource : NetworkButtonDataSource {
+    data class PushCall(
+        val remoteButtonBuildTimestamp: String,
+        val buttonAckToken: String,
+        val remoteButtonPushKey: String,
+        val idToken: String,
+    )
+
+    data class SnoozeCall(
+        val buildTimestamp: String,
+        val remoteButtonPushKey: String,
+        val idToken: String,
+        val snoozeDurationHours: String,
+        val snoozeEventTimestampSeconds: Long,
+    )
+
     private var pushResult: NetworkResult<Unit> = NetworkResult.Success(Unit)
     private var snoozeResult: NetworkResult<Unit> = NetworkResult.Success(Unit)
     private var fetchSnoozeResult: NetworkResult<Long> = NetworkResult.Success(0L)
 
-    var pushCount = 0
-        private set
-    var snoozeCount = 0
-        private set
-    var fetchSnoozeCount = 0
-        private set
+    private val _pushCalls = mutableListOf<PushCall>()
+    val pushCalls: List<PushCall> get() = _pushCalls
+    val pushCount: Int get() = _pushCalls.size
+
+    private val _snoozeCalls = mutableListOf<SnoozeCall>()
+    val snoozeCalls: List<SnoozeCall> get() = _snoozeCalls
+    val snoozeCount: Int get() = _snoozeCalls.size
+
+    private val _fetchSnoozeBuildTimestamps = mutableListOf<String>()
+    val fetchSnoozeBuildTimestamps: List<String> get() = _fetchSnoozeBuildTimestamps
+    val fetchSnoozeCount: Int get() = _fetchSnoozeBuildTimestamps.size
 
     fun setPushResult(value: NetworkResult<Unit>) {
         pushResult = value
@@ -38,7 +62,14 @@ class FakeNetworkButtonDataSource : NetworkButtonDataSource {
         remoteButtonPushKey: String,
         idToken: String,
     ): NetworkResult<Unit> {
-        pushCount++
+        _pushCalls.add(
+            PushCall(
+                remoteButtonBuildTimestamp = remoteButtonBuildTimestamp,
+                buttonAckToken = buttonAckToken,
+                remoteButtonPushKey = remoteButtonPushKey,
+                idToken = idToken,
+            ),
+        )
         return pushResult
     }
 
@@ -49,12 +80,20 @@ class FakeNetworkButtonDataSource : NetworkButtonDataSource {
         snoozeDurationHours: String,
         snoozeEventTimestampSeconds: Long,
     ): NetworkResult<Unit> {
-        snoozeCount++
+        _snoozeCalls.add(
+            SnoozeCall(
+                buildTimestamp = buildTimestamp,
+                remoteButtonPushKey = remoteButtonPushKey,
+                idToken = idToken,
+                snoozeDurationHours = snoozeDurationHours,
+                snoozeEventTimestampSeconds = snoozeEventTimestampSeconds,
+            ),
+        )
         return snoozeResult
     }
 
     override suspend fun fetchSnoozeEndTimeSeconds(buildTimestamp: String): NetworkResult<Long> {
-        fetchSnoozeCount++
+        _fetchSnoozeBuildTimestamps.add(buildTimestamp)
         return fetchSnoozeResult
     }
 }


### PR DESCRIPTION
## Summary
Opportunistic Rule 5 task #6: this fake's methods take 4-5 meaningful args each (tokens, timestamps, durations). Convert counters to backing call lists so future tests can assert on the exact arguments.

- `pushCalls: List<PushCall(remoteButtonBuildTimestamp, buttonAckToken, remoteButtonPushKey, idToken)>`
- `snoozeCalls: List<SnoozeCall(buildTimestamp, remoteButtonPushKey, idToken, snoozeDurationHours, snoozeEventTimestampSeconds)>`
- `fetchSnoozeBuildTimestamps: List<String>`
- `*Count` accessors backed by `.size` — no existing tests change

## Test plan
- [x] `:data:testDebugUnitTest` passes (no test changes needed)
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)