### PR TITLE
docs: Mark Phase 1 of PR review complete — 381 PRs reviewed

### DIFF
--- a/docs/pr-review/README.md
+++ b/docs/pr-review/README.md
@@ -1,5 +1,7 @@
 # PR Review
 
+**Phase 1 complete as of 2026-04-20.** All 381 PRs reviewed across 26 sessions. Ready for Phase 2 design.
+
 Retrospective review of every PR ever merged or closed in this repo. The end goal is to extract current goals, lessons, and patterns — then apply them universally across the Android code.
 
 This document is the durable plan. It survives across many sessions (up to ~100) with no loss of progress. Any session can start cold, read this file, and pick up where the previous session stopped.


### PR DESCRIPTION
Phase 1 of PR review complete. All 381 PRs (365 merged + 16 closed) reviewed across 26 sessions. Ready for Phase 2 design in a fresh session.