### PR TITLE
docs: Add TODOs on SnoozeRepository for future refinements

### DIFF
--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/SnoozeRepository.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/SnoozeRepository.kt
@@ -18,6 +18,18 @@ interface SnoozeRepository {
     /**
      * Send a snooze request. Returns true on success, false on any failure
      * (server config missing, HTTP error, connection failure).
+     *
+     * TODO: return [com.chriscartland.garage.domain.model.AppResult]
+     * `<Unit, ActionError>` instead of `Boolean`. Boolean collapses
+     * NotAuthenticated / MissingData / NetworkFailed into one signal; the
+     * UseCase above it already discriminates via AppResult and the UI shows
+     * different messages per case. Surfacing ActionError here lets the
+     * repository carry that signal end-to-end without reconstruction.
+     *
+     * TODO: replace [snoozeDurationHours]: String with a domain value type
+     * (e.g. SnoozeDurationServerOption). The "0h".."12h" encoding is
+     * stringly-typed and repeats the validation from the server; a sealed
+     * enum would make invalid durations impossible at the call site.
      */
     suspend fun snoozeNotifications(
         snoozeDurationHours: String,


### PR DESCRIPTION
## Summary
Inline TODOs at `SnoozeRepository.snoozeNotifications` capturing two follow-up refinements noted during the snooze bug hunt:

1. **Return type**: `Boolean` → `AppResult<Unit, ActionError>`. Boolean collapses `NotAuthenticated` / `MissingData` / `NetworkFailed` into one signal; the UseCase above it already discriminates via `AppResult` and the UI shows different messages per case. Keeping `Boolean` at the repository boundary means the signal is reconstructed rather than carried end-to-end.
2. **Stringly-typed duration**: `snoozeDurationHours: String` → a domain value type (sealed enum). The `"0h"`..`"12h"` encoding repeats server validation and lets invalid inputs pass the type system.

Documentation-only — no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)