### PR TITLE
docs: PR review phase 2 batch 2026-04-20 (PRs #354–#383, 30 assessments)

### DIFF
--- a/docs/pr-review/pr-0354.md
+++ b/docs/pr-review/pr-0354.md
@@ -12,3 +12,15 @@ phase1_reviewed: 2026-04-20
 **Notes:** The direct-write pattern here was later removed in PR #360 (pass-through model), re-added in PR #369 (android/170 regression hotfix), then finally removed in PR #372 after the root-cause DI fix in PR #371.
 
 **Files:** `AndroidGarage/domain/.../SnoozeRepository.kt`, `data/.../NetworkSnoozeRepository.kt`, `usecase/.../SnoozeNotificationsUseCase.kt`, `RemoteButtonViewModel.kt`, `SharedRepositoryUseCasesTest.kt` (new, 196 lines), `test-common/.../FakeSnoozeRepository.kt`, other test files.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** [ok]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** The `AppResult<SnoozeState, ActionError>` return shape survived — `Success.data` is the authoritative new state. The direct-VM-write "belt-and-suspenders" was a misdiagnosis of the DI scoping bug (#370/#371) and was ultimately removed in #372.
+
+**Superseded by:** #371 (root cause fix) → #372 (direct-write removed)
+
+**Still-current lesson:** When an observer-chain propagation bug is suspected, resist the urge to add a direct write as "belt and suspenders" — it masks the real bug and becomes load-bearing under pressure. Fix the propagation or prove it works; don't add a second path.

--- a/docs/pr-review/pr-0355.md
+++ b/docs/pr-review/pr-0355.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Document the structural issue behind the android/164-168 snooze-state propagation bug as a starting point for discussing the real fix. Three `DefaultRemoteButtonViewModel` instances coexist at runtime (dead Activity-scope, Home nav entry, Profile nav entry) because VM providers aren't `@Singleton` and `rememberViewModelStoreNavEntryDecorator<Screen>()` creates per-entry ViewModelStores. Each VM has its own `_snoozeState` and observer; Compose reads one which can miss emissions the others see. Covers ASCII data-flow map, why tests pass while production fails, dead `Main.kt:122` code, similar hazard in `DefaultDoorViewModel`, and five candidate solutions (A-E) — explicitly not picking one.
 
 **Files:** `AndroidGarage/docs/VIEWMODEL_SCOPING_ISSUE.md` (new).
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** [great]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Analysis doc that *did not* pick a solution — that restraint was the right call, because it let #356/#357 pick the full architectural answer rather than patching one symptom.
+
+**Still-current lesson:** When a bug's shape is structural, write the analysis doc *before* the fix — "here are five candidate solutions, I'm not picking yet" is a valid deliverable and forces the right conversation.

--- a/docs/pr-review/pr-0356.md
+++ b/docs/pr-review/pr-0356.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Write down architectural principles motivated by the android/164-168 snooze propagation bug. Core distinction: domain state (single source of truth, `@Singleton` Repository) vs. presentation state (per-screen, VM-local). Eight rules committing to a design where multiple VM instances are allowed but can't diverge: (1) domain state in `@Singleton` repos, (2) VMs expose repo `StateFlow`s by reference, (3) VM-local state for per-screen presentation only, (4) multi-VM convergence via repo, (5) explicit VM scoping, (6) `@Singleton` on repos not VMs, (7) `externalScope` vs `viewModelScope`, (8) delete dead VM references.
 
 **Files:** `AndroidGarage/docs/DECISIONS.md`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Named the "domain state vs presentation state" distinction that the rest of the state-ownership migration relies on — still the vocabulary used in lint messages and guides.
+
+**Still-current lesson:** The right granularity for "what should be singleton" is "is this the single source of truth for a domain concept?" — not "is this expensive to construct?" Domain-state singletons converge multiple VM instances; presentation state stays VM-local.

--- a/docs/pr-review/pr-0357.md
+++ b/docs/pr-review/pr-0357.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Consolidated documentation package for the ADR-022 state-ownership migration. New ADR-022 ("StateFlow at the repository boundary for state-y data") defines three data categories (state-y / cold list-y / event-y), interface shapes, VM shape, state-write logging, write-ordering rule, sign-out rule, Skie as iOS bridge, worked snooze example. New `MIGRATION_PLAN.md` with the 8-PR rollout sequence (PRs 1-8) plus Phase 2 deferrals. Amends ADR-006, ADR-013, ADR-017 Rule 6, ADR-019, ADR-020, ADR-021 to align with the new model.
 
 **Files:** `AndroidGarage/docs/DECISIONS.md`, `AndroidGarage/docs/MIGRATION_PLAN.md` (new).
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** ADR-022 is now the spine of the data layer. Three-category split (state-y / cold list-y / event-y), VM shape, write-ordering rule, sign-out rule — all still enforced via lint and followed for new repositories.
+
+**Still-current lesson:** When introducing a cross-cutting architectural rule, categorize your existing data into buckets first (state-y / list-y / event-y) — the right shape depends on the category, and "one size fits all" rules don't survive contact with mixed shapes.

--- a/docs/pr-review/pr-0358.md
+++ b/docs/pr-review/pr-0358.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** First of 8 PRs in the ADR-022 state-ownership migration. Adds `SnoozeMultiSubscriberIntegrationTest` wiring real `NetworkSnoozeRepository` with fake data sources + three concurrent subscribers to prove repository-only propagation is sufficient. Closes the coverage gap from the android/164-168 snooze bug: writes through the observation path must reach every subscriber simultaneously. No subscriber consults `snoozeNotifications()`'s return value. Enables PR #360 to remove the PR #354 direct-write workaround with regression coverage in place.
 
 **Files:** `AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/SnoozeMultiSubscriberIntegrationTest.kt` (new, 284 lines).
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Multi-subscriber integration test was the regression-proof that ADR-022's "writes propagate via observation only" works — and the shape of the test (real repo + N subscribers + fake data sources) generalizes beyond snooze.
+
+**Still-current lesson:** For shared-state repositories, write an N-subscriber integration test before removing any VM-local mirror — the test proves propagation, not just the happy-path emission.

--- a/docs/pr-review/pr-0359.md
+++ b/docs/pr-review/pr-0359.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Remove the unused `val buttonViewModel = viewModel { component.remoteButtonViewModel }` in `Main.kt` along with orphaned imports. Add a doc comment in `AppComponent.kt` noting the intentional non-`@Singleton` scoping of ViewModel providers (per-nav-entry per ADR-021 Rule 4). The dead declaration contributed to the android/164-168 snooze-state bug by creating an unused third VM instance in AppNavigation.
 
 **Files:** `AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt`, `di/AppComponent.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Dead-code cleanup — the orphaned VM instance was a genuine contributor to the earlier snooze bug, so deletion is more than aesthetic.

--- a/docs/pr-review/pr-0360.md
+++ b/docs/pr-review/pr-0360.md
@@ -12,3 +12,11 @@ phase1_reviewed: 2026-04-20
 **Notes:** Rolled back in PR #369 (android/170 regression) and later re-verified via #371/#372/#373 after the root-cause kotlin-inject DI fix.
 
 **Files:** `AndroidGarage/data/.../NetworkSnoozeRepository.kt`, `domain/.../SnoozeRepository.kt`, `usecase/.../ObserveSnoozeStateUseCase.kt`, `RemoteButtonViewModel.kt`, `FetchSnoozeStatusUseCase.kt`, `test-common/.../FakeSnoozeRepository.kt`, test files.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Originally correct ADR-022 application, briefly rolled back in #369 for the android/170 hotfix, reinstated by #371→#372→#373 after the DI root cause was fixed. Final state matches this PR's intent.

--- a/docs/pr-review/pr-0361.md
+++ b/docs/pr-review/pr-0361.md
@@ -9,4 +9,12 @@ phase1_reviewed: 2026-04-20
 
 **Goal:** Part of the ADR-022 8-PR state-ownership migration. `AuthRepository` exposes `val authState: StateFlow<AuthState>` (drops `getAuthState()` and `observeAuthState(): Flow`). `ObserveAuthStateUseCase` passes the repo's `StateFlow` through by reference. `DefaultAuthViewModel` exposes the repo's `StateFlow` by reference; local `_authState` mirror and `init { collect }` observer deleted. `PushRemoteButtonUseCase` and `SnoozeNotificationsUseCase` read `authState.value` instead of `getAuthState()`. Rule 9 state-write logging added. `DefaultAuthViewModelTest.authStateIsSameInstanceAsRepoStateFlow` guards against future mirror reintroduction.
 
-**Files:** `AndroidGarage/domain/.../AuthRepository.kt`, `data/.../FirebaseAuthRepository.kt`, `usecase/.../AuthViewModel.kt`, `ObserveAuthStateUseCase.kt`, `PushRemoteButtonUseCase.kt`, `SnoozeNotificationsUseCase.kt`, `test-common/.../FakeAuthRepository.kt`, test files.
+**Files:** `AndroidGarage/domain/.../AuthRepository.kt`, `data/.../FirebaseAuthRepository.kt`, `usecase/.../AuthViewModel.kt`, `ObserveAuthStateUseCase.kt`, `PushRemoteButtonUseCase.kt`, `SnoozeNotificationsUseCase.kt`, `test-common/.../PushRemoteButtonUseCase.kt`, `SnoozeNotificationsUseCase.kt`, `test-common/.../FakeAuthRepository.kt`, test files.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** [great]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Canonical application of ADR-022 to auth, including the identity-test guard (`authStateIsSameInstanceAsRepoStateFlow`) that prevents future mirror reintroduction — pattern still enforced.

--- a/docs/pr-review/pr-0362.md
+++ b/docs/pr-review/pr-0362.md
@@ -12,3 +12,15 @@ phase1_reviewed: 2026-04-20
 **Notes:** Introduced the `cached != null` short-circuit in `fetchServerConfig` that PR #366 later removed — the short-circuit silently broke force-refresh.
 
 **Files:** `AndroidGarage/data/.../CachedServerConfigRepository.kt`, `NetworkDoorRepository.kt`, `NetworkRemoteButtonRepository.kt`, `NetworkSnoozeRepository.kt`, `domain/.../ServerConfigRepository.kt`, test files, `AppComponent.kt`.
+
+## Phase 2 assessment
+
+**Primary:** buggy
+**Secondary:** [ok]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** The StateFlow migration for ServerConfig was the right direction, but it smuggled in a `cached != null` short-circuit in `fetchServerConfig()` that silently broke force-refresh — caught by #366 shortly after.
+
+**Fixed by:** #366
+
+**Still-current lesson:** "Coalesce concurrent fetches" and "return cached if already populated" look similar but aren't — a mutex coalesces *in-flight* calls while still letting each call hit the network. Review that distinction explicitly on any cached-repo refactor.

--- a/docs/pr-review/pr-0363.md
+++ b/docs/pr-review/pr-0363.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Part of the ADR-022 8-PR state-ownership migration. `FcmRegistrationManager.registrationStatus` becomes `StateFlow<FcmRegistrationStatus>` (was `Flow`). `DefaultDoorViewModel` exposes the manager's `StateFlow` by reference; local `_fcmRegistrationStatus` mirror and its `init { collect }` observer are deleted. Rule 9 state-write logging added at every `_registrationStatus.value = ...` site (register success, register error, restart). Observable state lives on the manager (not the repository) because the repo's methods are command-only.
 
 **Files:** `AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/FcmRegistrationManager.kt`, `DoorViewModel.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** [great]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Correct placement of observable state on the manager (not the repo) because the repo's methods are command-only — a useful category distinction between state-y and command-only components.
+
+**Still-current lesson:** When a repo's API is purely command-y (no query methods), observable state for that feature belongs on an app-scoped manager — don't shoehorn a `StateFlow` onto a repo that has nothing to return.

--- a/docs/pr-review/pr-0364.md
+++ b/docs/pr-review/pr-0364.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Part of the ADR-022 8-PR state-ownership migration. `DoorRepository.currentDoorEvent` becomes `val : StateFlow<DoorEvent?>` (was `Flow<DoorEvent?>`). `NetworkDoorRepository` launches an always-on collector on `externalScope` that consumes the Room flow and writes into a `MutableStateFlow` — explicitly not using `stateIn(WhileSubscribed)` which is banned by ADR-022. `recentDoorEvents` stays cold (list-y per ADR-022 categories). Rule 9 logging added on local flow emit. `DoorViewModel._currentDoorEvent` kept because `LoadingResult<T>` wrapping is a genuine derivation, not a mirror.
 
 **Files:** `AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/DoorRepository.kt`, `data/.../NetworkDoorRepository.kt`, `NetworkDoorRepositoryIntegrationTest.kt`, `test-common/.../FakeDoorRepository.kt`, `AppComponent.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Mechanical application of ADR-022 to DoorRepository — the "always-on collector on externalScope writing into MutableStateFlow" shape is the canonical pattern now.

--- a/docs/pr-review/pr-0365.md
+++ b/docs/pr-review/pr-0365.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Final PR of the 8-PR state-ownership migration. Makes the repository-owned-`StateFlow` invariant load-bearing via compile-time checks. `ViewModelStateFlowCheckTask` adds a Rule 2 check banning VM-local `MutableStateFlow<T>` for `T ∈ {SnoozeState, AuthState, FcmRegistrationStatus}` (allowlist-based); `SingletonGuardTask` extends `guardedMethodPatterns` to require `@Singleton` on every state-owning repository provider. ADR-021 and ADR-022 flipped to "Accepted and enforced."
 
 **Files:** `AndroidGarage/build.gradle.kts`, `AndroidGarage/buildSrc/src/main/kotlin/architecture/ViewModelStateFlowCheckTask.kt`, `AndroidGarage/docs/DECISIONS.md`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Turned ADR-021/022 from docs into compile-time enforcement — VM-local MutableStateFlow is now a build failure, and `@Singleton` on state-owning repos is guarded. Architecture decisions that aren't lint-enforced don't stick.
+
+**Still-current lesson:** When you land an ADR with a structural invariant (who may own which state), write the lint check the same week — ADRs without enforcement decay on the next regression.

--- a/docs/pr-review/pr-0366.md
+++ b/docs/pr-review/pr-0366.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Remove the `cached != null` short-circuit that PR #362 introduced in `CachedServerConfigRepository.fetchServerConfig()` — once populated, the cache could never refresh without a process restart, silently breaking flows that depend on server-side config changes. Restores true force-refresh semantics: every call hits the network, successful results write to `_serverConfig`, null results leave the cache untouched. Drops concurrent coalescing complexity (mutex already serializes). Two contract tests: `fetchServerConfigAlwaysRefreshesCache` and `nullFetchResultPreservesCachedValue`.
 
 **Files:** `AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/CachedServerConfigRepository.kt`, `CachedServerConfigRepositoryTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Fixes the #362 regression *and* establishes the fetchX() contract (three required tests) that became guide #376 — pattern is now universal.
+
+**Still-current lesson:** `fetchX()` is always "force refresh and return the fresh value"; `.value` reads from cache. Never short-circuit `fetch` on "already cached" — that silently breaks the refresh semantics the name promises.

--- a/docs/pr-review/pr-0367.md
+++ b/docs/pr-review/pr-0367.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Capture durable knowledge from the state-ownership migration session — mark Phase 1 complete in `MIGRATION_PLAN.md` (PRs #358–#365 + #366 follow-up), add Phase 2e with three better allowlist-scaling options for `ViewModelStateFlowCheckTask` (parse repo interfaces, `@DomainState` marker, inverted allowlist). `CLAUDE.md` gets the `gh pr merge --disable-auto` hook-block workaround (GraphQL `disablePullRequestAutoMerge` mutation) and the git-guardrails false-positive on branch names containing `main` as a word.
 
 **Files:** `AndroidGarage/docs/MIGRATION_PLAN.md`, `CLAUDE.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Routine session dump. Captured the `disablePullRequestAutoMerge` GraphQL workaround and the git-guardrails "main" branch-name false-positive — both still in memory and still hit in practice.

--- a/docs/pr-review/pr-0368.md
+++ b/docs/pr-review/pr-0368.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add `-PtestR8=true` and `-PdebuggableBenchmark=true` gradle flags that route `connectedAndroidTest` to the R8-enabled `benchmark` variant, enabling reproduction of release-only bugs (ADR-020 R8 keep-rule stripping; android/167/170 StateFlow propagation regression) in instrumented tests. Both flags default off; CI and normal `connectedAndroidTest` runs unaffected. Prerequisite for running `SnoozeStateInstrumentedPropagationTest` under R8.
 
 **Files:** `AndroidGarage/androidApp/build.gradle.kts`, `AndroidGarage/docs/R8_INSTRUMENTED_TESTS.md` (new).
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Opt-in R8 test harness is a portable tooling win — lets debug-variant instrumented tests reproduce release-only bugs (keep rules, codegen stripping) without burning CI time. Still present and still the right answer.
+
+**Still-current lesson:** Reproducing release-only bugs in instrumented tests needs a *deliberate* path — default-on would ruin CI speed. `-Pflag` routes `connectedAndroidTest` to a minified variant on demand.

--- a/docs/pr-review/pr-0369.md
+++ b/docs/pr-review/pr-0369.md
@@ -10,3 +10,15 @@ phase1_reviewed: 2026-04-20
 **Goal:** Hotfix for the android/170 snooze regression. Restores the PR #354 / android/169 pattern — VM-local `MutableStateFlow<SnoozeState>` + `init { observeSnoozeStateUseCase().collect }` + direct-write `_snoozeState.value = newState` in the success branch. Withdraws ADR-022 Rule 2 (VM exposes repo `StateFlow` by reference) because the pass-through pattern did not propagate repo writes to Compose on production devices. `bannedStateTypesInViewModels` emptied (Rule 2 withdrawn but Rule 1 stateIn-ban kept).
 
 **Files:** `AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt`, `buildSrc/.../ViewModelStateFlowCheckTask.kt`, `docs/DECISIONS.md`, `usecase/src/commonTest/.../SnoozeStateFlowPropagationTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** [ok]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Correct hotfix at the time — restore the known-working mirror+direct-write to stop the user-visible bug — but the pass-through model it withdrew was the right architecture; #371–#373 reinstated it after the DI root cause was fixed.
+
+**Superseded by:** #371 (root cause fix) → #372 (remove mirror again) → #373 (re-enable lint)
+
+**Still-current lesson:** When a production regression disproves a rule, disable the rule and ship the fix fast — but mark the reversal as provisional until the root cause is known. Don't delete the guard rail permanently on one data point.

--- a/docs/pr-review/pr-0370.md
+++ b/docs/pr-review/pr-0370.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Document the kotlin-inject `@Singleton` scoping bug found during the android/170 investigation in advance of the code fix. `DI_SINGLETON_REQUIREMENTS.md` enumerates R1-R4 (what the DI graph must guarantee), C1-C4 (kotlin-inject-specific constraints), detection recipes (inspect generated `InjectAppComponent.kt`, `ComponentGraphTest.singletonRepositoriesReturnSameInstance`, Rule 9 logcat counts), and fix direction. `MIGRATION_PLAN.md` adds Phase 2f to schedule the fix as deliberate work.
 
 **Files:** `AndroidGarage/docs/DI_SINGLETON_REQUIREMENTS.md` (new), `AndroidGarage/docs/MIGRATION_PLAN.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** [great]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** "Write the spec before the fix" paid off: the requirements doc named the four guarantees (R1-R4) and four constraints (C1-C4) #371 had to satisfy, so the fix had a rubric rather than a hunch.

--- a/docs/pr-review/pr-0371.md
+++ b/docs/pr-review/pr-0371.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Root-cause fix for the android/170 regression. Convert `AppComponent` concrete `val x @Provides get() = ...` providers to `abstract val` entry points and `@Provides fun` bodies that take deps as parameters — kotlin-inject only emits `_scoped.get(...)` caching for overrides of abstract declarations. Generated `InjectAppComponent.kt` grows 15 → 304 lines. Adds 14 identity guards in `ComponentGraphTest` (`assertSame` for 11 `@Singleton` types, `assertNotSame` for 2 per-nav-entry VM types).
 
 **Files:** `AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt`, `ComponentGraphTest.kt`, `MainActivity.kt`, `FCMService.kt`, `LogSummaryCard.kt`, `ProfileContent.kt`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** The root-cause fix for android/170. Abstract-entry + parameter-body shape is now the enforced convention (CLAUDE.md, guide, lint, identity tests). Pattern is foundational to the whole app's singleton correctness.
+
+**Still-current lesson:** When a DI container has a silent-fail mode (accepts the wrong shape without warning), read the generated code at least once — "compiled" and "correct" are independent properties of annotation-driven codegen.

--- a/docs/pr-review/pr-0372.md
+++ b/docs/pr-review/pr-0372.md
@@ -9,4 +9,14 @@ phase1_reviewed: 2026-04-20
 
 **Goal:** Empirically test whether the Phase 2f DI fix (android/173) was the complete root cause of the android/170 regression. Removes the VM-local `_snoozeState` mirror + `init { collect }` + direct-write from `DefaultRemoteButtonViewModel` and restores the ADR-022 pass-through (`override val snoozeState = observeSnoozeStateUseCase()`). If android/174 ships with card title flipping correctly on save, ADR-022 Rule 2 is validated.
 
-**Files:** `AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt`.
+**Files:** `AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RemoteButtonViewModel.kt`
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** [great]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** "Ship the thing that *should* work and watch production to confirm the root cause" is a valid A/B test; after #371's DI fix this was the minimal empirical verification, and android/174 shipped OK so ADR-022 was vindicated.
+
+**Still-current lesson:** After a root-cause fix to invisible framework behavior, keep a "remove the workaround" diff ready and ship it as its own release — that's the only empirical proof the root cause was complete..

--- a/docs/pr-review/pr-0373.md
+++ b/docs/pr-review/pr-0373.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** After android/174 shipped the pass-through snooze pattern with no VM-local mirror and worked on device (validating Phase 2f DI fix was the complete root cause of android/170), restore `ViewModelStateFlowCheckTask`'s `bannedStateTypesInViewModels` list to `(SnoozeState, AuthState, FcmRegistrationStatus)` and flip ADR-022 back to Accepted.
 
 **Files:** `AndroidGarage/buildSrc/src/main/kotlin/architecture/ViewModelStateFlowCheckTask.kt`, `AndroidGarage/docs/DECISIONS.md`, `AndroidGarage/docs/MIGRATION_PLAN.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Restores state-ownership lint after on-device verification — routine re-enable of the correct rule once the root cause was proven via #371–#372.

--- a/docs/pr-review/pr-0374.md
+++ b/docs/pr-review/pr-0374.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Capture the 5-month android/170 regression cycle as a first-class postmortem — timeline of releases 164–174, four invisibility properties of the bug, seven investigation failures, user reframing as the turning point, seven lessons with prescriptions, four reusable "hard-bug" checklists. Also adds an "AppComponent / kotlin-inject Safety" section to `CLAUDE.md` (shaped like "Room Database Safety") with two mechanical rules and a 5-step checklist for AppComponent edits.
 
 **Files:** `AndroidGarage/docs/POSTMORTEM_ANDROID_170.md` (new), `CLAUDE.md`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Turned a 5-month invisible bug into both a full postmortem and a mechanical CLAUDE.md safety checklist shaped like the existing "Room Database Safety" section — exactly the "defense-in-depth for invisible bugs" pattern.
+
+**Still-current lesson:** When a framework-contract bug escapes tests, add *four* layers: (1) postmortem with timeline, (2) CLAUDE.md safety section with mechanical rules, (3) generated-code inspection step, (4) identity test. Tests-pass ≠ architecture-works.

--- a/docs/pr-review/pr-0375.md
+++ b/docs/pr-review/pr-0375.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Create `AndroidGarage/docs/guides/` for portable third-person tech lessons. First guide `kotlin-inject.md` captures the `@Singleton` scoping gotcha behind android/170: abstract entry points required for overrides, parameter-based provider bodies required to avoid bypassing the `_scoped` cache.
 
 **Files:** `AndroidGarage/docs/guides/README.md`, `AndroidGarage/docs/guides/kotlin-inject.md`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Created the `guides/` folder for portable third-person lessons — pattern is now used repeatedly and is a clean separation from project-specific ADRs.
+
+**Still-current lesson:** ADRs record *this project's* decisions; portable third-person guides record *transferable* tech lessons — keep them in separate folders so future readers can grab just the lessons.

--- a/docs/pr-review/pr-0376.md
+++ b/docs/pr-review/pr-0376.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add a portable guide codifying the repository `StateFlow` + `fetchX()` contract lifted from the `CachedServerConfigRepository` regression (#362 → #366). Covers three-concept separation (observation via `StateFlow.value` / force-refresh via `suspend fetchX()` / cached read), null-return semantics (null = failure report, cache untouched), and three required tests (`fetchAlwaysRefreshesCache`, `nullResponsePreservesCache`, `fetchSwallowsDataSourceExceptions`).
 
 **Files:** `AndroidGarage/docs/guides/README.md`, `AndroidGarage/docs/guides/repository-api-patterns.md`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Turned a specific regression (#362 → #366) into a repeatable, test-backed repository contract that Phase 4 can enforce — guide still authoritative.
+
+**Still-current lesson:** Every `fetchX()` must have three contract tests: always-refresh, null-preserves-cache, exception-doesn't-clobber — write them when the flow is designed, not after the regression.

--- a/docs/pr-review/pr-0377.md
+++ b/docs/pr-review/pr-0377.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Round out the `AndroidGarage/docs/guides/` portable-lessons library with three third-person guides: `r8-keep-rules.md` (when R8 silently strips reflection/codegen/generic-erased code), `compose-nav3-vm-scoping.md` (`rememberViewModelStoreNavEntryDecorator` creates one store per nav entry), and `reactive-auth-listener.md` (auth is a stream; subscribe on `externalScope` not `viewModelScope`).
 
 **Files:** `AndroidGarage/docs/guides/README.md`, `r8-keep-rules.md`, `compose-nav3-vm-scoping.md`, `reactive-auth-listener.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** [great]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Content is solid portable guidance; the broader "extract third-person guides" pattern was already established by #375, so this is high-quality application rather than a new pattern.

--- a/docs/pr-review/pr-0378.md
+++ b/docs/pr-review/pr-0378.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Document the Android versioning rule in three places: `AndroidGarage/CHANGELOG.md` (authoritative), `CLAUDE.md` (one-line rule), and `.claude/skills/bump-android-version/SKILL.md`. Rule: major = rewrite/core-experience shift, minor = user-facing feature added or removed, patch = fixes/polish/refactors.
 
 **Files:** `AndroidGarage/CHANGELOG.md`, `CLAUDE.md`, `.claude/skills/bump-android-version/SKILL.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Codified the existing versioning rule in three load-bearing places; rule is still followed.

--- a/docs/pr-review/pr-0379.md
+++ b/docs/pr-review/pr-0379.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add docs-only fast path to `ci.yml` and `ci-post-merge.yml` — when every changed file matches the docs classification, skip the expensive `checks` reusable workflow and let the gate job (`CI Complete` / `Post-Merge Complete`) post success in ~20-30s.
 
 **Files:** `.github/workflows/ci.yml`, `.github/workflows/ci-post-merge.yml`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Established the docs-only fast-path pattern that now lives in CLAUDE.md and memory — the kind of CI optimization with a crisp correctness rule.
+
+**Still-current lesson:** Skip CI only when the change cannot affect what CI verifies — safe no-op optimization, not a speed trade-off.

--- a/docs/pr-review/pr-0380.md
+++ b/docs/pr-review/pr-0380.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add a docs-only fast path to `firebase-ci.yml` — skip the Firebase unit-test job when every changed file matches the docs classification (markdown, `docs/**`, `.claude/**`, `LICENSE`, `.gitignore`, `AndroidGarage/distribution/whatsnew/**`).
 
 **Files:** `.github/workflows/firebase-ci.yml`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Parallel of #379 for Firebase; rule now in CLAUDE.md and memory, applied consistently.

--- a/docs/pr-review/pr-0381.md
+++ b/docs/pr-review/pr-0381.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Eliminate duplicate Firebase CI runs by extracting the `test` job into `firebase-ci-checks.yml` (reusable workflow) and switching `firebase-ci.yml` to PR-only. Widens `firebase-deploy.yml`'s check-run name matcher from exact-match to `endswith("Run Unit Tests")` so deploys keep finding the check whether the reusable prefixes its name or not.
 
 **Files:** `.github/workflows/firebase-ci.yml`, `firebase-ci-checks.yml` (new), `firebase-deploy.yml`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Structural mirror of the Android reusable-checks split; `endswith` check-run matcher is the kind of small-but-right detail that kept deploys unblocked.

--- a/docs/pr-review/pr-0382.md
+++ b/docs/pr-review/pr-0382.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add Firebase post-merge CI workflow mirroring the Android split — runs on push to main, calls the reusable `firebase-ci-checks.yml`, and uses `ci-failure-tracker` to open/close a GitHub issue labeled `ci-failure/firebase-post-merge` on regression/recovery.
 
 **Files:** `.github/workflows/firebase-ci-post-merge.yml` (new). Diff also shows stacked-parent (#381) changes.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Applied the already-established Android post-merge + auto-issue pattern to Firebase — correct symmetry, nothing novel.

--- a/docs/pr-review/pr-0383.md
+++ b/docs/pr-review/pr-0383.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Update CLAUDE.md's "CI Architecture" section to document the new Firebase pre/post-merge split and the docs-only fast path.
 
 **Files:** `CLAUDE.md` — "CI Architecture" section. Final stacked PR in the #380 → #381 → #382 → #383 CI improvements chain; diff also shows workflow files from stacked parents.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Doc update that accompanies the #380–#383 CI work — routine and still accurate.


### PR DESCRIPTION
## Summary
Phase 2 session 1 — classified 30 PRs newest-first (#383 down through #354).

Category breakdown:
- **great** (11): #379, #376, #375, #374, #371, #368, #366, #365, #358, #357, #356
- **ok** (15): #383, #382, #381, #380, #378, #377, #373, #372, #370, #367, #364, #363, #361, #360, #359, #355
- **superseded** (2): #369, #354 — direct-write/mirror pattern pair, superseded by #371-#373 root-cause fix
- **buggy** (1): #362 — `cached != null` short-circuit in `fetchServerConfig`, fixed by #366

No PRs classified as **outdated-guidance** or **abandoned** in this batch.

Key still-current lessons captured:
- Docs-only CI skip rule (safe no-op optimization, not a speed trade-off)
- fetchX() contract (three required tests: refresh, null-preserves, exception)
- guides/ vs ADR/ separation (portable lessons vs project decisions)
- Tests-pass ≠ architecture-works for DI framework contracts
- ADR without lint enforcement decays
- Multi-subscriber integration tests for shared-state repositories
- Don't add "belt and suspenders" direct-writes alongside observer chains

## Test plan
- [ ] Docs-only change — `checks` workflow skipped via docs-only fast path
- [ ] Phase 2 queue shrinks by 30