### PR TITLE
fix: Restore VM-local snoozeState mirror + direct write (android/170 regression)

### DIFF
--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/ViewModelStateFlowCheckTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/ViewModelStateFlowCheckTask.kt
@@ -19,17 +19,16 @@ import java.io.File
  * Only literal `viewModelScope` is banned — `stateIn(applicationScope, ...)`
  * in a Manager class is legitimate.
  *
- * ### Rule 2 (ADR-022): no VM-local mirror of repository-owned state types
+ * ### Rule 2 (ADR-022, withdrawn): previously banned VM-local mirror of
+ * repository-owned state types.
  *
- * Domain state types whose ownership lives on a `@Singleton` repository
- * (ADR-022) must never be re-declared inside a ViewModel as a private
- * `MutableStateFlow<T>`. If a VM owns its own `MutableStateFlow<SnoozeState>`,
- * it's mirroring the repo's flow and will drift under multiple VM
- * instances (android/164-168).
- *
- * The allowlist holds the domain state types we've migrated so far. Adding
- * a new type to the list is how we extend enforcement as more state-y data
- * moves to repository ownership.
+ * Withdrawn after android/170 shipped the pass-through pattern and the
+ * repo-owned `StateFlow` failed to reach Compose on production devices
+ * even though every debug instrumented test passed. The VM-local mirror
+ * + init-collect + direct-write-from-command pattern (PR #354 /
+ * android/169) is the empirically-reliable shape. The allowlist is now
+ * empty — `bannedStateTypesInViewModels` is kept as a knob in case we
+ * ever need selective enforcement again, but it's intentionally inert.
  */
 abstract class ViewModelStateFlowCheckTask : DefaultTask() {
     @get:Input
@@ -39,13 +38,12 @@ abstract class ViewModelStateFlowCheckTask : DefaultTask() {
      * Domain state types that must be owned on the repository. A
      * `MutableStateFlow<X>` with any of these type arguments inside a
      * ViewModel is a mirror and fails the check.
+     *
+     * Intentionally empty after ADR-022 Rule 2 was withdrawn — see class
+     * KDoc. Re-populate only if a future ADR revives the selective ban.
      */
     @get:Input
-    var bannedStateTypesInViewModels: List<String> = listOf(
-        "SnoozeState",
-        "AuthState",
-        "FcmRegistrationStatus",
-    )
+    var bannedStateTypesInViewModels: List<String> = emptyList()
 
     private val stateInPattern = Regex("""\.stateIn\s*\(\s*viewModelScope""")
     private val fileNameRegex = Regex(".*ViewModel\\.kt")
@@ -54,9 +52,9 @@ abstract class ViewModelStateFlowCheckTask : DefaultTask() {
     fun check() {
         val violations = mutableListOf<String>()
 
-        val bannedTypeRegex = Regex(
-            """\bMutableStateFlow\s*<\s*(${bannedStateTypesInViewModels.joinToString("|")})\s*\??\s*>""",
-        )
+        val bannedTypeRegex = bannedStateTypesInViewModels
+            .takeIf { it.isNotEmpty() }
+            ?.let { Regex("""\bMutableStateFlow\s*<\s*(${it.joinToString("|")})\s*\??\s*>""") }
 
         for (dirPath in sourceDirs) {
             val dir = File(dirPath)
@@ -75,14 +73,13 @@ abstract class ViewModelStateFlowCheckTask : DefaultTask() {
                                     "Line: ${line.trim()}",
                             )
                         }
-                        val bannedMatch = bannedTypeRegex.find(line)
+                        val bannedMatch = bannedTypeRegex?.find(line)
                         if (bannedMatch != null) {
                             val typeArg = bannedMatch.groupValues[1]
                             violations.add(
                                 "${file.relativeTo(dir).path}:${index + 1}: " +
-                                    "VM-local MutableStateFlow<$typeArg> is banned (ADR-022). " +
-                                    "State-y types are owned by a @Singleton repository — expose the " +
-                                    "repo's StateFlow by reference (observeXUseCase()), do not mirror. " +
+                                    "VM-local MutableStateFlow<$typeArg> is banned. " +
+                                    "State-y types are owned by a @Singleton repository. " +
                                     "Line: ${line.trim()}",
                             )
                         }
@@ -96,6 +93,6 @@ abstract class ViewModelStateFlowCheckTask : DefaultTask() {
                     violations.joinToString("\n\n") { "  $it" },
             )
         }
-        logger.lifecycle("ViewModel StateFlow check passed: no stateIn(viewModelScope, ...) usages and no banned VM-local mirrors.")
+        logger.lifecycle("ViewModel StateFlow check passed: no stateIn(viewModelScope, ...) usages.")
     }
 }

--- a/AndroidGarage/docs/DECISIONS.md
+++ b/AndroidGarage/docs/DECISIONS.md
@@ -971,16 +971,45 @@ After this change, three VMs don't multiply the truth. They multiply only their 
 
 ## ADR-022: `StateFlow` at the Repository Boundary for State-y Data
 
-**Status:** Accepted and enforced. Partially supersedes ADR-013.
+**Status:** **Withdrawn (2026-04-19) after android/170 regression.** The
+Rule 2 "VM exposes repo's `StateFlow` by reference" requirement proved
+empirically unreliable on production devices — the snooze card title
+failed to update despite every debug instrumented test passing. See
+"Withdrawal" section below. The repository **still** owns a
+`StateFlow<T>` as its observation API (that part stays). What changed:
+ViewModels must keep their own `MutableStateFlow<T>` mirror, collect from
+the repo in `init`, and direct-write from command results — the PR #354
+/ android/169 pattern.
 
-**Enforcement** (per `MIGRATION_PLAN.md` PR 8):
-- `checkViewModelStateFlow` bans `MutableStateFlow<T>` in `*ViewModel.kt`
-  when `T` matches the domain-state allowlist (`SnoozeState`, `AuthState`,
-  `FcmRegistrationStatus`). Add a type to the allowlist in
-  `ViewModelStateFlowCheckTask.bannedStateTypesInViewModels` when its
-  repository migration lands.
-- `checkSingletonGuard` requires `@Singleton` on every
-  `provide<State-owning-Repository>` method in `AppComponent`.
+`checkViewModelStateFlow` Rule 2 enforcement was removed alongside the
+withdrawal. The `checkSingletonGuard` requirement for state-owning
+repositories stays.
+
+### Withdrawal
+
+android/170 shipped the by-reference pattern from this ADR's original
+rollout (PR #358–#365). Users reported immediately that the snooze card
+title did not update after saving, while the overlay below the button
+(VM-local `SnoozeAction`) did — the exact android/167 symptom. The
+regression reproduces only on production APKs; every debug instrumented
+test (`SnoozeStateInstrumentedPropagationTest`,
+`SnoozeMultiSubscriberIntegrationTest`, `assertSame` reference-identity
+checks) passed. Rolled back to android/169 via android/171 (rollforward
+with `--confirm-hash`). An R8-enabled benchmark-variant harness
+(`R8_INSTRUMENTED_TESTS.md`) was added for future diagnosis but is not
+the trigger — R8 stripping would crash with `ClassNotFoundException`
+rather than selectively failing one StateFlow subscription while others
+work.
+
+The VM-local mirror pattern (this ADR's anti-pattern) is the shape that
+actually ships reliably. android/169 used it and users did not report
+the bug. Keeping both `repo.snoozeState` as the source of truth and a
+VM mirror as a defensive layer is redundant — but the redundancy is
+what guarantees propagation. Rule 2 is withdrawn.
+
+Open question: *why* does the by-reference chain break on device while
+passing in debug tests? Hypotheses tracked in `MIGRATION_PLAN.md` Phase
+2f. Until the root cause is understood, do not re-enable the ban.
 
 ### Glossary
 

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt
@@ -69,9 +69,21 @@ class DefaultRemoteButtonViewModel(
 
     override val buttonState: StateFlow<RemoteButtonState> = stateMachine.state
 
-    // ADR-022: expose the repository's StateFlow by reference — no mirror.
-    // Every subscriber across the app reads from the same singleton instance.
-    override val snoozeState: StateFlow<SnoozeState> = observeSnoozeStateUseCase()
+    // Hotfix for android/170 regression: the ADR-022 pass-through pattern
+    // (`val snoozeState = observeSnoozeStateUseCase()`) empirically did not
+    // propagate repo writes to Compose on-device, even though debug
+    // instrumented tests passed. Restore the VM-local mirror + init-collect
+    // + direct-write-from-command pattern (the PR #354 pattern that
+    // shipped in android/169):
+    //   1. VM owns `_snoozeState: MutableStateFlow<SnoozeState>`
+    //   2. init { collect repo.snoozeState → _snoozeState }
+    //   3. On successful snooze submit, direct-write _snoozeState from the
+    //      server-authoritative result.data
+    // Writing from both the repo and the VM is redundant but harmless —
+    // the VM's collect re-syncs if the two ever diverge. See ADR-022
+    // revision for why the pass-through rule was withdrawn.
+    private val _snoozeState = MutableStateFlow<SnoozeState>(SnoozeState.Loading)
+    override val snoozeState: StateFlow<SnoozeState> = _snoozeState
 
     private val _snoozeAction = MutableStateFlow<SnoozeAction>(SnoozeAction.Idle)
     override val snoozeAction: StateFlow<SnoozeAction> = _snoozeAction
@@ -80,6 +92,9 @@ class DefaultRemoteButtonViewModel(
 
     init {
         listenToDoorEvent()
+        viewModelScope.launch(dispatchers.io) {
+            observeSnoozeStateUseCase().collect { _snoozeState.value = it }
+        }
         // First fetch is driven by SnoozeRepository.init on an app-lifetime
         // scope (see NetworkSnoozeRepository). Running it from here on
         // viewModelScope risked cancellation mid-fetch stranding the
@@ -151,11 +166,15 @@ class DefaultRemoteButtonViewModel(
                 )
             ) {
                 is AppResult.Success -> {
-                    // Repo already wrote [result.data] into its [snoozeState]
-                    // before returning, so the card title updates via the
-                    // shared flow (ADR-022). Here we only compute the
-                    // VM-local overlay action (Rule 3 — presentation state).
+                    // Direct-write the server-authoritative new state into
+                    // both _snoozeState (card title) and _snoozeAction (overlay).
+                    // Belt-and-suspenders alongside the repo's StateFlow write:
+                    // the repo is still the source of truth and the init-collect
+                    // observer re-syncs, but writing directly here guarantees
+                    // the Compose-visible value flips immediately without
+                    // depending on the pass-through chain.
                     val newState = result.data
+                    _snoozeState.value = newState
                     _snoozeAction.value = when (newState) {
                         is SnoozeState.Snoozing -> SnoozeAction.Succeeded.Set(newState.untilEpochSeconds)
                         SnoozeState.NotSnoozing -> SnoozeAction.Succeeded.Cleared

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SnoozeStateFlowPropagationTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SnoozeStateFlowPropagationTest.kt
@@ -99,25 +99,6 @@ class SnoozeStateFlowPropagationTest {
     }
 
     // ----------------------------------------------------------------
-    // 1. Reference identity: VM.snoozeState is the repo's StateFlow (ADR-022).
-    // ----------------------------------------------------------------
-    // VM must NOT mirror the repo's flow — it must expose the same instance
-    // by reference. `assertSame` makes this guarantee load-bearing.
-    @Test
-    fun vmSnoozeStateIsSameInstanceAsRepoStateFlow() =
-        runTest {
-            val fake = FakeSnoozeRepository()
-            val vm = buildVm(fake)
-            testDispatcher.scheduler.runCurrent()
-
-            kotlin.test.assertSame(
-                fake.snoozeState,
-                vm.snoozeState,
-                "VM must expose repo's StateFlow by reference (ADR-022)",
-            )
-        }
-
-    // ----------------------------------------------------------------
     // 2. Two-hop chain: every repo update is visible on vm.snoozeState.
     // ----------------------------------------------------------------
     @Test


### PR DESCRIPTION
## Summary

Hotfix for android/170 snooze regression. Restores the PR #354 / android/169 pattern: VM-local `MutableStateFlow<SnoozeState>` + `init { collect }` + direct-write from successful command result. Withdraws ADR-022 Rule 2 (VM exposes repo StateFlow by reference) — the pass-through pattern did not propagate repo writes to Compose on production devices.

## Context

- android/170 shipped the 8-PR state-ownership migration. Users reported the card title did not update after saving snooze. Overlay (VM-local `SnoozeAction`) updated correctly.
- Rolled back to android/169 via android/171.
- R8 is not the trigger — selective subscription failure doesn't match R8 stripping behavior.
- The VM already has the new state (`result.data`). This PR direct-writes it alongside the repo's write. Belt-and-suspenders, but empirically reliable.

## Changes

- `RemoteButtonViewModel`: restore `_snoozeState` mirror + `init { observeSnoozeStateUseCase().collect }` + direct-write `_snoozeState.value = newState` in `snoozeOpenDoorsNotifications` success branch
- `ViewModelStateFlowCheckTask`: `bannedStateTypesInViewModels` now empty (Rule 2 withdrawn); knob kept as a future opt-in
- `SnoozeStateFlowPropagationTest`: delete `vmSnoozeStateIsSameInstanceAsRepoStateFlow` (guarded the withdrawn invariant)
- `ADR-022`: status → **Withdrawn**. Class KDoc and Withdrawal section explain the android/170 evidence and the open root-cause question

## Test plan

- [x] `AndroidGarage/gradlew :usecase:testDebugUnitTest :data:testDebugUnitTest` passes
- [x] `./scripts/validate.sh` passes
- [x] `checkViewModelStateFlow` still enforces Rule 1 (stateIn ban)
- [ ] Manual on device after release: save snooze → card title flips immediately without kill+restart

## Release

Once this merges, cut android/172 pointing at the hotfix commit. Users on android/171 (the rollback) can upgrade directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)