### PR TITLE
refactor: FakeNetworkConfigDataSource — call-list pattern (ADR-017 Rule 5)

### DIFF
--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeNetworkConfigDataSource.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeNetworkConfigDataSource.kt
@@ -24,20 +24,24 @@ import com.chriscartland.garage.domain.model.ServerConfig
 /**
  * Fake [NetworkConfigDataSource] for unit testing.
  *
- * Configure responses with `setX()` methods. ADR-017 Rule 5.
+ * Configure responses with `setX()` methods. Tracks each call via
+ * `fetchServerConfigKeys` (ADR-017 Rule 5 — call-list pattern), so tests can
+ * assert on the exact `serverConfigKey` passed. The `fetchCount` accessor is
+ * a convenience read backed by the list.
  */
 class FakeNetworkConfigDataSource : NetworkConfigDataSource {
     private var serverConfigResult: NetworkResult<ServerConfig> = NetworkResult.ConnectionFailed
 
-    var fetchCount = 0
-        private set
+    private val _fetchServerConfigKeys = mutableListOf<String>()
+    val fetchServerConfigKeys: List<String> get() = _fetchServerConfigKeys
+    val fetchCount: Int get() = _fetchServerConfigKeys.size
 
     fun setServerConfigResult(value: NetworkResult<ServerConfig>) {
         serverConfigResult = value
     }
 
     override suspend fun fetchServerConfig(serverConfigKey: String): NetworkResult<ServerConfig> {
-        fetchCount++
+        _fetchServerConfigKeys.add(serverConfigKey)
         return serverConfigResult
     }
 }


### PR DESCRIPTION
## Summary
Opportunistic Rule 5 task #6: `fetchServerConfig(serverConfigKey)` takes an arg. Convert counter to call list.

- `fetchServerConfigKeys: List<String>`
- `fetchCount` backed by `.size` — no test changes

## Test plan
- [x] `:data:testDebugUnitTest` passes
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)