### PR TITLE
docs: PR review batch 2026-04-20 (PRs #383–#364, 20 files)

### DIFF
--- a/docs/pr-review/pr-0364.md
+++ b/docs/pr-review/pr-0364.md
@@ -1,0 +1,12 @@
+---
+pr: 364
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #364: refactor: DoorRepository.currentDoorEvent owns StateFlow (PR 5 of 8)
+
+**Goal:** Part of the ADR-022 8-PR state-ownership migration. `DoorRepository.currentDoorEvent` becomes `val : StateFlow<DoorEvent?>` (was `Flow<DoorEvent?>`). `NetworkDoorRepository` launches an always-on collector on `externalScope` that consumes the Room flow and writes into a `MutableStateFlow` — explicitly not using `stateIn(WhileSubscribed)` which is banned by ADR-022. `recentDoorEvents` stays cold (list-y per ADR-022 categories). Rule 9 logging added on local flow emit. `DoorViewModel._currentDoorEvent` kept because `LoadingResult<T>` wrapping is a genuine derivation, not a mirror.
+
+**Files:** `AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/DoorRepository.kt`, `data/.../NetworkDoorRepository.kt`, `NetworkDoorRepositoryIntegrationTest.kt`, `test-common/.../FakeDoorRepository.kt`, `AppComponent.kt`.

--- a/docs/pr-review/pr-0365.md
+++ b/docs/pr-review/pr-0365.md
@@ -1,0 +1,12 @@
+---
+pr: 365
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #365: chore: Lint enforcement for ADR-022 state ownership (PR 8 of 8)
+
+**Goal:** Final PR of the 8-PR state-ownership migration. Makes the repository-owned-`StateFlow` invariant load-bearing via compile-time checks. `ViewModelStateFlowCheckTask` adds a Rule 2 check banning VM-local `MutableStateFlow<T>` for `T ∈ {SnoozeState, AuthState, FcmRegistrationStatus}` (allowlist-based); `SingletonGuardTask` extends `guardedMethodPatterns` to require `@Singleton` on every state-owning repository provider. ADR-021 and ADR-022 flipped to "Accepted and enforced."
+
+**Files:** `AndroidGarage/build.gradle.kts`, `AndroidGarage/buildSrc/src/main/kotlin/architecture/ViewModelStateFlowCheckTask.kt`, `AndroidGarage/docs/DECISIONS.md`.

--- a/docs/pr-review/pr-0366.md
+++ b/docs/pr-review/pr-0366.md
@@ -1,0 +1,12 @@
+---
+pr: 366
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #366: fix: fetchServerConfig always refreshes the cache
+
+**Goal:** Remove the `cached != null` short-circuit that PR #362 introduced in `CachedServerConfigRepository.fetchServerConfig()` — once populated, the cache could never refresh without a process restart, silently breaking flows that depend on server-side config changes. Restores true force-refresh semantics: every call hits the network, successful results write to `_serverConfig`, null results leave the cache untouched. Drops concurrent coalescing complexity (mutex already serializes). Two contract tests: `fetchServerConfigAlwaysRefreshesCache` and `nullFetchResultPreservesCachedValue`.
+
+**Files:** `AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepository.kt`, `CachedServerConfigRepositoryTest.kt`.

--- a/docs/pr-review/pr-0367.md
+++ b/docs/pr-review/pr-0367.md
@@ -1,0 +1,12 @@
+---
+pr: 367
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #367: docs: Dump session context — StateFlow Phase 1 complete
+
+**Goal:** Capture durable knowledge from the state-ownership migration session — mark Phase 1 complete in `MIGRATION_PLAN.md` (PRs #358–#365 + #366 follow-up), add Phase 2e with three better allowlist-scaling options for `ViewModelStateFlowCheckTask` (parse repo interfaces, `@DomainState` marker, inverted allowlist). `CLAUDE.md` gets the `gh pr merge --disable-auto` hook-block workaround (GraphQL `disablePullRequestAutoMerge` mutation) and the git-guardrails false-positive on branch names containing `main` as a word.
+
+**Files:** `AndroidGarage/docs/MIGRATION_PLAN.md`, `CLAUDE.md`.

--- a/docs/pr-review/pr-0368.md
+++ b/docs/pr-review/pr-0368.md
@@ -1,0 +1,12 @@
+---
+pr: 368
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #368: chore: Add opt-in R8 instrumented test harness
+
+**Goal:** Add `-PtestR8=true` and `-PdebuggableBenchmark=true` gradle flags that route `connectedAndroidTest` to the R8-enabled `benchmark` variant, enabling reproduction of release-only bugs (ADR-020 R8 keep-rule stripping; android/167/170 StateFlow propagation regression) in instrumented tests. Both flags default off; CI and normal `connectedAndroidTest` runs unaffected. Prerequisite for running `SnoozeStateInstrumentedPropagationTest` under R8.
+
+**Files:** `AndroidGarage/androidApp/build.gradle.kts`, `AndroidGarage/docs/R8_INSTRUMENTED_TESTS.md` (new).

--- a/docs/pr-review/pr-0369.md
+++ b/docs/pr-review/pr-0369.md
@@ -1,0 +1,12 @@
+---
+pr: 369
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #369: fix: Restore VM-local snoozeState mirror + direct write (android/170 regression)
+
+**Goal:** Hotfix for the android/170 snooze regression. Restores the PR #354 / android/169 pattern — VM-local `MutableStateFlow<SnoozeState>` + `init { observeSnoozeStateUseCase().collect }` + direct-write `_snoozeState.value = newState` in the success branch. Withdraws ADR-022 Rule 2 (VM exposes repo `StateFlow` by reference) because the pass-through pattern did not propagate repo writes to Compose on production devices. `bannedStateTypesInViewModels` emptied (Rule 2 withdrawn but Rule 1 stateIn-ban kept).
+
+**Files:** `AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt`, `buildSrc/.../ViewModelStateFlowCheckTask.kt`, `docs/DECISIONS.md`, `usecase/src/commonTest/.../SnoozeStateFlowPropagationTest.kt`.

--- a/docs/pr-review/pr-0370.md
+++ b/docs/pr-review/pr-0370.md
@@ -1,0 +1,12 @@
+---
+pr: 370
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #370: docs: DI @Singleton requirements + verification (android/170 root cause)
+
+**Goal:** Document the kotlin-inject `@Singleton` scoping bug found during the android/170 investigation in advance of the code fix. `DI_SINGLETON_REQUIREMENTS.md` enumerates R1-R4 (what the DI graph must guarantee), C1-C4 (kotlin-inject-specific constraints), detection recipes (inspect generated `InjectAppComponent.kt`, `ComponentGraphTest.singletonRepositoriesReturnSameInstance`, Rule 9 logcat counts), and fix direction. `MIGRATION_PLAN.md` adds Phase 2f to schedule the fix as deliberate work.
+
+**Files:** `AndroidGarage/docs/DI_SINGLETON_REQUIREMENTS.md` (new), `AndroidGarage/docs/MIGRATION_PLAN.md`.

--- a/docs/pr-review/pr-0371.md
+++ b/docs/pr-review/pr-0371.md
@@ -1,0 +1,12 @@
+---
+pr: 371
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #371: fix: Make kotlin-inject @Singleton actually cache (Phase 2f)
+
+**Goal:** Root-cause fix for the android/170 regression. Convert `AppComponent` concrete `val x @Provides get() = ...` providers to `abstract val` entry points and `@Provides fun` bodies that take deps as parameters — kotlin-inject only emits `_scoped.get(...)` caching for overrides of abstract declarations. Generated `InjectAppComponent.kt` grows 15 → 304 lines. Adds 14 identity guards in `ComponentGraphTest` (`assertSame` for 11 `@Singleton` types, `assertNotSame` for 2 per-nav-entry VM types).
+
+**Files:** `AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt`, `ComponentGraphTest.kt`, `MainActivity.kt`, `FCMService.kt`, `LogSummaryCard.kt`, `ProfileContent.kt`.

--- a/docs/pr-review/pr-0372.md
+++ b/docs/pr-review/pr-0372.md
@@ -1,0 +1,12 @@
+---
+pr: 372
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #372: refactor: Remove snooze VM mirror, test ADR-022 pass-through on device
+
+**Goal:** Empirically test whether the Phase 2f DI fix (android/173) was the complete root cause of the android/170 regression. Removes the VM-local `_snoozeState` mirror + `init { collect }` + direct-write from `DefaultRemoteButtonViewModel` and restores the ADR-022 pass-through (`override val snoozeState = observeSnoozeStateUseCase()`). If android/174 ships with card title flipping correctly on save, ADR-022 Rule 2 is validated.
+
+**Files:** `AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt`.

--- a/docs/pr-review/pr-0373.md
+++ b/docs/pr-review/pr-0373.md
@@ -1,0 +1,12 @@
+---
+pr: 373
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #373: chore: Restore ADR-022 Rule 2 enforcement after android/174 verified
+
+**Goal:** After android/174 shipped the pass-through snooze pattern with no VM-local mirror and worked on device (validating Phase 2f DI fix was the complete root cause of android/170), restore `ViewModelStateFlowCheckTask`'s `bannedStateTypesInViewModels` list to `(SnoozeState, AuthState, FcmRegistrationStatus)` and flip ADR-022 back to Accepted.
+
+**Files:** `AndroidGarage/buildSrc/src/main/kotlin/architecture/ViewModelStateFlowCheckTask.kt`, `AndroidGarage/docs/DECISIONS.md`, `AndroidGarage/docs/MIGRATION_PLAN.md`.

--- a/docs/pr-review/pr-0374.md
+++ b/docs/pr-review/pr-0374.md
@@ -1,0 +1,12 @@
+---
+pr: 374
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #374: docs: Postmortem + CLAUDE.md guidance for android/170 kotlin-inject bug
+
+**Goal:** Capture the 5-month android/170 regression cycle as a first-class postmortem — timeline of releases 164–174, four invisibility properties of the bug, seven investigation failures, user reframing as the turning point, seven lessons with prescriptions, four reusable "hard-bug" checklists. Also adds an "AppComponent / kotlin-inject Safety" section to `CLAUDE.md` (shaped like "Room Database Safety") with two mechanical rules and a 5-step checklist for AppComponent edits.
+
+**Files:** `AndroidGarage/docs/POSTMORTEM_ANDROID_170.md` (new), `CLAUDE.md`.

--- a/docs/pr-review/pr-0375.md
+++ b/docs/pr-review/pr-0375.md
@@ -1,0 +1,12 @@
+---
+pr: 375
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #375: docs: Tech guides folder — kotlin-inject scoping
+
+**Goal:** Create `AndroidGarage/docs/guides/` for portable third-person tech lessons. First guide `kotlin-inject.md` captures the `@Singleton` scoping gotcha behind android/170: abstract entry points required for overrides, parameter-based provider bodies required to avoid bypassing the `_scoped` cache.
+
+**Files:** `AndroidGarage/docs/guides/README.md`, `AndroidGarage/docs/guides/kotlin-inject.md`.

--- a/docs/pr-review/pr-0376.md
+++ b/docs/pr-review/pr-0376.md
@@ -1,0 +1,12 @@
+---
+pr: 376
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #376: docs: guides/repository-api-patterns.md — fetchX() contract + tests
+
+**Goal:** Add a portable guide codifying the repository `StateFlow` + `fetchX()` contract lifted from the `CachedServerConfigRepository` regression (#362 → #366). Covers three-concept separation (observation via `StateFlow.value` / force-refresh via `suspend fetchX()` / cached read), null-return semantics (null = failure report, cache untouched), and three required tests (`fetchAlwaysRefreshesCache`, `nullResponsePreservesCache`, `fetchSwallowsDataSourceExceptions`).
+
+**Files:** `AndroidGarage/docs/guides/README.md`, `AndroidGarage/docs/guides/repository-api-patterns.md`.

--- a/docs/pr-review/pr-0377.md
+++ b/docs/pr-review/pr-0377.md
@@ -1,0 +1,12 @@
+---
+pr: 377
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #377: docs: Three portable tech guides — R8, Nav3 scoping, reactive auth
+
+**Goal:** Round out the `AndroidGarage/docs/guides/` portable-lessons library with three third-person guides: `r8-keep-rules.md` (when R8 silently strips reflection/codegen/generic-erased code), `compose-nav3-vm-scoping.md` (`rememberViewModelStoreNavEntryDecorator` creates one store per nav entry), and `reactive-auth-listener.md` (auth is a stream; subscribe on `externalScope` not `viewModelScope`).
+
+**Files:** `AndroidGarage/docs/guides/README.md`, `r8-keep-rules.md`, `compose-nav3-vm-scoping.md`, `reactive-auth-listener.md`.

--- a/docs/pr-review/pr-0378.md
+++ b/docs/pr-review/pr-0378.md
@@ -1,0 +1,12 @@
+---
+pr: 378
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #378: docs: Add versioning strategy
+
+**Goal:** Document the Android versioning rule in three places: `AndroidGarage/CHANGELOG.md` (authoritative), `CLAUDE.md` (one-line rule), and `.claude/skills/bump-android-version/SKILL.md`. Rule: major = rewrite/core-experience shift, minor = user-facing feature added or removed, patch = fixes/polish/refactors.
+
+**Files:** `AndroidGarage/CHANGELOG.md`, `CLAUDE.md`, `.claude/skills/bump-android-version/SKILL.md`.

--- a/docs/pr-review/pr-0379.md
+++ b/docs/pr-review/pr-0379.md
@@ -1,0 +1,12 @@
+---
+pr: 379
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #379: ci: Skip Android CI on docs-only changes
+
+**Goal:** Add docs-only fast path to `ci.yml` and `ci-post-merge.yml` — when every changed file matches the docs classification, skip the expensive `checks` reusable workflow and let the gate job (`CI Complete` / `Post-Merge Complete`) post success in ~20-30s.
+
+**Files:** `.github/workflows/ci.yml`, `.github/workflows/ci-post-merge.yml`.

--- a/docs/pr-review/pr-0380.md
+++ b/docs/pr-review/pr-0380.md
@@ -1,0 +1,12 @@
+---
+pr: 380
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #380: ci: Skip Firebase CI on docs-only changes
+
+**Goal:** Add a docs-only fast path to `firebase-ci.yml` — skip the Firebase unit-test job when every changed file matches the docs classification (markdown, `docs/**`, `.claude/**`, `LICENSE`, `.gitignore`, `AndroidGarage/distribution/whatsnew/**`).
+
+**Files:** `.github/workflows/firebase-ci.yml`.

--- a/docs/pr-review/pr-0381.md
+++ b/docs/pr-review/pr-0381.md
@@ -1,0 +1,12 @@
+---
+pr: 381
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #381: ci: Split Firebase CI into pre/post-merge; extract reusable checks
+
+**Goal:** Eliminate duplicate Firebase CI runs by extracting the `test` job into `firebase-ci-checks.yml` (reusable workflow) and switching `firebase-ci.yml` to PR-only. Widens `firebase-deploy.yml`'s check-run name matcher from exact-match to `endswith("Run Unit Tests")` so deploys keep finding the check whether the reusable prefixes its name or not.
+
+**Files:** `.github/workflows/firebase-ci.yml`, `firebase-ci-checks.yml` (new), `firebase-deploy.yml`.

--- a/docs/pr-review/pr-0382.md
+++ b/docs/pr-review/pr-0382.md
@@ -1,0 +1,12 @@
+---
+pr: 382
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #382: ci: Firebase post-merge CI with auto-issue tracker
+
+**Goal:** Add Firebase post-merge CI workflow mirroring the Android split — runs on push to main, calls the reusable `firebase-ci-checks.yml`, and uses `ci-failure-tracker` to open/close a GitHub issue labeled `ci-failure/firebase-post-merge` on regression/recovery.
+
+**Files:** `.github/workflows/firebase-ci-post-merge.yml` (new). Diff also shows stacked-parent (#381) changes.

--- a/docs/pr-review/pr-0383.md
+++ b/docs/pr-review/pr-0383.md
@@ -1,0 +1,12 @@
+---
+pr: 383
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #383: docs: Update CI architecture for Firebase split + docs-only path
+
+**Goal:** Update CLAUDE.md's "CI Architecture" section to document the new Firebase pre/post-merge split and the docs-only fast path.
+
+**Files:** `CLAUDE.md` — "CI Architecture" section. Final stacked PR in the #380 → #381 → #382 → #383 CI improvements chain; diff also shows workflow files from stacked parents.


### PR DESCRIPTION
## Summary

Phase 1 PR review batch — 20 files. Newest-first ordering, PRs #383 → #364 (skipping #384 which self-excluded via the loop-breaker rule — it only modified `docs/pr-review/`).

Each file captures one PR's goal and files touched, per the schema in `docs/pr-review/README.md`. Phase 2 (assessment) will append opinion sections below; do not edit Phase 1 content retroactively.

## Test plan
- [x] Only touches `docs/pr-review/**` (self-excludes from future review queues)
- [x] Each file follows the schema in `docs/pr-review/README.md`
- [x] Zero-padded filenames (4 digits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)