### PR TITLE
docs: Update CI architecture for Firebase split + docs-only path

### DIFF
--- a/.github/workflows/firebase-ci-checks.yml
+++ b/.github/workflows/firebase-ci-checks.yml
@@ -1,0 +1,44 @@
+name: Firebase CI Checks
+
+# Reusable workflow — called by both firebase-ci.yml (PR trigger)
+# and firebase-ci-post-merge.yml (push main trigger).
+
+on:
+  workflow_call:
+    inputs:
+      firebase:
+        description: Whether Firebase files changed
+        required: true
+        type: string
+
+jobs:
+  test:
+    name: Run Unit Tests
+    if: inputs.firebase == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        working-directory: FirebaseServer
+        run: npm install
+      - name: Build
+        working-directory: FirebaseServer
+        run: npm run build
+      - name: Run Unit Tests
+        working-directory: FirebaseServer
+        run: npm run tests
+      - name: Check for outdated dependencies
+        working-directory: FirebaseServer
+        continue-on-error: true
+        run: |
+          echo "::group::Outdated dependencies"
+          npm outdated || true
+          echo "::endgroup::"
+          OUTDATED=$(npm outdated --json 2>/dev/null || echo "{}")
+          if [ "$OUTDATED" != "{}" ]; then
+            echo "::warning::Some dependencies have newer versions available. Run 'npm outdated' locally to review."
+          fi

--- a/.github/workflows/firebase-ci-post-merge.yml
+++ b/.github/workflows/firebase-ci-post-merge.yml
@@ -1,0 +1,111 @@
+name: Firebase Post-Merge CI
+
+# Post-submit Firebase checks — runs on push to main only.
+# Re-runs the shared Firebase checks to catch merge-induced breakage.
+# Failures auto-create GitHub issues; fixes auto-close them.
+
+on:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      firebase: ${{ steps.filter.outputs.firebase }}
+      docs_only: ${{ steps.filter.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for Firebase changes
+        id: filter
+        run: |
+          BASE="${{ github.event.before }}"
+          CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null || echo "UNKNOWN")
+
+          if [ "$CHANGED" = "UNKNOWN" ]; then
+            echo "firebase=true" >> $GITHUB_OUTPUT
+            echo "docs_only=false" >> $GITHUB_OUTPUT
+            echo "Could not determine changes, running all checks"
+            exit 0
+          fi
+
+          # Docs-only fast path — see ci.yml for rationale.
+          NON_DOCS=$(echo "$CHANGED" | grep -vE '^(.*\.md$|docs/|.*/docs/|\.claude/|LICENSE$|\.gitignore$|AndroidGarage/distribution/whatsnew/)' || true)
+          if [ -z "$NON_DOCS" ] && [ -n "$CHANGED" ]; then
+            echo "firebase=false" >> $GITHUB_OUTPUT
+            echo "docs_only=true" >> $GITHUB_OUTPUT
+            echo "Docs-only change — skipping Firebase post-merge CI. Changed files:"
+            echo "$CHANGED"
+            exit 0
+          fi
+
+          echo "docs_only=false" >> $GITHUB_OUTPUT
+
+          if echo "$CHANGED" | grep -qE '^(FirebaseServer/|\.github/workflows/firebase-ci(-checks|-post-merge)?\.yml)'; then
+            echo "firebase=true" >> $GITHUB_OUTPUT
+            echo "Firebase files changed:"
+            echo "$CHANGED" | grep -E '^(FirebaseServer/|\.github/workflows/firebase-ci(-checks|-post-merge)?\.yml)'
+          else
+            echo "firebase=false" >> $GITHUB_OUTPUT
+            echo "No Firebase files changed. Changed files:"
+            echo "$CHANGED"
+          fi
+
+  # Shared checks (same as PR CI)
+  checks:
+    name: Checks
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    uses: ./.github/workflows/firebase-ci-checks.yml
+    with:
+      firebase: ${{ needs.changes.outputs.firebase }}
+
+  # Gate job — single check-run name for visibility on main.
+  firebase-post-merge-complete:
+    name: Firebase Post-Merge Complete
+    if: always()
+    needs: [checks]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        run: |
+          echo "Checks: ${{ needs.checks.result }}"
+          if [[ "${{ needs.checks.result }}" == "failure" || \
+                "${{ needs.checks.result }}" == "cancelled" ]]; then
+            echo "::error::Firebase post-merge CI failed"
+            exit 1
+          fi
+          echo "Firebase post-merge CI passed (or skipped — no Firebase changes / docs-only)"
+
+  # Track post-merge failures via a single GitHub issue
+  track-failure:
+    name: Track Firebase Post-Merge Failure
+    if: always() && needs.changes.outputs.firebase == 'true' && needs.changes.outputs.docs_only != 'true'
+    needs: [changes, checks]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Determine overall result
+        id: result
+        run: |
+          CHECKS="${{ needs.checks.result }}"
+          echo "checks=$CHECKS" >> $GITHUB_OUTPUT
+          if [[ "$CHECKS" == "failure" ]]; then
+            echo "overall=failure" >> $GITHUB_OUTPUT
+          else
+            echo "overall=success" >> $GITHUB_OUTPUT
+          fi
+      - uses: ./.github/actions/ci-failure-tracker
+        with:
+          label: ci-failure/firebase-post-merge
+          result: ${{ steps.result.outputs.overall }}
+          workflow-name: "Firebase Post-Merge CI (checks: ${{ steps.result.outputs.checks }})"

--- a/.github/workflows/firebase-ci.yml
+++ b/.github/workflows/firebase-ci.yml
@@ -1,10 +1,11 @@
 name: Firebase CI
 
+# Pre-submit checks — runs on PRs only.
+# Post-merge checks are in firebase-ci-post-merge.yml.
+
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ "main" ]
-  push:
     branches: [ "main" ]
 
 jobs:
@@ -26,12 +27,8 @@ jobs:
             exit 0
           fi
 
-          if [ "${{ github.event_name }}" = "push" ]; then
-            BASE="${{ github.event.before }}"
-          else
-            BASE="origin/${{ github.base_ref }}"
-            git fetch --depth=1 origin "${{ github.base_ref }}" 2>/dev/null || true
-          fi
+          BASE="origin/${{ github.base_ref }}"
+          git fetch --depth=1 origin "${{ github.base_ref }}" 2>/dev/null || true
 
           CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null || echo "UNKNOWN")
 
@@ -64,50 +61,26 @@ jobs:
             echo "$CHANGED"
           fi
 
-  test:
-    name: Run Unit Tests
+  checks:
+    name: Checks
     needs: changes
-    if: needs.changes.outputs.firebase == 'true' && needs.changes.outputs.docs_only != 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-      - name: Install dependencies
-        working-directory: FirebaseServer
-        run: npm install
-      - name: Build
-        working-directory: FirebaseServer
-        run: npm run build
-      - name: Run Unit Tests
-        working-directory: FirebaseServer
-        run: npm run tests
-      - name: Check for outdated dependencies
-        working-directory: FirebaseServer
-        continue-on-error: true
-        run: |
-          echo "::group::Outdated dependencies"
-          npm outdated || true
-          echo "::endgroup::"
-          OUTDATED=$(npm outdated --json 2>/dev/null || echo "{}")
-          if [ "$OUTDATED" != "{}" ]; then
-            echo "::warning::Some dependencies have newer versions available. Run 'npm outdated' locally to review."
-          fi
+    if: needs.changes.outputs.docs_only != 'true'
+    uses: ./.github/workflows/firebase-ci-checks.yml
+    with:
+      firebase: ${{ needs.changes.outputs.firebase }}
 
   # Gate job — required status check for Firebase.
   firebase-ci-complete:
     name: Firebase CI Complete
     if: always()
-    needs: [test]
+    needs: [checks]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
         run: |
-          echo "Tests: ${{ needs.test.result }}"
-          if [[ "${{ needs.test.result }}" == "failure" || \
-                "${{ needs.test.result }}" == "cancelled" ]]; then
+          echo "Checks: ${{ needs.checks.result }}"
+          if [[ "${{ needs.checks.result }}" == "failure" || \
+                "${{ needs.checks.result }}" == "cancelled" ]]; then
             echo "::error::Firebase CI failed"
             exit 1
           fi

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -18,8 +18,10 @@ jobs:
           TAG_SHA="${GITHUB_SHA}"
           echo "Checking Firebase CI status for commit $TAG_SHA..."
 
+          # Match "Run Unit Tests" whether it comes from the inline job (legacy) or
+          # the reusable workflow (prefixed as "<caller-job> / Run Unit Tests").
           TESTS_CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA/check-runs" \
-            --jq '[.check_runs[] | select(.name == "Run Unit Tests" and .app.slug == "github-actions")] | last | .conclusion')
+            --jq '[.check_runs[] | select((.name | endswith("Run Unit Tests")) and .app.slug == "github-actions")] | last | .conclusion')
 
           echo "Firebase Tests: $TESTS_CONCLUSION"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,9 +136,22 @@ Run `./scripts/validate.sh` before pushing. It mirrors CI: spotless (all modules
 Run `./scripts/run-instrumented-tests.sh` when changing Room entities/DAOs, DI wiring (AppComponent), navigation, or Activity lifecycle code. Requires a connected device or emulator. Not part of `validate.sh` (too slow for every run). A git hook warns on push when these files are changed.
 
 ### CI Architecture
+
+**Android:**
 - **Pre-submit** (`ci.yml` → `ci-checks.yml`): Runs on PRs. Gate job `CI Complete` is the required status check.
 - **Post-merge** (`ci-post-merge.yml` → `ci-checks.yml` + instrumented tests): Runs on push to main. Auto-creates GitHub issue on failure (`ci-failure/post-merge`), auto-closes on fix with flakiness detection.
-- **Screenshot generation**: Use `./scripts/generate-android-screenshots.sh` (never run screenshot Gradle tasks directly — hooks block this).
+
+**Firebase** (mirrors Android):
+- **Pre-submit** (`firebase-ci.yml` → `firebase-ci-checks.yml`): Runs on PRs. Gate job `Firebase CI Complete` is the required status check.
+- **Post-merge** (`firebase-ci-post-merge.yml` → `firebase-ci-checks.yml`): Runs on push to main. Auto-creates GitHub issue on failure (`ci-failure/firebase-post-merge`), auto-closes on fix.
+- The `firebase-deploy.yml` `verify-ci` step matches the `Run Unit Tests` check-run via `endswith(...)`, so it works whether the check comes from the inline name or the reusable-workflow-prefixed name.
+
+**Docs-only fast path (Android + Firebase):**
+- When every changed file matches `**/*.md`, `docs/**`, `.claude/**`, `LICENSE`, `.gitignore`, or `AndroidGarage/distribution/whatsnew/**`, the `checks` reusable workflow is skipped and the gate jobs post success in ~20–30s.
+- Mixed PRs (docs + code) take the full pipeline. Anything under `.github/**` or `scripts/**` is NOT docs — workflow and script edits still trigger full CI.
+- Rule: skip CI only when the change cannot affect what CI verifies.
+
+**Screenshot generation**: Use `./scripts/generate-android-screenshots.sh` (never run screenshot Gradle tasks directly — hooks block this).
 
 ### Room Database Safety
 Room schema changes break at runtime (not compile time). The following safeguards are in place:


### PR DESCRIPTION
## Summary
Updates `CLAUDE.md`'s "CI Architecture" section to document:
- The Firebase pre/post-merge split (mirrors Android)
- The docs-only fast path and its exact inclusion rule
- The `endswith` match in `firebase-deploy.yml`

Docs-only change — should take the fast path once the prior PRs land.

## Merge order
Final PR in the CI improvements stack.
- Full stack: #380 → #381 → #382 → (this PR)
- This PR merges after all the workflow changes are on main.

## Test plan
- [x] Pure documentation change
- [ ] After merge, the "CI Architecture" section in CLAUDE.md matches the on-disk workflow files

🤖 Generated with [Claude Code](https://claude.com/claude-code)