### PR TITLE
docs: PR review phase 2 batch 2026-04-20 session 2 (PRs #324–#353, 30 assessments)

### DIFF
--- a/docs/pr-review/pr-0324.md
+++ b/docs/pr-review/pr-0324.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Lock in the button ack token format (`android-<version>-<timestamp>`) as a contract — the server uses tokens to deduplicate button presses, so silent format changes break server-side dedup. 6 new tests verify: exact format, determinism for same inputs, sensitivity to timestamp/version, special-char filtering (`/`, `+`, ` ` → `.` for URL-safety), empty version produces valid output. Previously only integration coverage via `RemoteButtonViewModelTest`, which never asserted exact format.
 
 **Files:** `AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/CreateButtonAckTokenTest.kt` (new).
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Button ack token format is a wire contract with the server — the contract tests (format, determinism, special-char filtering) protect server-side dedup from silent client changes.
+
+**Still-current lesson:** Any string the server parses is a wire format — pin the exact shape in a contract test, not just a round-trip integration test. "Format still works" and "format unchanged" are different properties.

--- a/docs/pr-review/pr-0325.md
+++ b/docs/pr-review/pr-0325.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Update `dev-mode.sh` and `CLAUDE.md` so Claude removes `.claude/.dev-mode` itself when the user says stop, instead of only telling the user to do it. Previous instruction told Claude to "tell the user to run `rm .claude/.dev-mode`" but the next Stop hook fires before the user can act, so the loop stayed active.
 
 **Files:** `.claude/hooks/dev-mode.sh`, `CLAUDE.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Gave Claude the ability to self-disable dev mode when the user says stop — the missing first step that made the Stop hook actually stop; #329 extended this with more conditions.

--- a/docs/pr-review/pr-0326.md
+++ b/docs/pr-review/pr-0326.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Phase A, PR 1 of the reactive auth refactor (fixes auth state UI bug). Extends `AuthBridge` with reactive primitives: `observeAuthUser(): Flow<AuthUserInfo?>` wrapping Firebase `AuthStateListener` via `callbackFlow`; `getIdToken(forceRefresh: Boolean)` replacing `refreshIdToken()` — `false` for cached (listener path), `true` for network refresh. `getCurrentUser()` kept temporarily for migration. Updates `FakeAuthBridge` with controllable `MutableStateFlow` + `setAuthUser()` / `setIdTokenResult()`. Foundation for PR #328's reactive listener that fixes the imperative `getIdToken(forceRefresh=true)` network race.
 
 **Files:** `AndroidGarage/data/.../AuthBridge.kt`, `androidApp/.../auth/FirebaseAuthBridge.kt`, `data/.../FirebaseAuthRepository.kt`, `test-common/.../FakeAuthBridge.kt`, test files.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** [great]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Foundation PR for #328 — `callbackFlow` wrapping `AuthStateListener` is the right primitive. Separating `observeAuthUser()` (listener stream) from `getIdToken(forceRefresh)` (one-shot) is the right API shape.

--- a/docs/pr-review/pr-0327.md
+++ b/docs/pr-review/pr-0327.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Phase A, PR 2a of the reactive auth refactor. Adds `refreshIdToken(): FirebaseIdToken?` to `AuthRepository`. `EnsureFreshIdTokenUseCase` now calls `authRepository.refreshIdToken()` instead of deprecated `refreshFirebaseAuthState()`. After refresh, updates `_authState` with new token so UI stays in sync (no split-brain). `refreshFirebaseAuthState()` `@Deprecated` but kept for backwards compat — removed in PR #328.
 
 **Files:** `AndroidGarage/domain/.../AuthRepository.kt`, `data/.../FirebaseAuthRepository.kt`, `usecase/.../EnsureFreshIdTokenUseCase.kt`, `test-common/.../FakeAuthRepository.kt`, use case tests.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Intermediate step in the auth refactor — split the "refresh token + write to state" responsibility from the listener path so #328 could land cleanly.

--- a/docs/pr-review/pr-0328.md
+++ b/docs/pr-review/pr-0328.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** THE BUG FIX. Phase A, PR 2b of the auth refactor. Replace imperative `refreshFirebaseAuthState()` polling with reactive `observeAuthUser()` collection driven by Firebase's `AuthStateListener`. Root cause: after sign-in, `refreshFirebaseAuthState()` called `getIdToken(forceRefresh=true)` — a network call that could fail right after `signInWithCredential()` completed, causing the repo to commit `Unauthenticated` even though sign-in succeeded. The repo now collects from `authBridge.observeAuthUser()`: listener fires automatically after sign-in/sign-out; `signInWithGoogle()` is fire-and-forget; `signOut()` eagerly sets `Unauthenticated` then calls bridge; `getIdToken(false)` uses cached token (no network race). `FirebaseAuthRepositoryTest` rewritten with 8 tests using `UnconfinedTestDispatcher`.
 
 **Files:** `AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepository.kt`, `FirebaseAuthRepositoryTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** The reactive-listener rewrite replaced a latent network race (getIdToken(forceRefresh=true) at sign-in time) with a state-subscription-driven repo — still the canonical shape and the model for ADR-018 and guide #377.
+
+**Still-current lesson:** Auth is a stream, not a query — subscribe to the platform's `AuthStateListener` (or equivalent) and let writes be fire-and-forget. Imperative `forceRefresh` at sign-in time is a network race by design.

--- a/docs/pr-review/pr-0329.md
+++ b/docs/pr-review/pr-0329.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Update dev-mode Stop hook and `CLAUDE.md` so Claude removes `.claude/.dev-mode` itself when (1) user says stop, (2) all planned work is done — no meaningful parallel-PR-friendly tasks remain, (3) all open PRs are blocked on CI with nothing else to do. Previously only condition (1) was covered, leading to infinite loops searching for marginal work.
 
 **Files:** `.claude/hooks/dev-mode.sh`, `CLAUDE.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Second iteration of dev-mode self-disable (adds "work done" and "all PRs blocked" conditions); both hooks still present and both conditions still fire when applicable.

--- a/docs/pr-review/pr-0330.md
+++ b/docs/pr-review/pr-0330.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add guidance to `CLAUDE.md` for stacked (dependent) PRs. (1) Always `--base main` — CI only triggers on protected branches; `--base feature-branch` means CI never runs and changing base later doesn't re-trigger. (2) Document merge order in each PR body with position, dependencies, full stack list. (3) Auto-merge handles cascade — each PR waits for the previous CI cycle. (4) Temporary extra commits in diff auto-clean after parent squash-merges. Motivated by PRs #326→#327→#328 (auth refactor stack) hitting this issue 3 times.
 
 **Files:** `CLAUDE.md`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Stacked-PR guidance in CLAUDE.md is still load-bearing — the "always `--base main`" rule alone saves the stack from not running CI, and the merge-order documentation prevents misordered merges.
+
+**Still-current lesson:** GitHub CI only triggers on PRs targeting *protected* branches — `--base feature-branch` silently disables CI and changing the base later doesn't re-trigger. For dependent work, always stack with `--base main` and document merge order in each PR body.

--- a/docs/pr-review/pr-0331.md
+++ b/docs/pr-review/pr-0331.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Document the auth state UI bug as ADR-018 (Reactive Auth State) — root cause was imperative `getIdToken(forceRefresh=true)` network race latent since Oct 2024; trigger was PR #283 replacing direct StateFlow reference with `Flow + stateIn`. Rules: use platform listeners, commands fire-and-forget, don't wrap StateFlow in StateFlow, add UI integration tests for critical state. Adds `AuthStateUIPropagationTest` — 7 instrumented tests verifying the full StateFlow → `collectAsState()` → Compose recomposition chain (static rendering per AuthState, dynamic `MutableStateFlow` changes trigger recomposition, rapid sign-in/sign-out cycle).
 
 **Files:** `AndroidGarage/docs/DECISIONS.md`, `androidApp/src/androidTest/java/com/chriscartland/garage/ui/AuthStateUIPropagationTest.kt` (new, 228 lines).
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** ADR-018 (reactive auth state) is still in force and the UI propagation test is the right test shape — StateFlow → `collectAsState()` → Compose recomposition. Pattern generalized via guide #377.
+
+**Still-current lesson:** For state-critical UI flows, write an instrumented test that exercises the *full* chain `MutableStateFlow` → `collectAsState` → recomposition — unit tests of either end miss Compose-level wiring bugs.

--- a/docs/pr-review/pr-0332.md
+++ b/docs/pr-review/pr-0332.md
@@ -12,3 +12,13 @@ phase1_reviewed: 2026-04-20
 **Notes:** Reverted in PR #334 — content was a patch (bug fix), not a minor feature; versionName corrected to 2.4.1.
 
 **Files:** `AndroidGarage/version.properties`.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Wrong kind of bump — content was a patch, not a minor. Reversed in #334 and the versioning rule (added in #378) makes this mistake harder to repeat.
+
+**Superseded by:** #334

--- a/docs/pr-review/pr-0333.md
+++ b/docs/pr-review/pr-0333.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Fix the `repo-check` skill to report a dirty working tree as needing attention. Previously the output template only showed "clean" with no guidance on dirty state.
 
 **Files:** `.claude/skills/repo-check/SKILL.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Small skill template fix — "dirty tree needs attention" rule is still in the skill.

--- a/docs/pr-review/pr-0334.md
+++ b/docs/pr-review/pr-0334.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Correct versionName from 2.5.0 to 2.4.1 — the previous bump was applied as a minor release when the content was a patch (bug fix).
 
 **Files:** `AndroidGarage/version.properties`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Corrects #332's wrong-kind-of-bump; version rule (major/minor/patch) is codified now so this class of mistake is easier to avoid.

--- a/docs/pr-review/pr-0335.md
+++ b/docs/pr-review/pr-0335.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Snooze card now shows current notification status ("Door notifications enabled" or "Door notifications snoozed until X"). Action feedback (Saving/Saved/Error) moved to under the button (right side) to tie feedback to the action. Add NotSnoozing preview for screenshot tests. 10 new Compose UI tests covering all SnoozeState + SnoozeAction combinations.
 
 **Files:** `AndroidGarage/android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/ComponentsScreenshotTest.kt`, `androidApp/src/androidTest/java/com/chriscartland/garage/ui/SnoozeNotificationCardTest.kt` (new), `androidApp/src/main/java/com/chriscartland/garage/ui/SnoozeNotificationCard.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Polish UI change with real Compose test coverage (10 tests across all SnoozeState+SnoozeAction combinations) — exactly the right test shape for a small UI change.

--- a/docs/pr-review/pr-0336.md
+++ b/docs/pr-review/pr-0336.md
@@ -12,3 +12,13 @@ phase1_reviewed: 2026-04-20
 **Notes:** Later removed in PR #337 which clarified that whatsnew keeps only major versions.
 
 **Files:** `AndroidGarage/distribution/whatsnew/whatsnew-en-US`.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Added a patch-level entry to the public whatsnew; policy now is "whatsnew keeps only major versions" (#337). No harm done; just the wrong audience for the content.
+
+**Superseded by:** #337

--- a/docs/pr-review/pr-0337.md
+++ b/docs/pr-review/pr-0337.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Create `AndroidGarage/CHANGELOG.md` for internal release history with detailed notes per version. Remove 2.4.1 entry from `distribution/whatsnew/whatsnew-en-US` since Play Store public text keeps only major versions.
 
 **Files:** `AndroidGarage/CHANGELOG.md` (new), `AndroidGarage/distribution/whatsnew/whatsnew-en-US`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Separating internal `CHANGELOG.md` from public `whatsnew-en-US` is the right two-audience model — both files still live and the rule "whatsnew keeps only major versions" is enforced by the versioning docs.
+
+**Still-current lesson:** Keep two changelogs: an internal one that records every version, and a public one that records only minor/major. Mixing them forces choices that serve neither audience.

--- a/docs/pr-review/pr-0338.md
+++ b/docs/pr-review/pr-0338.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Update screenshot references for the snooze notification card with new status text ("Door notifications enabled" / "Door notifications snoozed until X") and action feedback moved to appear under the button. Adds NotSnoozing preview variant (2 new screenshots). 16 updated PNGs + 2 new PNGs. Also includes a small `SnoozeNotificationCard.kt` tweak.
 
 **Files:** `AndroidGarage/android-screenshot-tests/SCREENSHOT_GALLERY.md`, 18 screenshot PNGs under `android-screenshot-tests/src/screenshotTestDebug/reference/`, `AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/SnoozeNotificationCard.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Screenshot reference update — routine; references still accurate.

--- a/docs/pr-review/pr-0339.md
+++ b/docs/pr-review/pr-0339.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add 2.4.2 entry to `AndroidGarage/CHANGELOG.md` (snooze card status text + alignment) and bump `versionName` from 2.4.1 to 2.4.2.
 
 **Files:** `AndroidGarage/CHANGELOG.md`, `AndroidGarage/version.properties`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Mechanical changelog + version bump.

--- a/docs/pr-review/pr-0340.md
+++ b/docs/pr-review/pr-0340.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add two `.claude/skills/` entries: `/update-android-changelog` (adds a changelog entry for the current version based on recent commits) and `/bump-android-version` (increments versionName, default patch, supports minor and major). Typical workflow: `/update-android-changelog` → `/release-android` → `/bump-android-version`.
 
 **Files:** `.claude/skills/bump-android-version/SKILL.md`, `.claude/skills/update-android-changelog/SKILL.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Both skills still in the toolkit and used in the release workflow.

--- a/docs/pr-review/pr-0341.md
+++ b/docs/pr-review/pr-0341.md
@@ -12,3 +12,15 @@ phase1_reviewed: 2026-04-20
 **Notes:** The ViewModel-init fetch approach here was later replaced in #344 by moving the init fetch to the repository's `externalScope` to avoid VM cancellation stranding the state.
 
 **Files:** `AndroidGarage/usecase/.../RemoteButtonViewModel.kt`, `RemoteButtonViewModelTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** [ok]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** The diagnosis was right (no init fetch → stuck Loading) but the VM-init fetch was the wrong scope — #344 moved it to the repo's externalScope so VM cancellation can't strand the state write.
+
+**Superseded by:** #344
+
+**Still-current lesson:** "Fetch in ViewModel init" is a smell for any state that lives on a singleton repo — first writes should come from a scope tied to the repo (externalScope), not a scope that dies with the first screen.

--- a/docs/pr-review/pr-0342.md
+++ b/docs/pr-review/pr-0342.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Server-side fix. `shouldSendFcmForOpenDoor()` bypassed the 15-minute minimum open-door threshold when snooze status was `EXPIRED`, sending notifications like "Open for more than 0 minutes" when a user cleared snooze ("Do not snooze" = 0h, which sets `snoozeEndTime = now` → immediately `EXPIRED`). Now `EXPIRED` falls through to the same duration check as `NONE`. 3 new tests for notification body duration strings (0min, 20min, 90min).
 
 **Files:** `FirebaseServer/src/controller/fcm/OldDataFCM.ts`, `test/controller/fcm/OldDataFCMTest.ts`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Real server-side bug; fix is a single-line fallthrough with regression tests covering the three duration strings. Still correct behavior.

--- a/docs/pr-review/pr-0343.md
+++ b/docs/pr-review/pr-0343.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Update the existing 2.4.2 changelog entry to include PR #341's user-facing effect (snooze status loads immediately instead of showing Loading until the first 60s poll). Per the update-android-changelog skill rule, update existing version entry rather than creating a new version.
 
 **Files:** `AndroidGarage/CHANGELOG.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Correct application of the "update existing version entry, don't create a new one" changelog rule.

--- a/docs/pr-review/pr-0344.md
+++ b/docs/pr-review/pr-0344.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Fix android/164 snooze card stuck on "Door notifications" (Loading state) forever, even when the network call succeeds. Root cause: `DefaultRemoteButtonViewModel.init` launched `fetchSnoozeStatus()` on `viewModelScope`. If the VM was cancelled between the network call returning and the `snoozeStateFlow.value = ...` write, Ktor rethrows `CancellationException`, the `when(result)` branch is skipped, and the singleton `MutableStateFlow` stays at `Loading` for the rest of the process — every future VM observes the stuck flow. Fix: mirror the `FirebaseAuthRepository` ADR-018 pattern. `NetworkSnoozeRepository` takes an `externalScope` and drives the first fetch from its own `init` block. Subsequent user-triggered fetches stay on `viewModelScope` (benign cancellation because singleton is already populated). Two new test suites: `NetworkSnoozeRepositoryTest` (5 tests) and `SnoozeStateFlowPropagationTest` (6 tests).
 
 **Files:** `AndroidGarage/data/.../NetworkSnoozeRepository.kt`, `NetworkSnoozeRepositoryTest.kt` (new), `usecase/.../RemoteButtonViewModel.kt`, `RemoteButtonViewModelTest.kt`, `SnoozeStateFlowPropagationTest.kt` (new), `AppComponent.kt`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** First concrete application of the "first-fetch on externalScope from repo init" pattern (ADR-018 shape extended to snooze) — stopped the stuck-Loading class of bug at the root.
+
+**Still-current lesson:** If a singleton `MutableStateFlow` can reach a Loading/initial state that persists for the process lifetime, the first write must be driven from a scope that can't be cancelled by the caller — usually `externalScope.launch {}` in the repo's `init` block.

--- a/docs/pr-review/pr-0345.md
+++ b/docs/pr-review/pr-0345.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Replace bare `mutex.lock()` / `mutex.unlock()` pair in `CachedServerConfigRepository.getServerConfigCached()` with `withLock { ... }`. If `fetchServerConfig()` ever throws (transient network error, cancellation, serialization bug), the `unlock()` is skipped and the mutex stays locked for the process lifetime — every subsequent caller blocks forever. `withLock` releases on all exit paths including exceptions and cancellation. Latent bug surfaced during the snooze "stuck Loading" investigation (#344 fixes the user-visible symptom; this removes a related permanent-hang risk). Regression test: `mutexReleasedAfterFetchThrowsSoSubsequentCallsDoNotDeadlock`.
 
 **Files:** `AndroidGarage/data/.../CachedServerConfigRepository.kt`, `CachedServerConfigRepositoryTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Bare `mutex.lock()`/`unlock()` is a permanent-hang risk on any exception; `withLock` is the only correct idiom. Rule captured in memory and worth applying everywhere.
+
+**Still-current lesson:** Never write `mutex.lock()`/`unlock()` as a bare pair — a throw between them strands the lock for the process lifetime. `withLock { ... }` is not a style preference, it's a correctness requirement.

--- a/docs/pr-review/pr-0346.md
+++ b/docs/pr-review/pr-0346.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Follow-up to #344 — after the Loading fix landed, users reported the card title stays at "enabled" after saving a snooze (kill+reopen shows correct state; snooze persists server-side but in-session UI doesn't update). Root cause: same cancellation pattern as #344 at two call sites — `RemoteButtonViewModel.snoozeOpenDoorsNotifications` calls `fetchSnoozeStatusUseCase()` on `viewModelScope` after POST, and `ProfileContent`'s 60s polling `LaunchedEffect` fires `fetchSnoozeStatus` on `viewModelScope`. If either is cancelled after the network call returns but before the state write, Ktor rethrows `CancellationException` and the state write is skipped. Fix: `NetworkSnoozeRepository` owns all side effects — `externalScope.launch{}.join()` for fetch, `externalScope.async{}.await()` for submit with follow-up fetch on `externalScope`. No optimistic updates.
 
 **Files:** `AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkSnoozeRepository.kt`, `NetworkSnoozeRepositoryTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Generalized #344's externalScope pattern across both fetch and submit paths (including the 60s polling effect) — the source of ADR-019's Rule 1. Still the canonical shape for repository side effects.

--- a/docs/pr-review/pr-0347.md
+++ b/docs/pr-review/pr-0347.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Patch bump 2.4.2 → 2.4.3 covering the snooze fixes landing in #344 (stuck-Loading), #345 (mutex-withLock), #346 (post-submit state refresh).
 
 **Files:** `AndroidGarage/version.properties`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Version bump — mechanical.

--- a/docs/pr-review/pr-0348.md
+++ b/docs/pr-review/pr-0348.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add changelog entry for Android version 2.4.3, covering the snooze state refresh fix (#346).
 
 **Files:** `AndroidGarage/CHANGELOG.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Changelog bookkeeping — served its purpose.

--- a/docs/pr-review/pr-0349.md
+++ b/docs/pr-review/pr-0349.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** The server's `POST /snoozeNotificationsRequest` endpoint returns the `SnoozeRequest` in its response body — authoritative `snoozeEndTimeSeconds` is already in the client's hands the moment the POST succeeds. Previous design threw it away and relied on a follow-up GET, which wasn't reliable in production. `NetworkButtonDataSource.snoozeNotifications` return type `NetworkResult<Unit>` → `NetworkResult<Long>`. `NetworkSnoozeRepository` writes `snoozeStateFromEndTime(result.data)` to the flow immediately on success, no follow-up GET. `RemoteButtonViewModel` drops the redundant `fetchSnoozeStatusUseCase()` call after submit. Not optimistic — real server data from the POST response.
 
 **Files:** `AndroidGarage/data/.../NetworkButtonDataSource.kt`, `KtorNetworkButtonDataSource.kt`, `NetworkSnoozeRepository.kt`, `NetworkSnoozeRepositoryTest.kt`, `test-common/.../FakeNetworkButtonDataSource.kt`, `usecase/.../RemoteButtonViewModel.kt`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** "Use the POST response body, don't do a follow-up GET" is the ADR-019 Rule 2 pattern — simpler, faster, impossible to race, and still followed everywhere.
+
+**Still-current lesson:** If a server POST returns the new state in its response body, *use* it — a follow-up GET to read the same data is both slower and a race window. Shape the data source return type to carry the authoritative value.

--- a/docs/pr-review/pr-0350.md
+++ b/docs/pr-review/pr-0350.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Inline TODO comments at `SnoozeRepository.snoozeNotifications` capturing two future refinements from the snooze bug hunt. (1) Return type `Boolean` → `AppResult<Unit, ActionError>` so `NotAuthenticated`/`MissingData`/`NetworkFailed` discrimination is carried end-to-end rather than collapsed then reconstructed by the UseCase. (2) Stringly-typed `snoozeDurationHours: String` → a domain value type (sealed enum) so invalid inputs can't pass the type system. Documentation-only.
 
 **Files:** `AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/SnoozeRepository.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** TODO markers for two refinements — partially satisfied by #354's `AppResult` return type. Inline-TODO-as-design-artifact is low-stakes and still visible in code.

--- a/docs/pr-review/pr-0351.md
+++ b/docs/pr-review/pr-0351.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Capture architectural pattern from the snooze bug hunt (PRs #344-#349) as ADR-019 with two rules. Rule 1: side-effecting repository calls run on `externalScope` (applicationScope); callers `.join()`/`.await()` but caller cancellation doesn't strand state writes. Rule 2: update state from authoritative server POST response body, not a follow-up GET. No client-side optimistic writes. Updates `TESTING.md` test counts for 15 new tests added in this session (`NetworkSnoozeRepositoryTest` x9, `SnoozeStateFlowPropagationTest` x6).
 
 **Files:** `AndroidGarage/docs/DECISIONS.md`, `AndroidGarage/docs/TESTING.md`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** ADR-019 is foundational — "side effects on externalScope, state from server response body" is the rule every repository follows now and the cause of most pre-#344 stuck-state bugs being impossible.
+
+**Still-current lesson:** Any repository call that writes shared state must run on `externalScope`, not `viewModelScope` — caller cancellation is the default failure mode, and "it works in tests" hides it until release.

--- a/docs/pr-review/pr-0352.md
+++ b/docs/pr-review/pr-0352.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Three layers of defense against the android/167 release-only snooze propagation bug after unit, JVM integration, and emulator tests all passed but production still failed (pointing to R8 stripping). (1) Comprehensive `proguard-rules.pro` — explicit keeps for `$Companion`/`$$serializer` on every `@Serializable` class, `data.ktor.**` data classes, annotations. (2) Raw-body diagnostic log in `KtorNetworkButtonDataSource` — POST body read as text, logged verbatim alongside parsed `endTime`, then re-parsed with a local `Json { ignoreUnknownKeys; isLenient }`. (3) Two new regression tests wiring real repo + VM: `RealNetworkSnoozeRepositoryPropagationTest` (JVM) and `SnoozeStateInstrumentedPropagationTest` (Compose).
 
 **Files:** `AndroidGarage/androidApp/proguard-rules.pro`, `build.gradle.kts`, `SnoozeStateInstrumentedPropagationTest.kt` (new), `data/.../KtorNetworkButtonDataSource.kt`, `usecase/build.gradle.kts`, `RealNetworkSnoozeRepositoryPropagationTest.kt` (new).
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Three independent layers of defense shipped together (keep rules + raw-body log + regression tests) — canonical example of how to fix an invisible release-only bug.
+
+**Still-current lesson:** When unit, JVM-integration, and emulator tests all pass but production still fails → suspect R8. Three required responses: explicit keeps for `$Companion`/`$$serializer`, raw-body log at the decode site, instrumented propagation test.

--- a/docs/pr-review/pr-0353.md
+++ b/docs/pr-review/pr-0353.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Capture architectural lesson from the android/167 snooze-state bug investigation as ADR-020 with two rules. Rule 1: `proguard-rules.pro` keeps `kotlinx.serialization` infrastructure + all `data.ktor.**` response classes (file was empty before, relying on library consumer rules; R8 stripped stdlib classes like `kotlin.LazyKt`). Rule 2: raw-body diagnostic logging at network-data-source boundaries that produce state-critical data — release-only failures become a greppable `adb logcat` line. Updates `TESTING.md` test counts for the two new propagation tests from PR #352.
 
 **Files:** `AndroidGarage/docs/DECISIONS.md`, `AndroidGarage/docs/TESTING.md`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** ADR-020 still load-bearing — keep rules for kotlinx.serialization + `data.ktor.**` + raw-body logging at state-critical decodes are now non-negotiable, and #352 is the code that embodies them.
+
+**Still-current lesson:** Raw-body logs at network-data-source boundaries for state-critical decodes turn release-only R8 failures from silent-wrong into a single `adb logcat` line — add them *before* any suspected R8 bug, not after.


### PR DESCRIPTION
## Summary
Phase 2 session 2 — classified 30 PRs (#353 down through #324).

Category breakdown:
- **great** (12): #353, #352, #351, #349, #346, #345, #344, #337, #331, #330, #328, #324
- **ok** (15): #350, #348, #347, #343, #342, #340, #339, #338, #335, #334, #333, #329, #327, #326, #325
- **superseded** (3): #341 (→ #344), #336 (→ #337), #332 (→ #334)

No **buggy**, **outdated-guidance**, or **abandoned** in this batch.

Key still-current lessons captured:
- Raw-body logs at state-critical decode boundaries turn release-only R8 failures into a greppable logcat line
- Three-layer defense for invisible release-only bugs (keep rules + raw-body log + regression test)
- Side-effecting repository calls run on `externalScope`, never `viewModelScope`
- Use POST response body for authoritative state; don't follow up with a GET
- `mutex.withLock { ... }` is a correctness requirement, not a style preference
- Separate internal CHANGELOG from public whatsnew (two audiences)
- Auth is a stream — subscribe to platform `AuthStateListener`, don't poll imperatively
- Instrumented tests covering full `MutableStateFlow → collectAsState → recomposition` chain for state-critical UI
- `--base main` always for stacked PRs (CI only triggers on protected branches)
- Pin wire-format contracts (e.g., button ack token) in explicit contract tests

## Test plan
- [ ] Docs-only change — fast-path CI skip applies
- [ ] Phase 2 queue shrinks by 30 more