### PR TITLE
ui: Show door notification status on snooze card

### DIFF
--- a/AndroidGarage/android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/ComponentsScreenshotTest.kt
+++ b/AndroidGarage/android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/ComponentsScreenshotTest.kt
@@ -34,6 +34,7 @@ import com.chriscartland.garage.ui.RemoteButtonContentSucceededPreview
 import com.chriscartland.garage.ui.SnoozeNotificationCardClearedPreview
 import com.chriscartland.garage.ui.SnoozeNotificationCardErrorPreview
 import com.chriscartland.garage.ui.SnoozeNotificationCardLoadingPreview
+import com.chriscartland.garage.ui.SnoozeNotificationCardNotSnoozingPreview
 import com.chriscartland.garage.ui.SnoozeNotificationCardPreview
 import com.chriscartland.garage.ui.SnoozeNotificationCardSendingPreview
 import com.chriscartland.garage.ui.SnoozeNotificationCardSucceededPreview
@@ -260,6 +261,20 @@ fun SnoozeNotificationCardPreviewTest() {
 fun SnoozeNotificationCardLoadingPreviewTest() {
     AppTheme {
         SnoozeNotificationCardLoadingPreview()
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun SnoozeNotificationCardNotSnoozingPreviewTest() {
+    AppTheme {
+        SnoozeNotificationCardNotSnoozingPreview()
     }
 }
 

--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/SnoozeNotificationCardTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/SnoozeNotificationCardTest.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.chriscartland.garage.domain.model.SnoozeAction
+import com.chriscartland.garage.domain.model.SnoozeState
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Verifies that the snooze notification card displays the correct status
+ * and action text for each state combination.
+ *
+ * Status text (left side) always reflects the current server state.
+ * Action text (right side, under button) shows ephemeral feedback.
+ */
+class SnoozeNotificationCardTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    // --- Status text ---
+
+    @Test
+    fun loadingStateShowsDoorNotifications() {
+        composeTestRule.setContent {
+            SnoozeNotificationCard(
+                snoozeState = SnoozeState.Loading,
+                snoozeAction = SnoozeAction.Idle,
+            )
+        }
+        composeTestRule.onNodeWithText("Door notifications").assertIsDisplayed()
+    }
+
+    @Test
+    fun notSnoozingStateShowsEnabled() {
+        composeTestRule.setContent {
+            SnoozeNotificationCard(
+                snoozeState = SnoozeState.NotSnoozing,
+                snoozeAction = SnoozeAction.Idle,
+            )
+        }
+        composeTestRule.onNodeWithText("Door notifications enabled").assertIsDisplayed()
+    }
+
+    @Test
+    fun snoozingStateShowsSnoozedUntilTime() {
+        composeTestRule.setContent {
+            SnoozeNotificationCard(
+                snoozeState = SnoozeState.Snoozing(untilEpochSeconds = 999999999999L),
+                snoozeAction = SnoozeAction.Idle,
+            )
+        }
+        composeTestRule
+            .onNodeWithText("Door notifications snoozed until", substring = true)
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText("or until the door moves").assertIsDisplayed()
+    }
+
+    // --- Action overlay ---
+
+    @Test
+    fun idleActionShowsNoOverlay() {
+        composeTestRule.setContent {
+            SnoozeNotificationCard(
+                snoozeState = SnoozeState.NotSnoozing,
+                snoozeAction = SnoozeAction.Idle,
+            )
+        }
+        composeTestRule.onNodeWithText("Saving...").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Notifications resumed").assertDoesNotExist()
+    }
+
+    @Test
+    fun sendingActionShowsSaving() {
+        composeTestRule.setContent {
+            SnoozeNotificationCard(
+                snoozeState = SnoozeState.NotSnoozing,
+                snoozeAction = SnoozeAction.Sending,
+            )
+        }
+        composeTestRule.onNodeWithText("Saving...").assertIsDisplayed()
+    }
+
+    @Test
+    fun succeededClearedShowsNotificationsResumed() {
+        composeTestRule.setContent {
+            SnoozeNotificationCard(
+                snoozeState = SnoozeState.NotSnoozing,
+                snoozeAction = SnoozeAction.Succeeded.Cleared,
+            )
+        }
+        composeTestRule.onNodeWithText("Notifications resumed").assertIsDisplayed()
+    }
+
+    @Test
+    fun succeededSetShowsSavedMessage() {
+        composeTestRule.setContent {
+            SnoozeNotificationCard(
+                snoozeState = SnoozeState.Snoozing(untilEpochSeconds = 999999999999L),
+                snoozeAction = SnoozeAction.Succeeded.Set(untilEpochSeconds = 999999999999L),
+            )
+        }
+        composeTestRule
+            .onNodeWithText("Saved! Snoozing until", substring = true)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun failedNotAuthenticatedShowsSignInMessage() {
+        composeTestRule.setContent {
+            SnoozeNotificationCard(
+                snoozeState = SnoozeState.NotSnoozing,
+                snoozeAction = SnoozeAction.Failed.NotAuthenticated,
+            )
+        }
+        composeTestRule.onNodeWithText("Sign in to snooze notifications").assertIsDisplayed()
+    }
+
+    @Test
+    fun failedNetworkErrorShowsServerMessage() {
+        composeTestRule.setContent {
+            SnoozeNotificationCard(
+                snoozeState = SnoozeState.Snoozing(untilEpochSeconds = 999999999999L),
+                snoozeAction = SnoozeAction.Failed.NetworkError,
+            )
+        }
+        // Status text still shows snoozed (not overwritten by error)
+        composeTestRule
+            .onNodeWithText("Door notifications snoozed until", substring = true)
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText("Couldn't reach server").assertIsDisplayed()
+    }
+
+    @Test
+    fun failedMissingDataShowsMissingMessage() {
+        composeTestRule.setContent {
+            SnoozeNotificationCard(
+                snoozeState = SnoozeState.NotSnoozing,
+                snoozeAction = SnoozeAction.Failed.MissingData,
+            )
+        }
+        composeTestRule.onNodeWithText("No door event available").assertIsDisplayed()
+    }
+
+    // --- Button ---
+
+    @Test
+    fun snoozeButtonIsDisplayed() {
+        composeTestRule.setContent {
+            SnoozeNotificationCard(
+                snoozeState = SnoozeState.NotSnoozing,
+                snoozeAction = SnoozeAction.Idle,
+            )
+        }
+        composeTestRule.onNodeWithText("Snooze").assertIsDisplayed()
+    }
+}

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/SnoozeNotificationCard.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/SnoozeNotificationCard.kt
@@ -68,42 +68,44 @@ fun SnoozeNotificationCard(
                 modifier = Modifier
                     .height(IntrinsicSize.Min)
                     .padding(16.dp),
-                verticalAlignment = Alignment.CenterVertically,
+                verticalAlignment = Alignment.Top,
             ) {
                 Column(
                     modifier = Modifier
-                        .weight(1f)
-                        .align(Alignment.CenterVertically),
+                        .weight(1f),
                 ) {
                     SnoozeStatusText(snoozeState)
-                    SnoozeActionOverlay(snoozeAction)
                 }
                 Spacer(Modifier.width(16.dp))
-                if (snoozeAction is SnoozeAction.Sending) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(36.dp),
-                        strokeWidth = 3.dp,
-                    )
-                } else {
-                    Button(onClick = {
-                        if (showOptions) {
-                            selectedOption?.let {
-                                onSnooze(it)
-                                selectedOption = null
-                            }
-                        }
-                        showOptions = !showOptions
-                    }) {
-                        Text(
-                            if (showOptions) {
-                                if (selectedOption == null) "Cancel" else "Save"
-                            } else {
-                                "Snooze"
-                            },
-                            maxLines = 2,
-                            modifier = Modifier.align(Alignment.CenterVertically),
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    if (snoozeAction is SnoozeAction.Sending) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(36.dp),
+                            strokeWidth = 3.dp,
                         )
+                    } else {
+                        Button(onClick = {
+                            if (showOptions) {
+                                selectedOption?.let {
+                                    onSnooze(it)
+                                    selectedOption = null
+                                }
+                            }
+                            showOptions = !showOptions
+                        }) {
+                            Text(
+                                if (showOptions) {
+                                    if (selectedOption == null) "Cancel" else "Save"
+                                } else {
+                                    "Snooze"
+                                },
+                                maxLines = 2,
+                            )
+                        }
                     }
+                    SnoozeActionOverlay(snoozeAction)
                 }
             }
             if (showOptions) {
@@ -145,14 +147,15 @@ fun SnoozeNotificationCard(
 @Composable
 private fun SnoozeStatusText(snoozeState: SnoozeState) {
     when (snoozeState) {
-        SnoozeState.Loading,
-        SnoozeState.NotSnoozing,
-        -> {
-            Text("Snooze notifications")
+        SnoozeState.Loading -> {
+            Text("Door notifications")
+        }
+        SnoozeState.NotSnoozing -> {
+            Text("Door notifications enabled")
         }
         is SnoozeState.Snoozing -> {
             val snoozeTime = snoozeState.untilEpochSeconds.toFriendlyTimeShort()
-            Text("Snoozing notifications until $snoozeTime")
+            Text("Door notifications snoozed until $snoozeTime")
             Text(
                 text = "or until the door moves",
                 style = MaterialTheme.typography.labelSmall,
@@ -224,6 +227,15 @@ fun SnoozeNotificationCardPreview() {
 fun SnoozeNotificationCardLoadingPreview() {
     SnoozeNotificationCard(
         snoozeState = SnoozeState.Loading,
+        snoozeAction = SnoozeAction.Idle,
+    )
+}
+
+@Preview
+@Composable
+fun SnoozeNotificationCardNotSnoozingPreview() {
+    SnoozeNotificationCard(
+        snoozeState = SnoozeState.NotSnoozing,
         snoozeAction = SnoozeAction.Idle,
     )
 }


### PR DESCRIPTION
## Summary
- Snooze card now shows current notification status: "Door notifications enabled" or "Door notifications snoozed until <time>"
- Action feedback (Saving.../Saved!/Error) moved under the button (right side) to tie feedback to the action
- Added NotSnoozing preview for screenshot tests
- Added 10 Compose UI tests covering all SnoozeState + SnoozeAction combinations

## Test plan
- [ ] CI passes
- [ ] Manual: verify card text on device for enabled/snoozed states
- [ ] Manual: verify action feedback appears under button after snooze

🤖 Generated with [Claude Code](https://claude.com/claude-code)