### PR TITLE
ci: Skip Android CI on docs-only changes

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       android: ${{ steps.filter.outputs.android }}
+      docs_only: ${{ steps.filter.outputs.docs_only }}
     steps:
       - uses: actions/checkout@v4
       - name: Check for Android changes
@@ -33,9 +34,22 @@ jobs:
 
           if [ "$CHANGED" = "UNKNOWN" ]; then
             echo "android=true" >> $GITHUB_OUTPUT
+            echo "docs_only=false" >> $GITHUB_OUTPUT
             echo "Could not determine changes, running all checks"
             exit 0
           fi
+
+          # Docs-only fast path — see ci.yml for rationale.
+          NON_DOCS=$(echo "$CHANGED" | grep -vE '^(.*\.md$|docs/|.*/docs/|\.claude/|LICENSE$|\.gitignore$|AndroidGarage/distribution/whatsnew/)' || true)
+          if [ -z "$NON_DOCS" ] && [ -n "$CHANGED" ]; then
+            echo "android=false" >> $GITHUB_OUTPUT
+            echo "docs_only=true" >> $GITHUB_OUTPUT
+            echo "Docs-only change — skipping Android post-merge CI. Changed files:"
+            echo "$CHANGED"
+            exit 0
+          fi
+
+          echo "docs_only=false" >> $GITHUB_OUTPUT
 
           if echo "$CHANGED" | grep -qE '^(AndroidGarage/|scripts/|\.github/(workflows|actions)/)'; then
             echo "android=true" >> $GITHUB_OUTPUT
@@ -51,6 +65,7 @@ jobs:
   checks:
     name: Checks
     needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     uses: ./.github/workflows/ci-checks.yml
     with:
       android: ${{ needs.changes.outputs.android }}
@@ -109,7 +124,7 @@ jobs:
             exit 1
           fi
 
-          echo "All post-merge checks passed (or skipped — no Android changes)"
+          echo "All post-merge checks passed (or skipped — no Android changes / docs-only)"
 
   # Track post-merge failures via a single GitHub issue
   track-failure:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       android: ${{ steps.filter.outputs.android }}
+      docs_only: ${{ steps.filter.outputs.docs_only }}
     steps:
       - uses: actions/checkout@v4
       - name: Check for Android changes
@@ -21,6 +22,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "android=true" >> $GITHUB_OUTPUT
+            echo "docs_only=false" >> $GITHUB_OUTPUT
             echo "workflow_dispatch: running all checks"
             exit 0
           fi
@@ -32,9 +34,25 @@ jobs:
 
           if [ "$CHANGED" = "UNKNOWN" ]; then
             echo "android=true" >> $GITHUB_OUTPUT
+            echo "docs_only=false" >> $GITHUB_OUTPUT
             echo "Could not determine changes, running all checks"
             exit 0
           fi
+
+          # Docs-only fast path: skip CI when no change affects what CI verifies.
+          # Docs = markdown anywhere, docs/ directories, .claude/ (skills/hooks/settings
+          # affect dev tooling only, not shipped artifacts), LICENSE, .gitignore,
+          # and Android release metadata (CHANGELOG.md matches *.md, whatsnew/ below).
+          NON_DOCS=$(echo "$CHANGED" | grep -vE '^(.*\.md$|docs/|.*/docs/|\.claude/|LICENSE$|\.gitignore$|AndroidGarage/distribution/whatsnew/)' || true)
+          if [ -z "$NON_DOCS" ] && [ -n "$CHANGED" ]; then
+            echo "android=false" >> $GITHUB_OUTPUT
+            echo "docs_only=true" >> $GITHUB_OUTPUT
+            echo "Docs-only change — skipping Android CI. Changed files:"
+            echo "$CHANGED"
+            exit 0
+          fi
+
+          echo "docs_only=false" >> $GITHUB_OUTPUT
 
           if echo "$CHANGED" | grep -qE '^(AndroidGarage/|scripts/|\.github/(workflows|actions)/)'; then
             echo "android=true" >> $GITHUB_OUTPUT
@@ -49,6 +67,7 @@ jobs:
   checks:
     name: Checks
     needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
     uses: ./.github/workflows/ci-checks.yml
     with:
       android: ${{ needs.changes.outputs.android }}
@@ -77,4 +96,4 @@ jobs:
             exit 1
           fi
 
-          echo "All CI checks passed (or skipped — no Android changes)"
+          echo "All CI checks passed (or skipped — no Android changes / docs-only)"


### PR DESCRIPTION
## Summary
Adds a docs-only fast path to Android CI (both `ci.yml` and `ci-post-merge.yml`). When a PR / push changes only docs, the expensive `checks` reusable workflow is skipped and the `CI Complete` / `Post-Merge Complete` gate jobs post success in ~20-30s.

**Rule:** skip CI when a change cannot affect what CI verifies. Markdown, skill/hook/settings files, and text-only release metadata are not compiled, tested, or packaged. Anything under `.github/**` or `scripts/**` still triggers full CI.

## What's classified as docs
- `**/*.md` — markdown anywhere
- `docs/**` and `**/docs/**`
- `.claude/**` — skills, hooks, settings (dev tooling only)
- `LICENSE`, `.gitignore`
- `AndroidGarage/distribution/whatsnew/**` — Play Store metadata
- `AndroidGarage/CHANGELOG.md` — matches `*.md`

## What still triggers full CI
- Any file under `AndroidGarage/` that's not markdown or docs
- `scripts/**` (validate.sh and friends)
- `.github/workflows/**` and `.github/actions/**` (workflow changes must be tested)
- Mixed PRs (docs + code) — `docs_only=true` only when *every* changed file matches

## Test plan
- [x] This PR touches only `.github/workflows/` → should run full CI (not the fast path)
- [ ] Next docs-only PR should show `CI Complete` green in <60s with `Checks` skipped
- [ ] Mixed PR (docs + Kotlin) should run full pipeline as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)