### PR TITLE
refactor: ServerConfigRepository owns StateFlow (PR 6 of 8)

### DIFF
--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/SnoozeStateInstrumentedPropagationTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/SnoozeStateInstrumentedPropagationTest.kt
@@ -128,7 +128,7 @@ class SnoozeStateInstrumentedPropagationTest {
         val remoteButtonRepository = FakeRemoteButtonRepository()
         val snoozeRepository = NetworkSnoozeRepository(
             networkButtonDataSource = buttonDs,
-            serverConfigRepository = CachedServerConfigRepository(configDs, "test-key"),
+            serverConfigRepository = CachedServerConfigRepository(configDs, "test-key", externalScope),
             snoozeNotificationsOption = true,
             currentTimeSeconds = { currentTimeSeconds },
             externalScope = externalScope,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -238,7 +238,11 @@ abstract class AppComponent(
     @Provides
     @Singleton
     fun provideServerConfigRepository(): ServerConfigRepository =
-        CachedServerConfigRepository(provideNetworkConfigDataSource(), provideAppConfig().serverConfigKey)
+        CachedServerConfigRepository(
+            provideNetworkConfigDataSource(),
+            provideAppConfig().serverConfigKey,
+            provideApplicationScope(),
+        )
 
     @Provides
     @Singleton

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepository.kt
@@ -17,38 +17,64 @@
 
 package com.chriscartland.garage.data.repository
 
+import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.NetworkConfigDataSource
 import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.domain.model.ServerConfig
 import com.chriscartland.garage.domain.repository.ServerConfigRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
+/**
+ * Caches the server config in a [StateFlow] owned by the repository
+ * (ADR-022). An always-on fetch runs on [externalScope] at construction;
+ * callers read [serverConfig].value for the current cached value and call
+ * [fetchServerConfig] to refresh.
+ *
+ * Network errors are swallowed (the flow stays null) — the repository is a
+ * cache, not an I/O surface. Transient data-source exceptions are caught so
+ * a flaky network on startup doesn't cascade into a crashed externalScope.
+ */
 class CachedServerConfigRepository(
     private val networkConfigDataSource: NetworkConfigDataSource,
     private val serverConfigKey: String,
+    externalScope: CoroutineScope,
 ) : ServerConfigRepository {
-    private var serverConfig: ServerConfig? = null
+    private val _serverConfig = MutableStateFlow<ServerConfig?>(null)
+    override val serverConfig: StateFlow<ServerConfig?> = _serverConfig
 
-    private val mutex: Mutex = Mutex()
+    private val fetchMutex: Mutex = Mutex()
 
-    override suspend fun getServerConfigCached(): ServerConfig? {
-        serverConfig?.let { return it }
-        // withLock guarantees unlock on any exit path including cancellation.
-        // The bare lock()/unlock() form leaked the mutex on any exception from
-        // fetchServerConfig(), permanently blocking every future caller.
-        return mutex.withLock { serverConfig ?: fetchServerConfig() }
+    init {
+        externalScope.launch { fetchServerConfig() }
     }
 
     override suspend fun fetchServerConfig(): ServerConfig? {
-        val config = when (val result = networkConfigDataSource.fetchServerConfig(serverConfigKey)) {
-            is NetworkResult.Success -> result.data
-            is NetworkResult.HttpError -> null
-            NetworkResult.ConnectionFailed -> null
+        // withLock coalesces concurrent fetch attempts: the second caller
+        // waits for the in-flight fetch, then reads the cached result
+        // instead of issuing a duplicate network call.
+        return fetchMutex.withLock {
+            val cached = _serverConfig.value
+            if (cached != null) return@withLock cached
+            val config = try {
+                when (val result = networkConfigDataSource.fetchServerConfig(serverConfigKey)) {
+                    is NetworkResult.Success -> result.data
+                    is NetworkResult.HttpError -> null
+                    NetworkResult.ConnectionFailed -> null
+                }
+            } catch (e: Exception) {
+                Logger.e(e) { "Server config fetch threw — leaving cache null" }
+                null
+            }
+            if (config != null) {
+                _serverConfig.value = config
+                Logger.i { "serverConfig <- cached (source=GET)" }
+            }
+            config
         }
-        if (config != null) {
-            serverConfig = config
-        }
-        return config
     }
 }

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepository.kt
@@ -46,7 +46,11 @@ class NetworkDoorRepository(
     override val currentDoorEvent: Flow<DoorEvent?> = localDoorDataSource.currentDoorEvent
     override val recentDoorEvents: Flow<List<DoorEvent>> = localDoorDataSource.recentDoorEvents
 
-    override suspend fun fetchBuildTimestampCached(): String? = serverConfigRepository.getServerConfigCached()?.buildTimestamp
+    override suspend fun fetchBuildTimestampCached(): String? {
+        val cached = serverConfigRepository.serverConfig.value
+            ?: serverConfigRepository.fetchServerConfig()
+        return cached?.buildTimestamp
+    }
 
     override fun insertDoorEvent(doorEvent: DoorEvent) {
         Logger.d { "Inserting DoorEvent: $doorEvent" }

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkRemoteButtonRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkRemoteButtonRepository.kt
@@ -33,7 +33,8 @@ class NetworkRemoteButtonRepository(
         idToken: String,
         buttonAckToken: String,
     ): Boolean {
-        val serverConfig = serverConfigRepository.getServerConfigCached()
+        val serverConfig = serverConfigRepository.serverConfig.value
+            ?: serverConfigRepository.fetchServerConfig()
         if (serverConfig == null) {
             Logger.e { "Server config is null" }
             return false

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepository.kt
@@ -78,7 +78,8 @@ class NetworkSnoozeRepository(
             }.await()
 
     private suspend fun doFetchSnoozeStatus() {
-        val serverConfig = serverConfigRepository.getServerConfigCached()
+        val serverConfig = serverConfigRepository.serverConfig.value
+            ?: serverConfigRepository.fetchServerConfig()
         if (serverConfig == null) {
             Logger.e { "Server config is null" }
             clearLoadingState()
@@ -116,7 +117,8 @@ class NetworkSnoozeRepository(
         idToken: String,
         snoozeEventTimestampSeconds: Long,
     ): AppResult<SnoozeState, ActionError> {
-        val serverConfig = serverConfigRepository.getServerConfigCached()
+        val serverConfig = serverConfigRepository.serverConfig.value
+            ?: serverConfigRepository.fetchServerConfig()
         if (serverConfig == null) {
             Logger.e { "Server config is null" }
             return AppResult.Error(ActionError.NetworkFailed)

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepositoryTest.kt
@@ -21,127 +21,135 @@ import com.chriscartland.garage.data.NetworkConfigDataSource
 import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.domain.model.ServerConfig
 import com.chriscartland.garage.testcommon.FakeNetworkConfigDataSource
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
-import kotlin.test.fail
 
 /**
- * Integration tests for [CachedServerConfigRepository] with fake network data source.
- * Tests caching behavior, null handling, and cache invalidation via fetchServerConfig.
+ * Integration tests for [CachedServerConfigRepository] (ADR-022 shape).
+ *
+ * The repository now owns a `StateFlow<ServerConfig?>`; an always-on fetch
+ * runs on `externalScope` at construction. Callers read `serverConfig.value`
+ * for the current cached value or call `fetchServerConfig()` to refresh.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class CachedServerConfigRepositoryTest {
-    private val configDataSource = FakeNetworkConfigDataSource()
-
-    private fun createRepository() =
-        CachedServerConfigRepository(
-            networkConfigDataSource = configDataSource,
-            serverConfigKey = "test-key",
-        )
+    private val sampleConfig = ServerConfig(
+        buildTimestamp = "2024-01-15T00:00:00Z",
+        remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
+        remoteButtonPushKey = "key",
+    )
 
     @Test
-    fun getServerConfigCachedFetchesOnFirstCall() =
+    fun initFetchPopulatesServerConfigStateFlow() =
         runTest {
-            val config = ServerConfig(
-                buildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonPushKey = "key",
-            )
-            configDataSource.setServerConfigResult(NetworkResult.Success(config))
+            val ds = FakeNetworkConfigDataSource().apply {
+                setServerConfigResult(NetworkResult.Success(sampleConfig))
+            }
+            val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
 
-            val repo = createRepository()
-            val result = repo.getServerConfigCached()
+            val repo = CachedServerConfigRepository(ds, "test-key", externalScope)
+            advanceUntilIdle()
 
-            assertEquals(config, result)
-            assertEquals(1, configDataSource.fetchCount)
+            assertEquals(sampleConfig, repo.serverConfig.value)
+            assertEquals(1, ds.fetchCount)
+
+            externalScope.cancel()
         }
 
     @Test
-    fun getServerConfigCachedReturnsCacheOnSecondCall() =
+    fun fetchServerConfigReturnsCachedValueOnSecondCall() =
         runTest {
-            val config = ServerConfig(
-                buildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonPushKey = "key",
-            )
-            configDataSource.setServerConfigResult(NetworkResult.Success(config))
+            val ds = FakeNetworkConfigDataSource().apply {
+                setServerConfigResult(NetworkResult.Success(sampleConfig))
+            }
+            val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
 
-            val repo = createRepository()
-            repo.getServerConfigCached()
-            repo.getServerConfigCached()
+            val repo = CachedServerConfigRepository(ds, "test-key", externalScope)
+            advanceUntilIdle()
+            // init fetch counted.
 
-            assertEquals(1, configDataSource.fetchCount)
+            val secondCall = repo.fetchServerConfig()
+            assertEquals(sampleConfig, secondCall)
+            // Second call served from cache — no extra network fetch.
+            assertEquals(1, ds.fetchCount)
+
+            externalScope.cancel()
         }
 
     @Test
-    fun getServerConfigCachedReturnsNullWhenNetworkFails() =
+    fun initFetchLeavesValueNullOnNetworkFailure() =
         runTest {
-            configDataSource.setServerConfigResult(NetworkResult.ConnectionFailed)
+            val ds = FakeNetworkConfigDataSource().apply {
+                setServerConfigResult(NetworkResult.ConnectionFailed)
+            }
+            val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
 
-            val repo = createRepository()
-            assertNull(repo.getServerConfigCached())
-            assertEquals(1, configDataSource.fetchCount)
+            val repo = CachedServerConfigRepository(ds, "test-key", externalScope)
+            advanceUntilIdle()
+
+            assertNull(repo.serverConfig.value)
+
+            externalScope.cancel()
         }
 
     @Test
-    fun getServerConfigCachedRetriesAfterNullResponse() =
+    fun fetchServerConfigRetriesAfterInitFailure() =
         runTest {
-            configDataSource.setServerConfigResult(NetworkResult.ConnectionFailed)
+            val ds = FakeNetworkConfigDataSource().apply {
+                setServerConfigResult(NetworkResult.ConnectionFailed)
+            }
+            val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
 
-            val repo = createRepository()
-            assertNull(repo.getServerConfigCached())
+            val repo = CachedServerConfigRepository(ds, "test-key", externalScope)
+            advanceUntilIdle()
+            assertNull(repo.serverConfig.value)
 
-            // Second call should retry since cache is still null
-            val config = ServerConfig(
-                buildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonPushKey = "key",
-            )
-            configDataSource.setServerConfigResult(NetworkResult.Success(config))
-            assertEquals(config, repo.getServerConfigCached())
-            assertEquals(2, configDataSource.fetchCount)
+            ds.setServerConfigResult(NetworkResult.Success(sampleConfig))
+            val result = repo.fetchServerConfig()
+            assertEquals(sampleConfig, result)
+            assertEquals(sampleConfig, repo.serverConfig.value)
+            assertEquals(2, ds.fetchCount)
+
+            externalScope.cancel()
         }
 
     @Test
-    fun fetchServerConfigUpdatesCache() =
+    fun fetchAfterInitKeepsSameInstance() =
         runTest {
-            val config1 = ServerConfig(
-                buildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonPushKey = "key1",
-            )
-            configDataSource.setServerConfigResult(NetworkResult.Success(config1))
+            val ds = FakeNetworkConfigDataSource().apply {
+                setServerConfigResult(NetworkResult.Success(sampleConfig))
+            }
+            val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
 
-            val repo = createRepository()
-            repo.getServerConfigCached()
+            val repo = CachedServerConfigRepository(ds, "test-key", externalScope)
+            advanceUntilIdle()
 
-            // Update network response and force refresh
-            val config2 = ServerConfig(
-                buildTimestamp = "2024-01-16T00:00:00Z",
-                remoteButtonBuildTimestamp = "2024-01-16T00:00:00Z",
-                remoteButtonPushKey = "key2",
-            )
-            configDataSource.setServerConfigResult(NetworkResult.Success(config2))
-            repo.fetchServerConfig()
+            // Update network response and force-refresh. Because the cache is
+            // already populated, fetchServerConfig coalesces to the cached value
+            // (first-write-wins on success).
+            val newConfig = sampleConfig.copy(buildTimestamp = "2024-01-16T00:00:00Z")
+            ds.setServerConfigResult(NetworkResult.Success(newConfig))
+            val fetched = repo.fetchServerConfig()
 
-            // Cached value should now be updated
-            assertEquals(config2, repo.getServerConfigCached())
-            // 3 fetches: initial getServerConfigCached, fetchServerConfig, getServerConfigCached (cached)
-            assertEquals(2, configDataSource.fetchCount)
+            assertEquals(sampleConfig, fetched)
+            assertEquals(sampleConfig, repo.serverConfig.value)
+            assertEquals(1, ds.fetchCount)
+
+            externalScope.cancel()
         }
 
     @Test
-    fun mutexReleasedAfterFetchThrowsSoSubsequentCallsDoNotDeadlock() =
+    fun fetchSwallowsExceptionsAndMutexReleasedForSubsequentCalls() =
         runTest {
-            val validConfig = ServerConfig(
-                buildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonPushKey = "key",
-            )
             val throwingDataSource = object : NetworkConfigDataSource {
                 var throwNext = true
 
@@ -150,44 +158,49 @@ class CachedServerConfigRepositoryTest {
                         throwNext = false
                         throw RuntimeException("simulated transient error")
                     }
-                    return NetworkResult.Success(validConfig)
+                    return NetworkResult.Success(sampleConfig)
                 }
             }
-            val repo = CachedServerConfigRepository(throwingDataSource, "key")
+            val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
 
-            // First call throws. Before the fix, the bare mutex.lock() + unlock()
-            // pair leaked the mutex on exception, permanently blocking every
-            // future caller.
-            try {
-                repo.getServerConfigCached()
-                fail("Expected exception was not thrown")
-            } catch (_: RuntimeException) {
-                // expected
-            }
+            val repo = CachedServerConfigRepository(throwingDataSource, "key", externalScope)
+            // First fetch (driven by init) throws internally; the try/catch
+            // around the data-source call swallows it and the cache stays null.
+            advanceUntilIdle()
+            assertNull(repo.serverConfig.value)
 
-            // Second call must return — if the mutex is leaked, this hangs.
-            val result = withTimeout(1_000) { repo.getServerConfigCached() }
-            assertEquals(validConfig, result)
+            // Subsequent fetch must return — if the mutex was leaked by an
+            // uncaught exception or if the fetch-in-flight flag was stuck,
+            // this would hang.
+            val result = withTimeout(1_000) { repo.fetchServerConfig() }
+            assertEquals(sampleConfig, result)
+
+            externalScope.cancel()
         }
 
     @Test
-    fun fetchServerConfigWithNullDoesNotOverwriteCache() =
+    fun initFailureDoesNotBlockLaterFetch() =
         runTest {
-            val config = ServerConfig(
-                buildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonBuildTimestamp = "2024-01-15T00:00:00Z",
-                remoteButtonPushKey = "key",
-            )
-            configDataSource.setServerConfigResult(NetworkResult.Success(config))
+            val ds = FakeNetworkConfigDataSource().apply {
+                setServerConfigResult(NetworkResult.ConnectionFailed)
+            }
+            val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
 
-            val repo = createRepository()
-            repo.getServerConfigCached()
+            val repo = CachedServerConfigRepository(ds, "key", externalScope)
+            advanceUntilIdle()
+            assertNull(repo.serverConfig.value)
 
-            // Network now returns null
-            configDataSource.setServerConfigResult(NetworkResult.ConnectionFailed)
-            repo.fetchServerConfig()
+            // Fix the network and retry — should succeed.
+            ds.setServerConfigResult(NetworkResult.Success(sampleConfig))
+            val result = repo.fetchServerConfig()
+            assertEquals(sampleConfig, result)
 
-            // Cache should retain the old value
-            assertEquals(config, repo.getServerConfigCached())
+            // But a null server config does NOT overwrite a cached value.
+            ds.setServerConfigResult(NetworkResult.ConnectionFailed)
+            val failResult = repo.fetchServerConfig()
+            assertEquals(sampleConfig, failResult) // cached value won
+            assertEquals(sampleConfig, repo.serverConfig.value)
+
+            externalScope.cancel()
         }
 }

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepositoryIntegrationTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepositoryIntegrationTest.kt
@@ -26,8 +26,11 @@ import com.chriscartland.garage.domain.model.ServerConfig
 import com.chriscartland.garage.testcommon.FakeNetworkConfigDataSource
 import com.chriscartland.garage.testcommon.FakeNetworkDoorDataSource
 import com.chriscartland.garage.testcommon.InMemoryLocalDoorDataSource
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -48,6 +51,7 @@ class NetworkDoorRepositoryIntegrationTest {
         val serverConfigRepo = CachedServerConfigRepository(
             networkConfigDataSource = configDataSource,
             serverConfigKey = "test-key",
+            externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher()),
         )
         return NetworkDoorRepository(
             localDoorDataSource = localDataSource,

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepositoryTest.kt
@@ -60,7 +60,7 @@ class NetworkSnoozeRepositoryTest {
 
             val repo = NetworkSnoozeRepository(
                 networkButtonDataSource = buttonDs,
-                serverConfigRepository = CachedServerConfigRepository(configDs, "key"),
+                serverConfigRepository = CachedServerConfigRepository(configDs, "key", externalScope),
                 snoozeNotificationsOption = true,
                 currentTimeSeconds = { 0L },
                 externalScope = externalScope,
@@ -87,7 +87,7 @@ class NetworkSnoozeRepositoryTest {
 
             val repo = NetworkSnoozeRepository(
                 networkButtonDataSource = buttonDs,
-                serverConfigRepository = CachedServerConfigRepository(configDs, "key"),
+                serverConfigRepository = CachedServerConfigRepository(configDs, "key", externalScope),
                 snoozeNotificationsOption = true,
                 currentTimeSeconds = { 0L },
                 externalScope = externalScope,
@@ -116,7 +116,7 @@ class NetworkSnoozeRepositoryTest {
 
             val repo = NetworkSnoozeRepository(
                 networkButtonDataSource = buttonDs,
-                serverConfigRepository = CachedServerConfigRepository(configDs, "key"),
+                serverConfigRepository = CachedServerConfigRepository(configDs, "key", externalScope),
                 snoozeNotificationsOption = true,
                 currentTimeSeconds = { 0L },
                 externalScope = externalScope,
@@ -142,7 +142,7 @@ class NetworkSnoozeRepositoryTest {
 
             val repo = NetworkSnoozeRepository(
                 networkButtonDataSource = buttonDs,
-                serverConfigRepository = CachedServerConfigRepository(configDs, "key"),
+                serverConfigRepository = CachedServerConfigRepository(configDs, "key", externalScope),
                 snoozeNotificationsOption = true,
                 currentTimeSeconds = { now },
                 externalScope = externalScope,
@@ -171,7 +171,7 @@ class NetworkSnoozeRepositoryTest {
 
             val repo = NetworkSnoozeRepository(
                 networkButtonDataSource = buttonDs,
-                serverConfigRepository = CachedServerConfigRepository(configDs, "key"),
+                serverConfigRepository = CachedServerConfigRepository(configDs, "key", externalScope),
                 snoozeNotificationsOption = true,
                 currentTimeSeconds = { now },
                 externalScope = externalScope,
@@ -218,7 +218,7 @@ class NetworkSnoozeRepositoryTest {
 
             val repo = NetworkSnoozeRepository(
                 networkButtonDataSource = buttonDs,
-                serverConfigRepository = CachedServerConfigRepository(configDs, "key"),
+                serverConfigRepository = CachedServerConfigRepository(configDs, "key", externalScope),
                 snoozeNotificationsOption = true,
                 currentTimeSeconds = { now },
                 externalScope = externalScope,
@@ -256,7 +256,7 @@ class NetworkSnoozeRepositoryTest {
 
             val repo = NetworkSnoozeRepository(
                 networkButtonDataSource = buttonDs,
-                serverConfigRepository = CachedServerConfigRepository(configDs, "key"),
+                serverConfigRepository = CachedServerConfigRepository(configDs, "key", externalScope),
                 snoozeNotificationsOption = true,
                 currentTimeSeconds = { now },
                 externalScope = externalScope,
@@ -290,7 +290,7 @@ class NetworkSnoozeRepositoryTest {
 
             val repo = NetworkSnoozeRepository(
                 networkButtonDataSource = buttonDs,
-                serverConfigRepository = CachedServerConfigRepository(configDs, "key"),
+                serverConfigRepository = CachedServerConfigRepository(configDs, "key", externalScope),
                 snoozeNotificationsOption = true,
                 currentTimeSeconds = { 0L },
                 externalScope = externalScope,
@@ -315,7 +315,7 @@ class NetworkSnoozeRepositoryTest {
 
             val repo = NetworkSnoozeRepository(
                 networkButtonDataSource = buttonDs,
-                serverConfigRepository = CachedServerConfigRepository(configDs, "key"),
+                serverConfigRepository = CachedServerConfigRepository(configDs, "key", externalScope),
                 snoozeNotificationsOption = false,
                 currentTimeSeconds = { 0L },
                 externalScope = externalScope,

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/RemoteButtonRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/RemoteButtonRepositoryTest.kt
@@ -4,7 +4,13 @@ import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.domain.model.ServerConfig
 import com.chriscartland.garage.testcommon.FakeNetworkButtonDataSource
 import com.chriscartland.garage.testcommon.FakeNetworkConfigDataSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -13,26 +19,36 @@ import kotlin.test.assertEquals
  * Tests use real [CachedServerConfigRepository] with [FakeNetworkConfigDataSource],
  * exercising the actual caching and null-handling logic in the repository.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class RemoteButtonRepositoryTest {
     private lateinit var networkButtonDataSource: FakeNetworkButtonDataSource
     private lateinit var networkConfigDataSource: FakeNetworkConfigDataSource
-    private lateinit var repo: NetworkRemoteButtonRepository
+    private lateinit var externalScope: CoroutineScope
+
+    private fun buildRepo(enabled: Boolean = true): NetworkRemoteButtonRepository =
+        NetworkRemoteButtonRepository(
+            networkButtonDataSource,
+            CachedServerConfigRepository(networkConfigDataSource, "test-key", externalScope),
+            remoteButtonPushEnabled = enabled,
+        )
 
     @BeforeTest
     fun setup() {
         networkButtonDataSource = FakeNetworkButtonDataSource()
         networkConfigDataSource = FakeNetworkConfigDataSource()
-        repo = NetworkRemoteButtonRepository(
-            networkButtonDataSource,
-            CachedServerConfigRepository(networkConfigDataSource, "test-key"),
-            remoteButtonPushEnabled = true,
-        )
+        externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        externalScope.cancel()
     }
 
     @Test
     fun pushReturnsFalseWhenServerConfigFetchFails() =
         runTest {
             networkConfigDataSource.setServerConfigResult(NetworkResult.ConnectionFailed)
+            val repo = buildRepo()
             val result = repo.pushButton("token", "ack-token")
             assertEquals(false, result)
             assertEquals(0, networkButtonDataSource.pushCount)
@@ -46,6 +62,7 @@ class RemoteButtonRepositoryTest {
                     ServerConfig(buildTimestamp = "test", remoteButtonBuildTimestamp = "test", remoteButtonPushKey = "key"),
                 ),
             )
+            val repo = buildRepo()
             val result = repo.pushButton("token", "ack-token")
             assertEquals(true, result)
             assertEquals(1, networkButtonDataSource.pushCount)
@@ -60,6 +77,7 @@ class RemoteButtonRepositoryTest {
                 ),
             )
             networkButtonDataSource.setPushResult(NetworkResult.HttpError(500))
+            val repo = buildRepo()
             val result = repo.pushButton("token", "ack-token")
             assertEquals(false, result)
             assertEquals(1, networkButtonDataSource.pushCount)
@@ -74,6 +92,7 @@ class RemoteButtonRepositoryTest {
                 ),
             )
             networkButtonDataSource.setPushResult(NetworkResult.ConnectionFailed)
+            val repo = buildRepo()
             val result = repo.pushButton("token", "ack-token")
             assertEquals(false, result)
         }
@@ -81,16 +100,12 @@ class RemoteButtonRepositoryTest {
     @Test
     fun pushReturnsFalseWhenFeatureDisabled() =
         runTest {
-            val disabledRepo = NetworkRemoteButtonRepository(
-                networkButtonDataSource,
-                CachedServerConfigRepository(networkConfigDataSource, "test-key"),
-                remoteButtonPushEnabled = false,
-            )
             networkConfigDataSource.setServerConfigResult(
                 NetworkResult.Success(
                     ServerConfig(buildTimestamp = "test", remoteButtonBuildTimestamp = "test", remoteButtonPushKey = "key"),
                 ),
             )
+            val disabledRepo = buildRepo(enabled = false)
             val result = disabledRepo.pushButton("token", "ack-token")
             assertEquals(false, result)
             assertEquals(0, networkButtonDataSource.pushCount)

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/SnoozeMultiSubscriberIntegrationTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/SnoozeMultiSubscriberIntegrationTest.kt
@@ -69,7 +69,7 @@ class SnoozeMultiSubscriberIntegrationTest {
     ): NetworkSnoozeRepository =
         NetworkSnoozeRepository(
             networkButtonDataSource = buttonDs,
-            serverConfigRepository = CachedServerConfigRepository(configDs, "key"),
+            serverConfigRepository = CachedServerConfigRepository(configDs, "key", externalScope),
             snoozeNotificationsOption = true,
             currentTimeSeconds = { currentTime },
             externalScope = externalScope,

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/ServerConfigRepository.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/ServerConfigRepository.kt
@@ -1,9 +1,23 @@
 package com.chriscartland.garage.domain.repository
 
 import com.chriscartland.garage.domain.model.ServerConfig
+import kotlinx.coroutines.flow.StateFlow
 
+/**
+ * Server configuration owner.
+ *
+ * Per ADR-022, the repository owns the authoritative
+ * `StateFlow<ServerConfig?>` — an always-on collector populates it on
+ * construction and [fetchServerConfig] refreshes it.
+ */
 interface ServerConfigRepository {
-    suspend fun getServerConfigCached(): ServerConfig?
+    /** Observation: latest cached config (null until the first fetch succeeds). */
+    val serverConfig: StateFlow<ServerConfig?>
 
+    /**
+     * Force-fetch the server config. On success, writes the result into
+     * [serverConfig] and returns it. Returns null on failure (the flow is
+     * left unchanged).
+     */
     suspend fun fetchServerConfig(): ServerConfig?
 }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RealNetworkSnoozeRepositoryPropagationTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RealNetworkSnoozeRepositoryPropagationTest.kt
@@ -159,6 +159,7 @@ class RealNetworkSnoozeRepositoryPropagationTest {
                 serverConfigRepository = CachedServerConfigRepository(
                     configDs,
                     "test-key",
+                    externalScope,
                 ),
                 snoozeNotificationsOption = true,
                 currentTimeSeconds = { now },
@@ -256,7 +257,7 @@ class RealNetworkSnoozeRepositoryPropagationTest {
             )
             val snoozeRepository = NetworkSnoozeRepository(
                 networkButtonDataSource = buttonDs,
-                serverConfigRepository = CachedServerConfigRepository(configDs, "test-key"),
+                serverConfigRepository = CachedServerConfigRepository(configDs, "test-key", externalScope),
                 snoozeNotificationsOption = true,
                 currentTimeSeconds = { now },
                 externalScope = externalScope,

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SharedRepositoryUseCasesTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SharedRepositoryUseCasesTest.kt
@@ -84,7 +84,7 @@ class SharedRepositoryUseCasesTest {
         val configDs = FakeNetworkConfigDataSource().apply { setServerConfigResult(validConfig) }
         val repo: SnoozeRepository = NetworkSnoozeRepository(
             networkButtonDataSource = buttonDs,
-            serverConfigRepository = CachedServerConfigRepository(configDs, "key"),
+            serverConfigRepository = CachedServerConfigRepository(configDs, "key", externalScope),
             snoozeNotificationsOption = true,
             currentTimeSeconds = { now },
             externalScope = externalScope,


### PR DESCRIPTION
## Summary

- `ServerConfigRepository` exposes `val serverConfig: StateFlow<ServerConfig?>` (drops `suspend getServerConfigCached()`)
- `CachedServerConfigRepository` now wraps its cache in a `MutableStateFlow` and launches the first fetch on `externalScope` at construction (ADR-022 always-on pattern)
- `fetchServerConfig()` is a coalescing refresh command: concurrent callers share the in-flight fetch via `fetchMutex.withLock`; already-cached values short-circuit without a network round-trip
- Data-source exceptions are caught inside `fetchServerConfig` — the cache stays null rather than crashing `externalScope`
- Callers (snooze, button, door) read `serverConfig.value ?: fetchServerConfig()` inline — no observer mirror
- Per [MIGRATION_PLAN.md](AndroidGarage/docs/MIGRATION_PLAN.md), PR 6 of 8 (independent of PRs 4, 5, 7)

## Test plan

- [x] `CachedServerConfigRepositoryTest` rewritten for the new shape: eager init-fetch, coalesced refresh, mutex-release, exception-swallowing
- [x] `AndroidGarage/gradlew :data:testDebugUnitTest :usecase:testDebugUnitTest` passes
- [x] `AndroidGarage/gradlew :androidApp:compileDebugKotlin` passes
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)