### PR TITLE
fix: SnoozeRepository returns AppResult<SnoozeState, ActionError> + direct VM write

### DIFF
--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepository.kt
@@ -20,6 +20,8 @@ package com.chriscartland.garage.data.repository
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.NetworkButtonDataSource
 import com.chriscartland.garage.data.NetworkResult
+import com.chriscartland.garage.domain.model.ActionError
+import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.SnoozeState
 import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import com.chriscartland.garage.domain.repository.SnoozeRepository
@@ -68,7 +70,7 @@ class NetworkSnoozeRepository(
         snoozeDurationHours: String,
         idToken: String,
         snoozeEventTimestampSeconds: Long,
-    ): Boolean =
+    ): AppResult<SnoozeState, ActionError> =
         externalScope
             .async {
                 doSnoozeNotifications(snoozeDurationHours, idToken, snoozeEventTimestampSeconds)
@@ -110,16 +112,18 @@ class NetworkSnoozeRepository(
         snoozeDurationHours: String,
         idToken: String,
         snoozeEventTimestampSeconds: Long,
-    ): Boolean {
+    ): AppResult<SnoozeState, ActionError> {
         val serverConfig = serverConfigRepository.getServerConfigCached()
         if (serverConfig == null) {
             Logger.e { "Server config is null" }
-            return false
+            return AppResult.Error(ActionError.NetworkFailed)
         }
         if (!snoozeNotificationsOption) {
             Logger.w { "Snooze notifications disabled" }
             delay(500)
-            return true // Treat as success in feature-disabled mode
+            // Feature disabled: pretend it succeeded and surface the current
+            // flow value so callers don't see a phantom network failure.
+            return AppResult.Success(snoozeStateFlow.value)
         }
         return when (
             val result = networkButtonDataSource.snoozeNotifications(
@@ -131,19 +135,21 @@ class NetworkSnoozeRepository(
             )
         ) {
             is NetworkResult.Success -> {
-                // Write state directly from the server's POST response — the
-                // authoritative snoozeEndTimeSeconds is already in hand, no
-                // follow-up GET needed.
-                snoozeStateFlow.value = snoozeStateFromEndTime(result.data)
-                true
+                // Compute the new state from the server's authoritative end
+                // time, write it to the observable flow, and return the SAME
+                // value. Callers can use the return value directly (no
+                // observer race) or subscribe via observeSnoozeState().
+                val newState = snoozeStateFromEndTime(result.data)
+                snoozeStateFlow.value = newState
+                AppResult.Success(newState)
             }
             is NetworkResult.HttpError -> {
                 Logger.e { "Snooze HTTP ${result.code}" }
-                false
+                AppResult.Error(ActionError.NetworkFailed)
             }
             NetworkResult.ConnectionFailed -> {
                 Logger.e { "Snooze connection failed" }
-                false
+                AppResult.Error(ActionError.NetworkFailed)
             }
         }
     }

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepositoryTest.kt
@@ -11,6 +11,7 @@
 package com.chriscartland.garage.data.repository
 
 import com.chriscartland.garage.data.NetworkResult
+import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.ServerConfig
 import com.chriscartland.garage.domain.model.SnoozeState
 import com.chriscartland.garage.testcommon.FakeNetworkButtonDataSource
@@ -28,6 +29,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Protects against the android/164 "stuck Loading" bug.
@@ -185,7 +187,12 @@ class NetworkSnoozeRepositoryTest {
             )
             advanceUntilIdle()
 
-            assertEquals(true, submitted)
+            assertTrue(submitted is AppResult.Success, "Should succeed")
+            assertEquals(
+                SnoozeState.Snoozing(submittedSnoozeEnd),
+                (submitted as AppResult.Success).data,
+            )
+            // Return value matches the flow value — repo writes both.
             assertEquals(SnoozeState.Snoozing(submittedSnoozeEnd), repo.observeSnoozeState().first())
             // Only the init fetch runs — no follow-up GET after the POST.
             assertEquals(1, buttonDs.fetchSnoozeCount)
@@ -294,7 +301,7 @@ class NetworkSnoozeRepositoryTest {
             val submitted = repo.snoozeNotifications("1h", "t", 0L)
             advanceUntilIdle()
 
-            assertEquals(false, submitted)
+            assertTrue(submitted is AppResult.Error, "Should surface the network failure")
             assertEquals(SnoozeState.NotSnoozing, repo.observeSnoozeState().first())
 
             externalScope.cancel()

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/SnoozeRepository.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/SnoozeRepository.kt
@@ -1,5 +1,7 @@
 package com.chriscartland.garage.domain.repository
 
+import com.chriscartland.garage.domain.model.ActionError
+import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.SnoozeState
 import kotlinx.coroutines.flow.Flow
 
@@ -16,15 +18,16 @@ interface SnoozeRepository {
     suspend fun fetchSnoozeStatus()
 
     /**
-     * Send a snooze request. Returns true on success, false on any failure
-     * (server config missing, HTTP error, connection failure).
+     * Send a snooze request. On success returns the new [SnoozeState]
+     * computed from the server's authoritative response — the same value
+     * is simultaneously written to the flow exposed by [observeSnoozeState].
      *
-     * TODO: return [com.chriscartland.garage.domain.model.AppResult]
-     * `<Unit, ActionError>` instead of `Boolean`. Boolean collapses
-     * NotAuthenticated / MissingData / NetworkFailed into one signal; the
-     * UseCase above it already discriminates via AppResult and the UI shows
-     * different messages per case. Surfacing ActionError here lets the
-     * repository carry that signal end-to-end without reconstruction.
+     * Callers can use the returned state directly (no observer race) or
+     * rely on [observeSnoozeState] for broader reactivity.
+     *
+     * Returns [AppResult.Error] with [ActionError.NetworkFailed] on any
+     * network-layer failure. Auth/input errors (NotAuthenticated,
+     * MissingData) are not produced here — they're the UseCase's concern.
      *
      * TODO: replace [snoozeDurationHours]: String with a domain value type
      * (e.g. SnoozeDurationServerOption). The "0h".."12h" encoding is
@@ -35,5 +38,5 @@ interface SnoozeRepository {
         snoozeDurationHours: String,
         idToken: String,
         snoozeEventTimestampSeconds: Long,
-    ): Boolean
+    ): AppResult<SnoozeState, ActionError>
 }

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeSnoozeRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeSnoozeRepository.kt
@@ -1,5 +1,7 @@
 package com.chriscartland.garage.testcommon
 
+import com.chriscartland.garage.domain.model.ActionError
+import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.SnoozeState
 import com.chriscartland.garage.domain.repository.SnoozeRepository
 import kotlinx.coroutines.flow.Flow
@@ -12,6 +14,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
  * `snoozeCalls` (ADR-017 Rule 5 — call-list pattern), so tests can assert on
  * the exact duration / token / timestamp passed. `fetchSnoozeStatus` takes no
  * args so it stays as a plain counter accessor.
+ *
+ * Mirrors production: on a configured successful result, writes the result
+ * value to the observable flow AND returns it, so tests can assert on either
+ * the return path or the observer path.
  */
 class FakeSnoozeRepository : SnoozeRepository {
     data class SnoozeCall(
@@ -29,14 +35,15 @@ class FakeSnoozeRepository : SnoozeRepository {
     private var _fetchCount: Int = 0
     val fetchCount: Int get() = _fetchCount
 
-    /** Set this to false to make snoozeNotifications() return false (network failure). */
-    private var snoozeResult: Boolean = true
+    /** Controls what snoozeNotifications() returns. Default: success with NotSnoozing. */
+    private var snoozeResult: AppResult<SnoozeState, ActionError> =
+        AppResult.Success(SnoozeState.NotSnoozing)
 
     fun setSnoozeState(state: SnoozeState) {
         snoozeStateFlow.value = state
     }
 
-    fun setSnoozeResult(value: Boolean) {
+    fun setSnoozeResult(value: AppResult<SnoozeState, ActionError>) {
         snoozeResult = value
     }
 
@@ -50,7 +57,7 @@ class FakeSnoozeRepository : SnoozeRepository {
         snoozeDurationHours: String,
         idToken: String,
         snoozeEventTimestampSeconds: Long,
-    ): Boolean {
+    ): AppResult<SnoozeState, ActionError> {
         _snoozeCalls.add(
             SnoozeCall(
                 snoozeDurationHours = snoozeDurationHours,
@@ -58,6 +65,11 @@ class FakeSnoozeRepository : SnoozeRepository {
                 snoozeEventTimestampSeconds = snoozeEventTimestampSeconds,
             ),
         )
+        // Mirror the production repo: on success, propagate the result value
+        // to the observable flow so observers see it too.
+        if (snoozeResult is AppResult.Success) {
+            snoozeStateFlow.value = (snoozeResult as AppResult.Success<SnoozeState>).data
+        }
         return snoozeResult
     }
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
@@ -154,16 +154,18 @@ class DefaultRemoteButtonViewModel(
                 )
             ) {
                 is AppResult.Success -> {
-                    _snoozeAction.value = if (snoozeDuration == SnoozeDurationUIOption.None) {
-                        SnoozeAction.Succeeded.Cleared
-                    } else {
-                        // Compute optimistic snooze end time from duration.
-                        val durationSeconds = snoozeDuration.duration.inWholeSeconds
-                        val optimisticEnd = System.currentTimeMillis() / 1000 + durationSeconds
-                        SnoozeAction.Succeeded.Set(optimisticEnd)
+                    // The repo returned the authoritative SnoozeState computed
+                    // from the server's response. Use it directly for both the
+                    // action overlay AND the observable _snoozeState — direct
+                    // write bypasses any fragility in the observer chain so
+                    // the UI updates immediately regardless of flow plumbing.
+                    val newState = result.data
+                    _snoozeState.value = newState
+                    _snoozeAction.value = when (newState) {
+                        is SnoozeState.Snoozing -> SnoozeAction.Succeeded.Set(newState.untilEpochSeconds)
+                        SnoozeState.NotSnoozing -> SnoozeAction.Succeeded.Cleared
+                        SnoozeState.Loading -> SnoozeAction.Succeeded.Cleared
                     }
-                    // The repo writes the authoritative snoozeState from the
-                    // POST response itself — no follow-up fetch needed.
                     scheduleActionReset()
                 }
                 is AppResult.Error -> {

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SnoozeNotificationsUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SnoozeNotificationsUseCase.kt
@@ -20,14 +20,21 @@ package com.chriscartland.garage.usecase
 import com.chriscartland.garage.domain.model.ActionError
 import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.SnoozeState
 import com.chriscartland.garage.domain.repository.AuthRepository
 import com.chriscartland.garage.domain.repository.SnoozeRepository
 
 /**
  * Snoozes open-door notifications for a specified duration.
  *
- * Returns [AppResult] so callers can handle [ActionError.NotAuthenticated]
- * and [ActionError.MissingData] explicitly with exhaustive `when`.
+ * On success returns the server-authoritative [SnoozeState]. Callers can
+ * surface this directly in the UI (action overlay, card title) without
+ * waiting for the flow observer to forward it.
+ *
+ * Error cases:
+ * - [ActionError.NotAuthenticated] — user not signed in.
+ * - [ActionError.MissingData] — no current door event timestamp available.
+ * - [ActionError.NetworkFailed] — repository reported a network failure.
  */
 class SnoozeNotificationsUseCase(
     private val ensureFreshIdToken: EnsureFreshIdTokenUseCase,
@@ -37,7 +44,7 @@ class SnoozeNotificationsUseCase(
     suspend operator fun invoke(
         snoozeDurationHours: String,
         lastChangeTimeSeconds: Long?,
-    ): AppResult<Unit, ActionError> {
+    ): AppResult<SnoozeState, ActionError> {
         val authState = authRepository.getAuthState()
         if (authState !is AuthState.Authenticated) {
             return AppResult.Error(ActionError.NotAuthenticated)
@@ -46,15 +53,10 @@ class SnoozeNotificationsUseCase(
             return AppResult.Error(ActionError.MissingData)
         }
         val idToken = ensureFreshIdToken(authState)
-        val success = snoozeRepository.snoozeNotifications(
+        return snoozeRepository.snoozeNotifications(
             snoozeDurationHours = snoozeDurationHours,
             idToken = idToken.asString(),
             snoozeEventTimestampSeconds = lastChangeTimeSeconds,
         )
-        return if (success) {
-            AppResult.Success(Unit)
-        } else {
-            AppResult.Error(ActionError.NetworkFailed)
-        }
     }
 }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModelTest.kt
@@ -17,6 +17,8 @@
 
 package com.chriscartland.garage.usecase
 
+import com.chriscartland.garage.domain.model.ActionError
+import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.DisplayName
 import com.chriscartland.garage.domain.model.DoorEvent
@@ -288,7 +290,7 @@ class RemoteButtonViewModelTest {
         runTest {
             val viewModel = createAuthenticatedViewModel()
             doorRepository.setCurrentDoorEvent(DoorEvent(lastChangeTimeSeconds = 1000L))
-            snoozeRepository.setSnoozeResult(false)
+            snoozeRepository.setSnoozeResult(AppResult.Error(ActionError.NetworkFailed))
             testDispatcher.scheduler.runCurrent()
 
             viewModel.snoozeOpenDoorsNotifications(SnoozeDurationUIOption.OneHour)

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SharedRepositoryUseCasesTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SharedRepositoryUseCasesTest.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.data.NetworkResult
+import com.chriscartland.garage.data.repository.CachedServerConfigRepository
+import com.chriscartland.garage.data.repository.NetworkSnoozeRepository
+import com.chriscartland.garage.domain.model.AppResult
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.DisplayName
+import com.chriscartland.garage.domain.model.Email
+import com.chriscartland.garage.domain.model.FirebaseIdToken
+import com.chriscartland.garage.domain.model.ServerConfig
+import com.chriscartland.garage.domain.model.SnoozeState
+import com.chriscartland.garage.domain.model.User
+import com.chriscartland.garage.domain.repository.SnoozeRepository
+import com.chriscartland.garage.testcommon.FakeAuthRepository
+import com.chriscartland.garage.testcommon.FakeNetworkButtonDataSource
+import com.chriscartland.garage.testcommon.FakeNetworkConfigDataSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Verifies the intended architecture: multiple UseCase instances share a
+ * single [SnoozeRepository] singleton. A submit via `SnoozeNotificationsUseCase`
+ * must (a) return the new [SnoozeState] as a structured result and (b) be
+ * observable via a separately-constructed `ObserveSnoozeStateUseCase`
+ * backed by the SAME repository — proving the observe and mutate paths
+ * converge on one source of truth.
+ *
+ * Uses the REAL [NetworkSnoozeRepository] with fake data sources so the
+ * test exercises the production flow plumbing end-to-end (POST → flow
+ * write → observer → return value). This is the architectural contract:
+ * "UseCases are non-singleton, but they all share one repository singleton."
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SharedRepositoryUseCasesTest {
+    private lateinit var externalScope: CoroutineScope
+
+    private val validConfig = NetworkResult.Success(
+        ServerConfig(
+            buildTimestamp = "test",
+            remoteButtonBuildTimestamp = "test",
+            remoteButtonPushKey = "key",
+        ),
+    )
+
+    @BeforeTest
+    fun setup() {
+        externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+    }
+
+    @AfterTest
+    fun teardown() {
+        externalScope.cancel()
+    }
+
+    private fun buildSharedRepository(
+        now: Long,
+        fetchResult: NetworkResult<Long>,
+    ): Pair<FakeNetworkButtonDataSource, SnoozeRepository> {
+        val buttonDs = FakeNetworkButtonDataSource().apply {
+            setFetchSnoozeResult(fetchResult)
+        }
+        val configDs = FakeNetworkConfigDataSource().apply { setServerConfigResult(validConfig) }
+        val repo: SnoozeRepository = NetworkSnoozeRepository(
+            networkButtonDataSource = buttonDs,
+            serverConfigRepository = CachedServerConfigRepository(configDs, "key"),
+            snoozeNotificationsOption = true,
+            currentTimeSeconds = { now },
+            externalScope = externalScope,
+        )
+        return buttonDs to repo
+    }
+
+    private fun authenticatedAuthRepo(): FakeAuthRepository =
+        FakeAuthRepository().apply {
+            setAuthState(
+                AuthState.Authenticated(
+                    user = User(
+                        name = DisplayName("Test"),
+                        email = Email("t@t.test"),
+                        idToken = FirebaseIdToken(idToken = "tok", exp = Long.MAX_VALUE),
+                    ),
+                ),
+            )
+        }
+
+    @Test
+    fun submitViaOneUseCaseIsObservableViaAnother() =
+        runTest {
+            val now = 1_000L
+            val serverEndTime = 5_000L
+            val (buttonDs, sharedRepo) = buildSharedRepository(
+                now = now,
+                fetchResult = NetworkResult.Success(0L), // init fetch: no snooze yet
+            )
+            buttonDs.setSnoozeResult(NetworkResult.Success(serverEndTime))
+            val authRepo = authenticatedAuthRepo()
+
+            // Construct TWO independent UseCases — both new instances, both
+            // wired to the SAME shared repository. This is the production
+            // pattern: UseCases are created fresh per access (not @Singleton),
+            // the Repository is the only @Singleton.
+            val ensureFreshToken = EnsureFreshIdTokenUseCase(authRepo)
+            val submitUseCase = SnoozeNotificationsUseCase(ensureFreshToken, authRepo, sharedRepo)
+            val observeUseCase = ObserveSnoozeStateUseCase(sharedRepo)
+
+            advanceUntilIdle()
+            // Baseline: both paths agree — no active snooze.
+            assertEquals(SnoozeState.NotSnoozing, observeUseCase().first())
+
+            // Submit via the first UseCase. The return value is the new state.
+            val submitResult = submitUseCase(
+                snoozeDurationHours = "1h",
+                lastChangeTimeSeconds = 0L,
+            )
+            advanceUntilIdle()
+
+            // 1) Return value is a structured AppResult.Success carrying the
+            //    authoritative SnoozeState from the server response.
+            assertTrue(submitResult is AppResult.Success, "Submit should succeed")
+            val returnedState = (submitResult as AppResult.Success).data
+            assertEquals(SnoozeState.Snoozing(serverEndTime), returnedState)
+
+            // 2) The OTHER UseCase, constructed separately, observes the same
+            //    value via the shared repository singleton. This proves the
+            //    repo owns one source of truth and the two UseCase instances
+            //    don't have independent state.
+            val observedState = observeUseCase().first()
+            assertEquals(SnoozeState.Snoozing(serverEndTime), observedState)
+
+            // 3) Return value and observed value are the SAME state object —
+            //    the repo writes once and that write drives both paths.
+            assertEquals(returnedState, observedState)
+
+            // 4) Only one submit + one init fetch hit the network. No extra
+            //    GET after submit — the POST response is authoritative.
+            assertEquals(1, buttonDs.snoozeCount)
+            assertEquals(1, buttonDs.fetchSnoozeCount)
+        }
+
+    @Test
+    fun clearViaOneUseCaseIsObservableViaAnother() =
+        runTest {
+            // Same pattern for the clear ("Do not snooze") case. Server returns
+            // an end time equal to now (immediately expired) → repo maps to
+            // NotSnoozing → return value and observed value both show the clear.
+            val now = 1_000L
+            val (buttonDs, sharedRepo) = buildSharedRepository(
+                now = now,
+                fetchResult = NetworkResult.Success(5_000L), // init: active snooze
+            )
+            buttonDs.setSnoozeResult(NetworkResult.Success(now)) // clear — end time == now
+            val authRepo = authenticatedAuthRepo()
+
+            val ensureFreshToken = EnsureFreshIdTokenUseCase(authRepo)
+            val submitUseCase = SnoozeNotificationsUseCase(ensureFreshToken, authRepo, sharedRepo)
+            val observeUseCase = ObserveSnoozeStateUseCase(sharedRepo)
+
+            advanceUntilIdle()
+            assertEquals(SnoozeState.Snoozing(5_000L), observeUseCase().first())
+
+            val submitResult = submitUseCase(
+                snoozeDurationHours = "0h",
+                lastChangeTimeSeconds = 0L,
+            )
+            advanceUntilIdle()
+
+            assertTrue(submitResult is AppResult.Success, "Clear should succeed")
+            assertEquals(SnoozeState.NotSnoozing, (submitResult as AppResult.Success).data)
+
+            // The observe UseCase — a different instance, same repo — now sees
+            // the cleared state too.
+            assertEquals(SnoozeState.NotSnoozing, observeUseCase().first())
+        }
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SnoozeNotificationsUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SnoozeNotificationsUseCaseTest.kt
@@ -121,7 +121,7 @@ class SnoozeNotificationsUseCaseTest {
     fun snoozeReturnsNetworkFailedWhenRepositoryReturnsFalse() =
         runTest {
             authenticateUser()
-            fakeSnooze.setSnoozeResult(false)
+            fakeSnooze.setSnoozeResult(AppResult.Error(ActionError.NetworkFailed))
 
             val result = useCase("1h", 1000L)
 


### PR DESCRIPTION
## Summary
Per your ask and the TODO I'd left on the interface: `SnoozeRepository.snoozeNotifications` now returns a structured `AppResult<SnoozeState, ActionError>` whose `Success.data` is the new state. The repository still writes the same value to its `MutableStateFlow`, so observers see it — but callers now have a direct, race-free handle on the new state.

In the VM, `result.data` drives BOTH:
1. `_snoozeAction` overlay uses the authoritative server end time (no more client-computed optimistic time).
2. `_snoozeState` gets a **direct write** from the return value — bypassing any fragility in the observer→flow chain. Even if the Compose observer had a lifecycle quirk that missed the singleton emission, the direct write guarantees the UI updates. Belt-and-suspenders on top of the reactive flow.

## New test
`SharedRepositoryUseCasesTest` (2 tests) proves the intended architecture:
- Two UseCase instances (`SnoozeNotificationsUseCase`, `ObserveSnoozeStateUseCase`) constructed independently but wired to the SAME `@Singleton` repository.
- A submit via the first UseCase returns a structured `AppResult.Success(Snoozing(endTime))`.
- The second UseCase, constructed separately, observes the same value via the shared repository — proving UseCases aren't independent state silos, the repo singleton is the one source of truth.
- Return value and observed value are asserted equal — one write drives both paths.

Covers the `snooze` case (end time in future) and the `clear` case (end time == now → maps to `NotSnoozing`).

## Migration
- `SnoozeRepository` interface: `Boolean` → `AppResult<SnoozeState, ActionError>`.
- `NetworkSnoozeRepository.doSnoozeNotifications`: computes state, writes flow, returns same value.
- `SnoozeNotificationsUseCase`: passes through the repo's `AppResult` (no longer translates `Boolean → AppResult<Unit, _>`).
- `DefaultRemoteButtonViewModel.snoozeOpenDoorsNotifications`: uses `result.data` for `_snoozeState` (direct) and `_snoozeAction` overlay (authoritative time, no optimism).
- `FakeSnoozeRepository`: `setSnoozeResult` accepts `AppResult<SnoozeState, ActionError>`; mirrors production by writing `Success.data` to its flow.

## Test plan
- [x] All unit tests pass (data + usecase modules).
- [x] Instrumented Compose test `SnoozeStateInstrumentedPropagationTest` passes on `Medium_Phone_API_36` emulator.
- [x] New `SharedRepositoryUseCasesTest` — 2 tests pass.
- [x] `./scripts/validate.sh` passes.
- [ ] Manual verification on device: after installing android/169, save a snooze and confirm the card title updates to "Door notifications snoozed until X" without an app restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)