### PR TITLE
ci: Split Firebase CI into pre/post-merge; extract reusable checks

### DIFF
--- a/.github/workflows/firebase-ci-checks.yml
+++ b/.github/workflows/firebase-ci-checks.yml
@@ -1,0 +1,44 @@
+name: Firebase CI Checks
+
+# Reusable workflow — called by both firebase-ci.yml (PR trigger)
+# and firebase-ci-post-merge.yml (push main trigger).
+
+on:
+  workflow_call:
+    inputs:
+      firebase:
+        description: Whether Firebase files changed
+        required: true
+        type: string
+
+jobs:
+  test:
+    name: Run Unit Tests
+    if: inputs.firebase == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        working-directory: FirebaseServer
+        run: npm install
+      - name: Build
+        working-directory: FirebaseServer
+        run: npm run build
+      - name: Run Unit Tests
+        working-directory: FirebaseServer
+        run: npm run tests
+      - name: Check for outdated dependencies
+        working-directory: FirebaseServer
+        continue-on-error: true
+        run: |
+          echo "::group::Outdated dependencies"
+          npm outdated || true
+          echo "::endgroup::"
+          OUTDATED=$(npm outdated --json 2>/dev/null || echo "{}")
+          if [ "$OUTDATED" != "{}" ]; then
+            echo "::warning::Some dependencies have newer versions available. Run 'npm outdated' locally to review."
+          fi

--- a/.github/workflows/firebase-ci.yml
+++ b/.github/workflows/firebase-ci.yml
@@ -1,10 +1,11 @@
 name: Firebase CI
 
+# Pre-submit checks — runs on PRs only.
+# Post-merge checks are in firebase-ci-post-merge.yml.
+
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ "main" ]
-  push:
     branches: [ "main" ]
 
 jobs:
@@ -26,12 +27,8 @@ jobs:
             exit 0
           fi
 
-          if [ "${{ github.event_name }}" = "push" ]; then
-            BASE="${{ github.event.before }}"
-          else
-            BASE="origin/${{ github.base_ref }}"
-            git fetch --depth=1 origin "${{ github.base_ref }}" 2>/dev/null || true
-          fi
+          BASE="origin/${{ github.base_ref }}"
+          git fetch --depth=1 origin "${{ github.base_ref }}" 2>/dev/null || true
 
           CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null || echo "UNKNOWN")
 
@@ -64,50 +61,26 @@ jobs:
             echo "$CHANGED"
           fi
 
-  test:
-    name: Run Unit Tests
+  checks:
+    name: Checks
     needs: changes
-    if: needs.changes.outputs.firebase == 'true' && needs.changes.outputs.docs_only != 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-      - name: Install dependencies
-        working-directory: FirebaseServer
-        run: npm install
-      - name: Build
-        working-directory: FirebaseServer
-        run: npm run build
-      - name: Run Unit Tests
-        working-directory: FirebaseServer
-        run: npm run tests
-      - name: Check for outdated dependencies
-        working-directory: FirebaseServer
-        continue-on-error: true
-        run: |
-          echo "::group::Outdated dependencies"
-          npm outdated || true
-          echo "::endgroup::"
-          OUTDATED=$(npm outdated --json 2>/dev/null || echo "{}")
-          if [ "$OUTDATED" != "{}" ]; then
-            echo "::warning::Some dependencies have newer versions available. Run 'npm outdated' locally to review."
-          fi
+    if: needs.changes.outputs.docs_only != 'true'
+    uses: ./.github/workflows/firebase-ci-checks.yml
+    with:
+      firebase: ${{ needs.changes.outputs.firebase }}
 
   # Gate job — required status check for Firebase.
   firebase-ci-complete:
     name: Firebase CI Complete
     if: always()
-    needs: [test]
+    needs: [checks]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
         run: |
-          echo "Tests: ${{ needs.test.result }}"
-          if [[ "${{ needs.test.result }}" == "failure" || \
-                "${{ needs.test.result }}" == "cancelled" ]]; then
+          echo "Checks: ${{ needs.checks.result }}"
+          if [[ "${{ needs.checks.result }}" == "failure" || \
+                "${{ needs.checks.result }}" == "cancelled" ]]; then
             echo "::error::Firebase CI failed"
             exit 1
           fi

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -18,8 +18,10 @@ jobs:
           TAG_SHA="${GITHUB_SHA}"
           echo "Checking Firebase CI status for commit $TAG_SHA..."
 
+          # Match "Run Unit Tests" whether it comes from the inline job (legacy) or
+          # the reusable workflow (prefixed as "<caller-job> / Run Unit Tests").
           TESTS_CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA/check-runs" \
-            --jq '[.check_runs[] | select(.name == "Run Unit Tests" and .app.slug == "github-actions")] | last | .conclusion')
+            --jq '[.check_runs[] | select((.name | endswith("Run Unit Tests")) and .app.slug == "github-actions")] | last | .conclusion')
 
           echo "Firebase Tests: $TESTS_CONCLUSION"
 


### PR DESCRIPTION
## Summary
Firebase CI previously ran on both `pull_request` and `push: main`, producing duplicate runs on every Firebase-touching merge. This PR mirrors the Android split pattern:

- **New `firebase-ci-checks.yml`** — reusable workflow with the `Run Unit Tests` job, takes a `firebase` input.
- **`firebase-ci.yml`** — now PR-only, calls the reusable workflow. Keeps the `Firebase CI Complete` gate job name unchanged (required status check stays valid).
- **`firebase-deploy.yml`** — widened the check-run name match from `== "Run Unit Tests"` to `endswith("Run Unit Tests")` so the tag-based deploy keeps finding the check whether the reusable prefixes it or not.

The companion `firebase-ci-post-merge.yml` (Phase 2C) will follow in the next PR.

## Merge order
This is PR 1 of 2 in the Firebase CI split stack.
- **Depends on #380** (docs-only fast path for Firebase CI)
- Merge AFTER #380 lands on main.
- Full stack: #380 → (this PR) → (Phase 2C post-merge PR)

## Risk
The deploy check-run name change is the one thing that could break. The `endswith` match works with both old and new names, so if the refactor causes the name to change (e.g., to `Firebase CI / Checks / Run Unit Tests`), the deploy still finds it.

## Test plan
- [x] Validates workflow YAML
- [ ] After merge, next Firebase PR should show a single `Firebase CI Complete` check (not duplicated on push to main)
- [ ] When cutting the next server tag, `verify-ci` step should still find `Run Unit Tests` via `endswith` match

🤖 Generated with [Claude Code](https://claude.com/claude-code)