### PR TITLE
docs: Add 2.4.3 changelog entry

### DIFF
--- a/AndroidGarage/CHANGELOG.md
+++ b/AndroidGarage/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Internal release history. For Play Store "What's New" text, see `distribution/whatsnew/`.
 
+## 2.4.3
+- Snooze card updates to "snoozed until X" immediately after saving (no app restart needed)
+
 ## 2.4.2
 - Snooze card shows "Door notifications enabled" / "Door notifications snoozed until X"
 - Snooze status loads immediately instead of showing "Loading"


### PR DESCRIPTION
## Summary
- Adds changelog entry for 2.4.3 covering the snooze state refresh fix (#346).

## Merge order
- Stacks with #347 (version bump to 2.4.3) — either order is fine since the files are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)