### PR TITLE
fix: fetchServerConfig always refreshes the cache

### DIFF
--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepository.kt
@@ -53,13 +53,20 @@ class CachedServerConfigRepository(
         externalScope.launch { fetchServerConfig() }
     }
 
-    override suspend fun fetchServerConfig(): ServerConfig? {
-        // withLock coalesces concurrent fetch attempts: the second caller
-        // waits for the in-flight fetch, then reads the cached result
-        // instead of issuing a duplicate network call.
-        return fetchMutex.withLock {
-            val cached = _serverConfig.value
-            if (cached != null) return@withLock cached
+    /**
+     * Force-refresh the server config.
+     *
+     * Always hits the network and writes a successful result to
+     * [serverConfig]. The mutex serializes concurrent callers — two racing
+     * calls will each issue one network request (no in-flight coalescing);
+     * the second just waits for the first to return its lock.
+     *
+     * Returns the freshly-fetched [ServerConfig] on success, or null on any
+     * HTTP / connection / exception failure. Null does NOT overwrite a
+     * previously-cached successful value.
+     */
+    override suspend fun fetchServerConfig(): ServerConfig? =
+        fetchMutex.withLock {
             val config = try {
                 when (val result = networkConfigDataSource.fetchServerConfig(serverConfigKey)) {
                     is NetworkResult.Success -> result.data
@@ -67,14 +74,13 @@ class CachedServerConfigRepository(
                     NetworkResult.ConnectionFailed -> null
                 }
             } catch (e: Exception) {
-                Logger.e(e) { "Server config fetch threw — leaving cache null" }
+                Logger.e(e) { "Server config fetch threw — leaving cache untouched" }
                 null
             }
             if (config != null) {
                 _serverConfig.value = config
-                Logger.i { "serverConfig <- cached (source=GET)" }
+                Logger.i { "serverConfig <- $config (source=GET)" }
             }
             config
         }
-    }
 }

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepositoryTest.kt
@@ -65,22 +65,32 @@ class CachedServerConfigRepositoryTest {
             externalScope.cancel()
         }
 
+    /**
+     * Documents the contract of [CachedServerConfigRepository.fetchServerConfig]:
+     * it is a force-refresh. A server-side change in config is visible to the
+     * next caller without needing a process restart.
+     */
     @Test
-    fun fetchServerConfigReturnsCachedValueOnSecondCall() =
+    fun fetchServerConfigAlwaysRefreshesCache() =
         runTest {
+            val v1 = sampleConfig
+            val v2 = sampleConfig.copy(buildTimestamp = "2024-01-16T00:00:00Z")
             val ds = FakeNetworkConfigDataSource().apply {
-                setServerConfigResult(NetworkResult.Success(sampleConfig))
+                setServerConfigResult(NetworkResult.Success(v1))
             }
             val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
 
             val repo = CachedServerConfigRepository(ds, "test-key", externalScope)
             advanceUntilIdle()
-            // init fetch counted.
+            assertEquals(v1, repo.serverConfig.value)
 
-            val secondCall = repo.fetchServerConfig()
-            assertEquals(sampleConfig, secondCall)
-            // Second call served from cache — no extra network fetch.
-            assertEquals(1, ds.fetchCount)
+            // Server changes. fetchServerConfig must see the new value.
+            ds.setServerConfigResult(NetworkResult.Success(v2))
+            val refreshed = repo.fetchServerConfig()
+
+            assertEquals(v2, refreshed)
+            assertEquals(v2, repo.serverConfig.value)
+            assertEquals(2, ds.fetchCount) // init + refresh
 
             externalScope.cancel()
         }
@@ -122,8 +132,13 @@ class CachedServerConfigRepositoryTest {
             externalScope.cancel()
         }
 
+    /**
+     * Null responses (HTTP error / connection failure) leave the cache alone
+     * rather than overwriting a previously-successful value. Avoids a transient
+     * network blip blowing away the last known-good config.
+     */
     @Test
-    fun fetchAfterInitKeepsSameInstance() =
+    fun nullFetchResultPreservesCachedValue() =
         runTest {
             val ds = FakeNetworkConfigDataSource().apply {
                 setServerConfigResult(NetworkResult.Success(sampleConfig))
@@ -132,17 +147,13 @@ class CachedServerConfigRepositoryTest {
 
             val repo = CachedServerConfigRepository(ds, "test-key", externalScope)
             advanceUntilIdle()
-
-            // Update network response and force-refresh. Because the cache is
-            // already populated, fetchServerConfig coalesces to the cached value
-            // (first-write-wins on success).
-            val newConfig = sampleConfig.copy(buildTimestamp = "2024-01-16T00:00:00Z")
-            ds.setServerConfigResult(NetworkResult.Success(newConfig))
-            val fetched = repo.fetchServerConfig()
-
-            assertEquals(sampleConfig, fetched)
             assertEquals(sampleConfig, repo.serverConfig.value)
-            assertEquals(1, ds.fetchCount)
+
+            ds.setServerConfigResult(NetworkResult.ConnectionFailed)
+            val failResult = repo.fetchServerConfig()
+
+            assertNull(failResult) // fetch itself reports failure
+            assertEquals(sampleConfig, repo.serverConfig.value) // cache untouched
 
             externalScope.cancel()
         }
@@ -195,10 +206,12 @@ class CachedServerConfigRepositoryTest {
             val result = repo.fetchServerConfig()
             assertEquals(sampleConfig, result)
 
-            // But a null server config does NOT overwrite a cached value.
+            // A null server config does NOT overwrite a cached value. The
+            // fetch itself reports failure (null return); the cache stays
+            // on the last known-good value.
             ds.setServerConfigResult(NetworkResult.ConnectionFailed)
             val failResult = repo.fetchServerConfig()
-            assertEquals(sampleConfig, failResult) // cached value won
+            assertNull(failResult)
             assertEquals(sampleConfig, repo.serverConfig.value)
 
             externalScope.cancel()


### PR DESCRIPTION
## Summary

- `CachedServerConfigRepository.fetchServerConfig()` is now a true force-refresh: every call hits the network and writes a successful result to `_serverConfig`
- Null responses (HTTP / connection / exception) leave the cache alone — a transient network blip doesn't blow away the last known-good value
- Concurrent coalescing intentionally omitted: the mutex serializes racers (second caller waits, then issues its own request)
- Tests document the contract

## Context

PR #362 introduced a `cached != null` short-circuit in `fetchServerConfig`. Once populated, the cache could never refresh without a process restart — silently breaking any future flow that depends on server-side config changes (new build timestamps, rotated push keys). This PR restores the original `fetchServerConfig` semantics.

## Why drop concurrent coalescing

In practice the only concurrent callers are `init` + null-fallback reads in snooze/button/door repositories. Adding in-flight `Deferred` tracking added implementation complexity for a race that's rare and low-impact (one extra network call). The mutex still prevents interleaved state writes. Revisit if Rule 9 logs ever show duplicate-fetch patterns worth optimizing.

## Test plan

- [x] `AndroidGarage/gradlew :data:testDebugUnitTest` passes
- [x] `./scripts/validate.sh` passes
- [x] New `fetchServerConfigAlwaysRefreshesCache` test documents the contract: change network response → next `fetchServerConfig` returns v2, `serverConfig.value == v2`, `fetchCount == 2`
- [x] New `nullFetchResultPreservesCachedValue` test documents failure handling: null fetch result leaves the last-known-good cache in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)