### PR TITLE
refactor: Add refreshIdToken() to AuthRepository, update EnsureFreshIdTokenUseCase

### DIFF
--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepository.kt
@@ -23,6 +23,7 @@ import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.DisplayName
 import com.chriscartland.garage.domain.model.Email
+import com.chriscartland.garage.domain.model.FirebaseIdToken
 import com.chriscartland.garage.domain.model.GoogleIdToken
 import com.chriscartland.garage.domain.model.User
 import com.chriscartland.garage.domain.repository.AppLoggerRepository
@@ -97,6 +98,18 @@ class FirebaseAuthRepository(
         return this.also {
             _authState.value = it
         }
+    }
+
+    override suspend fun refreshIdToken(): FirebaseIdToken? {
+        val token = authBridge.getIdToken(forceRefresh = true) ?: return null
+        // Update _authState so the UI stays in sync with the fresh token.
+        val current = _authState.value
+        if (current is AuthState.Authenticated) {
+            _authState.value = current.copy(
+                user = current.user.copy(idToken = token),
+            )
+        }
+        return token
     }
 
     override suspend fun signOut() {

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/AuthRepository.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/AuthRepository.kt
@@ -1,6 +1,7 @@
 package com.chriscartland.garage.domain.repository
 
 import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.FirebaseIdToken
 import com.chriscartland.garage.domain.model.GoogleIdToken
 import kotlinx.coroutines.flow.Flow
 
@@ -13,6 +14,18 @@ interface AuthRepository {
 
     suspend fun signInWithGoogle(idToken: GoogleIdToken): AuthState
 
+    /**
+     * Force-refresh the ID token via the auth provider and return it.
+     *
+     * Also updates [observeAuthState] with the new token so the UI stays
+     * in sync (avoids split-brain where the UseCase has a fresh token but
+     * the ViewModel's StateFlow still shows the old expiry).
+     *
+     * Returns null if refresh fails (e.g., user signed out, network error).
+     */
+    suspend fun refreshIdToken(): FirebaseIdToken?
+
+    @Deprecated("Use refreshIdToken() instead", ReplaceWith("refreshIdToken()"))
     suspend fun refreshFirebaseAuthState(): AuthState
 
     suspend fun signOut()

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAuthRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAuthRepository.kt
@@ -18,6 +18,7 @@
 package com.chriscartland.garage.testcommon
 
 import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.FirebaseIdToken
 import com.chriscartland.garage.domain.model.GoogleIdToken
 import com.chriscartland.garage.domain.repository.AuthRepository
 import kotlinx.coroutines.flow.Flow
@@ -27,9 +28,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
  * Fake [AuthRepository] for unit testing.
  *
  * Configure responses with `setX()` methods. Tracks sign-in calls via
- * `signInCalls` (ADR-017 Rule 5 — call-list pattern), so tests can assert on
- * the exact `idToken` passed. `refresh` and `signOut` take no args, so they
- * stay as plain counter accessors.
+ * `signInCalls` (ADR-017 Rule 5 — call-list pattern).
  */
 class FakeAuthRepository : AuthRepository {
     private val _authState = MutableStateFlow<AuthState>(AuthState.Unknown)
@@ -41,11 +40,16 @@ class FakeAuthRepository : AuthRepository {
     private var _signOutCount: Int = 0
     val signOutCount: Int get() = _signOutCount
 
-    private var _refreshCount: Int = 0
-    val refreshCount: Int get() = _refreshCount
+    private var _refreshIdTokenCount: Int = 0
+    val refreshIdTokenCount: Int get() = _refreshIdTokenCount
 
     private var signInResult: AuthState? = null
-    private var refreshResult: AuthState? = null
+    private var refreshIdTokenResult: FirebaseIdToken? = null
+
+    // Keep deprecated field for tests that still use refreshFirebaseAuthState
+    private var legacyRefreshCount: Int = 0
+    val refreshCount: Int get() = legacyRefreshCount
+    private var legacyRefreshResult: AuthState? = null
 
     fun setAuthState(state: AuthState) {
         _authState.value = state
@@ -55,8 +59,13 @@ class FakeAuthRepository : AuthRepository {
         signInResult = value
     }
 
+    fun setRefreshIdTokenResult(value: FirebaseIdToken?) {
+        refreshIdTokenResult = value
+    }
+
+    @Deprecated("Use setRefreshIdTokenResult instead")
     fun setRefreshResult(value: AuthState?) {
-        refreshResult = value
+        legacyRefreshResult = value
     }
 
     override suspend fun getAuthState(): AuthState = _authState.value
@@ -70,9 +79,15 @@ class FakeAuthRepository : AuthRepository {
         return result
     }
 
+    override suspend fun refreshIdToken(): FirebaseIdToken? {
+        _refreshIdTokenCount++
+        return refreshIdTokenResult
+    }
+
+    @Deprecated("Use refreshIdToken() instead")
     override suspend fun refreshFirebaseAuthState(): AuthState {
-        _refreshCount++
-        return refreshResult ?: _authState.value
+        legacyRefreshCount++
+        return legacyRefreshResult ?: _authState.value
     }
 
     override suspend fun signOut() {

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/EnsureFreshIdTokenUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/EnsureFreshIdTokenUseCase.kt
@@ -26,8 +26,11 @@ import com.chriscartland.garage.domain.repository.AuthRepository
  *
  * Logic:
  * - If the cached token is still valid (exp > now), return it
- * - Otherwise, refresh the auth state and return the new token
- * - If refresh fails (user becomes unauthenticated), fall back to the cached token
+ * - Otherwise, force-refresh the token via the auth provider
+ * - If refresh fails, fall back to the cached token (best-effort)
+ *
+ * The refresh also updates the repository's auth state so the UI stays
+ * in sync with the new token expiry (no split-brain).
  */
 class EnsureFreshIdTokenUseCase(
     private val authRepository: AuthRepository,
@@ -39,11 +42,6 @@ class EnsureFreshIdTokenUseCase(
         if (currentAuth.user.idToken.exp > currentTimeMillis) {
             currentAuth.user.idToken
         } else {
-            val refreshed = authRepository.refreshFirebaseAuthState()
-            if (refreshed is AuthState.Authenticated) {
-                refreshed.user.idToken
-            } else {
-                currentAuth.user.idToken
-            }
+            authRepository.refreshIdToken() ?: currentAuth.user.idToken
         }
 }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/EnsureFreshIdTokenUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/EnsureFreshIdTokenUseCaseTest.kt
@@ -57,57 +57,47 @@ class EnsureFreshIdTokenUseCaseTest {
             val result = useCase(auth, currentTimeMillis = 4999L)
 
             assertEquals("cached-token", result.asString())
-            assertEquals(0, fakeAuth.refreshCount)
+            assertEquals(0, fakeAuth.refreshIdTokenCount)
         }
 
     @Test
     fun refreshesTokenWhenExpired() =
         runTest {
             val auth = makeAuth(token = "old-token", exp = 1000L)
-            val refreshedAuth = makeAuth(token = "new-token", exp = 9000L)
-            fakeAuth.setRefreshResult(refreshedAuth)
+            fakeAuth.setRefreshIdTokenResult(
+                FirebaseIdToken(idToken = "new-token", exp = 9000L),
+            )
 
             val result = useCase(auth, currentTimeMillis = 2000L)
 
             assertEquals("new-token", result.asString())
-            assertEquals(1, fakeAuth.refreshCount)
+            assertEquals(1, fakeAuth.refreshIdTokenCount)
         }
 
     @Test
     fun refreshesTokenWhenExactlyExpired() =
         runTest {
             val auth = makeAuth(token = "old-token", exp = 1000L)
-            val refreshedAuth = makeAuth(token = "new-token", exp = 9000L)
-            fakeAuth.setRefreshResult(refreshedAuth)
+            fakeAuth.setRefreshIdTokenResult(
+                FirebaseIdToken(idToken = "new-token", exp = 9000L),
+            )
 
             val result = useCase(auth, currentTimeMillis = 1000L)
 
             assertEquals("new-token", result.asString())
-            assertEquals(1, fakeAuth.refreshCount)
+            assertEquals(1, fakeAuth.refreshIdTokenCount)
         }
 
     @Test
-    fun fallsBackToCachedTokenWhenRefreshFailsWithUnauthenticated() =
+    fun fallsBackToCachedTokenWhenRefreshReturnsNull() =
         runTest {
             val auth = makeAuth(token = "old-token", exp = 1000L)
-            fakeAuth.setRefreshResult(AuthState.Unauthenticated)
+            fakeAuth.setRefreshIdTokenResult(null)
 
             val result = useCase(auth, currentTimeMillis = 2000L)
 
             assertEquals("old-token", result.asString())
-            assertEquals(1, fakeAuth.refreshCount)
-        }
-
-    @Test
-    fun fallsBackToCachedTokenWhenRefreshFailsWithUnknown() =
-        runTest {
-            val auth = makeAuth(token = "old-token", exp = 1000L)
-            fakeAuth.setRefreshResult(AuthState.Unknown)
-
-            val result = useCase(auth, currentTimeMillis = 2000L)
-
-            assertEquals("old-token", result.asString())
-            assertEquals(1, fakeAuth.refreshCount)
+            assertEquals(1, fakeAuth.refreshIdTokenCount)
         }
 
     @Test
@@ -117,6 +107,6 @@ class EnsureFreshIdTokenUseCaseTest {
             val result = useCase(auth, currentTimeMillis = 1000L)
 
             assertEquals("cached-token", result.asString())
-            assertEquals(0, fakeAuth.refreshCount)
+            assertEquals(0, fakeAuth.refreshIdTokenCount)
         }
 }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/PushRemoteButtonUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/PushRemoteButtonUseCaseTest.kt
@@ -107,18 +107,13 @@ class PushRemoteButtonUseCaseTest {
     fun pushRefreshesExpiredToken() =
         runTest {
             authenticateUser(token = "old-token", exp = 1000L)
-            val refreshedAuth = AuthState.Authenticated(
-                user = User(
-                    name = DisplayName("Test"),
-                    email = Email("test@test.com"),
-                    idToken = FirebaseIdToken(idToken = "new-token", exp = Long.MAX_VALUE),
-                ),
+            fakeAuth.setRefreshIdTokenResult(
+                FirebaseIdToken(idToken = "new-token", exp = Long.MAX_VALUE),
             )
-            fakeAuth.setRefreshResult(refreshedAuth)
 
             useCase("ack-123")
 
             assertEquals("new-token", fakePush.lastIdToken)
-            assertEquals(1, fakeAuth.refreshCount)
+            assertEquals(1, fakeAuth.refreshIdTokenCount)
         }
 }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SnoozeNotificationsUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SnoozeNotificationsUseCaseTest.kt
@@ -103,24 +103,18 @@ class SnoozeNotificationsUseCaseTest {
             authenticateUser(exp = 1000L)
             useCase("1h", null)
             // MissingData error returned before token refresh
-            assertEquals(0, fakeAuth.refreshCount)
+            assertEquals(0, fakeAuth.refreshIdTokenCount)
         }
 
     @Test
     fun snoozeRefreshesExpiredToken() =
         runTest {
             authenticateUser(token = "old", exp = 1000L)
-            fakeAuth.setRefreshResult(
-                AuthState.Authenticated(
-                    user = User(
-                        name = DisplayName("Test"),
-                        email = Email("test@test.com"),
-                        idToken = FirebaseIdToken(idToken = "fresh", exp = Long.MAX_VALUE),
-                    ),
-                ),
+            fakeAuth.setRefreshIdTokenResult(
+                FirebaseIdToken(idToken = "fresh", exp = Long.MAX_VALUE),
             )
             useCase("4h", 2000L)
-            assertEquals(1, fakeAuth.refreshCount)
+            assertEquals(1, fakeAuth.refreshIdTokenCount)
         }
 
     @Test


### PR DESCRIPTION
## Summary
Phase A, PR 2a: Adds `refreshIdToken(): FirebaseIdToken?` to `AuthRepository`.

EnsureFreshIdTokenUseCase now calls `authRepository.refreshIdToken()` instead of the deprecated `refreshFirebaseAuthState()`. Key: after refresh, updates `_authState` with the new token so the UI stays in sync (no split-brain).

`refreshFirebaseAuthState()` is `@Deprecated` but kept for backwards compatibility — removed in PR 2b.

## Stacking
Stacked on PR #326. After #326 merges, change base to main.

## Test plan
- [x] `:usecase:testDebugUnitTest` and `:data:testDebugUnitTest` pass
- [x] `./scripts/validate.sh` passes
- [x] EnsureFreshIdTokenUseCaseTest, PushRemoteButtonUseCaseTest, SnoozeNotificationsUseCaseTest updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)