### PR TITLE
docs: Tech guides folder — kotlin-inject scoping

### DIFF
--- a/AndroidGarage/docs/guides/README.md
+++ b/AndroidGarage/docs/guides/README.md
@@ -1,0 +1,35 @@
+# Technology Guides
+
+Portable, technology-specific lessons — intended to be useful **outside
+this repository**. Each guide captures gotchas, detection recipes, and
+tested patterns for one tool or library, without assuming familiarity
+with Smart Garage Door specifically.
+
+If you're new to a technology in this stack, start here. If you're
+bringing a lesson learned here to another project, copy the relevant
+guide — the content is deliberately non-repo-specific.
+
+## Guides
+
+- [`kotlin-inject.md`](kotlin-inject.md) — `@Singleton` scoping only
+  works through abstract entry points; runtime identity tests are the
+  only proof of singleton-ness.
+
+## How to use these guides in another project
+
+Each guide is standalone Markdown. Copy it verbatim into the target
+repo's `docs/guides/` and adapt the examples to that codebase's
+conventions. The core lesson and checklist should be transferable
+unchanged.
+
+## How to add a new guide
+
+1. Pick a technology with a concrete, testable failure mode you've hit
+   or investigated.
+2. Write the guide as **a new reader's reference**, not a diary. Third
+   person. No mentions of specific bug numbers / PRs unless they
+   contain a linkable, reproducible artifact.
+3. Include: the shape of the failure, why it happens, how to detect
+   it, how to fix it, how to prevent it (automated checks preferred).
+4. Add one "Minimum viable defense" section — the fewest checks that
+   would catch this class of bug in a new repo adopting the same tech.

--- a/AndroidGarage/docs/guides/kotlin-inject.md
+++ b/AndroidGarage/docs/guides/kotlin-inject.md
@@ -1,0 +1,283 @@
+# kotlin-inject scoping — gotchas and verification
+
+**Who this is for:** anyone using
+[kotlin-inject](https://github.com/evant/kotlin-inject) on a project,
+regardless of codebase. Covers the single class of bug that will break
+`@Singleton` in production while passing every test you write by hand.
+
+## TL;DR
+
+kotlin-inject only generates **scoped caching** (what `@Singleton`
+promises) when your `@Component` class has **abstract entry points**
+that the code generator can override. If every provider is a concrete
+`val x: T @Provides get() = ...` or concrete `fun provideX() = ...`,
+the compiler has nothing to override and emits an empty subclass —
+your `@Singleton` annotations become decorative. The generated
+`InjectAppComponent.kt` is the only source of truth.
+
+## The failure mode
+
+### What looks correct in source
+
+```kotlin
+@Component
+@Singleton
+abstract class AppComponent(
+    @get:Provides val application: Application,
+) {
+    val snoozeRepository: SnoozeRepository
+        @Provides @Singleton get() = NetworkSnoozeRepository(...)
+
+    @Provides @Singleton
+    fun provideAuthRepository(): AuthRepository =
+        FirebaseAuthRepository(provideAuthBridge(), provideLoggerRepo(), ...)
+    // ...
+}
+```
+
+`@Singleton` is present on every provider. `@Component @Singleton` is
+present on the class. A reviewer sees nothing wrong.
+
+### What the compiler actually emits
+
+```kotlin
+// build/generated/ksp/*/kotlin/.../InjectAppComponent.kt
+public class InjectAppComponent(application: Application) :
+    AppComponent(application),
+    ScopedComponent {
+  override val _scoped: LazyMap = LazyMap()
+}
+```
+
+Fifteen lines. `_scoped` is initialized and never consulted. No
+override of any provider. Every access to
+`component.snoozeRepository` runs the concrete `get()` body, which
+constructs a fresh `NetworkSnoozeRepository`. `@Singleton` is ignored.
+
+### Why
+
+kotlin-inject's code generator only overrides **abstract** members of
+the `@Component` class. If a provider is concrete, there's nothing to
+override — the Kotlin compiler resolves the call directly to the
+hand-written body, which runs every time it's called.
+
+Furthermore, scoped caching is only inserted when kotlin-inject
+**routes** the binding. When a `@Provides fun` body calls a sibling
+`@Provides fun` directly (e.g. `FirebaseAuthRepository(provideAuthBridge(), ...)`),
+those calls are regular Kotlin — they bypass the `_scoped` cache.
+Only parameters declared on the function signature get scope-routed.
+
+### Symptoms you'll see in production
+
+- Multiple instances of what should be a singleton repository.
+- State-owning repositories (that hold `MutableStateFlow<T>`, a
+  `Mutex`, or any cache) exhibiting per-consumer fragmentation:
+  different ViewModels see different states for the same domain type.
+- Writes to "the repository's flow" not reaching subscribers that read
+  "the repository's flow" — because they're different flow objects.
+- Debug tests pass because tests wire instances manually, bypassing the
+  broken DI graph entirely.
+
+## The two mechanical rules that make `@Singleton` work
+
+### Rule 1: Abstract entry points for every `@Singleton` provider
+
+kotlin-inject's generator inserts `_scoped.get("<key>") { provideX() }`
+into **overrides of abstract members**. Make every scoped binding
+reachable through an `abstract val` (or `abstract fun`) on the
+`@Component`.
+
+```kotlin
+@Component @Singleton
+abstract class AppComponent(...) {
+    // Entry points — one per @Singleton binding you want cached.
+    abstract val snoozeRepository: SnoozeRepository
+    abstract val authRepository: AuthRepository
+    abstract val appDatabase: AppDatabase
+    // ...
+
+    // Provider bodies — separate concrete functions.
+    @Provides @Singleton
+    fun provideSnoozeRepository(...): SnoozeRepository = ...
+
+    @Provides @Singleton
+    fun provideAuthRepository(...): AuthRepository = ...
+}
+```
+
+### Rule 2: Parameters, not sibling function calls, in `@Provides` bodies
+
+If a `@Provides` function depends on another `@Provides`-produced type,
+declare it as a **parameter**. Never call a sibling `provideY()` inside
+the body — that call is regular Kotlin and skips the cache.
+
+```kotlin
+// BAD: sibling call bypasses _scoped.
+@Provides @Singleton
+fun provideAuthRepository(): AuthRepository =
+    FirebaseAuthRepository(provideAuthBridge(), provideLoggerRepo(), ...)
+
+// GOOD: parameters route through _scoped.
+@Provides @Singleton
+fun provideAuthRepository(
+    authBridge: AuthBridge,
+    loggerRepo: AppLoggerRepository,
+    applicationScope: CoroutineScope,
+): AuthRepository =
+    FirebaseAuthRepository(authBridge, loggerRepo, applicationScope)
+```
+
+When the generator sees parameters, it resolves each one through the
+binding graph — including the scoped accessor when the dep is
+`@Singleton`.
+
+## How to verify (three independent signals)
+
+### 1. Read the generated component
+
+```bash
+# Path may vary; look for any InjectAppComponent*.kt under build/generated.
+./gradlew kspDebugKotlin
+cat $(find . -path '*/ksp/*' -name 'InjectAppComponent*.kt' | head -1)
+```
+
+Healthy file:
+- Many `override val X: T` declarations (one per abstract entry).
+- Each scoped override contains `_scoped.get("<key>") { ... }`.
+- VM / non-scoped entry overrides resolve deps by calling the scoped
+  accessor for each parameter.
+
+Broken file:
+- Under ~20 lines.
+- Only `override val _scoped: LazyMap = LazyMap()`.
+- No `override` for your `@Singleton` types.
+
+### 2. Runtime identity test
+
+```kotlin
+@Test
+fun snoozeRepositoryIsSingleton() {
+    val c = (application as MyApp).component
+    assertSame(c.snoozeRepository, c.snoozeRepository)
+}
+
+@Test
+fun authRepositoryIsSingleton() {
+    val c = (application as MyApp).component
+    assertSame(c.authRepository, c.authRepository)
+}
+```
+
+One `assertSame` per `@Singleton` entry point. Without these, the
+annotation has no runtime verification — it's indistinguishable from
+a decorator.
+
+The failing-then-passing pair is the strongest regression guard:
+- Before the fix: `assertSame` fails because two calls produce two
+  instances.
+- After the fix: `assertSame` passes.
+- Future regression (someone collapses an abstract entry back to
+  concrete, or adds a `@Singleton` binding without an abstract entry):
+  `assertSame` fails at CI.
+
+### 3. Log-based smoke in staging
+
+If a `@Singleton` state-owning repository has an `init`-side-effect
+(network fetch, listener registration, log line), that effect runs
+**once per instance**. Cold-start logcat for an app with N bugged
+instances shows N startup fetches. Healthy app shows 1.
+
+## Minimum viable defense (copy into any new project adopting kotlin-inject)
+
+- [ ] `@Component` class is abstract and declares `abstract val` for
+      every `@Singleton` binding that state depends on.
+- [ ] Every `@Provides fun` takes its deps as parameters; no sibling
+      `provideX()` calls inside bodies.
+- [ ] A `ComponentGraphTest` with one `assertSame(c.x, c.x)` per
+      `@Singleton` binding, running on CI (instrumented).
+- [ ] A one-line docstring at the top of the `@Component` class
+      stating the two rules — future edits see the intent at edit time.
+- [ ] Before merging any change to the `@Component`: regenerate KSP
+      and eyeball the `Inject*Component.kt` output.
+
+Four of these are cheap (<30 minutes to add). The identity test is
+the single highest-value check — it is the only mechanical signal
+that *actually* verifies `@Singleton` works.
+
+## Common patterns and anti-patterns
+
+### Anti-pattern: concrete `val x: T @Provides get()`
+
+```kotlin
+val snoozeRepository: SnoozeRepository
+    @Provides @Singleton get() = NetworkSnoozeRepository(...)  // NOT cached
+```
+
+Convenient-looking, broken. `@Singleton` is ignored because there's
+no abstract entry to override. Use either `abstract val x: T` +
+separate `@Provides fun provideX()`, OR just `@Provides fun provideX()`
+with no `val` at all.
+
+### Anti-pattern: calling sibling providers in bodies
+
+```kotlin
+@Provides @Singleton
+fun provideFooRepository(): FooRepository =
+    NetworkFooRepository(provideBar(), provideBaz())  // bypass
+```
+
+Even if `provideBar` and `provideBaz` are `@Singleton`, those calls
+construct fresh instances because they're resolved by the Kotlin
+compiler, not by kotlin-inject. Rewrite with parameters.
+
+### Pattern: testing entry points
+
+Add `abstract val` for any `@Singleton` you want to identity-test even
+if it's only consumed internally. A well-maintained component has an
+entry point for every state-owning type.
+
+### Pattern: per-Scope entry points
+
+Singleton isn't the only scope kotlin-inject supports. If you define
+custom scopes (e.g., `@UserSession`), the same rules apply: abstract
+entry points on the component with that scope, parameter-based
+providers, identity tests at the scope boundary.
+
+## When things go wrong
+
+### Symptom: `assertSame` fails for one binding, passes for others
+
+One provider is concrete, or its body calls a sibling directly. Find
+it — the generated file will be missing the `_scoped.get` call for
+that type.
+
+### Symptom: generated file grew but one binding still isn't cached
+
+Check the provider's parameter list. If it has no parameters but the
+concrete type constructor requires them, the compiler may be
+accepting an empty provider and not warning. Pass all deps as
+parameters.
+
+### Symptom: adding a new `@Singleton` silently doesn't cache
+
+Did you add an abstract entry? Without it, kotlin-inject has no
+reason to generate an override. Add `abstract val newRepository: NewRepository`
+and rerun KSP.
+
+## Reference
+
+- [kotlin-inject README — Scopes](https://github.com/evant/kotlin-inject/blob/main/README.md#scopes)
+- [kotlin-inject `@Component`](https://github.com/evant/kotlin-inject/blob/main/README.md#component)
+
+## Provenance of this guide
+
+This guide was written after a ~5-month regression cycle where
+`@Singleton` silently didn't cache, producing a user-visible state
+propagation bug that masqueraded as a Compose/Flow issue and survived
+multiple targeted fix attempts. The repository-specific postmortem is
+in `docs/POSTMORTEM_ANDROID_170.md`; this guide contains only the
+portable lessons.
+
+If you're adopting kotlin-inject in a new project, the four-item
+"Minimum viable defense" above is the most cost-effective protection
+against repeating this mistake.


### PR DESCRIPTION
## Summary

Adds a new `AndroidGarage/docs/guides/` folder for portable, non-repo-specific technology lessons. First guide: `kotlin-inject.md`, capturing the `@Singleton` scoping gotcha behind the android/170 regression in a form another project can lift verbatim.

## Why split from the postmortem

Three docs with distinct audiences:

| Doc | Audience |
|---|---|
| `docs/POSTMORTEM_ANDROID_170.md` (PR #374) | Smart Garage Door contributors looking at the incident |
| `docs/DI_SINGLETON_REQUIREMENTS.md` | This repo's AppComponent invariants |
| `docs/guides/kotlin-inject.md` **(this PR)** | Anyone on any project using kotlin-inject |

The guide is written in third person with no references to bug numbers, PRs, or Smart Garage Door specifics. The "Provenance" footer is the only pointer back to the incident context.

## Guide contents

- **TL;DR + failure-mode shape** — what looks correct vs. what the compiler emits
- **Two mechanical rules** — abstract entry points; parameter-based provider bodies
- **Three independent verification signals** — read generated file, runtime `assertSame`, log-based smoke
- **Minimum viable defense** — four checks that catch this class of bug in a new adopting project
- **Common patterns / anti-patterns**
- **Reference links** to upstream kotlin-inject docs

`guides/README.md` describes how to use these in other repos and how to add new guides.

## Test plan

- [x] Docs-only; no code changes
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)