### PR TITLE
chore: Bump versionName to 2.4.3

### DIFF
--- a/AndroidGarage/version.properties
+++ b/AndroidGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.4.2
+versionName=2.4.3


### PR DESCRIPTION
## Summary
- Patch bump from 2.4.2 → 2.4.3.
- Covers the snooze fixes landing today (#344 stuck-Loading, #345 mutex-withLock, #346 post-submit state refresh).

## Test plan
- [x] `AndroidGarage/version.properties` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)