### PR TITLE
fix: Apply 15-minute threshold when snooze is expired

### DIFF
--- a/FirebaseServer/src/controller/fcm/OldDataFCM.ts
+++ b/FirebaseServer/src/controller/fcm/OldDataFCM.ts
@@ -104,9 +104,8 @@ async function shouldSendFcmForOpenDoor(buildTimestamp: string, currentEvent: Se
       console.info('shouldSendFcmForOpenDoor: Snooze request is active, do not send a notification');
       return false;
     } else if (snoozeStatus.status === SnoozeStatus.EXPIRED) {
-      // Snooze request is expired. Send a notification.
-      console.info('shouldSendFcmForOpenDoor: Snooze request is expired, send a notification');
-      return true;
+      // Snooze request is expired. Fall through to the duration threshold check.
+      console.info('shouldSendFcmForOpenDoor: Snooze request is expired, check if the event is too old');
     } else { // SnoozeStatus.NONE
       // Fall back to checking if the event is too old.
       console.info('shouldSendFcmForOpenDoor: No snooze request, check if the event is too old');

--- a/FirebaseServer/test/controller/fcm/OldDataFCMTest.ts
+++ b/FirebaseServer/test/controller/fcm/OldDataFCMTest.ts
@@ -207,4 +207,40 @@ describe('getDoorNotClosedMessageFromEvent', () => {
         expect(actual).to.not.be.null;
         expect(actual).to.not.be.empty;
     });
+    it('returns body with 20 minutes for open door after 20 minutes', () => {
+        const buildTimestamp = 'Sat Mar 13 14:45:00 2021';
+        const currentEvent = <SensorEvent>{
+            type: SensorEventType.Open,
+            timestampSeconds: 1725781091,
+            message: "Test message",
+            checkInTimestampSeconds: 1725781092,
+        };
+        const now = 1725781091 + 20 * 60;
+        const message: TopicMessage = getDoorNotClosedMessageFromEvent(buildTimestamp, currentEvent, now);
+        expect(message.notification.body).to.equal('Open for more than 20 minutes');
+    });
+    it('returns body with 0 minutes for open door after 0 seconds', () => {
+        const buildTimestamp = 'Sat Mar 13 14:45:00 2021';
+        const currentEvent = <SensorEvent>{
+            type: SensorEventType.Open,
+            timestampSeconds: 1725781091,
+            message: "Test message",
+            checkInTimestampSeconds: 1725781092,
+        };
+        const now = 1725781091; // Same time as event — 0 seconds elapsed
+        const message: TopicMessage = getDoorNotClosedMessageFromEvent(buildTimestamp, currentEvent, now);
+        expect(message.notification.body).to.equal('Open for more than 0 minutes');
+    });
+    it('returns body with 1 hours for open door after 90 minutes', () => {
+        const buildTimestamp = 'Sat Mar 13 14:45:00 2021';
+        const currentEvent = <SensorEvent>{
+            type: SensorEventType.Open,
+            timestampSeconds: 1725781091,
+            message: "Test message",
+            checkInTimestampSeconds: 1725781092,
+        };
+        const now = 1725781091 + 90 * 60;
+        const message: TopicMessage = getDoorNotClosedMessageFromEvent(buildTimestamp, currentEvent, now);
+        expect(message.notification.body).to.equal('Open for more than 1 hours');
+    });
 });


### PR DESCRIPTION
## Summary
- `shouldSendFcmForOpenDoor()` bypassed the 15-minute minimum open-door threshold when snooze status was `EXPIRED`, sending notifications like "Open for more than 0 minutes"
- Now `EXPIRED` falls through to the same duration check as `NONE`
- Added 3 tests for notification body duration strings (0 min, 20 min, 90 min)

## Root cause
When a user clears snooze ("Do not snooze" = 0h), the server sets `snoozeEndTime = now`, which immediately becomes `EXPIRED`. The `EXPIRED` path unconditionally returned `true`, skipping the 15-minute threshold that the `NONE` path correctly applies.

## Test plan
- [ ] Server CI passes (`npm run tests` — 68 tests)
- [ ] Manual: clear snooze while door open < 15 min → no notification
- [ ] Manual: clear snooze while door open > 15 min → notification with correct duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)