### PR TITLE
docs: PR review batch 2026-04-20 session 2 (PRs #363–#344, 20 files)

### DIFF
--- a/docs/pr-review/pr-0344.md
+++ b/docs/pr-review/pr-0344.md
@@ -1,0 +1,12 @@
+---
+pr: 344
+state: merged
+date: 2026-04-18
+phase1_reviewed: 2026-04-20
+---
+
+# PR #344: fix: Drive snooze first-fetch on app scope (fixes stuck Loading bug)
+
+**Goal:** Fix android/164 snooze card stuck on "Door notifications" (Loading state) forever, even when the network call succeeds. Root cause: `DefaultRemoteButtonViewModel.init` launched `fetchSnoozeStatus()` on `viewModelScope`. If the VM was cancelled between the network call returning and the `snoozeStateFlow.value = ...` write, Ktor rethrows `CancellationException`, the `when(result)` branch is skipped, and the singleton `MutableStateFlow` stays at `Loading` for the rest of the process — every future VM observes the stuck flow. Fix: mirror the `FirebaseAuthRepository` ADR-018 pattern. `NetworkSnoozeRepository` takes an `externalScope` and drives the first fetch from its own `init` block. Subsequent user-triggered fetches stay on `viewModelScope` (benign cancellation because singleton is already populated). Two new test suites: `NetworkSnoozeRepositoryTest` (5 tests) and `SnoozeStateFlowPropagationTest` (6 tests).
+
+**Files:** `AndroidGarage/data/.../NetworkSnoozeRepository.kt`, `NetworkSnoozeRepositoryTest.kt` (new), `usecase/.../RemoteButtonViewModel.kt`, `RemoteButtonViewModelTest.kt`, `SnoozeStateFlowPropagationTest.kt` (new), `AppComponent.kt`.

--- a/docs/pr-review/pr-0345.md
+++ b/docs/pr-review/pr-0345.md
@@ -1,0 +1,12 @@
+---
+pr: 345
+state: merged
+date: 2026-04-18
+phase1_reviewed: 2026-04-20
+---
+
+# PR #345: fix: Use mutex.withLock in CachedServerConfigRepository (prevent deadlock)
+
+**Goal:** Replace bare `mutex.lock()` / `mutex.unlock()` pair in `CachedServerConfigRepository.getServerConfigCached()` with `withLock { ... }`. If `fetchServerConfig()` ever throws (transient network error, cancellation, serialization bug), the `unlock()` is skipped and the mutex stays locked for the process lifetime — every subsequent caller blocks forever. `withLock` releases on all exit paths including exceptions and cancellation. Latent bug surfaced during the snooze "stuck Loading" investigation (#344 fixes the user-visible symptom; this removes a related permanent-hang risk). Regression test: `mutexReleasedAfterFetchThrowsSoSubsequentCallsDoNotDeadlock`.
+
+**Files:** `AndroidGarage/data/.../CachedServerConfigRepository.kt`, `CachedServerConfigRepositoryTest.kt`.

--- a/docs/pr-review/pr-0346.md
+++ b/docs/pr-review/pr-0346.md
@@ -1,0 +1,12 @@
+---
+pr: 346
+state: merged
+date: 2026-04-18
+phase1_reviewed: 2026-04-20
+---
+
+# PR #346: fix: Route all snooze network work through externalScope (no optimistic updates)
+
+**Goal:** Follow-up to #344 — after the Loading fix landed, users reported the card title stays at "enabled" after saving a snooze (kill+reopen shows correct state; snooze persists server-side but in-session UI doesn't update). Root cause: same cancellation pattern as #344 at two call sites — `RemoteButtonViewModel.snoozeOpenDoorsNotifications` calls `fetchSnoozeStatusUseCase()` on `viewModelScope` after POST, and `ProfileContent`'s 60s polling `LaunchedEffect` fires `fetchSnoozeStatus` on `viewModelScope`. If either is cancelled after the network call returns but before the state write, Ktor rethrows `CancellationException` and the state write is skipped. Fix: `NetworkSnoozeRepository` owns all side effects — `externalScope.launch{}.join()` for fetch, `externalScope.async{}.await()` for submit with follow-up fetch on `externalScope`. No optimistic updates.
+
+**Files:** `AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepository.kt`, `NetworkSnoozeRepositoryTest.kt`.

--- a/docs/pr-review/pr-0347.md
+++ b/docs/pr-review/pr-0347.md
@@ -1,0 +1,12 @@
+---
+pr: 347
+state: merged
+date: 2026-04-18
+phase1_reviewed: 2026-04-20
+---
+
+# PR #347: chore: Bump versionName to 2.4.3
+
+**Goal:** Patch bump 2.4.2 → 2.4.3 covering the snooze fixes landing in #344 (stuck-Loading), #345 (mutex-withLock), #346 (post-submit state refresh).
+
+**Files:** `AndroidGarage/version.properties`.

--- a/docs/pr-review/pr-0348.md
+++ b/docs/pr-review/pr-0348.md
@@ -1,0 +1,12 @@
+---
+pr: 348
+state: merged
+date: 2026-04-18
+phase1_reviewed: 2026-04-20
+---
+
+# PR #348: docs: Add 2.4.3 changelog entry
+
+**Goal:** Add changelog entry for Android version 2.4.3, covering the snooze state refresh fix (#346).
+
+**Files:** `AndroidGarage/CHANGELOG.md`.

--- a/docs/pr-review/pr-0349.md
+++ b/docs/pr-review/pr-0349.md
@@ -1,0 +1,12 @@
+---
+pr: 349
+state: merged
+date: 2026-04-18
+phase1_reviewed: 2026-04-20
+---
+
+# PR #349: fix: Update snooze state directly from POST response (no follow-up GET)
+
+**Goal:** The server's `POST /snoozeNotificationsRequest` endpoint returns the `SnoozeRequest` in its response body — authoritative `snoozeEndTimeSeconds` is already in the client's hands the moment the POST succeeds. Previous design threw it away and relied on a follow-up GET, which wasn't reliable in production. `NetworkButtonDataSource.snoozeNotifications` return type `NetworkResult<Unit>` → `NetworkResult<Long>`. `NetworkSnoozeRepository` writes `snoozeStateFromEndTime(result.data)` to the flow immediately on success, no follow-up GET. `RemoteButtonViewModel` drops the redundant `fetchSnoozeStatusUseCase()` call after submit. Not optimistic — real server data from the POST response.
+
+**Files:** `AndroidGarage/data/.../NetworkButtonDataSource.kt`, `KtorNetworkButtonDataSource.kt`, `NetworkSnoozeRepository.kt`, `NetworkSnoozeRepositoryTest.kt`, `test-common/.../FakeNetworkButtonDataSource.kt`, `usecase/.../RemoteButtonViewModel.kt`.

--- a/docs/pr-review/pr-0350.md
+++ b/docs/pr-review/pr-0350.md
@@ -1,0 +1,12 @@
+---
+pr: 350
+state: merged
+date: 2026-04-18
+phase1_reviewed: 2026-04-20
+---
+
+# PR #350: docs: Add TODOs on SnoozeRepository for future refinements
+
+**Goal:** Inline TODO comments at `SnoozeRepository.snoozeNotifications` capturing two future refinements from the snooze bug hunt. (1) Return type `Boolean` → `AppResult<Unit, ActionError>` so `NotAuthenticated`/`MissingData`/`NetworkFailed` discrimination is carried end-to-end rather than collapsed then reconstructed by the UseCase. (2) Stringly-typed `snoozeDurationHours: String` → a domain value type (sealed enum) so invalid inputs can't pass the type system. Documentation-only.
+
+**Files:** `AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/SnoozeRepository.kt`.

--- a/docs/pr-review/pr-0351.md
+++ b/docs/pr-review/pr-0351.md
@@ -1,0 +1,12 @@
+---
+pr: 351
+state: merged
+date: 2026-04-18
+phase1_reviewed: 2026-04-20
+---
+
+# PR #351: docs: Dump session context — ADR-019 (externalScope + server-response state)
+
+**Goal:** Capture architectural pattern from the snooze bug hunt (PRs #344-#349) as ADR-019 with two rules. Rule 1: side-effecting repository calls run on `externalScope` (applicationScope); callers `.join()`/`.await()` but caller cancellation doesn't strand state writes. Rule 2: update state from authoritative server POST response body, not a follow-up GET. No client-side optimistic writes. Updates `TESTING.md` test counts for 15 new tests added in this session (`NetworkSnoozeRepositoryTest` x9, `SnoozeStateFlowPropagationTest` x6).
+
+**Files:** `AndroidGarage/docs/DECISIONS.md`, `AndroidGarage/docs/TESTING.md`.

--- a/docs/pr-review/pr-0352.md
+++ b/docs/pr-review/pr-0352.md
@@ -1,0 +1,12 @@
+---
+pr: 352
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #352: fix: Harden snooze POST parsing (R8 rules + diagnostic log + regression tests)
+
+**Goal:** Three layers of defense against the android/167 release-only snooze propagation bug after unit, JVM integration, and emulator tests all passed but production still failed (pointing to R8 stripping). (1) Comprehensive `proguard-rules.pro` — explicit keeps for `$Companion`/`$$serializer` on every `@Serializable` class, `data.ktor.**` data classes, annotations. (2) Raw-body diagnostic log in `KtorNetworkButtonDataSource` — POST body read as text, logged verbatim alongside parsed `endTime`, then re-parsed with a local `Json { ignoreUnknownKeys; isLenient }`. (3) Two new regression tests wiring real repo + VM: `RealNetworkSnoozeRepositoryPropagationTest` (JVM) and `SnoozeStateInstrumentedPropagationTest` (Compose).
+
+**Files:** `AndroidGarage/androidApp/proguard-rules.pro`, `build.gradle.kts`, `SnoozeStateInstrumentedPropagationTest.kt` (new), `data/.../KtorNetworkButtonDataSource.kt`, `usecase/build.gradle.kts`, `RealNetworkSnoozeRepositoryPropagationTest.kt` (new).

--- a/docs/pr-review/pr-0353.md
+++ b/docs/pr-review/pr-0353.md
@@ -1,0 +1,12 @@
+---
+pr: 353
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #353: docs: Dump session context — ADR-020 (R8 keep rules + raw-body logs)
+
+**Goal:** Capture architectural lesson from the android/167 snooze-state bug investigation as ADR-020 with two rules. Rule 1: `proguard-rules.pro` keeps `kotlinx.serialization` infrastructure + all `data.ktor.**` response classes (file was empty before, relying on library consumer rules; R8 stripped stdlib classes like `kotlin.LazyKt`). Rule 2: raw-body diagnostic logging at network-data-source boundaries that produce state-critical data — release-only failures become a greppable `adb logcat` line. Updates `TESTING.md` test counts for the two new propagation tests from PR #352.
+
+**Files:** `AndroidGarage/docs/DECISIONS.md`, `AndroidGarage/docs/TESTING.md`.

--- a/docs/pr-review/pr-0354.md
+++ b/docs/pr-review/pr-0354.md
@@ -1,0 +1,14 @@
+---
+pr: 354
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #354: fix: SnoozeRepository returns AppResult<SnoozeState, ActionError> + direct VM write
+
+**Goal:** `SnoozeRepository.snoozeNotifications` now returns `AppResult<SnoozeState, ActionError>` whose `Success.data` is the new state. Repository still writes to its `MutableStateFlow` for observers, but callers have a direct, race-free handle on the new state. In the VM, `result.data` drives both the `_snoozeAction` overlay (authoritative server end time, no client-computed optimism) and a direct write to `_snoozeState` — belt-and-suspenders fallback if the observer→flow chain has a lifecycle quirk. Adds `SharedRepositoryUseCasesTest` proving independently-constructed UseCases wired to the same `@Singleton` repo see each other's writes.
+
+**Notes:** The direct-write pattern here was later removed in PR #360 (pass-through model), re-added in PR #369 (android/170 regression hotfix), then finally removed in PR #372 after the root-cause DI fix in PR #371.
+
+**Files:** `AndroidGarage/domain/.../SnoozeRepository.kt`, `data/.../NetworkSnoozeRepository.kt`, `usecase/.../SnoozeNotificationsUseCase.kt`, `RemoteButtonViewModel.kt`, `SharedRepositoryUseCasesTest.kt` (new, 196 lines), `test-common/.../FakeSnoozeRepository.kt`, other test files.

--- a/docs/pr-review/pr-0355.md
+++ b/docs/pr-review/pr-0355.md
@@ -1,0 +1,12 @@
+---
+pr: 355
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #355: docs: Document ViewModel multi-instance scoping issue
+
+**Goal:** Document the structural issue behind the android/164-168 snooze-state propagation bug as a starting point for discussing the real fix. Three `DefaultRemoteButtonViewModel` instances coexist at runtime (dead Activity-scope, Home nav entry, Profile nav entry) because VM providers aren't `@Singleton` and `rememberViewModelStoreNavEntryDecorator<Screen>()` creates per-entry ViewModelStores. Each VM has its own `_snoozeState` and observer; Compose reads one which can miss emissions the others see. Covers ASCII data-flow map, why tests pass while production fails, dead `Main.kt:122` code, similar hazard in `DefaultDoorViewModel`, and five candidate solutions (A-E) — explicitly not picking one.
+
+**Files:** `AndroidGarage/docs/VIEWMODEL_SCOPING_ISSUE.md` (new).

--- a/docs/pr-review/pr-0356.md
+++ b/docs/pr-review/pr-0356.md
@@ -1,0 +1,12 @@
+---
+pr: 356
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #356: docs: ADR-021 — State Ownership and ViewModel Scoping Principles
+
+**Goal:** Write down architectural principles motivated by the android/164-168 snooze propagation bug. Core distinction: domain state (single source of truth, `@Singleton` Repository) vs. presentation state (per-screen, VM-local). Eight rules committing to a design where multiple VM instances are allowed but can't diverge: (1) domain state in `@Singleton` repos, (2) VMs expose repo `StateFlow`s by reference, (3) VM-local state for per-screen presentation only, (4) multi-VM convergence via repo, (5) explicit VM scoping, (6) `@Singleton` on repos not VMs, (7) `externalScope` vs `viewModelScope`, (8) delete dead VM references.
+
+**Files:** `AndroidGarage/docs/DECISIONS.md`.

--- a/docs/pr-review/pr-0357.md
+++ b/docs/pr-review/pr-0357.md
@@ -1,0 +1,12 @@
+---
+pr: 357
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #357: docs: State ownership package — ADR-022 + amendments to 6 ADRs + MIGRATION_PLAN
+
+**Goal:** Consolidated documentation package for the ADR-022 state-ownership migration. New ADR-022 ("StateFlow at the repository boundary for state-y data") defines three data categories (state-y / cold list-y / event-y), interface shapes, VM shape, state-write logging, write-ordering rule, sign-out rule, Skie as iOS bridge, worked snooze example. New `MIGRATION_PLAN.md` with the 8-PR rollout sequence (PRs 1-8) plus Phase 2 deferrals. Amends ADR-006, ADR-013, ADR-017 Rule 6, ADR-019, ADR-020, ADR-021 to align with the new model.
+
+**Files:** `AndroidGarage/docs/DECISIONS.md`, `AndroidGarage/docs/MIGRATION_PLAN.md` (new).

--- a/docs/pr-review/pr-0358.md
+++ b/docs/pr-review/pr-0358.md
@@ -1,0 +1,12 @@
+---
+pr: 358
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #358: test: Add SnoozeMultiSubscriberIntegrationTest (PR 1 of 8)
+
+**Goal:** First of 8 PRs in the ADR-022 state-ownership migration. Adds `SnoozeMultiSubscriberIntegrationTest` wiring real `NetworkSnoozeRepository` with fake data sources + three concurrent subscribers to prove repository-only propagation is sufficient. Closes the coverage gap from the android/164-168 snooze bug: writes through the observation path must reach every subscriber simultaneously. No subscriber consults `snoozeNotifications()`'s return value. Enables PR #360 to remove the PR #354 direct-write workaround with regression coverage in place.
+
+**Files:** `AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/SnoozeMultiSubscriberIntegrationTest.kt` (new, 284 lines).

--- a/docs/pr-review/pr-0359.md
+++ b/docs/pr-review/pr-0359.md
@@ -1,0 +1,12 @@
+---
+pr: 359
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #359: refactor: Delete dead buttonViewModel in AppNavigation (PR 3 of 8)
+
+**Goal:** Remove the unused `val buttonViewModel = viewModel { component.remoteButtonViewModel }` in `Main.kt` along with orphaned imports. Add a doc comment in `AppComponent.kt` noting the intentional non-`@Singleton` scoping of ViewModel providers (per-nav-entry per ADR-021 Rule 4). The dead declaration contributed to the android/164-168 snooze-state bug by creating an unused third VM instance in AppNavigation.
+
+**Files:** `AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt`, `di/AppComponent.kt`.

--- a/docs/pr-review/pr-0360.md
+++ b/docs/pr-review/pr-0360.md
@@ -1,0 +1,14 @@
+---
+pr: 360
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #360: refactor: SnoozeRepository owns StateFlow, drop VM mirror (PR 2 of 8)
+
+**Goal:** Part of the ADR-022 8-PR state-ownership migration. `SnoozeRepository` exposes `val snoozeState: StateFlow<SnoozeState>` (drops `observeSnoozeState(): Flow`). `ObserveSnoozeStateUseCase` passes the repo's `StateFlow` through by reference. `DefaultRemoteButtonViewModel` exposes the repo's `StateFlow` by reference; local `_snoozeState` mirror, observer launch, and PR #354 direct-write are deleted. Rule 9 state-write logging added. `SnoozeStateFlowPropagationTest.vmSnoozeStateIsSameInstanceAsRepoStateFlow` guards against future mirror reintroduction.
+
+**Notes:** Rolled back in PR #369 (android/170 regression) and later re-verified via #371/#372/#373 after the root-cause kotlin-inject DI fix.
+
+**Files:** `AndroidGarage/data/.../NetworkSnoozeRepository.kt`, `domain/.../SnoozeRepository.kt`, `usecase/.../ObserveSnoozeStateUseCase.kt`, `RemoteButtonViewModel.kt`, `FetchSnoozeStatusUseCase.kt`, `test-common/.../FakeSnoozeRepository.kt`, test files.

--- a/docs/pr-review/pr-0361.md
+++ b/docs/pr-review/pr-0361.md
@@ -1,0 +1,12 @@
+---
+pr: 361
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #361: refactor: AuthRepository owns StateFlow, drop VM mirror (PR 4 of 8)
+
+**Goal:** Part of the ADR-022 8-PR state-ownership migration. `AuthRepository` exposes `val authState: StateFlow<AuthState>` (drops `getAuthState()` and `observeAuthState(): Flow`). `ObserveAuthStateUseCase` passes the repo's `StateFlow` through by reference. `DefaultAuthViewModel` exposes the repo's `StateFlow` by reference; local `_authState` mirror and `init { collect }` observer deleted. `PushRemoteButtonUseCase` and `SnoozeNotificationsUseCase` read `authState.value` instead of `getAuthState()`. Rule 9 state-write logging added. `DefaultAuthViewModelTest.authStateIsSameInstanceAsRepoStateFlow` guards against future mirror reintroduction.
+
+**Files:** `AndroidGarage/domain/.../AuthRepository.kt`, `data/.../FirebaseAuthRepository.kt`, `usecase/.../AuthViewModel.kt`, `ObserveAuthStateUseCase.kt`, `PushRemoteButtonUseCase.kt`, `SnoozeNotificationsUseCase.kt`, `test-common/.../FakeAuthRepository.kt`, test files.

--- a/docs/pr-review/pr-0362.md
+++ b/docs/pr-review/pr-0362.md
@@ -1,0 +1,14 @@
+---
+pr: 362
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #362: refactor: ServerConfigRepository owns StateFlow (PR 6 of 8)
+
+**Goal:** Part of the ADR-022 8-PR state-ownership migration. `ServerConfigRepository` exposes `val serverConfig: StateFlow<ServerConfig?>` (drops `suspend getServerConfigCached()`). `CachedServerConfigRepository` wraps its cache in a `MutableStateFlow` and launches the first fetch on `externalScope` at construction (ADR-022 always-on pattern). `fetchServerConfig()` is a coalescing refresh command with mutex serialization. Callers read `serverConfig.value ?: fetchServerConfig()` inline — no observer mirror.
+
+**Notes:** Introduced the `cached != null` short-circuit in `fetchServerConfig` that PR #366 later removed — the short-circuit silently broke force-refresh.
+
+**Files:** `AndroidGarage/data/.../CachedServerConfigRepository.kt`, `NetworkDoorRepository.kt`, `NetworkRemoteButtonRepository.kt`, `NetworkSnoozeRepository.kt`, `domain/.../ServerConfigRepository.kt`, test files, `AppComponent.kt`.

--- a/docs/pr-review/pr-0363.md
+++ b/docs/pr-review/pr-0363.md
@@ -1,0 +1,12 @@
+---
+pr: 363
+state: merged
+date: 2026-04-19
+phase1_reviewed: 2026-04-20
+---
+
+# PR #363: refactor: FcmRegistrationManager exposes StateFlow (PR 7 of 8)
+
+**Goal:** Part of the ADR-022 8-PR state-ownership migration. `FcmRegistrationManager.registrationStatus` becomes `StateFlow<FcmRegistrationStatus>` (was `Flow`). `DefaultDoorViewModel` exposes the manager's `StateFlow` by reference; local `_fcmRegistrationStatus` mirror and its `init { collect }` observer are deleted. Rule 9 state-write logging added at every `_registrationStatus.value = ...` site (register success, register error, restart). Observable state lives on the manager (not the repository) because the repo's methods are command-only.
+
+**Files:** `AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/FcmRegistrationManager.kt`, `DoorViewModel.kt`.


### PR DESCRIPTION
## Summary

Phase 1 PR review batch session 2 — 20 files covering PRs #363 → #344. Continues newest-first ordering from session 1 (#383 → #364).

## Test plan
- [x] Only touches `docs/pr-review/**` (self-excludes from future review queues)
- [x] Each file follows the schema in `docs/pr-review/README.md`
- [x] Zero-padded filenames (4 digits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)