### PR TITLE
refactor: Add observeAuthUser() to AuthBridge + getIdToken(forceRefresh) param

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/FirebaseAuthBridge.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/auth/FirebaseAuthBridge.kt
@@ -23,8 +23,12 @@ import com.chriscartland.garage.data.AuthUserInfo
 import com.chriscartland.garage.domain.model.FirebaseIdToken
 import com.chriscartland.garage.domain.model.GoogleIdToken
 import com.google.firebase.Firebase
+import com.google.firebase.auth.FirebaseAuth.AuthStateListener
 import com.google.firebase.auth.GoogleAuthProvider
 import com.google.firebase.auth.auth
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -36,6 +40,23 @@ import kotlin.coroutines.suspendCoroutine
  * never directly import Firebase types.
  */
 class FirebaseAuthBridge : AuthBridge {
+    override fun observeAuthUser(): Flow<AuthUserInfo?> =
+        callbackFlow {
+            val listener = AuthStateListener { auth ->
+                val user = auth.currentUser
+                trySend(
+                    user?.let {
+                        AuthUserInfo(
+                            displayName = it.displayName ?: "",
+                            email = it.email ?: "",
+                        )
+                    },
+                )
+            }
+            Firebase.auth.addAuthStateListener(listener)
+            awaitClose { Firebase.auth.removeAuthStateListener(listener) }
+        }
+
     override suspend fun signInWithGoogleToken(idToken: GoogleIdToken): Boolean =
         suspendCoroutine { continuation ->
             val credential = GoogleAuthProvider.getCredential(idToken.asString(), null)
@@ -59,13 +80,13 @@ class FirebaseAuthBridge : AuthBridge {
         )
     }
 
-    override suspend fun refreshIdToken(): FirebaseIdToken? {
+    override suspend fun getIdToken(forceRefresh: Boolean): FirebaseIdToken? {
         val currentUser = Firebase.auth.currentUser ?: return null
         return suspendCancellableCoroutine { continuation ->
             currentUser
-                .getIdToken(true)
+                .getIdToken(forceRefresh)
                 .addOnSuccessListener { result ->
-                    Logger.d { "Firebase ID Token refreshed" }
+                    Logger.d { "Firebase ID Token retrieved (forceRefresh=$forceRefresh)" }
                     continuation.resume(
                         result.token?.let {
                             FirebaseIdToken(

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/AuthBridge.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/AuthBridge.kt
@@ -2,6 +2,7 @@ package com.chriscartland.garage.data
 
 import com.chriscartland.garage.domain.model.FirebaseIdToken
 import com.chriscartland.garage.domain.model.GoogleIdToken
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Platform abstraction for authentication operations.
@@ -12,8 +13,23 @@ import com.chriscartland.garage.domain.model.GoogleIdToken
  *
  * Each method maps to a Firebase Auth SDK call but uses domain types
  * instead of Firebase types, keeping the interface platform-agnostic.
+ *
+ * The primary state source is [observeAuthUser] — a reactive Flow driven
+ * by the platform's auth state listener (e.g., Firebase AuthStateListener).
+ * Commands ([signInWithGoogleToken], [signOut]) trigger state changes that
+ * the listener picks up automatically.
  */
 interface AuthBridge {
+    /**
+     * Observe the currently authenticated user, or null when signed out.
+     *
+     * Emits immediately with the current state when collected, then on every
+     * auth state change (sign-in, sign-out, token refresh).
+     *
+     * Android: wraps FirebaseAuth.AuthStateListener via callbackFlow.
+     */
+    fun observeAuthUser(): Flow<AuthUserInfo?>
+
     /**
      * Sign in using a Google ID token.
      *
@@ -27,15 +43,26 @@ interface AuthBridge {
      * Get the current authenticated user's profile, or null if not signed in.
      *
      * Android: Firebase.auth.currentUser
+     *
+     * Prefer [observeAuthUser] for reactive observation. This method is retained
+     * for callers that need a one-shot snapshot during migration.
      */
     fun getCurrentUser(): AuthUserInfo?
 
     /**
-     * Force-refresh the auth token and return it, or null on failure.
+     * Return the current ID token, optionally forcing a network refresh.
      *
-     * Android: Firebase.auth.currentUser.getIdToken(true)
+     * [forceRefresh] = false: returns the cached token (no network call).
+     * Use this in the [observeAuthUser] collector — the token is already fresh
+     * after sign-in or automatic Firebase refresh.
+     *
+     * [forceRefresh] = true: forces a network round-trip to Firebase servers.
+     * Use this only when the cached token is known to be expired (e.g.,
+     * [EnsureFreshIdTokenUseCase] detects exp < now).
+     *
+     * Android: Firebase.auth.currentUser.getIdToken(forceRefresh)
      */
-    suspend fun refreshIdToken(): FirebaseIdToken?
+    suspend fun getIdToken(forceRefresh: Boolean = false): FirebaseIdToken?
 
     /**
      * Sign out the current user.

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepository.kt
@@ -66,7 +66,7 @@ class FirebaseAuthRepository(
             val userInfo = authBridge.getCurrentUser()
                 ?: return AuthState.Unauthenticated.commit()
 
-            val idToken = authBridge.refreshIdToken()
+            val idToken = authBridge.getIdToken(forceRefresh = true)
                 ?: return AuthState.Unauthenticated.commit()
 
             return AuthState

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepositoryTest.kt
@@ -66,8 +66,8 @@ class FirebaseAuthRepositoryTest {
     @Test
     fun refreshReturnsAuthenticatedWhenUserAndTokenExist() =
         runTest {
-            authBridge.setUserInfo(AuthUserInfo(displayName = "Test User", email = "test@test.com"))
-            authBridge.setRefreshTokenResult(FirebaseIdToken(idToken = "token-123", exp = Long.MAX_VALUE))
+            authBridge.setAuthUser(AuthUserInfo(displayName = "Test User", email = "test@test.com"))
+            authBridge.setIdTokenResult(FirebaseIdToken(idToken = "token-123", exp = Long.MAX_VALUE))
 
             val repo = createRepository()
             val result = repo.refreshFirebaseAuthState()
@@ -82,7 +82,7 @@ class FirebaseAuthRepositoryTest {
     @Test
     fun refreshReturnsUnauthenticatedWhenNoUser() =
         runTest {
-            authBridge.setUserInfo(null)
+            authBridge.setAuthUser(null)
 
             val repo = createRepository()
             val result = repo.refreshFirebaseAuthState()
@@ -93,8 +93,8 @@ class FirebaseAuthRepositoryTest {
     @Test
     fun refreshReturnsUnauthenticatedWhenTokenRefreshFails() =
         runTest {
-            authBridge.setUserInfo(AuthUserInfo(displayName = "Test", email = "test@test.com"))
-            authBridge.setRefreshTokenResult(null)
+            authBridge.setAuthUser(AuthUserInfo(displayName = "Test", email = "test@test.com"))
+            authBridge.setIdTokenResult(null)
 
             val repo = createRepository()
             val result = repo.refreshFirebaseAuthState()
@@ -108,8 +108,8 @@ class FirebaseAuthRepositoryTest {
     fun signInDelegatesAndRefreshes() =
         runTest {
             authBridge.setSignInResult(true)
-            authBridge.setUserInfo(AuthUserInfo(displayName = "Signed In", email = "user@test.com"))
-            authBridge.setRefreshTokenResult(FirebaseIdToken(idToken = "new-token", exp = Long.MAX_VALUE))
+            authBridge.setAuthUser(AuthUserInfo(displayName = "Signed In", email = "user@test.com"))
+            authBridge.setIdTokenResult(FirebaseIdToken(idToken = "new-token", exp = Long.MAX_VALUE))
 
             val repo = createRepository()
             val result = repo.signInWithGoogle(GoogleIdToken("google-token"))
@@ -124,8 +124,8 @@ class FirebaseAuthRepositoryTest {
     @Test
     fun signOutDelegatesToBridgeAndUpdatesState() =
         runTest {
-            authBridge.setUserInfo(AuthUserInfo(displayName = "Test", email = "test@test.com"))
-            authBridge.setRefreshTokenResult(FirebaseIdToken(idToken = "token", exp = Long.MAX_VALUE))
+            authBridge.setAuthUser(AuthUserInfo(displayName = "Test", email = "test@test.com"))
+            authBridge.setIdTokenResult(FirebaseIdToken(idToken = "token", exp = Long.MAX_VALUE))
 
             val repo = createRepository()
             repo.signOut()
@@ -140,14 +140,14 @@ class FirebaseAuthRepositoryTest {
     fun authStateUpdatesOnRefresh() =
         runTest {
             // Start with a signed-in user so init refresh produces Authenticated
-            authBridge.setUserInfo(AuthUserInfo(displayName = "User", email = "user@test.com"))
-            authBridge.setRefreshTokenResult(FirebaseIdToken(idToken = "token", exp = Long.MAX_VALUE))
+            authBridge.setAuthUser(AuthUserInfo(displayName = "User", email = "user@test.com"))
+            authBridge.setIdTokenResult(FirebaseIdToken(idToken = "token", exp = Long.MAX_VALUE))
 
             val repo = createRepository()
 
             // Change bridge to return different user
-            authBridge.setUserInfo(AuthUserInfo(displayName = "New User", email = "new@test.com"))
-            authBridge.setRefreshTokenResult(FirebaseIdToken(idToken = "fresh", exp = Long.MAX_VALUE))
+            authBridge.setAuthUser(AuthUserInfo(displayName = "New User", email = "new@test.com"))
+            authBridge.setIdTokenResult(FirebaseIdToken(idToken = "fresh", exp = Long.MAX_VALUE))
             repo.refreshFirebaseAuthState()
 
             val state = repo.getAuthState()

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAuthBridge.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAuthBridge.kt
@@ -21,26 +21,30 @@ import com.chriscartland.garage.data.AuthBridge
 import com.chriscartland.garage.data.AuthUserInfo
 import com.chriscartland.garage.domain.model.FirebaseIdToken
 import com.chriscartland.garage.domain.model.GoogleIdToken
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 
 /**
  * Fake [AuthBridge] for unit testing.
  *
  * Configure responses with `setX()` methods. Tracks each call via call lists
- * (ADR-017 Rule 5 — call-list pattern), so tests can assert on the exact
- * arguments passed (e.g., the `idToken` from sign-in attempts), not just call
- * counts. The `*Count` accessors are convenience reads backed by the lists.
+ * (ADR-017 Rule 5 — call-list pattern).
+ *
+ * [observeAuthUser] emits from a controllable [MutableStateFlow]. Set it via
+ * [setAuthUser] to simulate Firebase AuthStateListener events.
+ * [getIdToken] returns the value set by [setIdTokenResult].
  */
 class FakeAuthBridge : AuthBridge {
+    private val authUserFlow = MutableStateFlow<AuthUserInfo?>(null)
     private var signInResult: Boolean = true
-    private var userInfo: AuthUserInfo? = null
-    private var refreshTokenResult: FirebaseIdToken? = null
+    private var idTokenResult: FirebaseIdToken? = null
 
     private val _signInCalls = mutableListOf<GoogleIdToken>()
     val signInCalls: List<GoogleIdToken> get() = _signInCalls
     val signInCount: Int get() = _signInCalls.size
 
-    private var _refreshCount: Int = 0
-    val refreshCount: Int get() = _refreshCount
+    private var _getIdTokenCount: Int = 0
+    val getIdTokenCount: Int get() = _getIdTokenCount
 
     private var _signOutCount: Int = 0
     val signOutCount: Int get() = _signOutCount
@@ -49,28 +53,30 @@ class FakeAuthBridge : AuthBridge {
         signInResult = value
     }
 
-    fun setUserInfo(value: AuthUserInfo?) {
-        userInfo = value
+    fun setAuthUser(value: AuthUserInfo?) {
+        authUserFlow.value = value
     }
 
-    fun setRefreshTokenResult(value: FirebaseIdToken?) {
-        refreshTokenResult = value
+    fun setIdTokenResult(value: FirebaseIdToken?) {
+        idTokenResult = value
     }
+
+    override fun observeAuthUser(): Flow<AuthUserInfo?> = authUserFlow
 
     override suspend fun signInWithGoogleToken(idToken: GoogleIdToken): Boolean {
         _signInCalls.add(idToken)
         return signInResult
     }
 
-    override fun getCurrentUser(): AuthUserInfo? = userInfo
+    override fun getCurrentUser(): AuthUserInfo? = authUserFlow.value
 
-    override suspend fun refreshIdToken(): FirebaseIdToken? {
-        _refreshCount++
-        return refreshTokenResult
+    override suspend fun getIdToken(forceRefresh: Boolean): FirebaseIdToken? {
+        _getIdTokenCount++
+        return idTokenResult
     }
 
     override suspend fun signOut() {
         _signOutCount++
-        userInfo = null
+        authUserFlow.value = null
     }
 }


### PR DESCRIPTION
## Summary
Phase A, PR 1 of the reactive auth refactor (fixes auth state UI bug).

Extends `AuthBridge` with the reactive primitive that will power the bug fix in PR 2b:
- `observeAuthUser(): Flow<AuthUserInfo?>` — wraps Firebase `AuthStateListener` via `callbackFlow`
- `getIdToken(forceRefresh: Boolean)` replaces `refreshIdToken()` — `false` for cached (listener path), `true` for network refresh (token expiry path)
- `getCurrentUser()` kept temporarily for migration

Updates `FakeAuthBridge` with controllable `MutableStateFlow` + `setAuthUser()` / `setIdTokenResult()`.

## Why
The current `refreshIdToken()` always does `getIdToken(true)` (network call). After sign-in, this can fail → repo commits Unauthenticated → UI doesn't update. The reactive listener (PR 2b) will use `getIdToken(false)` — no network, no race.

## Test plan
- [x] `:data:testDebugUnitTest` passes (FirebaseAuthRepositoryTest updated)
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)