### PR TITLE
refactor: FakeDoorFcmRepository — call-list pattern (ADR-017 Rule 5)

### DIFF
--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeDoorFcmRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeDoorFcmRepository.kt
@@ -24,17 +24,20 @@ import com.chriscartland.garage.domain.repository.DoorFcmRepository
 /**
  * Fake [DoorFcmRepository] for unit testing.
  *
- * Configure responses with `setX()` methods. ADR-017 Rule 5.
+ * Configure responses with `setX()` methods. Tracks register calls via
+ * `registerCalls` (ADR-017 Rule 5 — call-list pattern). The `registerCount`
+ * and `lastRegisteredTopic` accessors are convenience reads backed by the
+ * list, so existing tests continue to work without changes.
  */
 class FakeDoorFcmRepository : DoorFcmRepository {
     private var fetchStatusResult: DoorFcmState = DoorFcmState.Unknown
     private var registerResult: DoorFcmState = DoorFcmState.NotRegistered
     private var deregisterResult: DoorFcmState = DoorFcmState.NotRegistered
 
-    var registerCount = 0
-        private set
-    var lastRegisteredTopic: DoorFcmTopic? = null
-        private set
+    private val _registerCalls = mutableListOf<DoorFcmTopic>()
+    val registerCalls: List<DoorFcmTopic> get() = _registerCalls
+    val registerCount: Int get() = _registerCalls.size
+    val lastRegisteredTopic: DoorFcmTopic? get() = _registerCalls.lastOrNull()
 
     fun setFetchStatusResult(value: DoorFcmState) {
         fetchStatusResult = value
@@ -51,8 +54,7 @@ class FakeDoorFcmRepository : DoorFcmRepository {
     override suspend fun fetchStatus(): DoorFcmState = fetchStatusResult
 
     override suspend fun registerDoor(fcmTopic: DoorFcmTopic): DoorFcmState {
-        registerCount++
-        lastRegisteredTopic = fcmTopic
+        _registerCalls.add(fcmTopic)
         return registerResult
     }
 


### PR DESCRIPTION
## Summary
Final opportunistic Rule 5 task #6 fake. `registerDoor(fcmTopic)` already had `lastRegisteredTopic` as a single-arg capture — convert to a list for uniformity with the other call-list fakes and to enable assertions on re-registration sequences.

- `registerCalls: List<DoorFcmTopic>` — full sequence
- `registerCount` and `lastRegisteredTopic` accessors backed by `.size` / `.lastOrNull()`
- Existing tests unchanged

After this PR, all fakes with meaningful method args use the call-list pattern. Remaining no-arg counters (FakeDoorRepository, InMemoryLocalDoorDataSource, FakeSnoozeRepository.fetchCount, FakeAuthRepository.refreshCount/signOutCount, FakeAuthBridge.refreshCount/signOutCount) stay as plain counter accessors per ADR-017 Rule 5 ("counter style — call-list preferred" applies when args are meaningful).

## Test plan
- [x] `:usecase:testDebugUnitTest` passes
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)