### PR TITLE
chore: Add changelog and version bump skills

### DIFF
--- a/.claude/skills/bump-android-version/SKILL.md
+++ b/.claude/skills/bump-android-version/SKILL.md
@@ -1,0 +1,50 @@
+---
+description: Increment the Android versionName in version.properties. Default patch, supports minor and major.
+allowed-tools: Bash(*), Read, Edit
+user-invocable: true
+---
+
+# Bump Android Version
+
+Increment `versionName` in `AndroidGarage/version.properties` and create a PR.
+
+## Arguments
+
+- `patch` (default) — 2.4.1 → 2.4.2
+- `minor` — 2.4.1 → 2.5.0
+- `major` — 2.4.1 → 3.0.0
+
+If no argument is provided, default to `patch`.
+
+## Steps
+
+### 1. Read current version
+
+```bash
+cat AndroidGarage/version.properties
+```
+
+Parse the `versionName=X.Y.Z` value.
+
+### 2. Compute next version
+
+Apply the increment type to the current version:
+- **patch**: increment Z, keep X.Y
+- **minor**: increment Y, reset Z to 0, keep X
+- **major**: increment X, reset Y and Z to 0
+
+### 3. Update version.properties
+
+Write the new version to the file.
+
+### 4. Create PR
+
+- Branch: `chore/bump-version-X.Y.Z`
+- Commit: `chore: Bump versionName to X.Y.Z`
+- Create PR with `--base main` and enable auto-merge
+
+## Rules
+
+- Only modify `AndroidGarage/version.properties` — nothing else
+- Do not update the changelog (use `/update-android-changelog` for that)
+- Confirm the version bump with the user before creating the PR

--- a/.claude/skills/update-android-changelog/SKILL.md
+++ b/.claude/skills/update-android-changelog/SKILL.md
@@ -1,0 +1,51 @@
+---
+description: Add a changelog entry for the current Android version based on recent commits.
+allowed-tools: Bash(*), Read, Edit, Write, Grep, Glob
+user-invocable: true
+---
+
+# Update Android Changelog
+
+Add an entry to `AndroidGarage/CHANGELOG.md` for the current version based on recent changes.
+
+## Steps
+
+### 1. Read current version and changelog
+
+```bash
+cat AndroidGarage/version.properties
+```
+
+Read `AndroidGarage/CHANGELOG.md` to see existing entries and format.
+
+### 2. Find changes since last release
+
+```bash
+# Latest released tag
+git tag -l 'android/*' --sort=-version:refname | head -1
+
+# Commits since that tag
+git log android/N..HEAD --oneline
+```
+
+### 3. Draft changelog entry
+
+Summarize the user-facing changes (not internal refactors or CI fixes). Group by category if there are many changes. Match the style of existing entries — short bullet points, no commit hashes.
+
+Present the draft to the user for review before writing.
+
+### 4. Write the entry
+
+Add the new version section at the top of the changelog (after the header), above the previous version entry.
+
+### 5. Create PR
+
+Create a branch, commit, push, and create a PR with auto-merge.
+
+## Rules
+
+- Only include user-facing changes — skip CI, docs, refactoring, test-only PRs
+- Match the existing changelog style (short bullets, no jargon)
+- The version number comes from `version.properties`, not from the user
+- If the version already has a changelog entry, update it rather than duplicating
+- If args are provided, use them as the changelog content instead of inferring from commits


### PR DESCRIPTION
## Summary
- `/update-android-changelog` — adds a changelog entry for the current version based on recent commits
- `/bump-android-version` — increments versionName (default patch, supports `minor` and `major`)

Typical workflow: `/update-android-changelog` → `/release-android` → `/bump-android-version`

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)