### PR TITLE
refactor: AuthRepository owns StateFlow, drop VM mirror (PR 4 of 8)

### DIFF
--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepository.kt
@@ -29,9 +29,8 @@ import com.chriscartland.garage.domain.model.User
 import com.chriscartland.garage.domain.repository.AppLoggerRepository
 import com.chriscartland.garage.domain.repository.AuthRepository
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 /**
@@ -53,9 +52,8 @@ class FirebaseAuthRepository(
 ) : AuthRepository {
     private val _authState = MutableStateFlow<AuthState>(AuthState.Unknown)
 
-    override suspend fun getAuthState(): AuthState = _authState.value
-
-    override fun observeAuthState(): Flow<AuthState> = _authState.asStateFlow()
+    /** ADR-022: the repository owns the authoritative [StateFlow]. */
+    override val authState: StateFlow<AuthState> = _authState
 
     init {
         // Reactive: collect auth user changes from the platform listener.
@@ -86,6 +84,7 @@ class FirebaseAuthRepository(
                 }
                 logStateChange(newState)
                 _authState.value = newState
+                Logger.i { "authState <- $newState (source=listener)" }
             }
         }
     }
@@ -103,9 +102,11 @@ class FirebaseAuthRepository(
         // Update _authState so the UI stays in sync with the fresh token.
         val current = _authState.value
         if (current is AuthState.Authenticated) {
-            _authState.value = current.copy(
+            val newState = current.copy(
                 user = current.user.copy(idToken = token),
             )
+            _authState.value = newState
+            Logger.i { "authState <- $newState (source=refreshIdToken)" }
         }
         return token
     }
@@ -120,6 +121,7 @@ class FirebaseAuthRepository(
     override suspend fun signOut() {
         // Eagerly update UI before the bridge call — no visible delay.
         _authState.value = AuthState.Unauthenticated
+        Logger.i { "authState <- Unauthenticated (source=signOut)" }
         logStateChange(AuthState.Unauthenticated)
         authBridge.signOut()
         // The AuthStateListener will also fire and confirm Unauthenticated.

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepositoryTest.kt
@@ -24,7 +24,6 @@ import com.chriscartland.garage.domain.model.GoogleIdToken
 import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
 import com.chriscartland.garage.testcommon.FakeAuthBridge
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -59,7 +58,7 @@ class FirebaseAuthRepositoryTest {
             val (repo, _) = createRepository()
             advanceUntilIdle()
 
-            assertEquals(AuthState.Unauthenticated, repo.observeAuthState().first())
+            assertEquals(AuthState.Unauthenticated, repo.authState.value)
         }
 
     @Test
@@ -72,7 +71,7 @@ class FirebaseAuthRepositoryTest {
             val (repo, _) = createRepository(authBridge = bridge)
             advanceUntilIdle()
 
-            val state = repo.observeAuthState().first()
+            val state = repo.authState.value
             assertIs<AuthState.Authenticated>(state)
             assertEquals("Alice", state.user.name.asString())
             assertEquals("token-123", state.user.idToken.idToken)
@@ -88,7 +87,7 @@ class FirebaseAuthRepositoryTest {
             val (repo, _) = createRepository(authBridge = bridge)
             advanceUntilIdle()
 
-            assertEquals(AuthState.Unauthenticated, repo.observeAuthState().first())
+            assertEquals(AuthState.Unauthenticated, repo.authState.value)
         }
 
     @Test
@@ -99,7 +98,7 @@ class FirebaseAuthRepositoryTest {
             advanceUntilIdle()
 
             // Initially no user → Unauthenticated
-            assertEquals(AuthState.Unauthenticated, repo.observeAuthState().first())
+            assertEquals(AuthState.Unauthenticated, repo.authState.value)
 
             // User signs in (listener fires) — set token BEFORE user so the
             // collector sees the token when it processes the user emission.
@@ -107,7 +106,7 @@ class FirebaseAuthRepositoryTest {
             bridge.setAuthUser(AuthUserInfo(displayName = "Carol", email = "carol@test.com"))
             advanceUntilIdle()
 
-            val state = repo.observeAuthState().first()
+            val state = repo.authState.value
             assertIs<AuthState.Authenticated>(state)
             assertEquals("Carol", state.user.name.asString())
         }
@@ -121,12 +120,12 @@ class FirebaseAuthRepositoryTest {
 
             val (repo, _) = createRepository(authBridge = bridge)
             advanceUntilIdle()
-            assertIs<AuthState.Authenticated>(repo.observeAuthState().first())
+            assertIs<AuthState.Authenticated>(repo.authState.value)
 
             repo.signOut()
 
             // Eagerly set to Unauthenticated — no waiting for listener
-            assertEquals(AuthState.Unauthenticated, repo.observeAuthState().first())
+            assertEquals(AuthState.Unauthenticated, repo.authState.value)
             assertEquals(1, bridge.signOutCount)
         }
 
@@ -164,7 +163,7 @@ class FirebaseAuthRepositoryTest {
 
             assertEquals("fresh-token", refreshed?.idToken)
             // _authState should also be updated with the new token
-            val state = repo.observeAuthState().first()
+            val state = repo.authState.value
             assertIs<AuthState.Authenticated>(state)
             assertEquals("fresh-token", state.user.idToken.idToken)
         }

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/AuthRepository.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/AuthRepository.kt
@@ -3,23 +3,30 @@ package com.chriscartland.garage.domain.repository
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.FirebaseIdToken
 import com.chriscartland.garage.domain.model.GoogleIdToken
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 
+/**
+ * Authentication state owner.
+ *
+ * Per ADR-022, the repository owns the authoritative `StateFlow<AuthState>`;
+ * a platform listener (ADR-018) drives writes on an app-lifetime scope.
+ * ViewModels and UseCases expose this same [StateFlow] by reference — no
+ * mirrors. Callers can read [authState].value for synchronous one-shot
+ * access; commands ([signInWithGoogle], [signOut]) are fire-and-forget and
+ * the listener reflects the state change automatically.
+ */
 interface AuthRepository {
-    /** One-shot: current auth state right now. */
-    suspend fun getAuthState(): AuthState
-
-    /** Observation: auth state changes over time. */
-    fun observeAuthState(): Flow<AuthState>
+    /** Observation: the authoritative auth state as an owned [StateFlow]. */
+    val authState: StateFlow<AuthState>
 
     suspend fun signInWithGoogle(idToken: GoogleIdToken): AuthState
 
     /**
      * Force-refresh the ID token via the auth provider and return it.
      *
-     * Also updates [observeAuthState] with the new token so the UI stays
-     * in sync (avoids split-brain where the UseCase has a fresh token but
-     * the ViewModel's StateFlow still shows the old expiry).
+     * Also updates [authState] with the new token so the UI stays in sync
+     * (avoids split-brain where the UseCase has a fresh token but the
+     * ViewModel's StateFlow still shows the old expiry).
      *
      * Returns null if refresh fails (e.g., user signed out, network error).
      */

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAuthRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAuthRepository.kt
@@ -21,8 +21,8 @@ import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.FirebaseIdToken
 import com.chriscartland.garage.domain.model.GoogleIdToken
 import com.chriscartland.garage.domain.repository.AuthRepository
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Fake [AuthRepository] for unit testing.
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
  */
 class FakeAuthRepository : AuthRepository {
     private val _authState = MutableStateFlow<AuthState>(AuthState.Unknown)
+    override val authState: StateFlow<AuthState> = _authState
 
     private val _signInCalls = mutableListOf<GoogleIdToken>()
     val signInCalls: List<GoogleIdToken> get() = _signInCalls
@@ -67,10 +68,6 @@ class FakeAuthRepository : AuthRepository {
     fun setRefreshResult(value: AuthState?) {
         legacyRefreshResult = value
     }
-
-    override suspend fun getAuthState(): AuthState = _authState.value
-
-    override fun observeAuthState(): Flow<AuthState> = _authState
 
     override suspend fun signInWithGoogle(idToken: GoogleIdToken): AuthState {
         _signInCalls.add(idToken)

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AuthViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AuthViewModel.kt
@@ -24,7 +24,6 @@ import com.chriscartland.garage.domain.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.GoogleIdToken
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
@@ -44,18 +43,8 @@ class DefaultAuthViewModel(
     private val dispatchers: DispatcherProvider,
 ) : ViewModel(),
     AuthViewModel {
-    // Explicit MutableStateFlow + collect pattern (matches DoorViewModel).
-    // Previously used stateIn(Eagerly) but that caused UI to not reflect
-    // auth state changes on real devices — Compose collectAsState would see
-    // only the initial Unknown value.
-    private val _authState = MutableStateFlow<AuthState>(AuthState.Unknown)
-    override val authState: StateFlow<AuthState> = _authState
-
-    init {
-        viewModelScope.launch(dispatchers.io) {
-            observeAuthState().collect { _authState.value = it }
-        }
-    }
+    // ADR-022: expose the repository's StateFlow by reference — no mirror.
+    override val authState: StateFlow<AuthState> = observeAuthState()
 
     override fun signInWithGoogle(idToken: GoogleIdToken) {
         viewModelScope.launch(dispatchers.io) {

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveAuthStateUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveAuthStateUseCase.kt
@@ -19,15 +19,17 @@ package com.chriscartland.garage.usecase
 
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.repository.AuthRepository
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 
 /**
- * Observes the current authentication state.
+ * Exposes the repository's authoritative auth [StateFlow] by reference.
  *
- * Returns a [Flow] — the ViewModel converts to StateFlow for the UI.
+ * Per ADR-022, state-y data is owned by the repository and passed through
+ * UseCases and ViewModels without wrapping. The VM exposes the SAME
+ * instance to Compose.
  */
 class ObserveAuthStateUseCase(
     private val authRepository: AuthRepository,
 ) {
-    operator fun invoke(): Flow<AuthState> = authRepository.observeAuthState()
+    operator fun invoke(): StateFlow<AuthState> = authRepository.authState
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/PushRemoteButtonUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/PushRemoteButtonUseCase.kt
@@ -35,7 +35,7 @@ class PushRemoteButtonUseCase(
     private val remoteButtonRepository: RemoteButtonRepository,
 ) {
     suspend operator fun invoke(buttonAckToken: String): AppResult<Unit, ActionError> {
-        val authState = authRepository.getAuthState()
+        val authState = authRepository.authState.value
         if (authState !is AuthState.Authenticated) {
             return AppResult.Error(ActionError.NotAuthenticated)
         }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SnoozeNotificationsUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SnoozeNotificationsUseCase.kt
@@ -45,7 +45,7 @@ class SnoozeNotificationsUseCase(
         snoozeDurationHours: String,
         lastChangeTimeSeconds: Long?,
     ): AppResult<SnoozeState, ActionError> {
-        val authState = authRepository.getAuthState()
+        val authState = authRepository.authState.value
         if (authState !is AuthState.Authenticated) {
             return AppResult.Error(ActionError.NotAuthenticated)
         }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAuthViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAuthViewModelTest.kt
@@ -21,6 +21,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -52,6 +53,20 @@ class DefaultAuthViewModelTest {
     @Test
     fun initialAuthStateIsUnknown() {
         assertIs<AuthState.Unknown>(viewModel.authState.value)
+    }
+
+    /**
+     * ADR-022: VM exposes the repository's StateFlow by reference — no mirror.
+     * An `assertSame` guard catches any future refactor that reintroduces a
+     * local `MutableStateFlow` in the VM.
+     */
+    @Test
+    fun authStateIsSameInstanceAsRepoStateFlow() {
+        assertSame(
+            authRepo.authState,
+            viewModel.authState,
+            "VM must expose repo's StateFlow by reference (ADR-022)",
+        )
     }
 
     @Test

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SignInWithGoogleUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SignInWithGoogleUseCaseTest.kt
@@ -58,6 +58,6 @@ class SignInWithGoogleUseCaseTest {
 
             useCase(GoogleIdToken("token"))
 
-            assertIs<AuthState.Authenticated>(repo.getAuthState())
+            assertIs<AuthState.Authenticated>(repo.authState.value)
         }
 }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SignOutUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SignOutUseCaseTest.kt
@@ -44,6 +44,6 @@ class SignOutUseCaseTest {
 
             useCase()
 
-            assertIs<AuthState.Unauthenticated>(repo.getAuthState())
+            assertIs<AuthState.Unauthenticated>(repo.authState.value)
         }
 }


### PR DESCRIPTION
## Summary

- `AuthRepository` exposes `val authState: StateFlow<AuthState>` (drops `getAuthState()` and `observeAuthState(): Flow`) — repository owns the authoritative flow per ADR-022
- `ObserveAuthStateUseCase` passes the repo's `StateFlow` through by reference (no wrap)
- `DefaultAuthViewModel` exposes the repo's `StateFlow` by reference — local `_authState` mirror and `init { collect }` observer are **deleted**
- `PushRemoteButtonUseCase` and `SnoozeNotificationsUseCase` updated to read `authState.value` instead of `getAuthState()`
- Adds Rule 9 state-write logging at every `_authState.value = ...` site in `FirebaseAuthRepository` (listener, refreshIdToken, signOut)
- Adds `DefaultAuthViewModelTest.authStateIsSameInstanceAsRepoStateFlow` — `assertSame` guard against future mirror reintroduction
- Per [MIGRATION_PLAN.md](AndroidGarage/docs/MIGRATION_PLAN.md), PR 4 of 8

## Context

Auth state is already reactive via `AuthBridge.observeAuthUser()` on an app-lifetime scope (ADR-018). This PR removes the VM-layer mirror that was only adding a bug surface (PR #283 taught us this the hard way).

## Test plan

- [x] `AndroidGarage/gradlew :data:testDebugUnitTest :usecase:testDebugUnitTest` passes
- [x] `AndroidGarage/gradlew :androidApp:compileDebugKotlin` passes
- [x] `./scripts/validate.sh` passes
- [ ] Smoke on-device: sign-in, sign-out, token refresh across rotation

## Merge order

PR 4 of 8. Can land in parallel with PRs 5–7. After this + PR 2 + PRs 5–7, PR 8 lands the enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)