### PR TITLE
refactor: FcmRegistrationManager exposes StateFlow (PR 7 of 8)

### DIFF
--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorViewModel.kt
@@ -58,9 +58,9 @@ class DefaultDoorViewModel(
     private val fetchOnInit: Boolean = true,
 ) : ViewModel(),
     DoorViewModel {
-    // ADR-017 Rule 6: explicit MutableStateFlow + collect, no stateIn in ViewModels.
-    private val _fcmRegistrationStatus = MutableStateFlow(FcmRegistrationStatus.UNKNOWN)
-    override val fcmRegistrationStatus: StateFlow<FcmRegistrationStatus> = _fcmRegistrationStatus
+    // ADR-022: expose the manager's StateFlow by reference — no mirror.
+    override val fcmRegistrationStatus: StateFlow<FcmRegistrationStatus> =
+        fcmRegistrationManager.registrationStatus
 
     private val _currentDoorEvent =
         MutableStateFlow<LoadingResult<DoorEvent?>>(LoadingResult.Loading(null))
@@ -75,11 +75,6 @@ class DefaultDoorViewModel(
 
     init {
         Logger.d { "init" }
-        viewModelScope.launch(dispatchers.io) {
-            fcmRegistrationManager.registrationStatus.collect {
-                _fcmRegistrationStatus.value = it
-            }
-        }
         viewModelScope.launch(dispatchers.io) {
             checkInStalenessManager.isCheckInStale.collect {
                 _isCheckInStale.value = it

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/FcmRegistrationManager.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/FcmRegistrationManager.kt
@@ -24,8 +24,8 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 /**
@@ -35,7 +35,9 @@ import kotlinx.coroutines.launch
  * retries with fixed delay on failure, stops on success.
  *
  * [start] is idempotent — calling twice doesn't create two retry loops.
- * Status is observable via [registrationStatus].
+ * Status is observable via [registrationStatus] — per ADR-022, this is a
+ * `StateFlow<FcmRegistrationStatus>` so subscribers read `.value` for the
+ * current status and VMs expose it by reference.
  */
 class FcmRegistrationManager(
     private val registerFcmUseCase: RegisterFcmUseCase,
@@ -43,10 +45,10 @@ class FcmRegistrationManager(
     private val dispatcher: CoroutineDispatcher,
     private val retryDelayMillis: Long = DEFAULT_RETRY_DELAY,
 ) {
-    private val statusFlow = MutableStateFlow(FcmRegistrationStatus.UNKNOWN)
+    private val _registrationStatus = MutableStateFlow(FcmRegistrationStatus.UNKNOWN)
 
-    /** Observable registration status. ViewModel collects this. */
-    val registrationStatus: Flow<FcmRegistrationStatus> = statusFlow
+    /** Observable registration status (ADR-022). */
+    val registrationStatus: StateFlow<FcmRegistrationStatus> = _registrationStatus
 
     private var retryJob: Job? = null
 
@@ -55,7 +57,7 @@ class FcmRegistrationManager(
      * or already registered, this is a no-op.
      */
     fun start() {
-        if (statusFlow.value == FcmRegistrationStatus.REGISTERED) {
+        if (_registrationStatus.value == FcmRegistrationStatus.REGISTERED) {
             Logger.d { "FcmRegistrationManager: already registered" }
             return
         }
@@ -80,7 +82,8 @@ class FcmRegistrationManager(
         Logger.d { "FcmRegistrationManager: restarting" }
         retryJob?.cancel()
         retryJob = null
-        statusFlow.value = FcmRegistrationStatus.UNKNOWN
+        _registrationStatus.value = FcmRegistrationStatus.UNKNOWN
+        Logger.i { "fcmRegistrationStatus <- UNKNOWN (source=restart)" }
         retryJob = scope.launch(dispatcher) {
             attemptWithRetry()
         }
@@ -91,13 +94,15 @@ class FcmRegistrationManager(
             Logger.d { "FcmRegistrationManager: attempting registration" }
             when (val result = registerFcmUseCase()) {
                 is AppResult.Success -> {
-                    Logger.d { "FcmRegistrationManager: registered" }
-                    statusFlow.value = FcmRegistrationStatus.REGISTERED
+                    _registrationStatus.value = FcmRegistrationStatus.REGISTERED
+                    Logger.i { "fcmRegistrationStatus <- REGISTERED (source=registerUseCase)" }
                     return
                 }
                 is AppResult.Error -> {
-                    Logger.w { "FcmRegistrationManager: failed (${result.error}), retrying in ${retryDelayMillis}ms" }
-                    statusFlow.value = FcmRegistrationStatus.NOT_REGISTERED
+                    _registrationStatus.value = FcmRegistrationStatus.NOT_REGISTERED
+                    Logger.w {
+                        "fcmRegistrationStatus <- NOT_REGISTERED (source=registerUseCase error=${result.error}); retry in ${retryDelayMillis}ms"
+                    }
                     delay(retryDelayMillis)
                 }
             }


### PR DESCRIPTION
## Summary

- `FcmRegistrationManager.registrationStatus` is now `StateFlow<FcmRegistrationStatus>` (was `Flow`)
- `DefaultDoorViewModel` exposes the manager's `StateFlow` by reference — the local `_fcmRegistrationStatus` mirror and its `init { collect }` observer are **deleted**
- Adds Rule 9 state-write logging at every `_registrationStatus.value = ...` site (register success, register error, restart)
- Per [MIGRATION_PLAN.md](AndroidGarage/docs/MIGRATION_PLAN.md), PR 7 of 8

## Scope note

The plan says `DoorFcmRepository / manager (FcmRegistrationManager)`. The repository's methods are command-only (no observer chain today), so the observable state actually lives on the manager — that's where this PR focuses. Exposing the manager's StateFlow by reference is the minimum change that lets the VM stop mirroring.

## Test plan

- [x] `AndroidGarage/gradlew :usecase:testDebugUnitTest` passes (existing FcmRegistrationManagerTest tests still pass against the new type)
- [x] `AndroidGarage/gradlew :androidApp:compileDebugKotlin` passes
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)