### PR TITLE
fix: Use mutex.withLock in CachedServerConfigRepository (prevent deadlock)

### DIFF
--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepository.kt
@@ -22,6 +22,7 @@ import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.domain.model.ServerConfig
 import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 class CachedServerConfigRepository(
     private val networkConfigDataSource: NetworkConfigDataSource,
@@ -32,13 +33,11 @@ class CachedServerConfigRepository(
     private val mutex: Mutex = Mutex()
 
     override suspend fun getServerConfigCached(): ServerConfig? {
-        if (serverConfig != null) {
-            return serverConfig
-        }
-        mutex.lock()
-        val result = serverConfig ?: fetchServerConfig()
-        mutex.unlock()
-        return result
+        serverConfig?.let { return it }
+        // withLock guarantees unlock on any exit path including cancellation.
+        // The bare lock()/unlock() form leaked the mutex on any exception from
+        // fetchServerConfig(), permanently blocking every future caller.
+        return mutex.withLock { serverConfig ?: fetchServerConfig() }
     }
 
     override suspend fun fetchServerConfig(): ServerConfig? {

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepositoryTest.kt
@@ -17,14 +17,17 @@
 
 package com.chriscartland.garage.data.repository
 
+import com.chriscartland.garage.data.NetworkConfigDataSource
 import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.domain.model.ServerConfig
 import com.chriscartland.garage.testcommon.FakeNetworkConfigDataSource
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.fail
 
 /**
  * Integration tests for [CachedServerConfigRepository] with fake network data source.
@@ -129,6 +132,42 @@ class CachedServerConfigRepositoryTest {
             assertEquals(config2, repo.getServerConfigCached())
             // 3 fetches: initial getServerConfigCached, fetchServerConfig, getServerConfigCached (cached)
             assertEquals(2, configDataSource.fetchCount)
+        }
+
+    @Test
+    fun mutexReleasedAfterFetchThrowsSoSubsequentCallsDoNotDeadlock() =
+        runTest {
+            val validConfig = ServerConfig(
+                buildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+                remoteButtonPushKey = "key",
+            )
+            val throwingDataSource = object : NetworkConfigDataSource {
+                var throwNext = true
+
+                override suspend fun fetchServerConfig(serverConfigKey: String): NetworkResult<ServerConfig> {
+                    if (throwNext) {
+                        throwNext = false
+                        throw RuntimeException("simulated transient error")
+                    }
+                    return NetworkResult.Success(validConfig)
+                }
+            }
+            val repo = CachedServerConfigRepository(throwingDataSource, "key")
+
+            // First call throws. Before the fix, the bare mutex.lock() + unlock()
+            // pair leaked the mutex on exception, permanently blocking every
+            // future caller.
+            try {
+                repo.getServerConfigCached()
+                fail("Expected exception was not thrown")
+            } catch (_: RuntimeException) {
+                // expected
+            }
+
+            // Second call must return — if the mutex is leaked, this hangs.
+            val result = withTimeout(1_000) { repo.getServerConfigCached() }
+            assertEquals(validConfig, result)
         }
 
     @Test


### PR DESCRIPTION
## Summary
- `CachedServerConfigRepository.getServerConfigCached()` used a bare `mutex.lock()` / `mutex.unlock()` pair with no `try/finally`. If `fetchServerConfig()` ever throws (transient network error, cancellation, serialization bug, etc.) the `unlock()` is skipped and the mutex stays locked for the entire process lifetime. Every subsequent caller then blocks forever on `mutex.lock()`.
- `withLock { ... }` guarantees the mutex is released on all exit paths including exceptions and cancellation.

Latent bug — surfaced during the investigation of the snooze "stuck Loading" issue (#344 fixes the primary user-visible symptom; this one is a follow-up to remove the risk of a related permanent hang).

## Test plan
- [x] Added `mutexReleasedAfterFetchThrowsSoSubsequentCallsDoNotDeadlock` — proves a retry after a throwing fetch returns within 1s instead of hanging.
- [x] All 7 existing `CachedServerConfigRepositoryTest` cases still pass.
- [x] `./scripts/validate.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)