### PR TITLE
refactor: SnoozeRepository owns StateFlow, drop VM mirror (PR 2 of 8)

### DIFF
--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepository.kt
@@ -28,8 +28,8 @@ import com.chriscartland.garage.domain.repository.SnoozeRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 /**
@@ -54,13 +54,14 @@ class NetworkSnoozeRepository(
     private val currentTimeSeconds: () -> Long,
     private val externalScope: CoroutineScope,
 ) : SnoozeRepository {
-    private val snoozeStateFlow = MutableStateFlow<SnoozeState>(SnoozeState.Loading)
+    private val _snoozeState = MutableStateFlow<SnoozeState>(SnoozeState.Loading)
+
+    /** ADR-022: the repository owns the authoritative [StateFlow]. */
+    override val snoozeState: StateFlow<SnoozeState> = _snoozeState
 
     init {
         externalScope.launch { doFetchSnoozeStatus() }
     }
-
-    override fun observeSnoozeState(): Flow<SnoozeState> = snoozeStateFlow
 
     override suspend fun fetchSnoozeStatus() {
         externalScope.launch { doFetchSnoozeStatus() }.join()
@@ -95,7 +96,9 @@ class NetworkSnoozeRepository(
             )
         ) {
             is NetworkResult.Success -> {
-                snoozeStateFlow.value = snoozeStateFromEndTime(result.data)
+                val newState = snoozeStateFromEndTime(result.data)
+                _snoozeState.value = newState
+                Logger.i { "snoozeState <- $newState (source=GET)" }
             }
             is NetworkResult.HttpError -> {
                 Logger.e { "Snooze fetch HTTP ${result.code}" }
@@ -123,7 +126,7 @@ class NetworkSnoozeRepository(
             delay(500)
             // Feature disabled: pretend it succeeded and surface the current
             // flow value so callers don't see a phantom network failure.
-            return AppResult.Success(snoozeStateFlow.value)
+            return AppResult.Success(_snoozeState.value)
         }
         return when (
             val result = networkButtonDataSource.snoozeNotifications(
@@ -137,10 +140,12 @@ class NetworkSnoozeRepository(
             is NetworkResult.Success -> {
                 // Compute the new state from the server's authoritative end
                 // time, write it to the observable flow, and return the SAME
-                // value. Callers can use the return value directly (no
-                // observer race) or subscribe via observeSnoozeState().
+                // value. Subscribers observing [snoozeState] see the update
+                // via the flow alone — no caller needs the return value for
+                // correctness (ADR-022).
                 val newState = snoozeStateFromEndTime(result.data)
-                snoozeStateFlow.value = newState
+                _snoozeState.value = newState
+                Logger.i { "snoozeState <- $newState (source=POST)" }
                 AppResult.Success(newState)
             }
             is NetworkResult.HttpError -> {
@@ -156,8 +161,9 @@ class NetworkSnoozeRepository(
 
     /** If still Loading (first fetch), fall back to NotSnoozing so the UI doesn't show "Loading..." forever. */
     private fun clearLoadingState() {
-        if (snoozeStateFlow.value is SnoozeState.Loading) {
-            snoozeStateFlow.value = SnoozeState.NotSnoozing
+        if (_snoozeState.value is SnoozeState.Loading) {
+            _snoozeState.value = SnoozeState.NotSnoozing
+            Logger.i { "snoozeState <- NotSnoozing (source=clearLoading)" }
         }
     }
 

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepositoryTest.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelChildren
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
@@ -68,7 +67,7 @@ class NetworkSnoozeRepositoryTest {
             )
             advanceUntilIdle()
 
-            assertEquals(SnoozeState.NotSnoozing, repo.observeSnoozeState().first())
+            assertEquals(SnoozeState.NotSnoozing, repo.snoozeState.value)
             assertEquals(1, buttonDs.fetchSnoozeCount)
         }
 
@@ -100,7 +99,7 @@ class NetworkSnoozeRepositoryTest {
             advanceUntilIdle()
 
             // External-scope fetch from init still completed — state is NOT stuck.
-            assertEquals(SnoozeState.NotSnoozing, repo.observeSnoozeState().first())
+            assertEquals(SnoozeState.NotSnoozing, repo.snoozeState.value)
 
             externalScope.cancel()
             vmScope.cancel()
@@ -125,7 +124,7 @@ class NetworkSnoozeRepositoryTest {
             advanceUntilIdle()
 
             // Server config unavailable → fall back to NotSnoozing, never stay Loading.
-            assertEquals(SnoozeState.NotSnoozing, repo.observeSnoozeState().first())
+            assertEquals(SnoozeState.NotSnoozing, repo.snoozeState.value)
 
             externalScope.cancel()
         }
@@ -150,7 +149,7 @@ class NetworkSnoozeRepositoryTest {
             )
             advanceUntilIdle()
 
-            assertEquals(SnoozeState.Snoozing(futureEnd), repo.observeSnoozeState().first())
+            assertEquals(SnoozeState.Snoozing(futureEnd), repo.snoozeState.value)
 
             externalScope.cancel()
         }
@@ -178,7 +177,7 @@ class NetworkSnoozeRepositoryTest {
                 externalScope = externalScope,
             )
             advanceUntilIdle()
-            assertEquals(SnoozeState.NotSnoozing, repo.observeSnoozeState().first())
+            assertEquals(SnoozeState.NotSnoozing, repo.snoozeState.value)
 
             val submitted = repo.snoozeNotifications(
                 snoozeDurationHours = "1h",
@@ -193,7 +192,7 @@ class NetworkSnoozeRepositoryTest {
                 (submitted as AppResult.Success).data,
             )
             // Return value matches the flow value — repo writes both.
-            assertEquals(SnoozeState.Snoozing(submittedSnoozeEnd), repo.observeSnoozeState().first())
+            assertEquals(SnoozeState.Snoozing(submittedSnoozeEnd), repo.snoozeState.value)
             // Only the init fetch runs — no follow-up GET after the POST.
             assertEquals(1, buttonDs.fetchSnoozeCount)
             assertEquals(1, buttonDs.snoozeCount)
@@ -234,7 +233,7 @@ class NetworkSnoozeRepositoryTest {
             advanceUntilIdle()
 
             // State reaches Snoozing despite VM cancellation.
-            assertEquals(SnoozeState.Snoozing(snoozeEnd), repo.observeSnoozeState().first())
+            assertEquals(SnoozeState.Snoozing(snoozeEnd), repo.snoozeState.value)
 
             externalScope.cancel()
             vmScope.cancel()
@@ -263,7 +262,7 @@ class NetworkSnoozeRepositoryTest {
                 externalScope = externalScope,
             )
             advanceUntilIdle()
-            assertEquals(SnoozeState.NotSnoozing, repo.observeSnoozeState().first())
+            assertEquals(SnoozeState.NotSnoozing, repo.snoozeState.value)
 
             // Server now reports a snooze. Next fetch should pick it up.
             buttonDs.setFetchSnoozeResult(NetworkResult.Success(snoozeEnd))
@@ -273,7 +272,7 @@ class NetworkSnoozeRepositoryTest {
             vmScope.coroutineContext.cancelChildren()
             advanceUntilIdle()
 
-            assertEquals(SnoozeState.Snoozing(snoozeEnd), repo.observeSnoozeState().first())
+            assertEquals(SnoozeState.Snoozing(snoozeEnd), repo.snoozeState.value)
 
             externalScope.cancel()
             vmScope.cancel()
@@ -302,7 +301,7 @@ class NetworkSnoozeRepositoryTest {
             advanceUntilIdle()
 
             assertTrue(submitted is AppResult.Error, "Should surface the network failure")
-            assertEquals(SnoozeState.NotSnoozing, repo.observeSnoozeState().first())
+            assertEquals(SnoozeState.NotSnoozing, repo.snoozeState.value)
 
             externalScope.cancel()
         }
@@ -324,7 +323,7 @@ class NetworkSnoozeRepositoryTest {
             // Feature-disabled path has a delay(500); advanceUntilIdle covers it.
             advanceUntilIdle()
 
-            assertEquals(SnoozeState.NotSnoozing, repo.observeSnoozeState().first())
+            assertEquals(SnoozeState.NotSnoozing, repo.snoozeState.value)
             assertEquals(0, buttonDs.fetchSnoozeCount)
 
             externalScope.cancel()

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/SnoozeMultiSubscriberIntegrationTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/SnoozeMultiSubscriberIntegrationTest.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -48,9 +47,9 @@ import kotlin.test.assertTrue
  * write from the VM as a workaround; this test proves the repository-only path
  * is sufficient so the workaround can be removed in PR 2.
  *
- * Every subscriber here reads through [SnoozeRepository.observeSnoozeState] —
- * no one consults `snoozeNotifications()`'s return value. If the repository's
- * flow is correct, every subscriber must converge to the submitted state.
+ * Every subscriber here reads through [SnoozeRepository.snoozeState] — no one
+ * consults `snoozeNotifications()`'s return value. If the repository's flow is
+ * correct, every subscriber must converge to the submitted state.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class SnoozeMultiSubscriberIntegrationTest {
@@ -101,7 +100,7 @@ class SnoozeMultiSubscriberIntegrationTest {
             val repo = buildRepo(externalScope, buttonDs, configDs, now)
             advanceUntilIdle()
             // Initial fetch: NotSnoozing.
-            assertEquals(SnoozeState.NotSnoozing, repo.observeSnoozeState().first())
+            assertEquals(SnoozeState.NotSnoozing, repo.snoozeState.value)
 
             val seenA = mutableListOf<SnoozeState>()
             val seenB = mutableListOf<SnoozeState>()
@@ -118,13 +117,13 @@ class SnoozeMultiSubscriberIntegrationTest {
             )
             val jobs = mutableListOf<Job>()
             jobs += subscriberScopeA.launch {
-                repo.observeSnoozeState().collect { seenA.add(it) }
+                repo.snoozeState.collect { seenA.add(it) }
             }
             jobs += subscriberScopeB.launch {
-                repo.observeSnoozeState().collect { seenB.add(it) }
+                repo.snoozeState.collect { seenB.add(it) }
             }
             jobs += subscriberScopeC.launch {
-                repo.observeSnoozeState().collect { seenC.add(it) }
+                repo.snoozeState.collect { seenC.add(it) }
             }
             advanceUntilIdle()
             // All three subscribers got the initial replay.
@@ -203,7 +202,7 @@ class SnoozeMultiSubscriberIntegrationTest {
                 SupervisorJob() + UnconfinedTestDispatcher(testScheduler),
             )
             val lateJob = lateScope.launch {
-                repo.observeSnoozeState().collect { lateSeen.add(it) }
+                repo.snoozeState.collect { lateSeen.add(it) }
             }
             advanceUntilIdle()
 
@@ -250,10 +249,10 @@ class SnoozeMultiSubscriberIntegrationTest {
                 SupervisorJob() + UnconfinedTestDispatcher(testScheduler),
             )
             val jobA = scopeA.launch {
-                repo.observeSnoozeState().collect { seenA.add(it) }
+                repo.snoozeState.collect { seenA.add(it) }
             }
             val jobB = scopeB.launch {
-                repo.observeSnoozeState().collect { seenB.add(it) }
+                repo.snoozeState.collect { seenB.add(it) }
             }
             advanceUntilIdle()
 

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/SnoozeRepository.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/SnoozeRepository.kt
@@ -3,27 +3,32 @@ package com.chriscartland.garage.domain.repository
 import com.chriscartland.garage.domain.model.ActionError
 import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.SnoozeState
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Manages snooze-notification state for the garage door.
  *
  * Snoozing suppresses open-door notifications for a specified duration.
  * The snooze end time is persisted server-side and fetched on demand.
+ *
+ * State ownership (ADR-022): the repository owns the authoritative
+ * `StateFlow<SnoozeState>` and an always-on collector populates it from the
+ * network on construction. ViewModels and UseCases expose this same
+ * [StateFlow] by reference — no mirrors.
  */
 interface SnoozeRepository {
-    /** Observation: snooze state changes over time. */
-    fun observeSnoozeState(): Flow<SnoozeState>
+    /** Observation: the authoritative snooze state as an owned [StateFlow]. */
+    val snoozeState: StateFlow<SnoozeState>
 
     suspend fun fetchSnoozeStatus()
 
     /**
      * Send a snooze request. On success returns the new [SnoozeState]
      * computed from the server's authoritative response — the same value
-     * is simultaneously written to the flow exposed by [observeSnoozeState].
+     * is simultaneously written to [snoozeState].
      *
-     * Callers can use the returned state directly (no observer race) or
-     * rely on [observeSnoozeState] for broader reactivity.
+     * Callers can use the returned state directly or rely on [snoozeState]
+     * for broader reactivity.
      *
      * Returns [AppResult.Error] with [ActionError.NetworkFailed] on any
      * network-layer failure. Auth/input errors (NotAuthenticated,

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeSnoozeRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeSnoozeRepository.kt
@@ -4,8 +4,8 @@ import com.chriscartland.garage.domain.model.ActionError
 import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.SnoozeState
 import com.chriscartland.garage.domain.repository.SnoozeRepository
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Fake [SnoozeRepository] for unit testing.
@@ -26,7 +26,8 @@ class FakeSnoozeRepository : SnoozeRepository {
         val snoozeEventTimestampSeconds: Long,
     )
 
-    private val snoozeStateFlow = MutableStateFlow<SnoozeState>(SnoozeState.Loading)
+    private val _snoozeState = MutableStateFlow<SnoozeState>(SnoozeState.Loading)
+    override val snoozeState: StateFlow<SnoozeState> = _snoozeState
 
     private val _snoozeCalls = mutableListOf<SnoozeCall>()
     val snoozeCalls: List<SnoozeCall> get() = _snoozeCalls
@@ -40,14 +41,12 @@ class FakeSnoozeRepository : SnoozeRepository {
         AppResult.Success(SnoozeState.NotSnoozing)
 
     fun setSnoozeState(state: SnoozeState) {
-        snoozeStateFlow.value = state
+        _snoozeState.value = state
     }
 
     fun setSnoozeResult(value: AppResult<SnoozeState, ActionError>) {
         snoozeResult = value
     }
-
-    override fun observeSnoozeState(): Flow<SnoozeState> = snoozeStateFlow
 
     override suspend fun fetchSnoozeStatus() {
         _fetchCount++
@@ -68,7 +67,7 @@ class FakeSnoozeRepository : SnoozeRepository {
         // Mirror the production repo: on success, propagate the result value
         // to the observable flow so observers see it too.
         if (snoozeResult is AppResult.Success) {
-            snoozeStateFlow.value = (snoozeResult as AppResult.Success<SnoozeState>).data
+            _snoozeState.value = (snoozeResult as AppResult.Success<SnoozeState>).data
         }
         return snoozeResult
     }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/FetchSnoozeStatusUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/FetchSnoozeStatusUseCase.kt
@@ -22,7 +22,7 @@ import com.chriscartland.garage.domain.repository.SnoozeRepository
 /**
  * Fetches the current snooze status from the server.
  *
- * Updates the snooze state observable via [SnoozeRepository.observeSnoozeState].
+ * Updates the snooze state observable via [SnoozeRepository.snoozeState].
  */
 class FetchSnoozeStatusUseCase(
     private val snoozeRepository: SnoozeRepository,

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveSnoozeStateUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveSnoozeStateUseCase.kt
@@ -19,15 +19,17 @@ package com.chriscartland.garage.usecase
 
 import com.chriscartland.garage.domain.model.SnoozeState
 import com.chriscartland.garage.domain.repository.SnoozeRepository
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 
 /**
- * Observes the current snooze state as a [Flow].
+ * Exposes the repository's authoritative snooze [StateFlow] by reference.
  *
- * The ViewModel converts to StateFlow for the UI.
+ * Per ADR-022, state-y data is owned by the repository and passed through
+ * UseCases and ViewModels without wrapping. The VM exposes the SAME
+ * instance to Compose.
  */
 class ObserveSnoozeStateUseCase(
     private val snoozeRepository: SnoozeRepository,
 ) {
-    operator fun invoke(): Flow<SnoozeState> = snoozeRepository.observeSnoozeState()
+    operator fun invoke(): StateFlow<SnoozeState> = snoozeRepository.snoozeState
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
@@ -69,9 +69,9 @@ class DefaultRemoteButtonViewModel(
 
     override val buttonState: StateFlow<RemoteButtonState> = stateMachine.state
 
-    // ADR-017 Rule 6: explicit MutableStateFlow + collect, no stateIn in ViewModels.
-    private val _snoozeState = MutableStateFlow<SnoozeState>(SnoozeState.Loading)
-    override val snoozeState: StateFlow<SnoozeState> = _snoozeState
+    // ADR-022: expose the repository's StateFlow by reference — no mirror.
+    // Every subscriber across the app reads from the same singleton instance.
+    override val snoozeState: StateFlow<SnoozeState> = observeSnoozeStateUseCase()
 
     private val _snoozeAction = MutableStateFlow<SnoozeAction>(SnoozeAction.Idle)
     override val snoozeAction: StateFlow<SnoozeAction> = _snoozeAction
@@ -80,9 +80,6 @@ class DefaultRemoteButtonViewModel(
 
     init {
         listenToDoorEvent()
-        viewModelScope.launch(dispatchers.io) {
-            observeSnoozeStateUseCase().collect { _snoozeState.value = it }
-        }
         // First fetch is driven by SnoozeRepository.init on an app-lifetime
         // scope (see NetworkSnoozeRepository). Running it from here on
         // viewModelScope risked cancellation mid-fetch stranding the
@@ -154,13 +151,11 @@ class DefaultRemoteButtonViewModel(
                 )
             ) {
                 is AppResult.Success -> {
-                    // The repo returned the authoritative SnoozeState computed
-                    // from the server's response. Use it directly for both the
-                    // action overlay AND the observable _snoozeState — direct
-                    // write bypasses any fragility in the observer chain so
-                    // the UI updates immediately regardless of flow plumbing.
+                    // Repo already wrote [result.data] into its [snoozeState]
+                    // before returning, so the card title updates via the
+                    // shared flow (ADR-022). Here we only compute the
+                    // VM-local overlay action (Rule 3 — presentation state).
                     val newState = result.data
-                    _snoozeState.value = newState
                     _snoozeAction.value = when (newState) {
                         is SnoozeState.Snoozing -> SnoozeAction.Succeeded.Set(newState.untilEpochSeconds)
                         SnoozeState.NotSnoozing -> SnoozeAction.Succeeded.Cleared

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RealNetworkSnoozeRepositoryPropagationTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RealNetworkSnoozeRepositoryPropagationTest.kt
@@ -41,7 +41,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -169,7 +168,7 @@ class RealNetworkSnoozeRepositoryPropagationTest {
             // Repository init fetch resolves to NotSnoozing (server returned 0).
             // This matches the production precondition: card shows
             // "Door notifications enabled".
-            assertEquals(SnoozeState.NotSnoozing, snoozeRepository.observeSnoozeState().first())
+            assertEquals(SnoozeState.NotSnoozing, snoozeRepository.snoozeState.value)
 
             val testDispatcher = UnconfinedTestDispatcher(testScheduler)
             val ensureFreshIdToken = EnsureFreshIdTokenUseCase(authRepository)

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SnoozeStateFlowPropagationTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SnoozeStateFlowPropagationTest.kt
@@ -24,8 +24,6 @@ import com.chriscartland.garage.testcommon.FakeSnoozeRepository
 import com.chriscartland.garage.testcommon.TestDispatcherProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
@@ -42,18 +40,20 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
- * Rigorous tests for the snooze state reactive chain.
+ * Reactive-chain tests for the snooze state as it travels from the repository
+ * to the ViewModel.
  *
- * Chain: NetworkSnoozeRepository.snoozeStateFlow (MutableStateFlow, widened to Flow)
- *        → ObserveSnoozeStateUseCase (forwards)
- *        → DefaultRemoteButtonViewModel._snoozeState (MutableStateFlow)
+ * Chain (ADR-022): NetworkSnoozeRepository._snoozeState (MutableStateFlow)
+ *        → SnoozeRepository.snoozeState: StateFlow (same instance)
+ *        → ObserveSnoozeStateUseCase returns repo's StateFlow by reference
+ *        → DefaultRemoteButtonViewModel.snoozeState (same instance)
  *        → ProfileContent.collectAsState
  *
  * Reported bug (android/164): snoozeState stuck at Loading forever even when
- * the network call succeeds. These tests prove each hop preserves:
+ * the network call succeeds. These tests cover:
  *  - replay-on-subscribe (StateFlow semantics)
  *  - late-subscription delivery
- *  - no dropped emissions when state changes before the collector subscribes
+ *  - reference identity through the VM (Rule 2 — no mirror)
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class SnoozeStateFlowPropagationTest {
@@ -99,51 +99,26 @@ class SnoozeStateFlowPropagationTest {
     }
 
     // ----------------------------------------------------------------
-    // 1. Flow<SnoozeState> widening does not drop StateFlow semantics.
+    // 1. Reference identity: VM.snoozeState is the repo's StateFlow (ADR-022).
     // ----------------------------------------------------------------
-    // `observeSnoozeState(): Flow<SnoozeState>` hides the fact that the
-    // underlying object is a MutableStateFlow. The runtime type is
-    // unchanged — a .collect on it still replays the latest value to
-    // a late subscriber. Prove it.
+    // VM must NOT mirror the repo's flow — it must expose the same instance
+    // by reference. `assertSame` makes this guarantee load-bearing.
     @Test
-    fun widenedFlow_stillReplaysLatestValueToLateSubscriber() =
+    fun vmSnoozeStateIsSameInstanceAsRepoStateFlow() =
         runTest {
-            val source = MutableStateFlow<SnoozeState>(SnoozeState.Loading)
-            val widened: Flow<SnoozeState> = source
-
-            // Update BEFORE anyone subscribes.
-            source.value = SnoozeState.Snoozing(untilEpochSeconds = 42L)
-
-            // A late subscriber should still receive the current value.
-            val first = widened.first()
-            assertEquals(SnoozeState.Snoozing(42L), first)
-        }
-
-    @Test
-    fun widenedFlow_emitsAllTransitionsToActiveCollector() =
-        runTest {
-            val source = MutableStateFlow<SnoozeState>(SnoozeState.Loading)
-            val widened: Flow<SnoozeState> = source
-
-            val received = mutableListOf<SnoozeState>()
-            val job = launch {
-                widened.take(3).toList(received)
-            }
+            val fake = FakeSnoozeRepository()
+            val vm = buildVm(fake)
             testDispatcher.scheduler.runCurrent()
 
-            source.value = SnoozeState.NotSnoozing
-            testDispatcher.scheduler.runCurrent()
-            source.value = SnoozeState.Snoozing(100L)
-            testDispatcher.scheduler.runCurrent()
-
-            job.join()
-            // Conflation is acceptable for StateFlow — but initial + final must be present.
-            assertEquals(SnoozeState.Loading, received.first())
-            assertEquals(SnoozeState.Snoozing(100L), received.last())
+            kotlin.test.assertSame(
+                fake.snoozeState,
+                vm.snoozeState,
+                "VM must expose repo's StateFlow by reference (ADR-022)",
+            )
         }
 
     // ----------------------------------------------------------------
-    // 2. Two-hop MutableStateFlow chain reaches VM._snoozeState.
+    // 2. Two-hop chain: every repo update is visible on vm.snoozeState.
     // ----------------------------------------------------------------
     @Test
     fun fullChain_propagatesEveryTerminalValueToVm() =


### PR DESCRIPTION
## Summary

- `SnoozeRepository` exposes `val snoozeState: StateFlow<SnoozeState>` (drops `observeSnoozeState(): Flow`) — repository owns the authoritative flow per ADR-022
- `ObserveSnoozeStateUseCase` passes the repo's `StateFlow` through by reference (no wrap)
- `DefaultRemoteButtonViewModel` exposes the repo's `StateFlow` by reference — the local `_snoozeState` mirror, the observer launch, and the PR #354 direct write are **deleted**
- Adds Rule 9 state-write logging at every `_snoozeState.value = ...` site in `NetworkSnoozeRepository` (POST, GET, clearLoading)
- Adds `SnoozeStateFlowPropagationTest.vmSnoozeStateIsSameInstanceAsRepoStateFlow` — `assertSame` guard against future mirror reintroduction
- Per [MIGRATION_PLAN.md](AndroidGarage/docs/MIGRATION_PLAN.md), PR 2 of 8

## Why this matters

The android/164-168 bug was caused by multiple VM instances each maintaining their own mirror of the repo's Flow. One mirror fell out of sync, stranding the UI on a stale value. With the repo as sole StateFlow owner and VMs exposing by reference, there are no parallel mirrors to drift.

## Test plan

- [x] `AndroidGarage/gradlew :data:testDebugUnitTest :usecase:testDebugUnitTest :domain:testDebugUnitTest` passes
- [x] `AndroidGarage/gradlew :androidApp:compileDebugKotlin` passes
- [x] `./scripts/validate.sh` passes
- [x] `SnoozeMultiSubscriberIntegrationTest` (from PR #358) continues to pass — every subscriber sees updates via the repo flow alone
- [ ] Verify on-device: snooze → card title flips without kill+restart (was the original android/167 repro)

## Merge order

PR 2 of 8. Depends on PR #358 (merged). After this lands, PRs 4–7 can open in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)