### PR TITLE
docs: Add versioning strategy

### DIFF
--- a/.claude/skills/bump-android-version/SKILL.md
+++ b/.claude/skills/bump-android-version/SKILL.md
@@ -16,6 +16,16 @@ Increment `versionName` in `AndroidGarage/version.properties` and create a PR.
 
 If no argument is provided, default to `patch`.
 
+## Versioning rule
+
+See [`AndroidGarage/CHANGELOG.md#versioning`](../../../AndroidGarage/CHANGELOG.md) for the authoritative rule:
+
+- **Major** — App rewrite or a core-experience shift so significant the previous version feels like a different product.
+- **Minor** — A new user-facing feature or capability (something a user couldn't do before), **or** the removal of a user-facing feature.
+- **Patch** — Bug fixes, UI polish, performance, refactors. No new capability.
+
+Before bumping, classify the pending work against this rule and confirm with the user if the requested bump type doesn't match (e.g., user asks for `minor` but no new capability has landed — that's a patch).
+
 ## Steps
 
 ### 1. Read current version

--- a/AndroidGarage/CHANGELOG.md
+++ b/AndroidGarage/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Internal release history. For Play Store "What's New" text, see `distribution/whatsnew/`.
 
+## Versioning
+
+- **Major (X.0.0)** — App rewrite or a change in the core experience so significant the previous version feels like a different product.
+- **Minor (X.Y.0)** — A new user-facing feature or capability (something a user couldn't do before), **or** the removal of a user-facing feature.
+- **Patch (X.Y.Z)** — Bug fixes, UI polish, performance, refactors. No new capability.
+
+Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
+
 ## 2.4.3
 - Snooze card updates to "snoozed until X" immediately after saving (no app restart needed)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,8 @@ The script computes the next tag as `android/<highest + 1>`. The `--confirm-tag`
 
 **Validation is required by default.** Run `./scripts/validate.sh` before releasing. If validation hasn't passed on the commit, the release script will block. `--skip-validation` exists for emergencies (e.g., rollbacks to old tags) but should NOT be used routinely. Always ask the user before using `--skip-validation`.
 
+**Versioning rule (see [CHANGELOG.md](AndroidGarage/CHANGELOG.md#versioning)):** major = rewrite or core-experience shift; minor = added or removed user-facing feature/capability; patch = fixes, polish, refactors. `CHANGELOG.md` logs every version; `distribution/whatsnew/` gets one line per minor/major (patches roll up).
+
 ### Releasing Firebase Server
 Use `./scripts/release-firebase.sh` — same pattern as Android releases.
 


### PR DESCRIPTION
## Summary
Documents the versioning rule for Android releases:

- **Major** — App rewrite or core-experience shift
- **Minor** — User-facing feature added **or removed**
- **Patch** — Bug fixes, UI polish, performance, refactors

Captured in three places so future version bumps follow a consistent rule:
- `AndroidGarage/CHANGELOG.md` — authoritative strategy section at top of file
- `CLAUDE.md` — one-line rule under "Releasing Android" with link to the strategy
- `.claude/skills/bump-android-version/SKILL.md` — versioning rule surfaced to the bump skill

Also clarifies that `distribution/whatsnew/` gets a line per minor/major; patches roll up into the next minor's line (or get a combined line if promoted to production alone).

## Test plan
- [x] Docs-only change — no code paths affected
- [x] CHANGELOG renders correctly
- [x] CLAUDE.md link resolves
- [x] Skill file loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)