### PR TITLE
chore: Restore ADR-022 Rule 2 enforcement after android/174 verified

### DIFF
--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/ViewModelStateFlowCheckTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/ViewModelStateFlowCheckTask.kt
@@ -19,16 +19,22 @@ import java.io.File
  * Only literal `viewModelScope` is banned — `stateIn(applicationScope, ...)`
  * in a Manager class is legitimate.
  *
- * ### Rule 2 (ADR-022, withdrawn): previously banned VM-local mirror of
- * repository-owned state types.
+ * ### Rule 2 (ADR-022): no VM-local mirror of repository-owned state types
  *
- * Withdrawn after android/170 shipped the pass-through pattern and the
- * repo-owned `StateFlow` failed to reach Compose on production devices
- * even though every debug instrumented test passed. The VM-local mirror
- * + init-collect + direct-write-from-command pattern (PR #354 /
- * android/169) is the empirically-reliable shape. The allowlist is now
- * empty — `bannedStateTypesInViewModels` is kept as a knob in case we
- * ever need selective enforcement again, but it's intentionally inert.
+ * Domain state types whose ownership lives on a `@Singleton` repository
+ * must never be re-declared inside a ViewModel as a private
+ * `MutableStateFlow<T>`. The repo owns the authoritative flow; the VM
+ * exposes it by reference via the observe-UseCase.
+ *
+ * History: this rule was briefly withdrawn on 2026-04-19 after the
+ * android/170 regression, then reinstated on android/174 once Phase 2f
+ * fixed the kotlin-inject `@Singleton` scoping bug that silently broke
+ * the pass-through chain. See `docs/DI_SINGLETON_REQUIREMENTS.md` —
+ * this rule is meaningless without the DI fix, which itself is guarded
+ * by `ComponentGraphTest.*IsSingleton` tests.
+ *
+ * Extend the allowlist (`bannedStateTypesInViewModels`) as more state-y
+ * types migrate to the ADR-022 shape.
  */
 abstract class ViewModelStateFlowCheckTask : DefaultTask() {
     @get:Input
@@ -39,11 +45,14 @@ abstract class ViewModelStateFlowCheckTask : DefaultTask() {
      * `MutableStateFlow<X>` with any of these type arguments inside a
      * ViewModel is a mirror and fails the check.
      *
-     * Intentionally empty after ADR-022 Rule 2 was withdrawn — see class
-     * KDoc. Re-populate only if a future ADR revives the selective ban.
+     * Add new types as their repository migrations land.
      */
     @get:Input
-    var bannedStateTypesInViewModels: List<String> = emptyList()
+    var bannedStateTypesInViewModels: List<String> = listOf(
+        "SnoozeState",
+        "AuthState",
+        "FcmRegistrationStatus",
+    )
 
     private val stateInPattern = Regex("""\.stateIn\s*\(\s*viewModelScope""")
     private val fileNameRegex = Regex(".*ViewModel\\.kt")

--- a/AndroidGarage/docs/DECISIONS.md
+++ b/AndroidGarage/docs/DECISIONS.md
@@ -971,45 +971,44 @@ After this change, three VMs don't multiply the truth. They multiply only their 
 
 ## ADR-022: `StateFlow` at the Repository Boundary for State-y Data
 
-**Status:** **Withdrawn (2026-04-19) after android/170 regression.** The
-Rule 2 "VM exposes repo's `StateFlow` by reference" requirement proved
-empirically unreliable on production devices — the snooze card title
-failed to update despite every debug instrumented test passing. See
-"Withdrawal" section below. The repository **still** owns a
-`StateFlow<T>` as its observation API (that part stays). What changed:
-ViewModels must keep their own `MutableStateFlow<T>` mirror, collect from
-the repo in `init`, and direct-write from command results — the PR #354
-/ android/169 pattern.
+**Status:** **Accepted and enforced (2026-04-19, restored on android/174).**
+Partially supersedes ADR-013.
 
-`checkViewModelStateFlow` Rule 2 enforcement was removed alongside the
-withdrawal. The `checkSingletonGuard` requirement for state-owning
-repositories stays.
+**Enforcement:**
+- `checkViewModelStateFlow` bans `MutableStateFlow<T>` in `*ViewModel.kt`
+  when `T` matches `bannedStateTypesInViewModels` (`SnoozeState`,
+  `AuthState`, `FcmRegistrationStatus`). Extend the list as more state-y
+  types migrate.
+- `checkSingletonGuard` requires `@Singleton` on every
+  `provide<State-owning-Repository>` method in `AppComponent`.
+- `ComponentGraphTest.*IsSingleton` runs `assertSame` on every `@Singleton`
+  entry point — without this, `@Singleton` is a lie. See
+  `docs/DI_SINGLETON_REQUIREMENTS.md`.
 
-### Withdrawal
+### Timeline: withdrawal and restoration
 
-android/170 shipped the by-reference pattern from this ADR's original
-rollout (PR #358–#365). Users reported immediately that the snooze card
-title did not update after saving, while the overlay below the button
-(VM-local `SnoozeAction`) did — the exact android/167 symptom. The
-regression reproduces only on production APKs; every debug instrumented
-test (`SnoozeStateInstrumentedPropagationTest`,
-`SnoozeMultiSubscriberIntegrationTest`, `assertSame` reference-identity
-checks) passed. Rolled back to android/169 via android/171 (rollforward
-with `--confirm-hash`). An R8-enabled benchmark-variant harness
-(`R8_INSTRUMENTED_TESTS.md`) was added for future diagnosis but is not
-the trigger — R8 stripping would crash with `ClassNotFoundException`
-rather than selectively failing one StateFlow subscription while others
-work.
+- **android/170** — shipped this ADR's original rollout (PR #358–#365).
+  Users reported the snooze card title did not update after saving; the
+  overlay (VM-local `SnoozeAction`) did. Matched the android/167 symptom.
+- **android/171** — rollback to android/169's commit via `--confirm-hash`.
+- **android/172** — VM-local `_snoozeState` mirror + direct write hotfix
+  (PR #354 pattern). ADR-022 Rule 2 marked **Withdrawn** on the
+  assumption that the pass-through pattern itself was unreliable.
+- **android/173** — Phase 2f: fixed the kotlin-inject `@Singleton`
+  scoping bug. The generated `InjectAppComponent.kt` had been 15 lines of
+  empty subclass; no `@Singleton` provider was cached. Multiple
+  `NetworkSnoozeRepository` instances coexisted — POST wrote to one
+  flow, VM observed another. Pass-through had been correct all along;
+  the DI was lying about singletons.
+- **android/174** — removed the android/172 hotfix, restored the
+  pass-through. On device: snooze still works. The DI fix was the
+  complete root cause. ADR-022 Rule 2 **restored**.
 
-The VM-local mirror pattern (this ADR's anti-pattern) is the shape that
-actually ships reliably. android/169 used it and users did not report
-the bug. Keeping both `repo.snoozeState` as the source of truth and a
-VM mirror as a defensive layer is redundant — but the redundancy is
-what guarantees propagation. Rule 2 is withdrawn.
-
-Open question: *why* does the by-reference chain break on device while
-passing in debug tests? Hypotheses tracked in `MIGRATION_PLAN.md` Phase
-2f. Until the root cause is understood, do not re-enable the ban.
+Lesson: the debug instrumented tests passed because they construct a
+single VM with a single manually-wired repo — the production multi-
+instance DI graph was never exercised. `ComponentGraphTest.*IsSingleton`
+is now the load-bearing regression guard; without it, a future
+`AppComponent` drift would silently resurrect the same bug.
 
 ### Glossary
 

--- a/AndroidGarage/docs/MIGRATION_PLAN.md
+++ b/AndroidGarage/docs/MIGRATION_PLAN.md
@@ -323,33 +323,26 @@ the allowlist wasn't updated.
 
 ### Phase 2f — Fix kotlin-inject `@Singleton` scoping (load-bearing)
 
-**Status (2026-04-19):** Identified as the root cause of the android/170
-snooze regression that triggered the Phase 1 rollback. The generated
-`InjectAppComponent.kt` is an empty subclass — no `@Singleton` provider
-is being cached. See `DI_SINGLETON_REQUIREMENTS.md` for the full
-analysis, detection recipes, fix direction, and verification checklist.
+**Status:** ✅ Complete as of 2026-04-19 (android/173, PR #371). Validated
+empirically by android/174 (PR #372) — removing the android/172 VM-local
+mirror + direct-write, restoring the ADR-022 pass-through, snooze still
+works on device.
 
-Summary: `AppComponent` uses concrete `val x: T @Provides get() = ...`
-providers. kotlin-inject only generates scoped caching for **abstract
-entry points** — nothing to override here means nothing cached. Every
-`provideSnoozeRepository()` call constructs a fresh
-`NetworkSnoozeRepository` with its own `MutableStateFlow`. Within one VM
-the observe-UseCase's repo and the submit-UseCase's repo are different
-instances; the POST's `_snoozeState.value = newState` never reaches the
-observer.
+Resolution: converted `AppComponent` from concrete `val x: T @Provides
+get() = ...` providers to **abstract entry points** (`abstract val x: T`)
+with parameter-based `@Provides fun provide...()` bodies. The generated
+`InjectAppComponent.kt` grew from 15 → 304 lines; every `@Singleton`
+provider now routes through `_scoped.get(...)`. `ComponentGraphTest`
+added 14 identity-guard tests (`assertSame` on every `@Singleton` entry,
+`assertNotSame` on ViewModels) that would have caught this bug on day
+one if they had existed.
 
-The android/172 hotfix (restore VM-local mirror + direct write) sidesteps
-the DI bug but leaves the root cause in place. Fixing Phase 2f is a
-prerequisite for:
-- Reviving ADR-022 Rule 2 (VM exposes repo `StateFlow` by reference)
-- Removing the VM-local mirror in `RemoteButtonViewModel`
-- Trusting every other `@Singleton` provider (auth, door, server config,
-  FCM) to actually be singletons
+Downstream cleanup (also landed):
+- ADR-022 Rule 2 restored: VMs expose repo `StateFlow` by reference.
+- android/172 VM-local `_snoozeState` mirror + direct-write removed.
+- `ViewModelStateFlowCheckTask.bannedStateTypesInViewModels` re-populated.
 
-Trigger: schedule this as deliberate architectural work, not a hotfix.
-It re-shapes `AppComponent` and needs the
-`ComponentGraphTest.singletonRepositoriesReturnSameInstance` regression
-guard added first so the fix is proven at merge time.
+Full write-up: `DI_SINGLETON_REQUIREMENTS.md`.
 
 ## Phase 3 — iOS (Phase 38 in MIGRATION.md)
 


### PR DESCRIPTION
## Summary

android/174 shipped the pass-through pattern with no VM-local mirror — snooze still works on device. That validates the Phase 2f DI fix was the complete root cause of the android/170 regression. Reverts the temporary withdrawal of ADR-022 Rule 2.

## Changes

- **`ViewModelStateFlowCheckTask`** — `bannedStateTypesInViewModels` restored to `(SnoozeState, AuthState, FcmRegistrationStatus)`. Class KDoc rewritten to document the withdrawal/restoration cycle and point at `ComponentGraphTest.*IsSingleton` as the prerequisite.
- **ADR-022** — status flipped from **Withdrawn** back to **Accepted and enforced**. Added a Timeline section capturing android/170 → 171 → 172 → 173 → 174.
- **`MIGRATION_PLAN.md`** — Phase 2f marked ✅ Complete.

## Enforcement now in place

| Check | Guards |
|---|---|
| `checkViewModelStateFlow` | Bans VM-local `MutableStateFlow` for state-y types (Rule 2) |
| `checkSingletonGuard` | `@Singleton` required on state-owning repo providers |
| `ComponentGraphTest.*IsSingleton` | 11 `assertSame` tests — without these, `@Singleton` is a lie and Rule 2 is unsound |

Together these make the android/170 class of bug structurally impossible to reintroduce.

## Test plan

- [x] `AndroidGarage/gradlew checkViewModelStateFlow` passes (current code compliant)
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)