### PR TITLE
fix: Rewrite FirebaseAuthRepository to use reactive AuthStateListener

### DIFF
--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepository.kt
@@ -35,10 +35,16 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 /**
- * Auth repository that delegates all platform auth calls to [AuthBridge].
+ * Auth repository driven by the platform's auth state listener.
  *
- * No Firebase imports — all Firebase interaction happens through the bridge,
- * enabling unit testing with a fake bridge.
+ * State propagation is fully reactive:
+ * - [observeAuthUser][AuthBridge.observeAuthUser] emits whenever the platform
+ *   auth state changes (sign-in, sign-out, token refresh).
+ * - This collector maps each emission to [AuthState] and updates [_authState].
+ * - Commands ([signInWithGoogle], [signOut]) are fire-and-forget — the listener
+ *   picks up the resulting state change automatically.
+ *
+ * No Firebase imports — all platform interaction happens through [AuthBridge].
  */
 class FirebaseAuthRepository(
     private val authBridge: AuthBridge,
@@ -52,52 +58,44 @@ class FirebaseAuthRepository(
     override fun observeAuthState(): Flow<AuthState> = _authState.asStateFlow()
 
     init {
+        // Reactive: collect auth user changes from the platform listener.
+        // Firebase's AuthStateListener fires immediately when registered,
+        // so _authState transitions from Unknown → Authenticated/Unauthenticated
+        // within the first emission.
         externalScope.launch {
-            refreshFirebaseAuthState()
+            authBridge.observeAuthUser().collect { userInfo ->
+                val newState = if (userInfo != null) {
+                    val token = authBridge.getIdToken(forceRefresh = false)
+                    if (token != null) {
+                        AuthState.Authenticated(
+                            user = User(
+                                name = DisplayName(userInfo.displayName),
+                                email = Email(userInfo.email),
+                                idToken = token,
+                            ),
+                        )
+                    } else {
+                        // User exists but token unavailable — treat as unauthenticated.
+                        // This is defensive; Firebase should have a cached token after
+                        // AuthStateListener fires.
+                        Logger.w { "Auth user present but getIdToken returned null" }
+                        AuthState.Unauthenticated
+                    }
+                } else {
+                    AuthState.Unauthenticated
+                }
+                logStateChange(newState)
+                _authState.value = newState
+            }
         }
     }
 
     override suspend fun signInWithGoogle(idToken: GoogleIdToken): AuthState {
         authBridge.signInWithGoogleToken(idToken)
-        return refreshFirebaseAuthState()
-    }
-
-    override suspend fun refreshFirebaseAuthState(): AuthState {
-        try {
-            val userInfo = authBridge.getCurrentUser()
-                ?: return AuthState.Unauthenticated.commit()
-
-            val idToken = authBridge.getIdToken(forceRefresh = true)
-                ?: return AuthState.Unauthenticated.commit()
-
-            return AuthState
-                .Authenticated(
-                    user = User(
-                        name = DisplayName(userInfo.displayName),
-                        email = Email(userInfo.email),
-                        idToken = idToken,
-                    ),
-                ).commit()
-        } catch (e: Exception) {
-            return AuthState.Unauthenticated.commit()
-        }
-    }
-
-    private suspend fun AuthState.commit(): AuthState {
-        Logger.d { "AuthState.commit(): $this" }
-        when (this) {
-            is AuthState.Authenticated ->
-                appLogger.log(AppLoggerKeys.USER_AUTHENTICATED)
-
-            AuthState.Unauthenticated ->
-                appLogger.log(AppLoggerKeys.USER_UNAUTHENTICATED)
-
-            AuthState.Unknown ->
-                appLogger.log(AppLoggerKeys.USER_AUTH_UNKNOWN)
-        }
-        return this.also {
-            _authState.value = it
-        }
+        // State update happens reactively via the AuthStateListener collector.
+        // Return the current state (may still be pre-sign-in if the listener
+        // hasn't fired yet — callers should observe the Flow, not this return).
+        return _authState.value
     }
 
     override suspend fun refreshIdToken(): FirebaseIdToken? {
@@ -112,8 +110,30 @@ class FirebaseAuthRepository(
         return token
     }
 
+    @Deprecated("Use refreshIdToken() instead — this method is kept only for migration.")
+    override suspend fun refreshFirebaseAuthState(): AuthState {
+        // Delegate to the listener-based approach: just return current state.
+        // The reactive collector handles state updates.
+        return _authState.value
+    }
+
     override suspend fun signOut() {
-        AuthState.Unauthenticated.commit()
+        // Eagerly update UI before the bridge call — no visible delay.
+        _authState.value = AuthState.Unauthenticated
+        logStateChange(AuthState.Unauthenticated)
         authBridge.signOut()
+        // The AuthStateListener will also fire and confirm Unauthenticated.
+    }
+
+    private suspend fun logStateChange(state: AuthState) {
+        Logger.d { "AuthState: $state" }
+        when (state) {
+            is AuthState.Authenticated ->
+                appLogger.log(AppLoggerKeys.USER_AUTHENTICATED)
+            AuthState.Unauthenticated ->
+                appLogger.log(AppLoggerKeys.USER_UNAUTHENTICATED)
+            AuthState.Unknown ->
+                appLogger.log(AppLoggerKeys.USER_AUTH_UNKNOWN)
+        }
     }
 }

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepositoryTest.kt
@@ -23,135 +23,161 @@ import com.chriscartland.garage.domain.model.FirebaseIdToken
 import com.chriscartland.garage.domain.model.GoogleIdToken
 import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
 import com.chriscartland.garage.testcommon.FakeAuthBridge
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import kotlin.test.assertIs
+import kotlin.test.assertNull
 
+/**
+ * Tests for [FirebaseAuthRepository] with the reactive auth state listener.
+ *
+ * The repository collects from [FakeAuthBridge.observeAuthUser] (a MutableStateFlow)
+ * and maps each emission to [AuthState]. Tests verify the reactive chain by
+ * changing the bridge's auth user and observing the repository's auth state.
+ */
 @OptIn(ExperimentalCoroutinesApi::class)
 class FirebaseAuthRepositoryTest {
-    private val testDispatcher = StandardTestDispatcher()
-    private lateinit var authBridge: FakeAuthBridge
-    private lateinit var loggerRepo: FakeAppLoggerRepository
-
-    @BeforeTest
-    fun setup() {
-        Dispatchers.setMain(testDispatcher)
-        authBridge = FakeAuthBridge()
-        loggerRepo = FakeAppLoggerRepository()
+    private fun TestScope.createRepository(
+        authBridge: FakeAuthBridge = FakeAuthBridge(),
+        loggerRepo: FakeAppLoggerRepository = FakeAppLoggerRepository(),
+    ): Pair<FirebaseAuthRepository, FakeAuthBridge> {
+        val repo = FirebaseAuthRepository(authBridge, loggerRepo, backgroundScope)
+        return repo to authBridge
     }
 
-    @AfterTest
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    private fun createRepository(): FirebaseAuthRepository {
-        val testScope = CoroutineScope(testDispatcher)
-        val repo = FirebaseAuthRepository(authBridge, loggerRepo, testScope)
-        testDispatcher.scheduler.runCurrent()
-        return repo
-    }
-
-    // --- refreshFirebaseAuthState ---
+    // --- Reactive listener tests ---
 
     @Test
-    fun refreshReturnsAuthenticatedWhenUserAndTokenExist() =
-        runTest {
-            authBridge.setAuthUser(AuthUserInfo(displayName = "Test User", email = "test@test.com"))
-            authBridge.setIdTokenResult(FirebaseIdToken(idToken = "token-123", exp = Long.MAX_VALUE))
+    fun noUserEmitsUnauthenticated() =
+        runTest(UnconfinedTestDispatcher()) {
+            val (repo, _) = createRepository()
+            advanceUntilIdle()
 
-            val repo = createRepository()
-            val result = repo.refreshFirebaseAuthState()
-
-            assertTrue(result is AuthState.Authenticated)
-            val user = (result as AuthState.Authenticated).user
-            assertEquals("Test User", user.name.asString())
-            assertEquals("test@test.com", user.email.asString())
-            assertEquals("token-123", user.idToken.idToken)
+            assertEquals(AuthState.Unauthenticated, repo.observeAuthState().first())
         }
 
     @Test
-    fun refreshReturnsUnauthenticatedWhenNoUser() =
-        runTest {
-            authBridge.setAuthUser(null)
+    fun userWithTokenEmitsAuthenticated() =
+        runTest(UnconfinedTestDispatcher()) {
+            val bridge = FakeAuthBridge()
+            bridge.setAuthUser(AuthUserInfo(displayName = "Alice", email = "alice@test.com"))
+            bridge.setIdTokenResult(FirebaseIdToken(idToken = "token-123", exp = Long.MAX_VALUE))
 
-            val repo = createRepository()
-            val result = repo.refreshFirebaseAuthState()
+            val (repo, _) = createRepository(authBridge = bridge)
+            advanceUntilIdle()
 
-            assertEquals(AuthState.Unauthenticated, result)
+            val state = repo.observeAuthState().first()
+            assertIs<AuthState.Authenticated>(state)
+            assertEquals("Alice", state.user.name.asString())
+            assertEquals("token-123", state.user.idToken.idToken)
         }
 
     @Test
-    fun refreshReturnsUnauthenticatedWhenTokenRefreshFails() =
-        runTest {
-            authBridge.setAuthUser(AuthUserInfo(displayName = "Test", email = "test@test.com"))
-            authBridge.setIdTokenResult(null)
+    fun userWithoutTokenEmitsUnauthenticated() =
+        runTest(UnconfinedTestDispatcher()) {
+            val bridge = FakeAuthBridge()
+            bridge.setAuthUser(AuthUserInfo(displayName = "Bob", email = "bob@test.com"))
+            bridge.setIdTokenResult(null) // no token
 
-            val repo = createRepository()
-            val result = repo.refreshFirebaseAuthState()
+            val (repo, _) = createRepository(authBridge = bridge)
+            advanceUntilIdle()
 
-            assertEquals(AuthState.Unauthenticated, result)
+            assertEquals(AuthState.Unauthenticated, repo.observeAuthState().first())
+        }
+
+    @Test
+    fun authUserChangeUpdatesState() =
+        runTest(UnconfinedTestDispatcher()) {
+            val bridge = FakeAuthBridge()
+            val (repo, _) = createRepository(authBridge = bridge)
+            advanceUntilIdle()
+
+            // Initially no user → Unauthenticated
+            assertEquals(AuthState.Unauthenticated, repo.observeAuthState().first())
+
+            // User signs in (listener fires) — set token BEFORE user so the
+            // collector sees the token when it processes the user emission.
+            bridge.setIdTokenResult(FirebaseIdToken(idToken = "carol-token", exp = Long.MAX_VALUE))
+            bridge.setAuthUser(AuthUserInfo(displayName = "Carol", email = "carol@test.com"))
+            advanceUntilIdle()
+
+            val state = repo.observeAuthState().first()
+            assertIs<AuthState.Authenticated>(state)
+            assertEquals("Carol", state.user.name.asString())
+        }
+
+    @Test
+    fun signOutUpdatesStateImmediately() =
+        runTest(UnconfinedTestDispatcher()) {
+            val bridge = FakeAuthBridge()
+            bridge.setAuthUser(AuthUserInfo(displayName = "Dave", email = "dave@test.com"))
+            bridge.setIdTokenResult(FirebaseIdToken(idToken = "token", exp = Long.MAX_VALUE))
+
+            val (repo, _) = createRepository(authBridge = bridge)
+            advanceUntilIdle()
+            assertIs<AuthState.Authenticated>(repo.observeAuthState().first())
+
+            repo.signOut()
+
+            // Eagerly set to Unauthenticated — no waiting for listener
+            assertEquals(AuthState.Unauthenticated, repo.observeAuthState().first())
+            assertEquals(1, bridge.signOutCount)
         }
 
     // --- signInWithGoogle ---
 
     @Test
-    fun signInDelegatesAndRefreshes() =
-        runTest {
-            authBridge.setSignInResult(true)
-            authBridge.setAuthUser(AuthUserInfo(displayName = "Signed In", email = "user@test.com"))
-            authBridge.setIdTokenResult(FirebaseIdToken(idToken = "new-token", exp = Long.MAX_VALUE))
+    fun signInDelegatesToBridge() =
+        runTest(UnconfinedTestDispatcher()) {
+            val bridge = FakeAuthBridge()
+            bridge.setSignInResult(true)
+            bridge.setIdTokenResult(FirebaseIdToken(idToken = "token", exp = Long.MAX_VALUE))
 
-            val repo = createRepository()
-            val result = repo.signInWithGoogle(GoogleIdToken("google-token"))
+            val (repo, _) = createRepository(authBridge = bridge)
+            repo.signInWithGoogle(GoogleIdToken("google-token"))
 
-            assertEquals(1, authBridge.signInCount)
-            assertTrue(result is AuthState.Authenticated)
-            assertEquals("new-token", (result as AuthState.Authenticated).user.idToken.idToken)
+            assertEquals(1, bridge.signInCount)
+            assertEquals("google-token", bridge.signInCalls.first().asString())
         }
 
-    // --- signOut ---
+    // --- refreshIdToken ---
 
     @Test
-    fun signOutDelegatesToBridgeAndUpdatesState() =
-        runTest {
-            authBridge.setAuthUser(AuthUserInfo(displayName = "Test", email = "test@test.com"))
-            authBridge.setIdTokenResult(FirebaseIdToken(idToken = "token", exp = Long.MAX_VALUE))
+    fun refreshIdTokenReturnsTokenAndUpdatesState() =
+        runTest(UnconfinedTestDispatcher()) {
+            val bridge = FakeAuthBridge()
+            bridge.setAuthUser(AuthUserInfo(displayName = "Eve", email = "eve@test.com"))
+            bridge.setIdTokenResult(FirebaseIdToken(idToken = "old-token", exp = 1000L))
 
-            val repo = createRepository()
-            repo.signOut()
+            val (repo, _) = createRepository(authBridge = bridge)
+            advanceUntilIdle()
 
-            assertEquals(1, authBridge.signOutCount)
-            assertEquals(AuthState.Unauthenticated, repo.getAuthState())
+            // Now force-refresh returns a new token
+            bridge.setIdTokenResult(FirebaseIdToken(idToken = "fresh-token", exp = 9000L))
+            val refreshed = repo.refreshIdToken()
+
+            assertEquals("fresh-token", refreshed?.idToken)
+            // _authState should also be updated with the new token
+            val state = repo.observeAuthState().first()
+            assertIs<AuthState.Authenticated>(state)
+            assertEquals("fresh-token", state.user.idToken.idToken)
         }
 
-    // --- authState flow ---
-
     @Test
-    fun authStateUpdatesOnRefresh() =
-        runTest {
-            // Start with a signed-in user so init refresh produces Authenticated
-            authBridge.setAuthUser(AuthUserInfo(displayName = "User", email = "user@test.com"))
-            authBridge.setIdTokenResult(FirebaseIdToken(idToken = "token", exp = Long.MAX_VALUE))
+    fun refreshIdTokenReturnsNullWhenBridgeFails() =
+        runTest(UnconfinedTestDispatcher()) {
+            val bridge = FakeAuthBridge()
+            bridge.setIdTokenResult(null)
 
-            val repo = createRepository()
+            val (repo, _) = createRepository(authBridge = bridge)
+            advanceUntilIdle()
 
-            // Change bridge to return different user
-            authBridge.setAuthUser(AuthUserInfo(displayName = "New User", email = "new@test.com"))
-            authBridge.setIdTokenResult(FirebaseIdToken(idToken = "fresh", exp = Long.MAX_VALUE))
-            repo.refreshFirebaseAuthState()
-
-            val state = repo.getAuthState()
-            assertTrue(state is AuthState.Authenticated)
-            assertEquals("New User", (state as AuthState.Authenticated).user.name.asString())
+            assertNull(repo.refreshIdToken())
         }
 }


### PR DESCRIPTION
## Summary
**THE BUG FIX.** Phase A, PR 2b.

Replaces imperative `refreshFirebaseAuthState()` polling with reactive `observeAuthUser()` collection driven by Firebase's `AuthStateListener`.

### Root cause
After sign-in, `refreshFirebaseAuthState()` called `getIdToken(forceRefresh=true)` — a network call that could fail right after `signInWithCredential()` completed. The repo committed `Unauthenticated` even though sign-in succeeded. UI showed stale state until app kill.

### Fix
The repo now collects from `authBridge.observeAuthUser()`. The listener fires automatically after sign-in/sign-out, so:
- `signInWithGoogle()` is fire-and-forget (listener handles state update)
- `signOut()` eagerly sets `Unauthenticated` (no UX delay), then calls bridge
- `getIdToken(false)` in the collector uses cached token (no network race)

### Test changes
Rewrote `FirebaseAuthRepositoryTest` for reactive pattern:
- 8 tests verify bridge `setAuthUser()` emissions propagate to `repo.observeAuthState()`
- Uses `UnconfinedTestDispatcher` so Flow emissions process eagerly

## Stacking
Stacked on PR #327 → #326. After both merge, change base to main.

## Test plan
- [x] `:data:testDebugUnitTest --tests *FirebaseAuthRepositoryTest*` — 8/8 pass
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)