### PR TITLE
chore: Add 2.4.2 changelog, bump version

### DIFF
--- a/AndroidGarage/CHANGELOG.md
+++ b/AndroidGarage/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Internal release history. For Play Store "What's New" text, see `distribution/whatsnew/`.
 
+## 2.4.2
+- Snooze card shows "Door notifications enabled" / "Door notifications snoozed until X"
+- Action feedback (Saved/Error) aligned under button
+- Improved card layout alignment
+
 ## 2.4.1
 - Faster sign-in updates and improved stability
 - Fixed auth state not updating UI until app restart (reactive AuthStateListener)

--- a/AndroidGarage/version.properties
+++ b/AndroidGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.4.1
+versionName=2.4.2


### PR DESCRIPTION
## Summary
- Add 2.4.2 entry to `AndroidGarage/CHANGELOG.md` (snooze card status text + alignment)
- Bump `versionName` from 2.4.1 to 2.4.2

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)