### PR TITLE
docs: Add 2.4.2 snooze-init fix to changelog

### DIFF
--- a/AndroidGarage/CHANGELOG.md
+++ b/AndroidGarage/CHANGELOG.md
@@ -4,6 +4,7 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 ## 2.4.2
 - Snooze card shows "Door notifications enabled" / "Door notifications snoozed until X"
+- Snooze status loads immediately instead of showing "Loading"
 - Action feedback (Saved/Error) aligned under button
 - Improved card layout alignment
 


### PR DESCRIPTION
## Summary

Updates the 2.4.2 changelog entry to include PR #341's user-facing effect: snooze status now loads immediately instead of showing "Loading" until the first 60s poll.

## Why

PR #339 bumped the version to 2.4.2 and wrote the initial 2.4.2 changelog, but PR #341 (snooze-init fix) landed after. Per the update-android-changelog skill rule, I updated the existing 2.4.2 section rather than creating a new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)