### PR TITLE
ci: Firebase post-merge CI with auto-issue tracker

### DIFF
--- a/.github/workflows/firebase-ci-checks.yml
+++ b/.github/workflows/firebase-ci-checks.yml
@@ -1,0 +1,44 @@
+name: Firebase CI Checks
+
+# Reusable workflow — called by both firebase-ci.yml (PR trigger)
+# and firebase-ci-post-merge.yml (push main trigger).
+
+on:
+  workflow_call:
+    inputs:
+      firebase:
+        description: Whether Firebase files changed
+        required: true
+        type: string
+
+jobs:
+  test:
+    name: Run Unit Tests
+    if: inputs.firebase == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        working-directory: FirebaseServer
+        run: npm install
+      - name: Build
+        working-directory: FirebaseServer
+        run: npm run build
+      - name: Run Unit Tests
+        working-directory: FirebaseServer
+        run: npm run tests
+      - name: Check for outdated dependencies
+        working-directory: FirebaseServer
+        continue-on-error: true
+        run: |
+          echo "::group::Outdated dependencies"
+          npm outdated || true
+          echo "::endgroup::"
+          OUTDATED=$(npm outdated --json 2>/dev/null || echo "{}")
+          if [ "$OUTDATED" != "{}" ]; then
+            echo "::warning::Some dependencies have newer versions available. Run 'npm outdated' locally to review."
+          fi

--- a/.github/workflows/firebase-ci-post-merge.yml
+++ b/.github/workflows/firebase-ci-post-merge.yml
@@ -1,0 +1,111 @@
+name: Firebase Post-Merge CI
+
+# Post-submit Firebase checks — runs on push to main only.
+# Re-runs the shared Firebase checks to catch merge-induced breakage.
+# Failures auto-create GitHub issues; fixes auto-close them.
+
+on:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      firebase: ${{ steps.filter.outputs.firebase }}
+      docs_only: ${{ steps.filter.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for Firebase changes
+        id: filter
+        run: |
+          BASE="${{ github.event.before }}"
+          CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null || echo "UNKNOWN")
+
+          if [ "$CHANGED" = "UNKNOWN" ]; then
+            echo "firebase=true" >> $GITHUB_OUTPUT
+            echo "docs_only=false" >> $GITHUB_OUTPUT
+            echo "Could not determine changes, running all checks"
+            exit 0
+          fi
+
+          # Docs-only fast path — see ci.yml for rationale.
+          NON_DOCS=$(echo "$CHANGED" | grep -vE '^(.*\.md$|docs/|.*/docs/|\.claude/|LICENSE$|\.gitignore$|AndroidGarage/distribution/whatsnew/)' || true)
+          if [ -z "$NON_DOCS" ] && [ -n "$CHANGED" ]; then
+            echo "firebase=false" >> $GITHUB_OUTPUT
+            echo "docs_only=true" >> $GITHUB_OUTPUT
+            echo "Docs-only change — skipping Firebase post-merge CI. Changed files:"
+            echo "$CHANGED"
+            exit 0
+          fi
+
+          echo "docs_only=false" >> $GITHUB_OUTPUT
+
+          if echo "$CHANGED" | grep -qE '^(FirebaseServer/|\.github/workflows/firebase-ci(-checks|-post-merge)?\.yml)'; then
+            echo "firebase=true" >> $GITHUB_OUTPUT
+            echo "Firebase files changed:"
+            echo "$CHANGED" | grep -E '^(FirebaseServer/|\.github/workflows/firebase-ci(-checks|-post-merge)?\.yml)'
+          else
+            echo "firebase=false" >> $GITHUB_OUTPUT
+            echo "No Firebase files changed. Changed files:"
+            echo "$CHANGED"
+          fi
+
+  # Shared checks (same as PR CI)
+  checks:
+    name: Checks
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    uses: ./.github/workflows/firebase-ci-checks.yml
+    with:
+      firebase: ${{ needs.changes.outputs.firebase }}
+
+  # Gate job — single check-run name for visibility on main.
+  firebase-post-merge-complete:
+    name: Firebase Post-Merge Complete
+    if: always()
+    needs: [checks]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        run: |
+          echo "Checks: ${{ needs.checks.result }}"
+          if [[ "${{ needs.checks.result }}" == "failure" || \
+                "${{ needs.checks.result }}" == "cancelled" ]]; then
+            echo "::error::Firebase post-merge CI failed"
+            exit 1
+          fi
+          echo "Firebase post-merge CI passed (or skipped — no Firebase changes / docs-only)"
+
+  # Track post-merge failures via a single GitHub issue
+  track-failure:
+    name: Track Firebase Post-Merge Failure
+    if: always() && needs.changes.outputs.firebase == 'true' && needs.changes.outputs.docs_only != 'true'
+    needs: [changes, checks]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Determine overall result
+        id: result
+        run: |
+          CHECKS="${{ needs.checks.result }}"
+          echo "checks=$CHECKS" >> $GITHUB_OUTPUT
+          if [[ "$CHECKS" == "failure" ]]; then
+            echo "overall=failure" >> $GITHUB_OUTPUT
+          else
+            echo "overall=success" >> $GITHUB_OUTPUT
+          fi
+      - uses: ./.github/actions/ci-failure-tracker
+        with:
+          label: ci-failure/firebase-post-merge
+          result: ${{ steps.result.outputs.overall }}
+          workflow-name: "Firebase Post-Merge CI (checks: ${{ steps.result.outputs.checks }})"

--- a/.github/workflows/firebase-ci.yml
+++ b/.github/workflows/firebase-ci.yml
@@ -1,10 +1,11 @@
 name: Firebase CI
 
+# Pre-submit checks — runs on PRs only.
+# Post-merge checks are in firebase-ci-post-merge.yml.
+
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ "main" ]
-  push:
     branches: [ "main" ]
 
 jobs:
@@ -26,12 +27,8 @@ jobs:
             exit 0
           fi
 
-          if [ "${{ github.event_name }}" = "push" ]; then
-            BASE="${{ github.event.before }}"
-          else
-            BASE="origin/${{ github.base_ref }}"
-            git fetch --depth=1 origin "${{ github.base_ref }}" 2>/dev/null || true
-          fi
+          BASE="origin/${{ github.base_ref }}"
+          git fetch --depth=1 origin "${{ github.base_ref }}" 2>/dev/null || true
 
           CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null || echo "UNKNOWN")
 
@@ -64,50 +61,26 @@ jobs:
             echo "$CHANGED"
           fi
 
-  test:
-    name: Run Unit Tests
+  checks:
+    name: Checks
     needs: changes
-    if: needs.changes.outputs.firebase == 'true' && needs.changes.outputs.docs_only != 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-      - name: Install dependencies
-        working-directory: FirebaseServer
-        run: npm install
-      - name: Build
-        working-directory: FirebaseServer
-        run: npm run build
-      - name: Run Unit Tests
-        working-directory: FirebaseServer
-        run: npm run tests
-      - name: Check for outdated dependencies
-        working-directory: FirebaseServer
-        continue-on-error: true
-        run: |
-          echo "::group::Outdated dependencies"
-          npm outdated || true
-          echo "::endgroup::"
-          OUTDATED=$(npm outdated --json 2>/dev/null || echo "{}")
-          if [ "$OUTDATED" != "{}" ]; then
-            echo "::warning::Some dependencies have newer versions available. Run 'npm outdated' locally to review."
-          fi
+    if: needs.changes.outputs.docs_only != 'true'
+    uses: ./.github/workflows/firebase-ci-checks.yml
+    with:
+      firebase: ${{ needs.changes.outputs.firebase }}
 
   # Gate job — required status check for Firebase.
   firebase-ci-complete:
     name: Firebase CI Complete
     if: always()
-    needs: [test]
+    needs: [checks]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
         run: |
-          echo "Tests: ${{ needs.test.result }}"
-          if [[ "${{ needs.test.result }}" == "failure" || \
-                "${{ needs.test.result }}" == "cancelled" ]]; then
+          echo "Checks: ${{ needs.checks.result }}"
+          if [[ "${{ needs.checks.result }}" == "failure" || \
+                "${{ needs.checks.result }}" == "cancelled" ]]; then
             echo "::error::Firebase CI failed"
             exit 1
           fi

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -18,8 +18,10 @@ jobs:
           TAG_SHA="${GITHUB_SHA}"
           echo "Checking Firebase CI status for commit $TAG_SHA..."
 
+          # Match "Run Unit Tests" whether it comes from the inline job (legacy) or
+          # the reusable workflow (prefixed as "<caller-job> / Run Unit Tests").
           TESTS_CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA/check-runs" \
-            --jq '[.check_runs[] | select(.name == "Run Unit Tests" and .app.slug == "github-actions")] | last | .conclusion')
+            --jq '[.check_runs[] | select((.name | endswith("Run Unit Tests")) and .app.slug == "github-actions")] | last | .conclusion')
 
           echo "Firebase Tests: $TESTS_CONCLUSION"
 


### PR DESCRIPTION
## Summary
Completes the Firebase CI split (Phase 2C of the plan). New workflow `firebase-ci-post-merge.yml` runs on push to main, calls the shared `firebase-ci-checks.yml` reusable workflow, and uses the existing `ci-failure-tracker` composite action to open/close a GitHub issue labeled `ci-failure/firebase-post-merge`.

Mirrors the Android `ci-post-merge.yml` pattern: a regression in main gets an auto-filed tracker issue; the issue auto-closes when the next passing push arrives.

Firebase has no instrumented / integration test tier today, so this runs the same unit tests as the PR CI. Value today = the issue tracker; tomorrow = a hook for adding Firebase emulator integration tests without another refactor.

## Merge order
This is PR 2 of 2 in the Firebase CI split stack.
- **Depends on #381** (extract firebase-ci-checks.yml + PR-only trigger)
- Merge AFTER #381 lands on main.
- Full stack: #380 → #381 → (this PR)

## Test plan
- [x] Workflow YAML validates
- [ ] After merge, next push to main should trigger `Firebase Post-Merge CI`
- [ ] On a failing commit, should auto-open an issue with label `ci-failure/firebase-post-merge`
- [ ] On the next passing commit, should auto-close the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)