### PR TITLE
docs: Phase 2 protocol for PR review

### DIFF
--- a/docs/pr-review/README.md
+++ b/docs/pr-review/README.md
@@ -6,10 +6,10 @@ This document is the durable plan. It survives across many sessions (up to ~100)
 
 ## Phases
 
-Work proceeds in four phases. Each phase spans multiple sessions (10–30 PRs per session).
+Work proceeds in four phases. Each phase spans multiple sessions (30+ PRs per session).
 
-1. **Phase 1 — List (current).** Write one minimal markdown file per PR capturing goal, files touched, state, date. This is a mechanical pass, not a judgment pass.
-2. **Phase 2 — Assess.** Latest opinion on each PR (great / ok / superseded / buggy / outdated guidance). *Protocol designed in a fresh session after Phase 1 completes.*
+1. **Phase 1 — List.** ✅ Complete 2026-04-20. One minimal markdown file per PR capturing goal, files, state, date.
+2. **Phase 2 — Assess.** Latest opinion on each PR (great / ok / superseded / buggy / outdated-guidance / abandoned). **Protocol below.**
 3. **Phase 3 — Summarize.** Extract the still-current goals and lessons from Phase 2 into a compact doc. *Protocol designed after Phase 2 completes.*
 4. **Phase 4 — Apply.** Plan to apply the current lessons universally across Android code. *Protocol designed after Phase 3 completes.*
 
@@ -139,6 +139,124 @@ Phase 1 PR review batch — N files. Reviews PRs #X through #Y (descending; newe
 
 ---
 
+## Session protocol (Phase 2)
+
+A Phase 2 session is one sitting of work, 30+ PR assessments, ending in a single PR merged to main. Mechanics match Phase 1; the per-PR work is judgment, not capture.
+
+### 1. Session start
+
+**Step 1 — Phase 1 catchup first.** Run the Phase 1 queue check (see "Session protocol (Phase 1)"). If there are new PRs needing Phase 1 files, write those first, in the same session branch. Then continue with Phase 2.
+
+**Step 2 — Regenerate the Phase 2 queue.** List all `docs/pr-review/pr-NNNN.md` files that lack a `## Phase 2 assessment` section:
+
+```bash
+# One Bash call
+grep -L "## Phase 2 assessment" docs/pr-review/pr-*.md | sort -r
+```
+
+`-L` prints files that *don't* match. `sort -r` gives newest-first by filename (since filenames are zero-padded PR numbers).
+
+**Step 3 — Create the session branch.** Branch name format: `docs/pr-review-phase2-batch-YYYY-MM-DD-HHMMSS` (UTC). Get timestamp in one Bash call, type it literally in the next.
+
+### 2. For each PR in the queue
+
+**Step 1 — Read the Phase 1 file.** The goal, files, and any notes are the starting point.
+
+**Step 2 — Classify (fast path).** Pick one of six primary labels:
+
+| Label | When |
+|---|---|
+| **great** | Intent and outcome both correct. Pattern still current. Worth replicating. |
+| **ok** | Served its purpose, no issues, nothing exceptional. Most PRs. |
+| **superseded** | Correct at the time but later replaced by different work (not a fix — a new approach). |
+| **buggy** | Shipped with a bug that was later fixed, OR the code was wrong. |
+| **outdated-guidance** | Added docs/ADR/rule we later decided was wrong and reversed. |
+| **abandoned** | Closed-unmerged and not replaced. |
+
+**Tie-breaker: latest opinion.** If the current codebase would do it this way → great/ok. If we'd do it differently now → superseded / outdated-guidance. Pattern over code: if the *pattern* still lives even when the specific code was absorbed, primary=great.
+
+**Step 3 — Escalate if ANY of these apply** (don't guess):
+
+1. Phase 1 notes mention supersedence / revert / fix without naming the PR
+2. Primary label would be **great** (lesson depends on getting this right)
+3. Primary label would be **buggy** or **outdated-guidance** (Phase 4 depends on this)
+4. The rationale would read "I think…" or "probably" (genuine uncertainty)
+5. Multiple concerns in one PR and unclear which dominates
+
+**Escalation playbook** (stop when sufficient):
+
+1. Read the Phase 1 file fully.
+2. Search Phase 1 for later PRs mentioning this one: `grep -l "#NNN" docs/pr-review/pr-*.md`.
+3. Check current code state: for "great" candidates, does the pattern still exist? (`git grep`, `Read` on named files). For "outdated-guidance": does the ADR still exist with original wording?
+4. Read PR body + comments: `gh pr view <n> --comments`.
+5. Read the diff (last resort): `gh pr diff <n>`.
+
+**Step 4 — Write the assessment section.** Append to the existing `docs/pr-review/pr-NNNN.md`:
+
+```markdown
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** [ok]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** <one sentence — why this label>
+
+**Superseded by:** #xxx           <!-- only if superseded -->
+**Fixed by:** #xxx                 <!-- only if buggy -->
+**Reversed by:** #xxx or ADR-xxx   <!-- only if outdated-guidance -->
+
+**Still-current lesson:** <one sentence — only if novel/non-obvious AND not already codified in an ADR/guide/lint rule; omit otherwise>
+```
+
+**Secondary labels** (frontmatter `[list]`) catch mixed content. Example: `primary: great, secondary: [ok]` for a PR whose main pattern is great but consumer updates are routine. Use `[]` if nothing secondary applies.
+
+**Still-current lesson — HIGH bar.** Skip if:
+- Already in an ADR (`AndroidGarage/docs/DECISIONS.md`)
+- Already in a guide (`AndroidGarage/docs/guides/`)
+- Already enforced by a lint rule (`buildSrc/.../architecture/*`)
+- Obvious to any Android developer
+
+Include only genuinely novel, non-obvious lessons that Phase 4 could propagate.
+
+**Step 5 — Commit:**
+
+```bash
+git add docs/pr-review/pr-NNNN.md
+git commit -m "pr-review-phase2: PR #NNNN — <primary-label>"
+```
+
+One commit per file.
+
+### 3. Session stop
+
+Stop when **any** of these applies:
+- 30+ assessments done this session AND context usage is getting heavy
+- Queue empty (Phase 2 is complete — see end condition below)
+- User says stop
+
+**Create the session PR** (same pattern as Phase 1):
+
+```bash
+git push -u origin docs/pr-review-phase2-batch-YYYY-MM-DD-HHMMSS
+gh pr create --base main --title "docs: PR review phase 2 batch YYYY-MM-DD (PRs #X–#Y, N assessments)" --body "<body>"
+gh pr merge --auto --squash --delete-branch <n>
+```
+
+---
+
+## Phase 2 end condition
+
+Phase 2 is complete when a session starts, runs the Phase 2 queue check, and finds **zero** `pr-NNNN.md` files without a `## Phase 2 assessment` section (and no Phase 1 catchup needed).
+
+At that point:
+1. Add a note to this README's top: `**Phase 2 complete as of YYYY-MM-DD.**`
+2. Open a new session (clean context) to design Phase 3 via clarifying questions.
+3. Commit that design session's output as a Phase 3 section in this README.
+
+---
+
 ## Loop-breaker rule
 
 Every session generates a PR that modifies `docs/pr-review/**`. Without a rule, those PRs would themselves appear in the queue → infinite loop.
@@ -215,4 +333,5 @@ If a new PR is merged **during** Phases 2/3/4, it lacks a Phase 1 file. Phase 2+
 
 ## Rough budget
 
-At 381 PRs (365 merged + 16 closed as of this plan's creation) and ~20 PRs per session, Phase 1 fits in approximately **19 sessions**. New PRs merged during Phase 1 add marginal work (they show up at the top of the queue next session).
+- **Phase 1 (complete):** 381 PRs, 26 sessions, finished 2026-04-20.
+- **Phase 2:** At 30+ assessments per session, ~13 sessions to cover 381 PRs. Escalation is per-PR, not per-session, so most sessions stay on-pace.


### PR DESCRIPTION
## Summary

Phase 2 design captured in `docs/pr-review/README.md`. Protocol mirrors Phase 1 mechanics; per-PR work is judgment, not capture.

## Key decisions

- **6 primary labels:** great / ok / superseded / buggy / outdated-guidance / abandoned
- **Mixed-content PRs:** primary label + optional secondary list
- **Tie-breaker:** latest opinion — if the current codebase would do it this way → great/ok; if we'd do it differently now → superseded / outdated-guidance
- **Lesson bar:** HIGH — only novel lessons not already codified in ADRs, guides, or lint rules
- **Escalation:** 5 triggers, 5-step playbook. Aggressive escalation preferred when any uncertainty
- **Schema:** appends \`## Phase 2 assessment\` section to each existing \`pr-NNNN.md\`; never edits Phase 1 sections

## Budget

~13 sessions at 30+ assessments each.

## Test plan
- [ ] Protocol is clear enough for a cold session to pick up
- [ ] Classification thresholds are unambiguous
- [ ] Escalation triggers cover the real uncertainty cases
- [ ] High lesson bar keeps Phase 3 output scannable
- [ ] Loop-breaker rule still applies (session PRs only touch \`docs/pr-review/**\`)

No auto-merge — please review the Phase 2 protocol before it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)