### PR TITLE
fix: Fetch snooze status on ViewModel init

### DIFF
--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
@@ -83,6 +83,8 @@ class DefaultRemoteButtonViewModel(
         viewModelScope.launch(dispatchers.io) {
             observeSnoozeStateUseCase().collect { _snoozeState.value = it }
         }
+        // Trigger initial fetch so state moves from Loading immediately.
+        fetchSnoozeStatus()
     }
 
     private fun listenToDoorEvent() {

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModelTest.kt
@@ -215,15 +215,21 @@ class RemoteButtonViewModelTest {
         }
 
     @Test
+    fun initFetchesSnoozeStatus() {
+        createViewModel()
+        assertEquals(1, snoozeRepository.fetchCount)
+    }
+
+    @Test
     fun fetchSnoozeStatusCallsThroughToRepository() =
         runTest {
             val viewModel = createViewModel()
-            assertEquals(0, snoozeRepository.fetchCount)
+            assertEquals(1, snoozeRepository.fetchCount) // 1 from init
 
             viewModel.fetchSnoozeStatus()
             testDispatcher.scheduler.runCurrent()
 
-            assertEquals(1, snoozeRepository.fetchCount)
+            assertEquals(2, snoozeRepository.fetchCount)
         }
 
     @Test


### PR DESCRIPTION
## Summary
- SnoozeState was stuck on `Loading` because the ViewModel never triggered the initial fetch
- The only fetch came from a `LaunchedEffect` in `ProfileContent` (60s polling), so the card showed "Door notifications" (Loading text) instead of "Door notifications enabled"
- Same class of bug as the auth state issue (ADR-018): state must be populated eagerly, not rely on UI-layer polling
- Added `initFetchesSnoozeStatus` test, updated existing fetch count assertion

## Test plan
- [ ] CI passes
- [ ] Manual: verify "Door notifications enabled" shows immediately on Profile tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)