### PR TITLE
fix: Update snooze state directly from POST response (no follow-up GET)

### DIFF
--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/NetworkButtonDataSource.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/NetworkButtonDataSource.kt
@@ -13,13 +13,18 @@ interface NetworkButtonDataSource {
         idToken: String,
     ): NetworkResult<Unit>
 
+    /**
+     * Submits a snooze request. On success, returns the authoritative
+     * `snoozeEndTimeSeconds` from the server response so callers can update
+     * state without a follow-up GET.
+     */
     suspend fun snoozeNotifications(
         buildTimestamp: String,
         remoteButtonPushKey: String,
         idToken: String,
         snoozeDurationHours: String,
         snoozeEventTimestampSeconds: Long,
-    ): NetworkResult<Unit>
+    ): NetworkResult<Long>
 
     suspend fun fetchSnoozeEndTimeSeconds(buildTimestamp: String): NetworkResult<Long>
 }

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/ktor/KtorNetworkButtonDataSource.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/ktor/KtorNetworkButtonDataSource.kt
@@ -65,7 +65,7 @@ class KtorNetworkButtonDataSource(
         idToken: String,
         snoozeDurationHours: String,
         snoozeEventTimestampSeconds: Long,
-    ): NetworkResult<Unit> {
+    ): NetworkResult<Long> {
         return try {
             val response = client.post("snoozeNotificationsRequest") {
                 parameter("buildTimestamp", buildTimestamp)
@@ -78,12 +78,16 @@ class KtorNetworkButtonDataSource(
             if (!response.status.isSuccess()) {
                 return NetworkResult.HttpError(response.status.value)
             }
-            val body = response.body<KtorSnoozeResponse>()
+            // Server returns the SnoozeRequest object directly (see
+            // FirebaseServer/src/functions/http/Snooze.ts — it sends the
+            // snooze, not a wrapper). The authoritative end time is here.
+            val body = response.body<KtorSnoozeSubmitResponse>()
             if (body.error != null) {
                 Logger.e { "Snooze error: ${body.error}" }
                 return NetworkResult.HttpError(response.status.value)
             }
-            NetworkResult.Success(Unit)
+            val endTime = body.snoozeEndTimeSeconds ?: 0L
+            NetworkResult.Success(endTime)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
@@ -117,8 +121,14 @@ class KtorNetworkButtonDataSource(
 
 // region Serializable response types
 
+/**
+ * Server response for POST /snoozeNotificationsRequest. The server sends the
+ * `SnoozeRequest` object at the top level (not nested under `snooze`), so
+ * `snoozeEndTimeSeconds` is a direct field here.
+ */
 @Serializable
-private data class KtorSnoozeResponse(
+private data class KtorSnoozeSubmitResponse(
+    val snoozeEndTimeSeconds: Long? = null,
     val error: String? = null,
 )
 

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepository.kt
@@ -68,17 +68,11 @@ class NetworkSnoozeRepository(
         snoozeDurationHours: String,
         idToken: String,
         snoozeEventTimestampSeconds: Long,
-    ): Boolean {
-        val success = externalScope
+    ): Boolean =
+        externalScope
             .async {
                 doSnoozeNotifications(snoozeDurationHours, idToken, snoozeEventTimestampSeconds)
             }.await()
-        if (success) {
-            // Refresh from real server data — no optimistic local write.
-            externalScope.launch { doFetchSnoozeStatus() }
-        }
-        return success
-    }
 
     private suspend fun doFetchSnoozeStatus() {
         val serverConfig = serverConfigRepository.getServerConfigCached()
@@ -136,7 +130,13 @@ class NetworkSnoozeRepository(
                 snoozeEventTimestampSeconds = snoozeEventTimestampSeconds,
             )
         ) {
-            is NetworkResult.Success -> true
+            is NetworkResult.Success -> {
+                // Write state directly from the server's POST response — the
+                // authoritative snoozeEndTimeSeconds is already in hand, no
+                // follow-up GET needed.
+                snoozeStateFlow.value = snoozeStateFromEndTime(result.data)
+                true
+            }
             is NetworkResult.HttpError -> {
                 Logger.e { "Snooze HTTP ${result.code}" }
                 false

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepositoryTest.kt
@@ -154,15 +154,16 @@ class NetworkSnoozeRepositoryTest {
         }
 
     @Test
-    fun successfulSubmitTriggersFetchUpdatingStateFromRealServerResponse() =
+    fun successfulSubmitUpdatesStateFromPostResponse() =
         runTest {
-            // After submit succeeds, the server flips the snooze to an active
-            // window. The next fetch must return that new end time and update
-            // the singleton state — no optimistic local write in the repo.
+            // The server returns the snoozeEndTimeSeconds in the POST response
+            // body. The repo writes state directly from it — no follow-up GET
+            // needed (authoritative data is already in hand).
             val now = 1000L
             val submittedSnoozeEnd = 5000L
             val buttonDs = FakeNetworkButtonDataSource().apply {
                 setFetchSnoozeResult(NetworkResult.Success(0L)) // initial: no snooze
+                setSnoozeResult(NetworkResult.Success(submittedSnoozeEnd)) // POST returns end time
             }
             val configDs = FakeNetworkConfigDataSource().apply { setServerConfigResult(validConfig) }
             val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
@@ -177,9 +178,6 @@ class NetworkSnoozeRepositoryTest {
             advanceUntilIdle()
             assertEquals(SnoozeState.NotSnoozing, repo.observeSnoozeState().first())
 
-            // Simulate server: after submit the GET returns the new snooze end.
-            buttonDs.setFetchSnoozeResult(NetworkResult.Success(submittedSnoozeEnd))
-
             val submitted = repo.snoozeNotifications(
                 snoozeDurationHours = "1h",
                 idToken = "t",
@@ -188,11 +186,9 @@ class NetworkSnoozeRepositoryTest {
             advanceUntilIdle()
 
             assertEquals(true, submitted)
-            // State reflects the server's GET response, not any client-side
-            // optimistic computation.
             assertEquals(SnoozeState.Snoozing(submittedSnoozeEnd), repo.observeSnoozeState().first())
-            // submit POST + post-submit GET = 1 submit + 2 fetches (init + post-submit).
-            assertEquals(2, buttonDs.fetchSnoozeCount)
+            // Only the init fetch runs — no follow-up GET after the POST.
+            assertEquals(1, buttonDs.fetchSnoozeCount)
             assertEquals(1, buttonDs.snoozeCount)
 
             externalScope.cancel()
@@ -202,12 +198,13 @@ class NetworkSnoozeRepositoryTest {
     fun callerCancellationDuringSubmitDoesNotStrandState() =
         runTest {
             // The VM scope calls snoozeNotifications then is cancelled. The
-            // submit runs on externalScope and completes; the post-submit
-            // fetch updates state even though the VM's await threw.
+            // submit runs on externalScope and writes state from the POST
+            // response even though the VM's await threw.
             val now = 1000L
             val snoozeEnd = 5000L
             val buttonDs = FakeNetworkButtonDataSource().apply {
-                setFetchSnoozeResult(NetworkResult.Success(snoozeEnd))
+                setFetchSnoozeResult(NetworkResult.Success(0L))
+                setSnoozeResult(NetworkResult.Success(snoozeEnd))
             }
             val configDs = FakeNetworkConfigDataSource().apply { setServerConfigResult(validConfig) }
             val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
@@ -276,7 +273,7 @@ class NetworkSnoozeRepositoryTest {
         }
 
     @Test
-    fun failedSubmitDoesNotTriggerExtraFetch() =
+    fun failedSubmitDoesNotTouchState() =
         runTest {
             val buttonDs = FakeNetworkButtonDataSource().apply {
                 setFetchSnoozeResult(NetworkResult.Success(0L))
@@ -293,14 +290,12 @@ class NetworkSnoozeRepositoryTest {
                 externalScope = externalScope,
             )
             advanceUntilIdle()
-            val fetchesAfterInit = buttonDs.fetchSnoozeCount
 
             val submitted = repo.snoozeNotifications("1h", "t", 0L)
             advanceUntilIdle()
 
             assertEquals(false, submitted)
-            // No post-submit fetch on failure — the state is untouched.
-            assertEquals(fetchesAfterInit, buttonDs.fetchSnoozeCount)
+            assertEquals(SnoozeState.NotSnoozing, repo.observeSnoozeState().first())
 
             externalScope.cancel()
         }

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeNetworkButtonDataSource.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeNetworkButtonDataSource.kt
@@ -29,7 +29,7 @@ class FakeNetworkButtonDataSource : NetworkButtonDataSource {
     )
 
     private var pushResult: NetworkResult<Unit> = NetworkResult.Success(Unit)
-    private var snoozeResult: NetworkResult<Unit> = NetworkResult.Success(Unit)
+    private var snoozeResult: NetworkResult<Long> = NetworkResult.Success(0L)
     private var fetchSnoozeResult: NetworkResult<Long> = NetworkResult.Success(0L)
 
     private val _pushCalls = mutableListOf<PushCall>()
@@ -48,7 +48,7 @@ class FakeNetworkButtonDataSource : NetworkButtonDataSource {
         pushResult = value
     }
 
-    fun setSnoozeResult(value: NetworkResult<Unit>) {
+    fun setSnoozeResult(value: NetworkResult<Long>) {
         snoozeResult = value
     }
 
@@ -79,7 +79,7 @@ class FakeNetworkButtonDataSource : NetworkButtonDataSource {
         idToken: String,
         snoozeDurationHours: String,
         snoozeEventTimestampSeconds: Long,
-    ): NetworkResult<Unit> {
+    ): NetworkResult<Long> {
         _snoozeCalls.add(
             SnoozeCall(
                 buildTimestamp = buildTimestamp,

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
@@ -162,7 +162,8 @@ class DefaultRemoteButtonViewModel(
                         val optimisticEnd = System.currentTimeMillis() / 1000 + durationSeconds
                         SnoozeAction.Succeeded.Set(optimisticEnd)
                     }
-                    fetchSnoozeStatusUseCase()
+                    // The repo writes the authoritative snoozeState from the
+                    // POST response itself — no follow-up fetch needed.
                     scheduleActionReset()
                 }
                 is AppResult.Error -> {


### PR DESCRIPTION
## Summary
The server's `POST /snoozeNotificationsRequest` endpoint returns the `SnoozeRequest` in the response body (see `FirebaseServer/src/functions/http/Snooze.ts:156`). That's authoritative data — `snoozeEndTimeSeconds` is already in the client's hands the moment the POST succeeds. The previous design threw it away and relied on a follow-up GET, which wasn't reliable in production (the user confirmed the UI still never updated after saving).

Now the Android client uses the POST response directly.

## Changes
- `NetworkButtonDataSource.snoozeNotifications`: return type `NetworkResult<Unit>` → `NetworkResult<Long>` (the `snoozeEndTimeSeconds`).
- `KtorNetworkButtonDataSource`: parses the snooze at the JSON top level (the server sends the `SnoozeRequest` directly, not wrapped).
- `NetworkSnoozeRepository`: on successful submit, writes `snoozeStateFromEndTime(result.data)` to the flow immediately. No follow-up GET.
- `RemoteButtonViewModel`: drops the redundant `fetchSnoozeStatusUseCase()` call after a successful submit — the repo already wrote the authoritative state.
- `FakeNetworkButtonDataSource`: `setSnoozeResult` accepts `NetworkResult<Long>`.

## Not optimistic
This is real server data. The client doesn't guess an end time — it uses the end time the server reports in the response. The previous "optimistic" overlay text in the VM (`SnoozeAction.Succeeded.Set(optimisticEnd)`) is unchanged; it's a short-lived action feedback, not state. The card title is now driven purely by the server's POST response.

## Test plan
- [x] `successfulSubmitUpdatesStateFromPostResponse` — proves the POST response drives the state with no follow-up GET.
- [x] `callerCancellationDuringSubmitDoesNotStrandState` — still passes with the new pattern (submit runs on externalScope, state writes happen before the caller's await resumes).
- [x] `fetchSnoozeStatusWritesToFlowEvenWhenCallerCancels` — polling path unchanged.
- [x] `failedSubmitDoesNotTouchState` — repo doesn't mutate state on HTTP error.
- [x] 9 `NetworkSnoozeRepositoryTest` tests + 6 `SnoozeStateFlowPropagationTest` + all `RemoteButtonViewModelTest` cases pass.
- [x] `./scripts/validate.sh` passes.
- [ ] Manual verification on device: save a snooze, card title updates immediately to "Door notifications snoozed until X" without needing an app restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)