### PR TITLE
docs: Add Android CHANGELOG, remove 2.4.1 from public whatsnew

### DIFF
--- a/AndroidGarage/CHANGELOG.md
+++ b/AndroidGarage/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Android Changelog
+
+Internal release history. For Play Store "What's New" text, see `distribution/whatsnew/`.
+
+## 2.4.1
+- Faster sign-in updates and improved stability
+- Fixed auth state not updating UI until app restart (reactive AuthStateListener)
+- Door notification card now shows current status (enabled/snoozed)
+
+## 2.4
+- Redesigned garage door button with confirmation flow and network status diagram
+- Improved color contrast for accessibility
+
+## 2.3
+- Improved architecture and performance
+
+## 2.2
+- New colors and design
+
+## 2.1
+- Snooze garage notifications when the door is open
+- Snooze applies to all users for the current door position
+
+## 2.0
+- Brand new app built with Jetpack Compose

--- a/AndroidGarage/distribution/whatsnew/whatsnew-en-US
+++ b/AndroidGarage/distribution/whatsnew/whatsnew-en-US
@@ -1,4 +1,3 @@
-2.4.1: Faster sign-in updates and improved stability.
 2.4: Redesigned garage door button with confirmation flow and network status diagram. Improved color contrast for accessibility.
 2.3: Improved architecture and performance.
 2.2: New colors and design!


### PR DESCRIPTION
## Summary
- Create `AndroidGarage/CHANGELOG.md` for internal release history with detailed notes per version
- Remove 2.4.1 entry from `distribution/whatsnew/whatsnew-en-US` (Play Store public text keeps only major versions)

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)