### PR TITLE
docs: ADR-017 fully complete — Rule 5 task #6 done, lint enforced

### DIFF
--- a/AndroidGarage/docs/DECISIONS.md
+++ b/AndroidGarage/docs/DECISIONS.md
@@ -643,12 +643,18 @@ These were tracked as separate follow-up PRs. The rules above apply immediately 
 2. Refactor `DoorViewModel` staleness ticker into `CheckInStalenessManager` (Rule 2 + ADR-015) — DONE (#299)
 3. Audit all ViewModels for `stateIn` usage; convert to explicit pattern (Rule 6) — DONE (#298)
 4. Add lint check banning `stateIn(viewModelScope, ...)` in ViewModel files (Rule 6 enforcement) — DONE (#300)
-5. Convert fakes with public `var` for results to `setX()` methods (Rule 5) — DONE (#301, #302, #303, #304, #305)
-6. Adopt call-list pattern for new fakes; migrate counter-style fakes opportunistically (Rule 5) — Ongoing
+5. Convert fakes with public `var` for results to `setX()` methods (Rule 5) — DONE (#301, #302, #303, #304, #305, #308)
+6. Adopt call-list pattern for new fakes; migrate counter-style fakes opportunistically (Rule 5) — DONE (#307, #309, #313, #314, #315, #316, #317, #318, #319, #320)
+
+### Enforcement
+
+- `ViewModelStateFlowCheckTask` (#300) bans `.stateIn(viewModelScope, ...)` in ViewModel files (Rule 6)
+- `FakePublicVarCheckTask` (#310, #313) bans public `var` and public mutable collections on `Fake*` classes (Rule 5)
 
 ### Consequences
 
 - One pattern per test concern — no "which style do I use" decisions for new code
-- The auth state UI bug (PR #295) is now a structural impossibility — Rule 6 enforced by `ViewModelStateFlowCheckTask` (PR #300)
+- The auth state UI bug (PR #295) is now a structural impossibility — Rule 6 enforced
 - Test code reads consistently across modules, easier to onboard
-- All mandatory migration tasks completed in 2026-04-16; only the opportunistic call-list migration remains
+- All migration tasks (mandatory + opportunistic) completed 2026-04-16
+- Every fake whose methods take meaningful args now exposes a `*Calls: List<…>` for argument assertions; counter-only fakes (no-arg methods) keep simple counter accessors


### PR DESCRIPTION
## Summary
Marks ADR-017 as fully complete:
- Task #5 (mandatory): all setX() conversions DONE — adds #308 to the list (the missed FakeDoorRepository.buildTimestamp).
- Task #6 (opportunistic): all fakes with meaningful method args now use call-list pattern. PRs #307, #309, #313–#320.

Adds an "Enforcement" section listing both lint checks:
- #300 `ViewModelStateFlowCheckTask` (Rule 6)
- #310/#313 `FakePublicVarCheckTask` (Rule 5)

## Test plan
- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)