### PR TITLE
refactor: FakeAuthRepository — call-list pattern (ADR-017 Rule 5)

### DIFF
--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAuthRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAuthRepository.kt
@@ -26,17 +26,23 @@ import kotlinx.coroutines.flow.MutableStateFlow
 /**
  * Fake [AuthRepository] for unit testing.
  *
- * Configure responses with `setX()` methods. ADR-017 Rule 5.
+ * Configure responses with `setX()` methods. Tracks sign-in calls via
+ * `signInCalls` (ADR-017 Rule 5 — call-list pattern), so tests can assert on
+ * the exact `idToken` passed. `refresh` and `signOut` take no args, so they
+ * stay as plain counter accessors.
  */
 class FakeAuthRepository : AuthRepository {
     private val _authState = MutableStateFlow<AuthState>(AuthState.Unknown)
 
-    var signInCount = 0
-        private set
-    var signOutCount = 0
-        private set
-    var refreshCount = 0
-        private set
+    private val _signInCalls = mutableListOf<GoogleIdToken>()
+    val signInCalls: List<GoogleIdToken> get() = _signInCalls
+    val signInCount: Int get() = _signInCalls.size
+
+    private var _signOutCount: Int = 0
+    val signOutCount: Int get() = _signOutCount
+
+    private var _refreshCount: Int = 0
+    val refreshCount: Int get() = _refreshCount
 
     private var signInResult: AuthState? = null
     private var refreshResult: AuthState? = null
@@ -58,19 +64,19 @@ class FakeAuthRepository : AuthRepository {
     override fun observeAuthState(): Flow<AuthState> = _authState
 
     override suspend fun signInWithGoogle(idToken: GoogleIdToken): AuthState {
-        signInCount++
+        _signInCalls.add(idToken)
         val result = signInResult ?: _authState.value
         _authState.value = result
         return result
     }
 
     override suspend fun refreshFirebaseAuthState(): AuthState {
-        refreshCount++
+        _refreshCount++
         return refreshResult ?: _authState.value
     }
 
     override suspend fun signOut() {
-        signOutCount++
+        _signOutCount++
         _authState.value = AuthState.Unauthenticated
     }
 }


### PR DESCRIPTION
## Summary
Opportunistic Rule 5 task #6: `signInWithGoogle(idToken)` takes a meaningful arg. Convert counter to call list.

- `signInCalls: List<GoogleIdToken>`
- `signInCount` accessor backed by `.size` — existing tests unchanged
- `refreshCount` / `signOutCount` stay as plain counter accessors (no args)

## Test plan
- [x] `:usecase:testDebugUnitTest` passes
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)