### PR TITLE
docs: Three portable tech guides — R8, Nav3 scoping, reactive auth

### DIFF
--- a/AndroidGarage/docs/guides/README.md
+++ b/AndroidGarage/docs/guides/README.md
@@ -18,6 +18,16 @@ guide — the content is deliberately non-repo-specific.
   repository `StateFlow` + `fetchX()` contract: always-refresh
   semantics, null-preserves-cache, exception resilience, and the three
   tests that encode them.
+- [`r8-keep-rules.md`](r8-keep-rules.md) — R8 silently strips
+  reflection / codegen / generic-erased code. Categories, symptoms,
+  keep-rule templates, and release-variant smoke testing.
+- [`compose-nav3-vm-scoping.md`](compose-nav3-vm-scoping.md) — Nav3
+  creates one VM per nav entry. Design for N instances; put shared
+  state in `@Singleton` repositories.
+- [`reactive-auth-listener.md`](reactive-auth-listener.md) — auth is
+  a stream, not a one-shot. Repository subscribes to the platform's
+  auth callback on app-lifetime scope; commands are fire-and-forget;
+  the listener is the source of truth.
 
 ## How to use these guides in another project
 

--- a/AndroidGarage/docs/guides/compose-nav3-vm-scoping.md
+++ b/AndroidGarage/docs/guides/compose-nav3-vm-scoping.md
@@ -1,0 +1,210 @@
+# Compose Nav3 ViewModel scoping — multi-instance reality
+
+**Who this is for:** Compose developers using
+`androidx.navigation3` (Nav3) with
+`rememberViewModelStoreNavEntryDecorator<T>()` to scope ViewModels per
+navigation entry. Covers the default multi-instance behavior, what it
+means for shared state, and the invariants to enforce.
+
+## TL;DR
+
+Nav3's `rememberViewModelStoreNavEntryDecorator<ScreenType>()` creates
+one `ViewModelStore` **per navigation entry**. Two screens in the back
+stack = two independent `ViewModelStore`s = two independent VM
+instances of the same class. Shared state across screens lives in
+`@Singleton` repositories, not in "the" ViewModel.
+
+Treat "there is one `FooViewModel` in the app" as a false assumption.
+Design for N.
+
+## The default behavior
+
+```kotlin
+NavDisplay(
+    backStack = backStack,
+    entryDecorators = listOf(
+        rememberSaveableStateHolderNavEntryDecorator<Screen>(),
+        rememberViewModelStoreNavEntryDecorator<Screen>(),
+    ),
+    entryProvider = entryProvider {
+        entry<Screen.Home> { HomeContent(...) }
+        entry<Screen.Profile> { ProfileContent(...) }
+    },
+)
+
+@Composable
+fun HomeContent() {
+    val vm: FooViewModel = viewModel { component.fooViewModel }  // VM1
+    // ...
+}
+
+@Composable
+fun ProfileContent() {
+    val vm: FooViewModel = viewModel { component.fooViewModel }  // VM2 (different!)
+    // ...
+}
+```
+
+The `rememberViewModelStoreNavEntryDecorator` attaches one
+`ViewModelStoreOwner` per nav entry. `viewModel { ... }` keys on the
+class by default — the cache lookup happens inside the entry's store,
+so Home and Profile each get their own `FooViewModel` instance.
+
+When the user navigates back from Profile and re-navigates to
+Profile, Nav3 pops + re-creates that entry's store — so
+**re-entering a screen creates a fresh VM** unless your back-stack
+handling preserves the entry.
+
+## Why this matters
+
+Three common architectural assumptions silently break if you forget
+the multi-instance reality:
+
+### 1. "My ViewModel owns the state — there is one."
+
+Per-nav-entry scoping makes this false. Each entry's VM has its own
+`_state: MutableStateFlow<T>`. If two screens display the same domain
+state (e.g., a snooze setting visible on both Home and Profile),
+those two VMs diverge silently until something re-syncs them.
+
+**Fix:** the ViewModel doesn't own the state. A `@Singleton`
+repository does. Every VM exposes the **same** flow reference by
+getting it from the repo via an observe-UseCase. See
+[`kotlin-inject.md`](kotlin-inject.md) for how to make the repository
+an actual singleton — the default in most DI frameworks requires
+configuration.
+
+### 2. "I can cache the result in the VM and it'll be there when the user comes back."
+
+Only if the same nav entry is retained. A back/navigate-forward
+sequence often re-creates the entry → new store → new VM → empty
+cache. Anything expensive the VM did must be re-done unless the
+underlying repository caches.
+
+**Fix:** put the cache in the repository. The VM is a projection,
+not a cache.
+
+### 3. "Exactly one observer means I can use a `SharedFlow` with replay=0."
+
+N observers in general. A `SharedFlow { replay = 0 }` as a
+one-shot-event mechanism silently misses deliveries if a second VM
+tries to collect after the emission. Use `Channel` with single
+consumer, or a persistent state-based representation.
+
+## The invariant to enforce
+
+If two ViewModels of the same class can coexist (they can, in Nav3),
+then the only correct way to share state between them is a
+`@Singleton` repository that both VMs receive by injection. The
+repository owns a `StateFlow<T>`; both VMs expose it by reference via
+their own observe-UseCase property; neither VM holds a
+`MutableStateFlow<T>` for the same domain state.
+
+Combined with the two kotlin-inject rules (abstract entry points +
+parameter-based providers, see [`kotlin-inject.md`](kotlin-inject.md)),
+this gives you:
+
+```
+Home's FooViewModel           Profile's FooViewModel
+   │                              │
+   └──── snoozeState (ref) ───────┘
+            │
+            ▼
+   SnoozeRepository (@Singleton)
+        ._snoozeState: MutableStateFlow<SnoozeState>
+```
+
+Both VMs point at the same flow. A write from either VM's `submit()`
+command reaches both observers because the repo is shared.
+
+## How to verify your scoping works
+
+### Runtime assertion
+
+In an instrumented test, resolve two VMs from separate nav entries
+and check they're **different** instances (non-singleton) but their
+shared state flow is the **same** reference:
+
+```kotlin
+@Test
+fun vmPerNavEntryButSharedRepoFlow() {
+    val c = (application as MyApp).component
+    val vm1 = c.fooViewModel
+    val vm2 = c.fooViewModel
+    // VMs are per-access (not singleton)
+    assertNotSame(vm1, vm2)
+    // But the state they expose is the SAME flow (repo is singleton)
+    assertSame(vm1.fooState, vm2.fooState)
+}
+```
+
+The `assertNotSame` on VMs documents the intent (per-nav-entry
+scoping). The `assertSame` on the state flow proves shared state is
+actually shared.
+
+### Log-based smoke
+
+Put a `Logger.i { "FooViewModel init: $this" }` in the VM's init
+block. Cold-start the app and navigate through your screens. Count
+the init lines per screen visit. If a screen that should retain its
+VM on navigate-away/back instead shows a new init on each re-entry,
+the back-stack handling is re-creating the entry.
+
+## Minimum viable defense
+
+- [ ] A `ComponentGraphTest` (or equivalent) with `assertNotSame` on
+      VMs and `assertSame` on their shared repo flows.
+- [ ] Every domain state type has exactly one `MutableStateFlow`
+      instance in the app — enforced by lint / grep: no
+      `MutableStateFlow<DomainState>` in any `*ViewModel.kt`.
+- [ ] A top-of-file KDoc on your DI component noting "ViewModels are
+      per-nav-entry by design; shared state lives in `@Singleton`
+      repositories."
+- [ ] Init-log-per-instance during development. Count occurrences.
+      More than you expect = something is re-creating.
+
+## Common pitfalls
+
+### Pitfall: `activityViewModel { ... }` doesn't help
+
+Nav3's decorator-based scoping bypasses the `ViewModelStoreOwner`
+chain in many cases. Falling back to `activityViewModel` may work for
+some screens but not others, and couples VM lifetime to the Activity
+— fighting Nav3 rather than working with it. Prefer making the
+state live in a singleton.
+
+### Pitfall: `rememberSaveable` on a VM reference
+
+A VM is not `Saveable`. Don't try. Put state-to-survive-process-death
+in a `SavedStateHandle` wired into the VM, or in DataStore.
+
+### Pitfall: "Nav3 + Hilt's `hiltViewModel()` works like Nav2 did"
+
+Not quite. `hiltViewModel()` uses the nearest `ViewModelStoreOwner`
+— Nav3's decorator is that owner, scoping per-entry. Same multi-
+instance reality applies even with Hilt. Not unique to kotlin-inject.
+
+### Pitfall: assuming one VM in code review
+
+`viewModel { ... }` at two call sites looks like it returns "the"
+ViewModel. Without knowing the Nav3 scoping, reviewers approve
+architecturally-incorrect designs that rely on singleton VM
+semantics. Make the scoping visible: a comment at every
+`viewModel { ... }` call site helps, or a project-wide convention
+enforced by lint.
+
+## When to break the rule
+
+Some state is genuinely per-screen and per-visit: form input,
+scroll position, a currently-open dialog. These should live in the
+VM (or even the Composable via `remember`) and are correctly discarded
+when the screen is popped. The "share state via singleton"
+prescription is for domain state, not presentation state.
+
+## Reference
+
+- [androidx.navigation3 docs](https://developer.android.com/reference/androidx/navigation3/runtime/package-summary)
+- [`kotlin-inject.md`](kotlin-inject.md) — how to make the singleton
+  actually a singleton; prerequisite for this guide's invariant.
+- [`repository-api-patterns.md`](repository-api-patterns.md) — how to
+  shape the singleton repository the VMs share.

--- a/AndroidGarage/docs/guides/r8-keep-rules.md
+++ b/AndroidGarage/docs/guides/r8-keep-rules.md
@@ -1,0 +1,228 @@
+# R8 keep rules — what gets stripped, how to detect, how to prevent
+
+**Who this is for:** Android developers shipping release builds with
+R8/ProGuard minification enabled. Covers the categories of code that
+R8 silently strips, the symptoms, and the minimum keep rules that
+survive the next library upgrade.
+
+## TL;DR
+
+R8 removes code it believes is unused. It's wrong about any code
+reached via reflection, annotation-processing generated code, JNI,
+service loader, or generic type information. Symptoms in release
+builds only. Debug instrumented tests will not catch them because
+debug builds skip R8.
+
+Write **keep rules** for: serialization infrastructure (both the
+framework's and your own data classes), HTTP client request/response
+types, classes looked up by name (`Class.forName`), and anything
+reached through a deferred generic `T::class`.
+
+## The failure mode
+
+### Symptom categories
+
+- **`ClassNotFoundException` / `NoSuchMethodException`** — obvious.
+  The class was stripped; a reflection lookup failed at runtime.
+- **`@Serializable` fields silently parse as null / default values** —
+  much worse. The field name survives (because it's read by the
+  generated serializer) but the `$serializer` or `$Companion` class
+  got stripped. Runtime "succeeds" but the object is empty.
+- **Ktor/Retrofit `body<T>()` returns wrong-shaped objects** — same
+  mechanism. The request/response type's generated serializer got
+  stripped.
+- **`Class.forName("some.package.ClassName")` fails** — classes
+  reached only via name-based lookup are invisible to R8.
+- **`enumValueOf<T>()` fails** — generic enum lookup needs keep rules
+  for each enum that's only referenced through the generic parameter.
+
+### Why R8 doesn't know
+
+R8 walks the call graph from your app's entry points (`onCreate`,
+service classes declared in manifest, etc.) and keeps what's reachable.
+When a class is only reached through:
+- A string name (`Class.forName`, `Intent` action strings, R8 sees no edge)
+- A generic type erased at runtime (`inline fun <reified T> decode()` —
+  R8 sees erased type at the call site)
+- Annotation-processor-generated code that R8 processes separately
+  (kotlinx.serialization, kotlin-parcelize)
+- A reflection lookup (`KClass.members`)
+
+…R8 treats it as unreachable and strips it. The stripped code was
+always going to run in production; R8 just didn't know.
+
+### Why debug builds "work"
+
+Debug builds disable R8 (`isMinifyEnabled = false`). The strip never
+happens. Every instrumented test against a debug variant therefore
+runs with the full class set intact. The bug only appears when R8 is
+on — i.e., release APKs and Play Store internal/production tracks.
+
+## Categories of code that need keep rules
+
+### 1. kotlinx.serialization
+
+The generated `$serializer` inner class for `@Serializable` data
+classes is reflectively resolved. kotlinx.serialization ships some
+consumer rules but real-world apps need to reinforce them:
+
+```
+-keepattributes *Annotation*, InnerClasses
+
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1> {
+    static <1>$Companion Companion;
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+-if @kotlinx.serialization.Serializable class **
+-keep class <1>$$serializer { *; }
+
+-if @kotlinx.serialization.Serializable class **
+-keep class <1>$Companion { *; }
+
+-keepclassmembers class kotlinx.serialization.json.** {
+    *** Companion;
+}
+-keepclasseswithmembers class kotlinx.serialization.json.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+```
+
+### 2. Ktor client request/response types
+
+`response.body<T>()` relies on T's generated serializer at runtime.
+Even with the serialization rules above, the specific data classes
+your Ktor client uses should be kept explicitly:
+
+```
+-keep class com.example.network.** { *; }
+-keepclassmembers class com.example.network.** { *; }
+```
+
+Narrow the package as much as you can; `com.example.**` is too
+broad and defeats R8's shrinking elsewhere.
+
+### 3. Classes looked up by string name
+
+Anywhere you see `Class.forName(...)`, `ClassLoader.loadClass(...)`,
+or an Intent whose component name is a string literal:
+
+```
+-keep class com.example.services.** { *; }
+```
+
+### 4. Parcelable / Parcelize
+
+`@Parcelize` classes are kept by the plugin's consumer rules in
+newer versions. Verify at the proguard rules output if you use an
+older version.
+
+### 5. Enums reached through generics
+
+```kotlin
+inline fun <reified T : Enum<T>> parseEnum(name: String): T =
+    enumValueOf(name)
+```
+
+R8 doesn't see which enum gets substituted. Keep the enums:
+
+```
+-keepclassmembers class * extends java.lang.Enum {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+```
+
+### 6. Your own reflection targets
+
+If any part of your code uses `::class.memberProperties`,
+`KClass.constructors`, or accesses methods by string name, keep the
+target class and its members.
+
+## How to detect stripped code before users do
+
+### Detect via diagnostic logging at the deserialization boundary
+
+When a `@Serializable` class returns unexpectedly empty / null fields,
+the default reaction is "the server returned bad data." That's
+usually wrong. The server was fine; R8 stripped the serializer.
+
+**Log the raw body** at the Ktor/Retrofit response boundary, then
+log the parsed type. When the raw body contains JSON with your
+expected fields but the parsed object is empty, R8 is the culprit.
+
+```kotlin
+val text = response.bodyAsText()
+Logger.d { "Raw response: $text" }
+val parsed = Json.decodeFromString<MyResponse>(text)
+Logger.d { "Parsed: $parsed" }
+```
+
+Leave the log behind for state-critical decode paths — Rule 9-style
+observability. Adding it is cheap; removing it after a bug is
+painful because the bug has already shipped.
+
+### Detect via release-variant smoke tests
+
+Build a `benchmark` variant that inherits from `release` (R8 on) but
+is signed with a debug key and optionally debuggable. Install on a
+device and run instrumented tests against it. If the test targets
+`:app:connectedBenchmarkAndroidTest`, the APK under test is R8-
+minified.
+
+This catches the major ClassNotFoundException-class failures. It
+won't catch "fields parse as null" unless your test asserts on
+specific field values — which you should anyway.
+
+### Detect via release-APK smoke pre-release
+
+Before every release tag, install the release APK on a device
+(internal testing track is ideal) and walk through critical flows.
+R8 bugs tend to cluster at JSON boundaries and reflection sites —
+make sure your smoke script touches both.
+
+## Minimum viable defense (for any project adopting R8)
+
+- [ ] Add the kotlinx.serialization keep rules above (if you use it).
+- [ ] Narrowly keep your network-layer data packages (`Ktor`, Retrofit).
+- [ ] Write a "raw body logged at decode" diagnostic at every
+      state-critical deserialization boundary.
+- [ ] Add a release-variant instrumented test harness that at least
+      one critical-path test can run against.
+- [ ] Smoke test the release APK on a physical device before every
+      release tag, not just debug.
+
+## Common pitfalls
+
+### Pitfall: "consumer rules ship with the library, so I don't need my own"
+
+Partially true. Library consumer rules handle the framework level
+(e.g., keeping `KSerializer` itself). They often do NOT cover your
+specific `@Serializable` data classes — those need the `@Serializable
+→ keep $serializer` if-match pattern shown above.
+
+### Pitfall: "I'll just `-keep class **`"
+
+Defeats R8 entirely. The APK balloons and launch time suffers. Keep
+rules should be narrow to specific packages.
+
+### Pitfall: "tests pass so R8 is fine"
+
+Debug tests don't run R8. Release-variant tests (`connectedBenchmark
+AndroidTest` on a minified build) are the only instrumented signal.
+See the [R8 instrumented test recipe](../R8_INSTRUMENTED_TESTS.md) in
+this repo for an implementation — the same pattern applies elsewhere.
+
+### Pitfall: assuming stack traces point at R8
+
+A stripped class usually doesn't crash with a clear "R8 stripped me"
+message. It manifests as downstream `NullPointerException`,
+deserialization-default-value bugs, or feature silently not working.
+When a release-only bug appears, add R8 to your hypothesis list
+before jumping to lifecycle / process-death theories.
+
+## Reference
+
+- [R8 / ProGuard docs — keep rules](https://developer.android.com/build/shrink-code)
+- [kotlinx.serialization Android R8 rules](https://github.com/Kotlin/kotlinx.serialization#android)

--- a/AndroidGarage/docs/guides/reactive-auth-listener.md
+++ b/AndroidGarage/docs/guides/reactive-auth-listener.md
@@ -1,0 +1,247 @@
+# Reactive auth listener pattern
+
+**Who this is for:** anyone modeling authentication state in a
+mobile app or any app where auth is a stream of changes (sign-in,
+sign-out, token refresh) rather than a one-shot login operation.
+Applies to Firebase Auth, custom OAuth flows, biometric unlocks,
+or any SDK that exposes an "auth state" callback.
+
+## TL;DR
+
+Auth state is event-driven: the platform's auth SDK tells you when
+sign-in, sign-out, or token refresh happens. Your repository should
+subscribe to that callback on an app-lifetime scope and translate
+each event into a `StateFlow<AuthState>` write. The rest of the app
+observes; no polling, no one-shot `getCurrentUser()` calls scattered
+around. Sign-in and sign-out are fire-and-forget commands; the
+listener reflects the result.
+
+## The anti-pattern: imperative polling
+
+```kotlin
+// Don't do this.
+class AuthViewModel {
+    private val _authState = MutableStateFlow(AuthState.Unknown)
+    val authState: StateFlow<AuthState> = _authState
+
+    init {
+        viewModelScope.launch {
+            while (true) {
+                val user = firebase.currentUser
+                _authState.value = if (user != null) Authenticated(user) else Unauthenticated
+                delay(1000)
+            }
+        }
+    }
+
+    fun signIn(token: String) {
+        viewModelScope.launch {
+            val user = firebase.signInWithCredential(token)
+            _authState.value = if (user != null) Authenticated(user) else Unauthenticated
+        }
+    }
+}
+```
+
+Problems:
+- **Wastes battery** polling for state that rarely changes.
+- **Misses fast transitions** — token refresh → re-sign-in happens
+  faster than the polling period, state flaps.
+- **Duplicates logic** — both `init` and `signIn` write the state;
+  they can disagree.
+- **Scope-bound to the VM** — if the VM is destroyed mid-sign-in
+  (configuration change), the state update is cancelled with the
+  `viewModelScope`. See below for the cancellation pitfall.
+
+## The pattern: listener-driven repository
+
+```kotlin
+class FirebaseAuthRepository(
+    private val authBridge: AuthBridge,
+    externalScope: CoroutineScope,  // app-lifetime, NOT viewModelScope
+) : AuthRepository {
+    private val _authState = MutableStateFlow<AuthState>(AuthState.Unknown)
+    override val authState: StateFlow<AuthState> = _authState
+
+    init {
+        externalScope.launch {
+            authBridge.observeAuthUser().collect { userInfo ->
+                val newState = when (userInfo) {
+                    null -> AuthState.Unauthenticated
+                    else -> {
+                        val token = authBridge.getIdToken(forceRefresh = false)
+                        if (token != null) AuthState.Authenticated(User(userInfo, token))
+                        else AuthState.Unauthenticated
+                    }
+                }
+                _authState.value = newState
+            }
+        }
+    }
+
+    // Commands are fire-and-forget. Listener picks up the state change.
+    override suspend fun signInWithGoogle(idToken: GoogleIdToken): AuthState {
+        authBridge.signInWithGoogleToken(idToken)
+        return _authState.value  // may still be pre-sign-in;
+                                 // callers should observe, not use this return
+    }
+
+    override suspend fun signOut() {
+        _authState.value = AuthState.Unauthenticated  // eager UI update
+        authBridge.signOut()  // listener also fires and confirms
+    }
+}
+```
+
+Key properties:
+
+1. **The listener is the source of truth.** `sign-in` kicks off the
+   SDK; the listener observes the result and updates state. Commands
+   do not race against the listener.
+2. **`externalScope`, not viewModelScope.** If the VM is cancelled
+   mid-sign-in (config change, user navigates away), the state update
+   must still happen. App-lifetime scope guarantees this.
+3. **State is a `StateFlow<AuthState>`.** Current value always
+   available via `.value`. Observers see every transition.
+4. **Sign-out is eager.** Optimistic UI update before the SDK call;
+   listener confirms shortly after. Avoids a "stale signed-in state"
+   flash while the SDK processes sign-out.
+
+## The cancellation pitfall
+
+This is the subtle one. The Android `ViewModelScope` is cancelled on
+VM destruction (config change, navigate away, sign-out-triggered
+recreate). If your auth update runs on `viewModelScope`, it can be
+cancelled after the network call returns but before the state write:
+
+```kotlin
+// viewModelScope flow
+viewModelScope.launch {
+    val user = firebase.signIn(...)     // network call
+    // <-- VM destroyed here, coroutine cancelled
+    _authState.value = Authenticated(user)  // never runs
+}
+```
+
+The `StateFlow<AuthState>` is stuck at its pre-sign-in value forever
+(for this VM). If the VM holds "the" state, new VMs of the same class
+will have fresh state but anything that references the old VM's flow
+is stranded.
+
+Fix: use an app-lifetime `externalScope` for state writes. The VM
+observes; it does not write. Commands either delegate to the
+repository (which uses `externalScope`) or return their result
+directly without touching flows.
+
+## AuthState modeling
+
+A useful three-case sealed type:
+
+```kotlin
+sealed interface AuthState {
+    object Unknown : AuthState            // listener hasn't fired yet
+    object Unauthenticated : AuthState    // signed out or never signed in
+    data class Authenticated(val user: User) : AuthState
+}
+```
+
+- `Unknown` exists because the listener is async. The first emission
+  after app launch might take a few hundred ms. Distinguishing
+  "haven't checked yet" from "checked and signed out" prevents UI
+  flash during the check.
+- `Authenticated` carries the `User` object (display name, email,
+  token). Makes the state self-contained; no `getCurrentUser()`
+  lookup elsewhere.
+- No explicit `SigningIn` / `SigningOut` state. Those are
+  presentation concerns (a spinner in the UI) — model them in the
+  ViewModel as a separate `SignInAction` flow, not in the domain
+  `AuthState`. Keeps the invariants cleaner.
+
+## Token refresh
+
+ID tokens typically expire in ~1 hour. Two places need freshness:
+
+1. **At the auth state level.** When the SDK auto-refreshes, the
+   listener fires again with the new token. The state flow updates.
+2. **At the point of use.** Before a network call that needs a valid
+   token, call a `ensureFreshIdToken()` UseCase that checks expiry
+   and force-refreshes if needed.
+
+```kotlin
+class EnsureFreshIdTokenUseCase(private val authRepo: AuthRepository) {
+    suspend operator fun invoke(authState: AuthState.Authenticated): FirebaseIdToken {
+        val current = authState.user.idToken
+        if (current.exp > (System.currentTimeMillis() / 1000) + 60) return current
+        return authRepo.refreshIdToken() ?: current  // fallback
+    }
+}
+```
+
+The repository's `refreshIdToken()` writes the new token into
+`_authState` so the rest of the app sees it without polling.
+
+## Minimum viable defense
+
+- [ ] Auth state is a `StateFlow<AuthState>` on a `@Singleton`
+      repository, not in a ViewModel.
+- [ ] Listener subscription launches on an app-lifetime scope
+      (`externalScope` / `ApplicationScope`), not any VM scope.
+- [ ] Commands (`signIn`, `signOut`, `refreshToken`) write state on
+      `externalScope` — either directly or via the listener.
+- [ ] At least one test proves a VM cancellation mid-sign-in does
+      not strand the auth state.
+- [ ] UI observes the `StateFlow`; no `getCurrentUser()` one-shot
+      reads scattered in screens.
+
+## Common pitfalls
+
+### Pitfall: using `viewModelScope` for the listener
+
+If the listener itself runs on a VM scope, destroying the VM
+unsubscribes the listener. State updates stop. New VMs don't
+resubscribe because the singleton repo's `init` already ran (once).
+
+**Fix:** the listener ALWAYS runs on `externalScope` in the
+repository's `init { }`. One subscription per process lifetime.
+
+### Pitfall: conflating sign-in command flight with auth state
+
+Putting `SigningIn` in `AuthState` couples domain state to UI flow.
+Makes `when (authState)` exhaustively check UI-only transitions in
+every consumer.
+
+**Fix:** separate the domain state from the presentation state.
+`AuthState` has Unknown / Unauthenticated / Authenticated. A
+VM-local `SignInAction` (Sending, Succeeded, Failed.X) handles the
+command lifecycle.
+
+### Pitfall: not modeling Unknown
+
+"No signed-in user" defaulting to `Unauthenticated` means the UI
+shows the sign-in button during the ~300ms between app launch and
+the first listener emission. Users see a flash.
+
+**Fix:** start as `Unknown`, let the UI show a neutral loading
+state, transition to Authenticated or Unauthenticated when the
+listener fires.
+
+### Pitfall: ignoring sign-out race
+
+If sign-out triggers a VM recreation (e.g., navigation reset), and
+your sign-out command writes state on `viewModelScope`, the write
+can be cancelled when the VM dies. User sees a signed-in UI briefly
+after tapping "Sign out."
+
+**Fix:** eager optimistic sign-out state write in the repository,
+on `externalScope`. The SDK call follows. The listener confirms.
+Three layers all move in the same direction.
+
+## Reference
+
+- [Firebase Auth `AuthStateListener`](https://firebase.google.com/docs/auth/android/manage-users#get_the_currently_signed-in_user)
+- [`repository-api-patterns.md`](repository-api-patterns.md) — the
+  `StateFlow` + fetch contract for repositories.
+- [`compose-nav3-vm-scoping.md`](compose-nav3-vm-scoping.md) — why
+  VMs can't own auth state in a multi-instance world.
+- [`kotlin-inject.md`](kotlin-inject.md) — making the auth
+  repository an actual singleton.


### PR DESCRIPTION
## Summary

Completes the `docs/guides/` portable-lessons library with three more guides covering the remaining session knowledge. Each is written in third person, assumes no Smart Garage Door context, and includes a "Minimum viable defense" checklist for teams adopting the same tech elsewhere.

## New guides

### `r8-keep-rules.md`

When R8 silently strips reflection / codegen / generic-erased code. Categories (kotlinx.serialization `$serializer`, Ktor `body<T>()` types, `Class.forName` lookups, `enumValueOf<T>`), symptoms (ClassNotFoundException, silent null-field parse, wrong-shape objects), keep-rule templates, and release-variant smoke testing.

### `compose-nav3-vm-scoping.md`

`rememberViewModelStoreNavEntryDecorator<ScreenType>` creates one `ViewModelStore` per nav entry. Design for N ViewModels of the same class coexisting. Domain state lives in `@Singleton` repositories; VMs are projections. Runtime assertion pattern: `assertNotSame` on VMs, `assertSame` on their shared flow refs.

### `reactive-auth-listener.md`

Auth is a stream, not a one-shot login. Repository subscribes to the platform's auth callback on `externalScope` (app-lifetime), not `viewModelScope`. Commands are fire-and-forget; the listener is the source of truth. Three-case `AuthState` (Unknown / Unauthenticated / Authenticated). Token refresh at point of use via `EnsureFreshIdToken` UseCase. Covers the cancellation pitfall where `viewModelScope` cancellation mid-sign-in would strand the flow.

## Cross-referencing

Each guide links to the others where relevant. Nav3 scoping relies on kotlin-inject for actual singletons; reactive auth relies on both kotlin-inject and repository-api-patterns. The guide ecosystem is self-contained.

## Merge order

Stacked on PR #376 to avoid README conflict. Full stack after #374 (postmortem) + #375 (guides folder) + #376 (repo-api-patterns): this adds four bullets to the Guides index.

## Test plan

- [x] Docs-only; no code changes
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)