### PR TITLE
refactor: Delete dead buttonViewModel in AppNavigation (PR 3 of 8)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -99,7 +99,13 @@ import me.tatarka.inject.annotations.Provides
 abstract class AppComponent(
     @get:Provides val application: Application,
 ) {
-    // ViewModels
+    // ViewModels.
+    //
+    // These providers are intentionally NOT @Singleton — each call site (Compose
+    // rememberViewModelStoreNavEntryDecorator<Screen>) receives its own VM
+    // instance scoped to that nav entry's lifecycle. This is the ADR-021 Rule 4
+    // pattern: multiple VMs are allowed, correctness comes from the single
+    // @Singleton repositories they share (ADR-021 Rule 1, ADR-022).
     val authViewModel: DefaultAuthViewModel
         @Provides get() = DefaultAuthViewModel(
             provideObserveAuthStateUseCase(),

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -45,18 +45,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
-import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.ui.theme.AppTheme
 import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
 import com.chriscartland.garage.usecase.AppLoggerViewModel
 import com.chriscartland.garage.usecase.AuthViewModel
 import com.chriscartland.garage.usecase.DoorViewModel
-import com.chriscartland.garage.usecase.RemoteButtonViewModel
 import kotlinx.serialization.Serializable
 import java.time.Instant
 
@@ -118,8 +115,6 @@ fun AppNavigation(
     doorViewModel: DoorViewModel,
     appLoggerViewModel: AppLoggerViewModel,
 ) {
-    val component = rememberAppComponent()
-    val buttonViewModel: RemoteButtonViewModel = viewModel { component.remoteButtonViewModel }
     val currentDoorEvent by doorViewModel.currentDoorEvent.collectAsState()
     val lastCheckInTime = currentDoorEvent.data?.lastCheckInTimeSeconds?.let {
         Instant.ofEpochSecond(it)


### PR DESCRIPTION
## Summary

- Removes the unused `val buttonViewModel = viewModel { component.remoteButtonViewModel }` in `Main.kt` along with its now-orphaned imports
- Adds a doc comment above the ViewModel providers in `AppComponent.kt` noting the intentional non-@Singleton scoping (per-nav-entry by design per ADR-021 Rule 4)
- Per [MIGRATION_PLAN.md](AndroidGarage/docs/MIGRATION_PLAN.md), this is PR 3 of 8 — independent of PRs 2/4–7

## Context

The dead declaration existed from before HomeContent/ProfileContent extracted their own VMs via `rememberViewModelStoreNavEntryDecorator<Screen>()`. It contributed to the android/164-168 snooze-state bug by creating an unused third VM instance in AppNavigation. Removing it reduces noise and makes the scoping rule visible at each provider.

## Test plan

- [x] `AndroidGarage/gradlew :androidApp:compileDebugKotlin` passes
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)