### PR TITLE
chore: Lint enforcement for ADR-022 state ownership (PR 8 of 8)

### DIFF
--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -70,6 +70,21 @@ tasks.register<architecture.ArchitectureCheckTask>("checkArchitecture") {
 
 tasks.register<architecture.SingletonGuardTask>("checkSingletonGuard") {
     sourceDir = "$rootDir/androidApp/src/main/java"
+    guardedMethodPatterns = listOf(
+        // Framework singletons — multiple instances crash or corrupt.
+        "provideAppDatabase",
+        "provideAppSettings",
+        "provideHttpClient",
+        // ADR-022 state-owning repositories — if not @Singleton, the owned
+        // StateFlow is instantiated per-caller and every subscriber sees its
+        // own timeline (the android/164-168 class of bug).
+        "provideAuthRepository",
+        "provideSnoozeRepository",
+        "provideDoorRepository",
+        "provideServerConfigRepository",
+        "provideDoorFcmRepository",
+        "provideFcmRegistrationManager",
+    )
 }
 
 tasks.register<architecture.LayerImportCheckTask>("checkLayerImports") {

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/ViewModelStateFlowCheckTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/ViewModelStateFlowCheckTask.kt
@@ -7,7 +7,9 @@ import org.gradle.api.tasks.TaskAction
 import java.io.File
 
 /**
- * Bans `.stateIn(viewModelScope, ...)` in ViewModel files (ADR-017 Rule 6).
+ * Enforces two ViewModel rules related to state exposure.
+ *
+ * ### Rule 1 (ADR-017 Rule 6): no `.stateIn(viewModelScope, ...)`
  *
  * The `stateIn(Eagerly)` pattern caused a real production bug where
  * Compose collectors did not observe upstream state changes (see PR #295,
@@ -16,17 +18,45 @@ import java.io.File
  *
  * Only literal `viewModelScope` is banned — `stateIn(applicationScope, ...)`
  * in a Manager class is legitimate.
+ *
+ * ### Rule 2 (ADR-022): no VM-local mirror of repository-owned state types
+ *
+ * Domain state types whose ownership lives on a `@Singleton` repository
+ * (ADR-022) must never be re-declared inside a ViewModel as a private
+ * `MutableStateFlow<T>`. If a VM owns its own `MutableStateFlow<SnoozeState>`,
+ * it's mirroring the repo's flow and will drift under multiple VM
+ * instances (android/164-168).
+ *
+ * The allowlist holds the domain state types we've migrated so far. Adding
+ * a new type to the list is how we extend enforcement as more state-y data
+ * moves to repository ownership.
  */
 abstract class ViewModelStateFlowCheckTask : DefaultTask() {
     @get:Input
     var sourceDirs: List<String> = emptyList()
 
-    private val pattern = Regex("""\.stateIn\s*\(\s*viewModelScope""")
+    /**
+     * Domain state types that must be owned on the repository. A
+     * `MutableStateFlow<X>` with any of these type arguments inside a
+     * ViewModel is a mirror and fails the check.
+     */
+    @get:Input
+    var bannedStateTypesInViewModels: List<String> = listOf(
+        "SnoozeState",
+        "AuthState",
+        "FcmRegistrationStatus",
+    )
+
+    private val stateInPattern = Regex("""\.stateIn\s*\(\s*viewModelScope""")
     private val fileNameRegex = Regex(".*ViewModel\\.kt")
 
     @TaskAction
     fun check() {
         val violations = mutableListOf<String>()
+
+        val bannedTypeRegex = Regex(
+            """\bMutableStateFlow\s*<\s*(${bannedStateTypesInViewModels.joinToString("|")})\s*\??\s*>""",
+        )
 
         for (dirPath in sourceDirs) {
             val dir = File(dirPath)
@@ -37,11 +67,22 @@ abstract class ViewModelStateFlowCheckTask : DefaultTask() {
                 .filter { it.extension == "kt" && fileNameRegex.matches(it.name) }
                 .forEach { file ->
                     file.readLines().forEachIndexed { index, line ->
-                        if (pattern.containsMatchIn(line)) {
+                        if (stateInPattern.containsMatchIn(line)) {
                             violations.add(
                                 "${file.relativeTo(dir).path}:${index + 1}: " +
                                     "stateIn(viewModelScope, ...) is banned in ViewModels (ADR-017 Rule 6). " +
                                     "Use explicit MutableStateFlow + init.collect instead. " +
+                                    "Line: ${line.trim()}",
+                            )
+                        }
+                        val bannedMatch = bannedTypeRegex.find(line)
+                        if (bannedMatch != null) {
+                            val typeArg = bannedMatch.groupValues[1]
+                            violations.add(
+                                "${file.relativeTo(dir).path}:${index + 1}: " +
+                                    "VM-local MutableStateFlow<$typeArg> is banned (ADR-022). " +
+                                    "State-y types are owned by a @Singleton repository — expose the " +
+                                    "repo's StateFlow by reference (observeXUseCase()), do not mirror. " +
                                     "Line: ${line.trim()}",
                             )
                         }
@@ -55,6 +96,6 @@ abstract class ViewModelStateFlowCheckTask : DefaultTask() {
                     violations.joinToString("\n\n") { "  $it" },
             )
         }
-        logger.lifecycle("ViewModel StateFlow check passed: no stateIn(viewModelScope, ...) usages.")
+        logger.lifecycle("ViewModel StateFlow check passed: no stateIn(viewModelScope, ...) usages and no banned VM-local mirrors.")
     }
 }

--- a/AndroidGarage/docs/DECISIONS.md
+++ b/AndroidGarage/docs/DECISIONS.md
@@ -851,7 +851,7 @@ Rule 2 (raw-body logging at network-data-source boundaries) is a specific instan
 
 ## ADR-021: State Ownership and ViewModel Scoping Principles
 
-**Status:** Accepted
+**Status:** Accepted and enforced.
 
 **Context:** The android/164-168 snooze-state propagation bug (see `VIEWMODEL_SCOPING_ISSUE.md`) exposed an unstated assumption in the architecture: that "there is one `RemoteButtonViewModel`." In fact there were three — Activity-scope (dead code), Home nav entry, Profile nav entry — each with its own `_snoozeState: MutableStateFlow<SnoozeState>` mirroring the singleton repository. Compose read from one; the others emitted independently. Under production conditions the read-side VM could silently miss an emission while the other two saw it.
 
@@ -971,7 +971,16 @@ After this change, three VMs don't multiply the truth. They multiply only their 
 
 ## ADR-022: `StateFlow` at the Repository Boundary for State-y Data
 
-**Status:** Accepted. Partially supersedes ADR-013.
+**Status:** Accepted and enforced. Partially supersedes ADR-013.
+
+**Enforcement** (per `MIGRATION_PLAN.md` PR 8):
+- `checkViewModelStateFlow` bans `MutableStateFlow<T>` in `*ViewModel.kt`
+  when `T` matches the domain-state allowlist (`SnoozeState`, `AuthState`,
+  `FcmRegistrationStatus`). Add a type to the allowlist in
+  `ViewModelStateFlowCheckTask.bannedStateTypesInViewModels` when its
+  repository migration lands.
+- `checkSingletonGuard` requires `@Singleton` on every
+  `provide<State-owning-Repository>` method in `AppComponent`.
 
 ### Glossary
 


### PR DESCRIPTION
## Summary

Makes the repository-owned-`StateFlow` invariant load-bearing via compile-time checks. After this PR, any accidental reintroduction of a VM-local mirror or a non-singleton state-owning repository fails the `validate.sh` lint gate before it can land.

### `ViewModelStateFlowCheckTask`

- **Rule 2 check (new):** bans `MutableStateFlow<T>` inside a `*ViewModel.kt` when `T` is in a domain-state-type allowlist (`SnoozeState`, `AuthState`, `FcmRegistrationStatus`). Extend the allowlist (`bannedStateTypesInViewModels`) as more state-y types migrate.
- Preserves the existing Rule 1 `stateIn(viewModelScope)` ban (ADR-017 Rule 6).

### `SingletonGuardTask`

- Extends `guardedMethodPatterns` to cover every state-owning repository provider in `AppComponent`:
  `provideAuthRepository`, `provideSnoozeRepository`, `provideDoorRepository`, `provideServerConfigRepository`, `provideDoorFcmRepository`, `provideFcmRegistrationManager`.
- Non-`@Singleton` on any of these would re-create the android/164-168 multi-instance class of bug.

### ADR status updates

- **ADR-021**: `Accepted` → `Accepted and enforced`.
- **ADR-022**: `Accepted and enforced`. Calls out which lint tasks enforce what and how to extend the allowlist.

## Test plan

- [x] `AndroidGarage/gradlew checkSingletonGuard checkViewModelStateFlow` passes (current codebase complies)
- [x] `./scripts/validate.sh` passes

## Merge order

PR 8 of 8. **Do not enable auto-merge** — reviewing the enforcement threshold before it becomes binding is worthwhile. Per [MIGRATION_PLAN.md](AndroidGarage/docs/MIGRATION_PLAN.md) verification checklist: "No auto-merge on the enforcement PR (PR 8) without manual approval."

Also depends on PR #364 (PR 5) landing so `DoorEvent?` state is available — intentionally excluded from the allowlist in this PR's initial cut; add it once PR 5 is on main if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)