### PR TITLE
refactor: DoorRepository.currentDoorEvent owns StateFlow (PR 5 of 8)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -233,6 +233,7 @@ abstract class AppComponent(
             provideNetworkDoorDataSource(),
             provideServerConfigRepository(),
             provideAppConfig().recentEventCount,
+            provideApplicationScope(),
         )
 
     @Provides

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepository.kt
@@ -27,15 +27,20 @@ import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.model.FetchError
 import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.domain.repository.ServerConfigRepository
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 
 class NetworkDoorRepository(
     private val localDoorDataSource: LocalDoorDataSource,
     private val networkDoorDataSource: NetworkDoorDataSource,
     private val serverConfigRepository: ServerConfigRepository,
     private val recentEventCount: Int,
+    externalScope: CoroutineScope,
 ) : DoorRepository {
     override val currentDoorPosition: Flow<DoorPosition>
         get() =
@@ -43,8 +48,24 @@ class NetworkDoorRepository(
                 .map {
                     it?.doorPosition ?: DoorPosition.UNKNOWN
                 }.distinctUntilChanged()
-    override val currentDoorEvent: Flow<DoorEvent?> = localDoorDataSource.currentDoorEvent
+
+    // ADR-022: repository-owned StateFlow backed by an always-on collector
+    // over the Room flow. `stateIn(WhileSubscribed(5s))` is explicitly banned
+    // — it causes Room queries to restart and drops subscribers' state on a
+    // configuration change.
+    private val _currentDoorEvent = MutableStateFlow<DoorEvent?>(null)
+    override val currentDoorEvent: StateFlow<DoorEvent?> = _currentDoorEvent
+
     override val recentDoorEvents: Flow<List<DoorEvent>> = localDoorDataSource.recentDoorEvents
+
+    init {
+        externalScope.launch {
+            localDoorDataSource.currentDoorEvent.collect { event ->
+                _currentDoorEvent.value = event
+                Logger.i { "currentDoorEvent <- $event (source=local)" }
+            }
+        }
+    }
 
     override suspend fun fetchBuildTimestampCached(): String? {
         val cached = serverConfigRepository.serverConfig.value

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepositoryIntegrationTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepositoryIntegrationTest.kt
@@ -47,7 +47,9 @@ class NetworkDoorRepositoryIntegrationTest {
     private val networkDataSource = FakeNetworkDoorDataSource()
     private val configDataSource = FakeNetworkConfigDataSource()
 
-    private fun createRepository(): NetworkDoorRepository {
+    private fun createRepository(
+        externalScope: CoroutineScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher()),
+    ): NetworkDoorRepository {
         val serverConfigRepo = CachedServerConfigRepository(
             networkConfigDataSource = configDataSource,
             serverConfigKey = "test-key",
@@ -58,6 +60,7 @@ class NetworkDoorRepositoryIntegrationTest {
             networkDoorDataSource = networkDataSource,
             serverConfigRepository = serverConfigRepo,
             recentEventCount = 10,
+            externalScope = externalScope,
         )
     }
 

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/DoorRepository.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/DoorRepository.kt
@@ -5,15 +5,19 @@ import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.model.FetchError
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 
 interface DoorRepository {
     /** Observation: current door position derived from latest event. */
     val currentDoorPosition: Flow<DoorPosition>
 
-    /** Observation: current door event from local cache. */
-    val currentDoorEvent: Flow<DoorEvent?>
+    /**
+     * Observation: current door event owned as a [StateFlow] (ADR-022 —
+     * state-y). Backed by an always-on collector over the local Room flow.
+     */
+    val currentDoorEvent: StateFlow<DoorEvent?>
 
-    /** Observation: recent door events from local cache. */
+    /** Observation: recent door events from local cache (list-y, cold). */
     val recentDoorEvents: Flow<List<DoorEvent>>
 
     suspend fun fetchBuildTimestampCached(): String?

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeDoorRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeDoorRepository.kt
@@ -24,14 +24,15 @@ import com.chriscartland.garage.domain.model.FetchError
 import com.chriscartland.garage.domain.repository.DoorRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 class FakeDoorRepository : DoorRepository {
-    private val _currentDoorEvent = MutableStateFlow(DoorEvent())
+    private val _currentDoorEvent = MutableStateFlow<DoorEvent?>(DoorEvent())
     private val _recentDoorEvents = MutableStateFlow<List<DoorEvent>>(emptyList())
     private val _currentDoorPosition = MutableStateFlow(DoorPosition.UNKNOWN)
 
     override val currentDoorPosition: Flow<DoorPosition> = _currentDoorPosition
-    override val currentDoorEvent: Flow<DoorEvent?> = _currentDoorEvent
+    override val currentDoorEvent: StateFlow<DoorEvent?> = _currentDoorEvent
     override val recentDoorEvents: Flow<List<DoorEvent>> = _recentDoorEvents
 
     var fetchCurrentDoorEventCount = 0
@@ -62,7 +63,8 @@ class FakeDoorRepository : DoorRepository {
 
     override suspend fun fetchCurrentDoorEvent(): AppResult<DoorEvent, FetchError> {
         fetchCurrentDoorEventCount++
-        return AppResult.Success(_currentDoorEvent.value)
+        return _currentDoorEvent.value?.let { AppResult.Success(it) }
+            ?: AppResult.Error(FetchError.NotReady)
     }
 
     override suspend fun fetchRecentDoorEvents(): AppResult<List<DoorEvent>, FetchError> {


### PR DESCRIPTION
## Summary

- `DoorRepository.currentDoorEvent` is now `val : StateFlow<DoorEvent?>` (was `Flow<DoorEvent?>`)
- `recentDoorEvents` stays a cold `Flow<List<DoorEvent>>` — list-y per ADR-022 §Categories
- `NetworkDoorRepository` launches an always-on collector on `externalScope` that consumes the Room flow and writes into a `MutableStateFlow` — does **not** use `stateIn(WhileSubscribed)` (explicitly banned by ADR-022)
- Adds Rule 9 state-write logging when the local flow emits
- `FakeDoorRepository` matches the new interface
- `AppComponent` wires `provideApplicationScope()` into `NetworkDoorRepository`
- Per [MIGRATION_PLAN.md](AndroidGarage/docs/MIGRATION_PLAN.md), PR 5 of 8

## Derivation vs. mirror

`DoorViewModel._currentDoorEvent` stays — it wraps the repo state in `LoadingResult<T>` which is a genuine derivation (new type, new semantics), not a mirror. This is consistent with ADR-022's guidance that per-VM transforms are acceptable.

## Test plan

- [x] `AndroidGarage/gradlew :data:testDebugUnitTest :usecase:testDebugUnitTest` passes
- [x] `AndroidGarage/gradlew :androidApp:compileDebugKotlin` passes
- [x] `./scripts/validate.sh` passes
- [ ] Smoke on-device: door state updates after fetch, no Room query restarts on recomposition

🤖 Generated with [Claude Code](https://claude.com/claude-code)