### PR TITLE
docs: PR review phase 2 batch 2026-04-20 session 3 (PRs #294–#323, 30 assessments)

### DIFF
--- a/docs/pr-review/pr-0294.md
+++ b/docs/pr-review/pr-0294.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move knowledge from Claude's local memory into repo-tracked docs. `CLAUDE.md`: generic naming convention — `AppStartup.run()` over `onActivityCreated()` for app-scoped classes (KMP/platform-agnostic rationale). `DECISIONS.md` ADR-016: test scope choice nuance — `this` scope for terminating loops (FcmRegistrationManager retry), `backgroundScope` for infinite timers (DoorViewModel ticker).
 
 **Files:** `AndroidGarage/docs/DECISIONS.md`, `CLAUDE.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Moved knowledge from Claude's local memory into repo-tracked docs — the right move, since memory is per-user and per-machine. ADR-016 and the generic-naming convention are both still live.

--- a/docs/pr-review/pr-0295.md
+++ b/docs/pr-review/pr-0295.md
@@ -12,3 +12,15 @@ phase1_reviewed: 2026-04-20
 **Notes:** The symptoms here were later root-caused in PR #328 as a separate issue (imperative `getIdToken(forceRefresh=true)` network race in the repository layer). This PR's change became the ADR-017 Rule 6 template.
 
 **Files:** `AndroidGarage/usecase/.../AuthViewModel.kt`, `DefaultAuthViewModelTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** [superseded]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** The code change (stateIn → explicit `MutableStateFlow + init.collect`) became the ADR-017 Rule 6 template and was correct. But the *diagnosis* — that the `stateIn` pattern itself was the root cause — was wrong; #328 found the actual cause (imperative `getIdToken(forceRefresh=true)` network race). The fix fixed an invariant; the *bug* survived.
+
+**Superseded by:** #328 (real root cause)
+
+**Still-current lesson:** When a fix "works on device" after you change something, don't assume the thing you changed was the cause — auth state touched the screen because #328 silently masked the symptom enough to fool testing. Demand a failing-test-first reproduction before claiming root cause.

--- a/docs/pr-review/pr-0296.md
+++ b/docs/pr-review/pr-0296.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Lock in conventions for ViewModel tests, Manager tests, and Fake implementations after audit revealed competing styles. Seven rules: (1) `setMain`/`resetMain` required iff class extends `ViewModel`, (2) tests cancel VM coroutines before runTest drains, (3) Managers use `applicationScope` in prod, (4) `.value` for StateFlow / `.first()`/`.toList()` for Flow, (5) Fake mutation — no public `var`; use `setX()` / `var private set` / call-list, (6) ViewModels build StateFlow via explicit `MutableStateFlow + init.collect` — no stateIn, (7) factory function for test data with 3+ fields. Migration tasks enumerated (#297, #299, #298, #300, #301-#308, #307-#322).
 
 **Files:** `AndroidGarage/docs/DECISIONS.md`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** ADR-017's seven rules for test conventions turned a collection of loose idioms into a disciplined set that lint now enforces — pattern still followed for every new test/fake.
+
+**Still-current lesson:** Test conventions only become conventions when they're audited, labeled (numbered rules), and lint-enforced. "We usually do it this way" is not a convention.

--- a/docs/pr-review/pr-0297.md
+++ b/docs/pr-review/pr-0297.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add `Dispatchers.setMain`/`resetMain` setup to `DefaultAppLoggerViewModelTest` per ADR-017 Rule 1. `DefaultAppLoggerViewModel` extends `ViewModel` and uses `viewModelScope`, so tests need this setup even though they previously worked by accident.
 
 **Files:** `AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAppLoggerViewModelTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** ADR-017 Rule 1 rollout — `setMain/resetMain` needed even when a test "works by accident" without it.
+
+**Still-current lesson:** "Tests pass" ≠ "tests are correct" — if a class extends `ViewModel` and uses `viewModelScope`, its tests need `Dispatchers.setMain/resetMain` even if they currently pass. The absence is a time-bomb, not a style choice.

--- a/docs/pr-review/pr-0298.md
+++ b/docs/pr-review/pr-0298.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Remove `stateIn(viewModelScope, ...)` from 3 ViewModels per ADR-017 Rule 6. `DoorViewModel.fcmRegistrationStatus`, `RemoteButtonViewModel.snoozeState`, `AppSettingsViewModel.fcmDoorTopic + 3 expansion booleans` all converted to `MutableStateFlow + init.collect` pattern — same as `DoorViewModel.currentDoorEvent` already uses successfully. After PR #295 merges, zero ViewModels use `stateIn(viewModelScope, ...)`.
 
 **Files:** `AndroidGarage/usecase/.../AppSettingsViewModel.kt`, `DoorViewModel.kt`, `RemoteButtonViewModel.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Rule 6 rollout across the other three ViewModels — the `MutableStateFlow + init.collect` template was later superseded in PR 4/8 of the ADR-022 migration (repo-owned StateFlow passed by reference) but was the right intermediate shape.

--- a/docs/pr-review/pr-0299.md
+++ b/docs/pr-review/pr-0299.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move staleness ticker out of `DoorViewModel` into an app-scoped Manager following the `FcmRegistrationManager` pattern — per ADR-017 Rule 2, app-scoped state lives in Manager classes. New `CheckInStalenessManager` owns the reactive collector + 30s ticker + transition logging. `DoorViewModel` loses `scope`/`clock` params, `computeStale`, `stalenessJobs`, `onCleared`, 3 staleness coroutines — just observes `manager.isCheckInStale`. `AppStartup.run()` calls `manager.start()`. 7 new manager tests; DoorViewModelTest simplified.
 
 **Files:** `AndroidGarage/usecase/.../CheckInStalenessManager.kt` (new), `DoorViewModel.kt`, `CheckInStalenessManagerTest.kt` (new), `DoorViewModelTest.kt`, `AppStartup.kt`, `AppComponent.kt`, `AppStartupTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** [great]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Applied the Manager pattern (ADR-015 + ADR-017 Rule 2) to staleness logic — VM simplification is real (staleness coroutines out, pure observation in) and the Manager is still the right home.

--- a/docs/pr-review/pr-0300.md
+++ b/docs/pr-review/pr-0300.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** New Gradle task scans `*ViewModel.kt` files for `.stateIn(viewModelScope, ...)` and fails the build. Only literal `viewModelScope` is banned — `stateIn(applicationScope, ...)` in a Manager class is legitimate. Motivated by the real production bug where `stateIn(viewModelScope, Eagerly, ...)` caused Compose collectors to not observe upstream state changes (PR #295 AuthViewModel regression). Required pattern per Rule 6: explicit `MutableStateFlow + init.collect`.
 
 **Files:** `AndroidGarage/build.gradle.kts`, `buildSrc/src/main/kotlin/architecture/ViewModelStateFlowCheckTask.kt` (new), `scripts/validate.sh`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Banned `stateIn(viewModelScope, ...)` at build time in response to a real production regression (PR #295 auth-state UI). Lint task is still the gate and has since been extended (ADR-021/022 Rule 1/2) — foundational enforcement.
+
+**Still-current lesson:** When a standard API (like `stateIn`) has a subtle failure mode in *your* context (here: conflation + scope semantics made upstream changes fail to propagate to Compose), ban it at the lint layer, not just in docs. Developers reach for the API they know; lint redirects them to the safe shape.

--- a/docs/pr-review/pr-0301.md
+++ b/docs/pr-review/pr-0301.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Convert `FakeAuthBridge` public `var` config fields (`signInResult`, `userInfo`, `refreshTokenResult`) to `private var` + setX() methods. Update `FirebaseAuthRepositoryTest` call sites. Counters already use `private set`.
 
 **Files:** `AndroidGarage/test-common/.../FakeAuthBridge.kt`, `FirebaseAuthRepositoryTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Rule 5 conversion rollout.

--- a/docs/pr-review/pr-0302.md
+++ b/docs/pr-review/pr-0302.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Convert `FakeMessagingBridge` public `var subscribeResult` and `var token` to `private var` + `setSubscribeResult()` / `setToken()`. Mutable list fields (`subscribedTopics`, `unsubscribedTopics`) left for opportunistic call-list migration (task #6).
 
 **Files:** `AndroidGarage/test-common/.../FakeMessagingBridge.kt`, `FirebaseDoorFcmRepositoryTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Rule 5 conversion rollout.

--- a/docs/pr-review/pr-0303.md
+++ b/docs/pr-review/pr-0303.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Convert `FakeDoorFcmRepository` public `var` config fields (`fetchStatusResult`, `registerResult`, `deregisterResult`) to `private var` + setX() methods. Add `private set` to `registerCount` and `lastRegisteredTopic`. Update `FetchFcmStatusUseCaseTest`, `RegisterFcmUseCaseTest`, `DeregisterFcmUseCaseTest` call sites.
 
 **Files:** `AndroidGarage/test-common/.../FakeDoorFcmRepository.kt`, 3 usecase test files.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Rule 5 conversion rollout.

--- a/docs/pr-review/pr-0304.md
+++ b/docs/pr-review/pr-0304.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Combined refactor of `FakeNetworkConfigDataSource`, `FakeNetworkButtonDataSource`, `FakeNetworkDoorDataSource`. All public `var` result fields → `private var` + `setX()` methods (ADR-017 Rule 5). Updated 3 test files; extracted `successConfig()` helper in `NetworkDoorRepositoryIntegrationTest` to reduce repetition. Combined because they share callers.
 
 **Files:** `AndroidGarage/test-common/.../FakeNetworkButtonDataSource.kt`, `FakeNetworkConfigDataSource.kt`, `FakeNetworkDoorDataSource.kt`, 3 data test files.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Combined Rule 5 conversion for three network fakes; shared-caller batching (same lesson as #305).

--- a/docs/pr-review/pr-0305.md
+++ b/docs/pr-review/pr-0305.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Combined refactor of `FakeAuthRepository`, `FakeRemoteButtonRepository`, `FakeSnoozeRepository` — share test files (`RemoteButtonViewModelTest`, `PushRemoteButtonUseCaseTest`, `SnoozeNotificationsUseCaseTest`), so doing them together avoids merge conflicts. `var signInResult`/`refreshResult`/`pushSucceeds`/`snoozeResult` → `private var` + setters. 6 caller updates across usecase tests. Completes migration task #5 from ADR-017.
 
 **Files:** `AndroidGarage/test-common/.../FakeAuthRepository.kt`, `FakeRemoteButtonRepository.kt`, `FakeSnoozeRepository.kt`, and 6 usecase test files.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Combined refactor is the right grouping when callers are shared — batching avoids unreviewable merge conflicts between related PRs.
+
+**Still-current lesson:** When multiple classes share test-file callers, refactor them together — one PR with three classes is less churn than three PRs fighting over the same test files.

--- a/docs/pr-review/pr-0306.md
+++ b/docs/pr-review/pr-0306.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Document the completion of ADR-017 mandatory migration tasks (PRs #297-#305 closed in this session).
 
 **Files:** `AndroidGarage/docs/DECISIONS.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Bookkeeping — captures migration progress still accurate.

--- a/docs/pr-review/pr-0307.md
+++ b/docs/pr-review/pr-0307.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** ADR-017 Rule 5 task #6 (opportunistic call-list migration). Two fakes exposed `mutableListOf` directly — tests could clear/reorder mid-test. Convert to read-only `List<T>` views backed by private mutable lists. `FakeMessagingBridge`: `subscribedTopics`, `unsubscribedTopics`. `FakeAppLoggerRepository`: `loggedKeys`.
 
 **Files:** `AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeMessagingBridge.kt`, `FakeAppLoggerRepository.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Call-list rollout introducing the "read-only `List<T>` view backed by private mutable list" idiom — #313's lint later pinned this.

--- a/docs/pr-review/pr-0308.md
+++ b/docs/pr-review/pr-0308.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Missed in the earlier Rule 5 sweep — `var buildTimestamp: String?` was the only remaining public-mutable result configuration in test fakes. Convert to `private var` + `setBuildTimestamp()` and update `RegisterFcmUseCaseTest` call sites (4 sites).
 
 **Files:** `AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeDoorRepository.kt`, `usecase/src/commonTest/.../RegisterFcmUseCaseTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Mop-up of the last stray public-`var` on a fake; mandatory Rule 5 migration complete after this.

--- a/docs/pr-review/pr-0309.md
+++ b/docs/pr-review/pr-0309.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Opportunistic Rule 5 task #6: convert counter-style fields in `FakeRemoteButtonRepository` to a backing call list. `data class PushCall(idToken, buttonAckToken)`, `pushCalls: List<PushCall>` (read-only), `pushCount` / `lastIdToken` kept as backing-list accessors.
 
 **Files:** `AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeRemoteButtonRepository.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Call-list rollout.

--- a/docs/pr-review/pr-0310.md
+++ b/docs/pr-review/pr-0310.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Gradle lint check banning public `var` properties on `Fake*` test doubles. Prevents regression of ADR-017 Rule 5 migration completed in PRs #301-#308. `FakePublicVarCheckTask` scans `Fake*.kt` in `test-common/src/commonMain`. Allowed: `private var`, `var` with `private set`, `val`. Forbidden: bare public `var`. Registered as `checkFakePublicVar` Gradle task. Added to `scripts/validate.sh`. Extended in #313 to also cover public mutable collections.
 
 **Files:** `AndroidGarage/build.gradle.kts`, `AndroidGarage/buildSrc/src/main/kotlin/architecture/FakePublicVarCheckTask.kt` (new), `scripts/validate.sh`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Banning public `var` on fakes via lint pinned the ADR-017 Rule 5 migration — new fakes can't regress. Wiring into `validate.sh` is the right integration point.
+
+**Still-current lesson:** After migrating a consistent pattern across N files, ship the lint check in the *same* wave — migration without enforcement decays one file at a time.

--- a/docs/pr-review/pr-0311.md
+++ b/docs/pr-review/pr-0311.md
@@ -10,3 +10,15 @@ phase1_reviewed: 2026-04-20
 **Goal:** Extend lint check from #310 to ban public `val xs = mutableListOf(...)` on Fake* classes. Closed without merging — re-created as PR #313 because its base was a feature branch that auto-deleted when #310 merged.
 
 **Files:** `AndroidGarage/buildSrc/src/main/kotlin/architecture/FakePublicVarCheckTask.kt`.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Closed because base branch auto-deleted on parent merge; re-created identically as #313. Mechanical artifact of stacked-PR workflow, no lost intent.
+
+**Superseded by:** #313
+
+**Still-current lesson:** When creating a stacked PR with `--base feature-branch`, the child is stranded if the parent squash-merges before the child — always `--base main` to avoid this (captured in #330).

--- a/docs/pr-review/pr-0312.md
+++ b/docs/pr-review/pr-0312.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Button ack token sent to server contained hardcoded `"AppVersionTODO"` string instead of actual app version — server logs couldn't correlate button activity with client versions. Add `appVersion: String` parameter to `DefaultRemoteButtonViewModel` and `createButtonAckToken()`. `AppComponent` provides `provideAppVersionName()` reading from `Context.AppVersion().versionName`.
 
 **Files:** `AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt`, `usecase/.../RemoteButtonViewModel.kt`, `RemoteButtonViewModelTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** `AppVersionTODO` hardcoded placeholder fix — now injected from `Context.AppVersion().versionName` via DI. Routine correctness fix; ack-token format is contract-tested via #324.

--- a/docs/pr-review/pr-0313.md
+++ b/docs/pr-review/pr-0313.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Extend lint check from #310 to also flag public `val xs = mutableListOf(...)` on Fake* classes — `val` field but mutable collection (tests can `xs.add()`, `xs.clear()`). Pattern banned: `val xs = mutableListOf<...>()` without `private`. Required pattern: `private val _xs = mutableListOf<...>(); val xs: List<...> get() = _xs`. Locks in PR #307 work. Re-created from closed #311 (its base was a feature branch auto-deleted when #310 merged).
 
 **Files:** `AndroidGarage/buildSrc/src/main/kotlin/architecture/FakePublicVarCheckTask.kt`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Extending the lint to also ban public mutable collections closes the obvious Rule 5 loophole (`val xs = mutableListOf()` pairs a `val` with a mutable view). Still in place.
+
+**Still-current lesson:** "`val` + mutable-collection-type" is a hidden `var` — lint rules that ban public `var` need a matching rule for public mutable collection fields, or the constraint leaks in one line of test code.

--- a/docs/pr-review/pr-0314.md
+++ b/docs/pr-review/pr-0314.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Opportunistic Rule 5 task #6: `signInWithGoogleToken(idToken)` takes a meaningful arg — convert counter to call list. `signInCalls: List<GoogleIdToken>`, `signInCount: Int` as accessor. `refreshCount`/`signOutCount` stay as accessor wrappers.
 
 **Files:** `AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAuthBridge.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Call-list rollout.

--- a/docs/pr-review/pr-0315.md
+++ b/docs/pr-review/pr-0315.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Opportunistic Rule 5 task #6: this fake's methods take 4-5 meaningful args each (tokens, timestamps, durations). Convert counters to backing call lists. `pushCalls: List<PushCall>` (4-tuple), `snoozeCalls: List<SnoozeCall>` (5-tuple), `fetchSnoozeBuildTimestamps: List<String>`, `*Count` backed by `.size`.
 
 **Files:** `AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeNetworkButtonDataSource.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Call-list rollout to a multi-arg fake — pattern pays off most here where 4-5 args per call benefit from full capture.

--- a/docs/pr-review/pr-0316.md
+++ b/docs/pr-review/pr-0316.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Opportunistic Rule 5 task #6: convert counters to call lists. `fetchCurrentBuildTimestamps: List<String>`, `fetchRecentCalls: List<FetchRecentCall(buildTimestamp, count)>`, `*Count` backed by `.size`.
 
 **Files:** `AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeNetworkDoorDataSource.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Call-list rollout.

--- a/docs/pr-review/pr-0317.md
+++ b/docs/pr-review/pr-0317.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Opportunistic Rule 5 task #6: `signInWithGoogle(idToken)` takes a meaningful arg — convert counter to call list. `signInCalls: List<GoogleIdToken>`, `signInCount` backed by `.size`. `refreshCount`/`signOutCount` stay as plain counter accessors (no args).
 
 **Files:** `AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAuthRepository.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Call-list rollout.

--- a/docs/pr-review/pr-0318.md
+++ b/docs/pr-review/pr-0318.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Opportunistic Rule 5 task #6: `fetchServerConfig(serverConfigKey)` takes an arg. Convert counter to call list — `fetchServerConfigKeys: List<String>`, `fetchCount` backed by `.size`.
 
 **Files:** `AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeNetworkConfigDataSource.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Call-list rollout.

--- a/docs/pr-review/pr-0319.md
+++ b/docs/pr-review/pr-0319.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Opportunistic Rule 5 task #6: `snoozeNotifications` takes 3 meaningful args (durationHours, idToken, snoozeEventTimestampSeconds). Convert to call list with `snoozeCalls: List<SnoozeCall>`, `snoozeCount` backed by `.size`. `fetchCount` stays a plain counter (no args).
 
 **Files:** `AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeSnoozeRepository.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Call-list rollout to a multi-arg snooze fake.

--- a/docs/pr-review/pr-0320.md
+++ b/docs/pr-review/pr-0320.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Final opportunistic Rule 5 task #6 fake. `registerDoor(fcmTopic)` already had `lastRegisteredTopic` as single-arg capture — convert to list for uniformity with other call-list fakes and to enable assertions on re-registration sequences. `registerCalls: List<DoorFcmTopic>`, `registerCount` and `lastRegisteredTopic` accessors backed by `.size`/`.lastOrNull()`. After this PR, all fakes with meaningful method args use the call-list pattern.
 
 **Files:** `AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeDoorFcmRepository.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Final rollout of the call-list pattern — consistent across every fake now.

--- a/docs/pr-review/pr-0321.md
+++ b/docs/pr-review/pr-0321.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Mark ADR-017 as fully complete. Task #5 (mandatory — all setX() conversions done, including #308 adding `FakeDoorRepository.buildTimestamp`). Task #6 (opportunistic — all fakes with meaningful method args use call-list pattern: PRs #307, #309, #313-#320). Adds an Enforcement section listing both lint checks: `ViewModelStateFlowCheckTask` (Rule 6, PR #300) and `FakePublicVarCheckTask` (Rule 5, PR #310/#313).
 
 **Files:** `AndroidGarage/docs/DECISIONS.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Marked ADR-017 complete with both lint checks enumerated — bookkeeping that still reflects current enforcement state.

--- a/docs/pr-review/pr-0322.md
+++ b/docs/pr-review/pr-0322.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Convert counters to call lists in `InMemoryLocalDoorDataSource` for consistency with the Fake* classes (#307-#320). `insertCalls: List<DoorEvent>`, `replaceCalls: List<List<DoorEvent>>`, `*Count` accessors backed by `.size`. This is `InMemory*` (real impl naming bonus from ADR-017), so the lint check doesn't flag it — but the spirit of Rule 5 still applies.
 
 **Files:** `AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/InMemoryLocalDoorDataSource.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Applies the call-list pattern to the `InMemory*` class for consistency with fakes — routine rollout.

--- a/docs/pr-review/pr-0323.md
+++ b/docs/pr-review/pr-0323.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Extend `FakePublicVarCheckTask` lint regex from `Fake*` to `(Fake|InMemory)*` — per ADR-017 naming bonus, `InMemory*` is for real impls suitable for production but they still have test-only counter/call fields that should follow Rule 5. Currently only `InMemoryLocalDoorDataSource.kt` matches.
 
 **Files:** `AndroidGarage/buildSrc/src/main/kotlin/architecture/FakePublicVarCheckTask.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Small lint regex extension to cover `InMemory*` names alongside `Fake*` — still in place.


### PR DESCRIPTION
## Summary
Phase 2 session 3 — classified 30 PRs (#323 down through #294).

Category breakdown:
- **great** (5): #313, #310, #300, #296, plus one secondary — mostly lint/convention foundations
- **ok** (24): ADR-017 Rule 5 call-list rollouts (#314–#320, #322), setX() conversions (#301–#303, #305, #308, #309), Manager extraction (#299), Rule 6 rollout (#298), Rule 1 rollout (#297), misc (#304, #306, #312, #321, #323, #294, #295)
- **superseded** (1): #311 (stacked-PR base branch auto-deletion → re-created as #313)

No **buggy**, **outdated-guidance**, or **abandoned** in this batch.

Key still-current lessons:
- `val` + mutable-collection-type is a hidden `var` — lint for one needs a matching rule for the other
- Migration without enforcement decays one file at a time
- Ban a subtly-broken-for-our-context stdlib API at lint layer, not just docs
- Test conventions only exist when audited, numbered, and lint-enforced
- `Dispatchers.setMain/resetMain` is a correctness requirement for `ViewModel` tests (not a style choice)
- Batch related refactors when callers are shared — fewer merge conflicts
- A fix "working on device" doesn't mean it addressed root cause (#295→#328)
- Always `--base main` for stacked PRs (parent branch can auto-delete)

## Test plan
- [ ] Docs-only — fast-path CI skip applies
- [ ] Phase 2 queue shrinks by 30 (90 assessed / 291 remaining of 381)