### PR TITLE
docs: PR review phase 2 batch 2026-04-20 session 4 (PRs #264–#293, 30 assessments)

### DIFF
--- a/docs/pr-review/pr-0264.md
+++ b/docs/pr-review/pr-0264.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add the implementation plan file created after PR #263 merged. Three items: home 67/33 split, button success/failure colors, empty states. Plus a review list for 12 deferred spec sections.
 
 **Files:** `AndroidGarage/docs/design/PLAN-HOME-SPLIT-BUTTON-COLORS-EMPTY-STATES.md` (new).
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Design plan doc checked into the repo — persistent context for follow-up work.

--- a/docs/pr-review/pr-0265.md
+++ b/docs/pr-review/pr-0265.md
@@ -12,3 +12,15 @@ phase1_reviewed: 2026-04-20
 **Notes:** This PushStatus.SENDING dependency caused the PR #276 stuck-in-Sending bug when UseCase fails and never emits SENDING.
 
 **Files:** `AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ButtonStateMachine.kt`, `ButtonStateMachineTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** buggy
+**Secondary:** [superseded]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Fixed a real false-timeout bug but introduced the PR #276 stuck-in-Sending bug by making the timeout dependent on a PushStatus event that might never arrive. Both this fix's mechanism and the whole PushStatus StateFlow were replaced by #282's suspend-return model.
+
+**Fixed by:** #276 (VM reset) then **superseded by** #282 (PushStatus removed entirely)
+
+**Still-current lesson:** Gating a critical timeout on a flow event adds a failure mode every time the event can go missing. Prefer "start timeout on explicit boundary call" over "start timeout when you hear this signal."

--- a/docs/pr-review/pr-0266.md
+++ b/docs/pr-review/pr-0266.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Rename 9 `RemoteButtonState` variants (Arming→Preparing, Armed→AwaitingConfirmation, NotConfirmed→Cancelled, Sending→SendingToServer, Sent→SendingToDoor, Received→Succeeded, SendingTimeout→ServerFailed, SentTimeout→DoorFailed). New `GarageDoorButton` — standard M3 button with idle/confirm/status layouts. New `NetworkProgressDiagram` — 3-node (📱→☁️→🏠) animated diagram. `RemoteButtonState.toNetworkDiagramState()` mapping with 10 tests. Remove old circular gradient button, parallelogram progress bar.
 
 **Files:** `AndroidGarage/androidApp/ui/GarageDoorButton.kt` (new, 206 lines), `NetworkProgressDiagram.kt` (new, 321 lines), `RemoteButtonDiagramMapping.kt` (new), delete `Parallelogram.kt`, `RemoteButtonContent.kt`, `RemoteButtonDiagramMappingTest.kt` (new), many other files + 48 screenshot PNGs.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Button UX redesign (ADR-012) plus renamed state variants (Preparing/AwaitingConfirmation/SendingToServer/SendingToDoor/Succeeded/Server|DoorFailed) that make the state machine legible. Names still in use, button still in use.
+
+**Still-current lesson:** State-machine variant names should describe the user-visible phase, not the internal verb — "SendingToServer" → "SendingToDoor" → "Succeeded" reads like the UX, while "Sent → Received" requires a model to interpret.

--- a/docs/pr-review/pr-0267.md
+++ b/docs/pr-review/pr-0267.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** `ContrastCheck` utility (WCAG 2.1 luminance + contrast ratio calculation). `ThemeContrastTest` tests all M3 + door status color pairs meet 4.5:1 (new colors automatically tested). `HardcodedColorCheckTask` build-time bans `Color(0x...)` outside theme files. Fixed 7 pre-existing contrast violations in dark M3 and door status colors.
 
 **Files:** `AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/theme/Color.kt`, `test/.../ThemeContrastTest.kt` (new), `ContrastCheck.kt` (new), `buildSrc/.../HardcodedColorCheckTask.kt` (new), `build.gradle.kts`, `scripts/validate.sh`, 11 screenshot PNGs.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Two durable wins: unit tests that exercise WCAG contrast for every theme color pair (new colors auto-covered), and a lint that bans raw `Color(0x...)` outside theme files. Both still enforced via `validate.sh`.
+
+**Still-current lesson:** Accessibility invariants (contrast, touch targets) deserve test + lint, not code review. A test that covers "every color pair in the theme" automatically catches new colors you didn't remember to check.

--- a/docs/pr-review/pr-0268.md
+++ b/docs/pr-review/pr-0268.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** `SnoozeState.Loading` is the default before any fetch, not an active loading indicator. Changed to show "Snooze notifications" (same as `NotSnoozing`) instead of "Loading snooze status...". If snooze is active, it updates to "Snoozing until..." when the fetch completes.
 
 **Files:** `AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/SnoozeNotificationCard.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** UI copy — treats `Loading` as the default (not an indicator); made moot by #344's first-fetch-on-externalScope so Loading is transient, but this still rendered the right thing.

--- a/docs/pr-review/pr-0269.md
+++ b/docs/pr-review/pr-0269.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Bump versionName 2.3.1 → 2.4.0 (minor: new features — button UX redesign (ADR-012), network progress diagram, WCAG contrast enforcement, button timeout fix).
 
 **Files:** `AndroidGarage/version.properties`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Version bump; correctly classified as minor per versioning rule later codified in #378.

--- a/docs/pr-review/pr-0270.md
+++ b/docs/pr-review/pr-0270.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Increase `GarageIcon` in history list items from 56dp → 84dp. Cards are ~50% taller, easier to read and tap. Updated screenshot references.
 
 **Files:** `AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorStatusCard.kt`, `android-screenshot-tests/SCREENSHOT_GALLERY.md`, 6 screenshot PNGs.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** UI polish — still in place.

--- a/docs/pr-review/pr-0271.md
+++ b/docs/pr-review/pr-0271.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add whatsnew entry for v2.4: button redesign, network diagram, contrast fixes.
 
 **Files:** `AndroidGarage/distribution/whatsnew/whatsnew-en-US`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Release notes — routine.

--- a/docs/pr-review/pr-0272.md
+++ b/docs/pr-review/pr-0272.md
@@ -12,3 +12,13 @@ phase1_reviewed: 2026-04-20
 **Notes:** Most of these 7 initial collections were replaced by 2 curated ones (app overview + button flow) in PR #274.
 
 **Files:** 14 collection YAML/MD files under `android-screenshot-tests/collections/`, `scripts/generate-android-screenshots.sh`, `generate-screenshot-collections.sh` (new, 131 lines).
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** [ok]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Generator script survives; the 7 initial collections were reduced to 2 curated ones in #274. Infrastructure lived, content was triaged.
+
+**Superseded by:** #274 (collection content triage)

--- a/docs/pr-review/pr-0273.md
+++ b/docs/pr-review/pr-0273.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Curated screenshot galleries declared in YAML, generated as Markdown. app-overview.yaml (14 screenshots across tabs), button-flow.yaml (5-step happy path). `generate-screenshot-collections.sh` reads YAML, finds PNGs by stable test name, generates Markdown. Closed without merging — replaced by PR #274's more complete implementation.
 
 **Files:** `AndroidGarage/android-screenshot-tests/collections/app-overview.{md,yaml}`, `button-flow.{md,yaml}`, `scripts/generate-screenshot-collections.sh`, `generate-android-screenshots.sh`.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Closed unmerged; replaced by #274.
+
+**Superseded by:** #274

--- a/docs/pr-review/pr-0274.md
+++ b/docs/pr-review/pr-0274.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** New `scripts/check-screenshot-health.sh` detects blank PNGs (<1KB) — warns, never blocks. `/check-screenshot-health` skill surfaces screenshot issues. Replace 7 exhaustive dumps with 2 curated collections (app overview + button flow). Fix collection script for per-screenshot `test_class`. Auto-runs after screenshot generation.
 
 **Files:** `.claude/skills/check-screenshot-health/skill.md` (new), `scripts/check-screenshot-health.sh` (new), `scripts/generate-android-screenshots.sh`, `scripts/generate-screenshot-collections.sh`, 10+ collection YAML/MD files.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Screenshot-health tooling — still in place and useful; "warns, never blocks" is the right policy for screenshot drift.

--- a/docs/pr-review/pr-0275.md
+++ b/docs/pr-review/pr-0275.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Fix 3 blank previews — DoorStatusCard (wrapped in AppTheme), HomeContent (wrapped in AppTheme), ProfileContent (stateless overload with demo data). Add 3 new full-screen tab previews with Scaffold + TopAppBar + nav bar: Home, History, Settings. Update collections to use full-screen tab screenshots. Closed without merging — superseded by #290.
 
 **Files:** `AndroidGarage/android-screenshot-tests/**`, `androidApp/ui/FullScreenPreviews.kt` (later replaced by `TabPreviews.kt`), `DoorStatusCard.kt`, `HomeContent.kt`, `ProfileContent.kt`, `scripts/generate-screenshot-collections.sh`.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Closed unmerged; replaced by #290 with the same goal and `TabPreviews.kt` naming.
+
+**Superseded by:** #290

--- a/docs/pr-review/pr-0276.md
+++ b/docs/pr-review/pr-0276.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** When `PushRemoteButtonUseCase` fails (auth, config, network), `PushStatus.SENDING` never arrives from the repository — state machine stays in `SendingToServer` forever because timeout was moved to start on `PushStatus.SENDING` in PR #265. Fix: ViewModel resets the state machine on UseCase error. New `confirmWhenNotAuthenticatedResetsToReady` test.
 
 **Files:** `AndroidGarage/usecase/.../RemoteButtonViewModel.kt`, `RemoteButtonViewModelTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** VM reset on UseCase error is still the right pattern; later simplified when #282 removed the event-y StateFlow, but the general shape (reset state-machine on error) lives on.

--- a/docs/pr-review/pr-0277.md
+++ b/docs/pr-review/pr-0277.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** The `ButtonStateMachine` previously relied entirely on `PushStatus.SENDING` arriving to start the network timeout timer. If that event was never received (exception before repository call, StateFlow conflation on fast error paths), machine stayed in `SendingToServer` forever with no recovery. Now confirm tap starts a fallback network timeout immediately; when `PushStatus.SENDING` arrives, timer is restarted. Also guards `PushStatus.SENDING` handler to only apply when already in `SendingToServer`. Closed unmerged — superseded by PR #282 which removed PushStatus StateFlow entirely.
 
 **Files:** `AndroidGarage/data/.../NetworkRemoteButtonRepository.kt`, `domain/model/RemoteButtonModel.kt`, `repository/RemoteButtonRepository.kt`, `usecase/.../ButtonStateMachine.kt`, `RemoteButtonViewModel.kt`, delete `ObservePushButtonStatusUseCase.kt`, test files, `AppComponent.kt`, docs.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Added a fallback timeout to paper over missed `PushStatus.SENDING` events; #282 removed the StateFlow and the need for a fallback.
+
+**Superseded by:** #282

--- a/docs/pr-review/pr-0278.md
+++ b/docs/pr-review/pr-0278.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Fix three reliability gaps between confirm tap and HTTP request: (1) `PushRemoteButtonUseCase` could throw uncaught exceptions from token refresh or repository errors, stranding state machine in SendingToServer; (2) `NetworkRemoteButtonRepository` set `SENDING` before checking server config (null config caused misleading SENDING→IDLE→SendingToDoor); (3) ViewModel had no safety net for unexpected exceptions. Fixes: try-catch in UseCase returning `AppResult.Error(NetworkFailed)`, move `SENDING` after server-config check, ViewModel belt-and-suspenders try-catch reset. Closed unmerged — superseded by later PRs (#279, #280, #282) that addressed the root StateFlow conflation issue.
 
 **Files:** `AndroidGarage/data/.../NetworkRemoteButtonRepository.kt`, `test-common/.../FakeAuthRepository.kt`, `FakeRemoteButtonRepository.kt`, `usecase/.../PushRemoteButtonUseCase.kt`, `RemoteButtonViewModel.kt`, test files.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Piled three defensive fixes on top of the conflation bug; #282's "delete the StateFlow" got rid of the need for any of them.
+
+**Superseded by:** #282

--- a/docs/pr-review/pr-0279.md
+++ b/docs/pr-review/pr-0279.md
@@ -10,3 +10,15 @@ phase1_reviewed: 2026-04-20
 **Goal:** `FakeRemoteButtonRepository.pushButton()` set `SENDING` then `IDLE` synchronously — StateFlow conflated `SENDING` away, collectors never saw it. Added `yield()` between assignments to match real repository behavior (HTTP call yields). Updated ViewModel test to verify button reaches `SendingToDoor` after network completes. Explains why UI jumped from Sending straight to door moved.
 
 **Files:** `AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeRemoteButtonRepository.kt`, `usecase/.../RemoteButtonViewModelTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** [great]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Diagnosed a real divergence — fake's synchronous path conflated what real code's suspension observed — but the correct long-term fix was removing the event-y StateFlow (#282), not patching the fake.
+
+**Superseded by:** #282
+
+**Still-current lesson:** When a fake needs `yield()` to match real code's event visibility, the event-y data is on the wrong primitive — StateFlow conflates; events need channels or direct calls.

--- a/docs/pr-review/pr-0280.md
+++ b/docs/pr-review/pr-0280.md
@@ -12,3 +12,13 @@ phase1_reviewed: 2026-04-20
 **Notes:** Both the yield workaround and the entire PushStatus StateFlow were removed in PR #282.
 
 **Files:** `AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkRemoteButtonRepository.kt`.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** `yield()`-to-preserve-conflated-event is a smell — #282 correctly removed the event-y StateFlow altogether rather than patching around it.
+
+**Superseded by:** #282

--- a/docs/pr-review/pr-0281.md
+++ b/docs/pr-review/pr-0281.md
@@ -12,3 +12,15 @@ phase1_reviewed: 2026-04-20
 **Notes:** Direction later reversed by ADR-022 (#357) — StateFlow for state-y data lives at the repository boundary, not the ViewModel.
 
 **Files:** `AndroidGarage/docs/DECISIONS.md`.
+
+## Phase 2 assessment
+
+**Primary:** outdated-guidance
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** ADR-013's "no StateFlow below ViewModel" direction led to multi-bug rewraps in #283/#284 and was later reversed by ADR-022 (PR #357).
+
+**Reversed by:** #357 / ADR-022
+
+**Still-current lesson:** Rules of the form "never expose X at this boundary" are risky when X is the primitive that matches the *shape* of the data. Think in terms of "what kind of data is this" (state-y / list-y / event-y) before writing a blanket layer rule.

--- a/docs/pr-review/pr-0282.md
+++ b/docs/pr-review/pr-0282.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Remove `StateFlow<PushStatus>` that caused the button to get stuck in SendingToServer — StateFlow conflated `SENDING` before the state machine observed it; UI showed "Sending..." forever. Fix: ViewModel calls `stateMachine.onNetworkStarted()` / `onNetworkCompleted()` directly based on UseCase suspend return. No Flow, no conflation, no timing dependency. Removed `PushStatus` enum, `pushButtonStatus` StateFlow, `ObservePushButtonStatusUseCase`, `yield()` workaround. Tests and prod use same mechanism (direct method calls).
 
 **Files:** `AndroidGarage/domain/.../RemoteButtonState.kt`, `RemoteButtonRepository.kt`, `data/.../NetworkRemoteButtonRepository.kt`, `usecase/.../ButtonStateMachine.kt`, `RemoteButtonViewModel.kt`, `PushRemoteButtonUseCase.kt`, delete `ObservePushButtonStatusUseCase.kt`, several test files, `AppComponent.kt`, `docs/design/PLAN-REMOVE-PUSH-STATUS.md`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Deleting the PushStatus StateFlow entirely (rather than patching conflation with `yield()`) was the right fix — suspend return + direct state-machine calls have no timing dependency. Tests and prod use the same mechanism.
+
+**Still-current lesson:** When you keep adding `yield()` to make a StateFlow event-y chain not lose events, the real answer is "that's not state, it's an event" — switch to a suspend return + method call and the conflation problem disappears.

--- a/docs/pr-review/pr-0283.md
+++ b/docs/pr-review/pr-0283.md
@@ -12,3 +12,15 @@ phase1_reviewed: 2026-04-20
 **Notes:** Introduced the bug later fixed by #295 (the `stateIn(Eagerly)` symptom) and root-caused by #328. Later reverted by ADR-022 (#361) which moved StateFlow ownership back to the repository.
 
 **Files:** `AndroidGarage/domain/.../AuthRepository.kt`, `data/.../FirebaseAuthRepository.kt`, `test-common/.../FakeAuthRepository.kt`, `usecase/.../AuthViewModel.kt`, `ObserveAuthStateUseCase.kt`, `PushRemoteButtonUseCase.kt`, `SnoozeNotificationsUseCase.kt`, test files.
+
+## Phase 2 assessment
+
+**Primary:** outdated-guidance
+**Secondary:** [buggy]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Splitting repo `StateFlow` into `suspend getAuthState()` + `observeAuthState(): Flow` forced the VM to rewrap with `stateIn(Eagerly)`, which introduced the bug #295 tried to fix and #328 root-caused. ADR-022 reversed the direction — repo owns the `StateFlow`.
+
+**Reversed by:** #361 / ADR-022
+
+**Still-current lesson:** Every extra wrap on a StateFlow chain (`stateIn` in the VM re-broadcasts a repo flow) is a new place for conflation to drop a signal — prefer passing the repo's StateFlow by reference.

--- a/docs/pr-review/pr-0284.md
+++ b/docs/pr-review/pr-0284.md
@@ -12,3 +12,15 @@ phase1_reviewed: 2026-04-20
 **Notes:** Later reverted by ADR-022 (PR #360) which moved StateFlow ownership back to the repository — the rule here was wrong in its direction.
 
 **Files:** `AndroidGarage/domain/.../SnoozeRepository.kt`, `data/.../NetworkSnoozeRepository.kt`, `test-common/.../FakeSnoozeRepository.kt`, `usecase/.../FetchSnoozeStatusUseCase.kt`, `ObserveSnoozeStateUseCase.kt`, `RemoteButtonViewModel.kt`, `ObserveSnoozeStateUseCaseTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** outdated-guidance
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** ADR-013 "no StateFlow below ViewModel layer" was the wrong direction — it later forced every VM to rebuild state with `stateIn` and created the conflation bugs that ADR-022 reversed. The rule itself was rescinded.
+
+**Reversed by:** #360 / ADR-022
+
+**Still-current lesson:** Don't ban `StateFlow` at repository boundaries — repo-owned `StateFlow` is the right place for domain state, and forcing VMs to re-wrap it adds bugs. If the problem is "VMs shouldn't wrap state twice," lint for the wrapping, not the exposure.

--- a/docs/pr-review/pr-0285.md
+++ b/docs/pr-review/pr-0285.md
@@ -12,3 +12,15 @@ phase1_reviewed: 2026-04-20
 **Notes:** Both `FcmRegistration` composable and `FcmRegistrationAction` were later deleted in PR #289 when FCM registration moved to app-scoped `FcmRegistrationManager`.
 
 **Files:** `AndroidGarage/androidApp/fcm/FcmRegistration.kt`, `usecase/.../FcmRegistrationAction.kt` (new, later deleted), `FcmRegistrationActionTest.kt` (new).
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Fixed a "registering..." no-op by adding a Composable-level action dispatcher; the whole mechanism was deleted in #289 when FCM moved to an app-scoped Manager — the fix worked but was in the wrong layer.
+
+**Superseded by:** #289
+
+**Still-current lesson:** If a Composable is dispatching actions based on state transitions, that logic probably belongs in an app-scoped Manager — Composables are for rendering, not orchestrating long-running side effects.

--- a/docs/pr-review/pr-0286.md
+++ b/docs/pr-review/pr-0286.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move FCM registration and startup logging from `MainActivity.onCreate()` into `AppStartupActions` — testable class with no Android framework dependencies. 3 tests verify FCM registration and logging happen on startup.
 
 **Files:** `AndroidGarage/androidApp/.../AppStartupActions.kt` (new), `MainActivity.kt`, `AppStartupActionsTest.kt` (new).
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Hollowing out `MainActivity.onCreate()` into a testable `AppStartup*` class is the right move (later renamed `AppStartup.run()` for KMP-friendliness per #294's generic-naming rule).

--- a/docs/pr-review/pr-0287.md
+++ b/docs/pr-review/pr-0287.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Extract parse + insert logic from `FCMService.onMessageReceived()` into plain Kotlin `FcmMessageHandler` class (no Android framework dependency). Testable with fakes. 4 tests: empty data, invalid payload, valid insert, logging.
 
 **Files:** `AndroidGarage/androidApp/.../fcm/FcmMessageHandler.kt` (new), `FCMService.kt`, `FcmMessageHandlerTest.kt` (new), `androidApp/build.gradle.kts`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Testability extraction — Android-free `FcmMessageHandler` with its own tests. Still the right shape.

--- a/docs/pr-review/pr-0288.md
+++ b/docs/pr-review/pr-0288.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Document ADR-014 (FCM registration ownership moves from ViewModel to app-scoped startup) and capture decisions and work from the session.
 
 **Files:** `AndroidGarage/docs/DECISIONS.md`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** ADR-014 "FCM registration ownership leaves the ViewModel" is the doc that anchored the Manager pattern — still the canonical rule.

--- a/docs/pr-review/pr-0289.md
+++ b/docs/pr-review/pr-0289.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move FCM registration from `DoorViewModel` to app-scoped `FcmRegistrationManager` per ADR-014/015. Manager is singleton, owns retry loop (fixed delay, forever), idempotent `start()`. `RegisterFcmUseCase` returns `AppResult<Unit, ActionError>` (single attempt). `DoorViewModel` removes `registerFcm()`, `fetchFcmRegistrationStatus()` — observes manager via Flow. Delete `FcmRegistration.kt` composable and `FcmRegistrationAction.kt`. 6 manager tests, 4 use case tests.
 
 **Files:** `AndroidGarage/usecase/.../FcmRegistrationManager.kt` (new, 110 lines), `DoorViewModel.kt`, `RegisterFcmUseCase.kt`, delete `FcmRegistrationAction.kt` + `FcmRegistration.kt`, `AppStartup.kt`, `AppComponent.kt`, tests.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Canonical Manager pattern — singleton, owns retry loop, idempotent `start()`, driven by `AppStartup` not ViewModel init. Still the template for other Manager classes (CheckInStalenessManager in #299).
+
+**Still-current lesson:** Operations that must outlive any screen (FCM registration, push retry, staleness ticker) belong in app-scoped Managers, not ViewModels. Manager has a singleton instance, idempotent `start()`, and lives on `applicationScope`.

--- a/docs/pr-review/pr-0290.md
+++ b/docs/pr-review/pr-0290.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Fix `ProfileContent` blank screenshot by calling stateless overload with demo data + fake `PermissionState` (instead of DI-dependent overload). Add 3 new full-screen tab previews (Home, History, Settings) in `TabPreviews.kt` with Scaffold, TopAppBar, and BottomNavigationBar. Update app-overview collection to lead with tab screenshots instead of component-only shots. Regenerate all 96 reference screenshots.
 
 **Files:** `AndroidGarage/android-screenshot-tests/**`, `androidApp/ui/TabPreviews.kt` (new), `DoorStatusCard.kt`, `HomeContent.kt`, `ProfileContent.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Screenshot fixes + full-screen previews; diagnosed that DI-dependent previews render blank — lesson captured in update-android-screenshots skill.

--- a/docs/pr-review/pr-0291.md
+++ b/docs/pr-review/pr-0291.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Display layer: `DurationSince` content-lambda composable → `rememberDurationSince()` returning `State<Duration>` (flat layout, no wrapping — fixes blank screenshot root cause). Business layer: `DoorViewModel.isCheckInStale: StateFlow<Boolean>` with `AppClock` + 30s periodic ticker. Staleness logging moved from `Main.kt` composable to ViewModel coroutine. `DefaultDoorViewModel` accepts `CoroutineScope` (FcmRegistrationManager pattern); tests pass `backgroundScope` — ticker cancelled when test ends, no hanging. New `AppClock` domain interface + `FakeClock`. 7 call sites migrated. 6 new staleness tests.
 
 **Files:** `AndroidGarage/androidApp/ui/*.kt` (7 files), `domain/.../AppClock.kt` (new), `test-common/.../FakeClock.kt` (new), `usecase/.../DoorViewModel.kt`, `DoorViewModelTest.kt`, `AppComponent.kt`, screenshot gallery.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Three lasting wins in one PR: `AppClock` domain abstraction (KMP-friendly), reactive `isCheckInStale` StateFlow in the VM (replaces imperative timer), and scope injection (`CoroutineScope` param → `backgroundScope` in tests) that motivated ADR-016. All patterns still used.
+
+**Still-current lesson:** Delay loops in ViewModel init (`while (true) { delay(30_000); … }`) hang tests under `runTest`. Inject the scope so tests can pass `backgroundScope` — cancelled when the test ends, no manual cleanup.

--- a/docs/pr-review/pr-0292.md
+++ b/docs/pr-review/pr-0292.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Follow-up to #291. `color()`/`onColor()` accept `isStale: Boolean` instead of computing internally via `System.currentTimeMillis()` — delete `OLD_DURATION_FOR_DOOR_CHECK_IN` and `DoorEvent?.isStale()` extension to eliminate dual computation that could momentarily disagree with ViewModel. `FakeClock` KDoc warns about single-threaded usage. New `isCheckInStale_isTrue_whenStaleEventArrives` test verifies reactive path without ticker.
 
 **Files:** `AndroidGarage/androidApp/.../DoorStatusCard.kt`, `HomeContent.kt`, `Main.kt`, `OldLastCheckInBanner.kt`, `theme/DoorStatusColorScheme.kt`, `test-common/.../FakeClock.kt`, `usecase/.../DoorViewModelTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Passing `isStale: Boolean` into color helpers eliminated dual computation (`System.currentTimeMillis()` in composables + ViewModel ticker) that could disagree by ms. Pattern "consume the derived state, don't recompute it" is still the right shape.
+
+**Still-current lesson:** If a value is derived in a ViewModel StateFlow, downstream UI/helpers should *consume* that value, not recompute it. Two code paths computing the same thing will diverge — sometimes visibly.

--- a/docs/pr-review/pr-0293.md
+++ b/docs/pr-review/pr-0293.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Document ADR-016 (DurationSince split and scope injection pattern for ViewModel coroutines with delay loops). Update test count to 290+ across 49 files (new staleness tests).
 
 **Files:** `AndroidGarage/docs/DECISIONS.md`, `AndroidGarage/docs/TESTING.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** ADR-016 (scope injection for ViewModels with delay loops) still live; motivation for the `backgroundScope`-in-tests rule that prevents hangs.


### PR DESCRIPTION
## Summary
Phase 2 session 4 — classified 30 PRs (#293 down through #264).

Category breakdown:
- **great** (5): #292, #291, #289, #288, #282, #267, #266 — Manager pattern, reactive state, StateFlow conflation root cause, UX redesign with legible state names, accessibility-by-lint
- **ok** (15): misc routine
- **superseded** (6): #285 (→#289), #280/#279/#278/#277/#275/#273/#272 (screen/button fix chain → #282/#290/#274)
- **outdated-guidance** (2): #283 (reversed by ADR-022), #281 (ADR-013 reversed by ADR-022)
- **buggy** (1): #265 — timeout-on-SENDING dependency introduced #276 stuck-Sending

Key still-current lessons:
- Don't recompute derived state — consume it (the Compose/VM divergence lesson)
- Delay loops in VM init need scope injection (`backgroundScope` in tests) — ADR-016
- App-scoped Managers own retry loops, tickers, and registration — not VMs
- Don't ban a primitive at a layer when the primitive matches the data shape
- `yield()`-to-preserve-events is a smell — switch to suspend return + method call
- State-machine names describe user-visible phases, not internal verbs
- Accessibility invariants (contrast) need test + lint, not review
- Gating timeouts on flow events adds a failure mode for every missed signal

## Test plan
- [ ] Docs-only — fast-path CI skip applies
- [ ] Phase 2 queue: 381 → 261 remaining (120 assessed across 4 sessions)