### PR TITLE
docs: PR review phase 2 batch 2026-04-20 session 7 (PRs #174–#203, 30 assessments)

### DIFF
--- a/docs/pr-review/pr-0174.md
+++ b/docs/pr-review/pr-0174.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move `FirebaseAuthRepository` from androidApp to `data/src/commonMain/`. Depend on `AppLoggerDataSource` (shared) instead of `AppLoggerRepository` (Android). Keep `RC_ONE_TAP_SIGN_IN` in androidApp (Android sign-in constant).
 
 **Files:** `AndroidGarage/data/src/commonMain/kotlin/.../FirebaseAuthRepository.kt`, `androidApp/auth/AuthConstants.kt` (new), `AppComponent.kt`, test files.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Phase 22 — auth repo moved to shared; platform bridge keeps Firebase out of common.

--- a/docs/pr-review/pr-0175.md
+++ b/docs/pr-review/pr-0175.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move `DefaultRemoteButtonViewModel` + interface from androidApp to `usecase/src/commonMain/`. Add `androidx.lifecycle:lifecycle-viewmodel` KMP dependency (KMP since 2.8.0). Add `allowedPrefixes` to `ImportBoundaryCheckTask` for KMP-compatible androidx. Replace `java.util.Date` with `Long` in `createButtonAckToken()`. Remove `@Inject` — DI via explicit `@Provides`.
 
 **Files:** `AndroidGarage/usecase/src/commonMain/kotlin/.../RemoteButtonViewModel.kt`, `usecase/build.gradle.kts`, `buildSrc/.../ImportBoundaryCheckTask.kt`, `libs.versions.toml`, UI call sites.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** First VM moved to usecase/commonMain; established that `androidx.lifecycle:lifecycle-viewmodel` works in KMP.

--- a/docs/pr-review/pr-0176.md
+++ b/docs/pr-review/pr-0176.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move shared `AppLoggerRepository` interface to `domain/src/commonMain/`. Rename androidApp's to `AndroidAppLoggerRepository` (extends domain + adds CSV). Delete `AppLoggerDataSource` from data module (superseded). Prerequisite for moving DoorViewModel.
 
 **Files:** `AndroidGarage/domain/src/commonMain/kotlin/.../AppLoggerRepository.kt` (new), delete `data/.../AppLoggerDataSource.kt`, `androidApp/applogger/AppLoggerRepository.kt`, `AppLoggerViewModel.kt`, `AuthViewModel.kt`, `DoorViewModel.kt`, `DoorFcmRepository.kt`, `FCMService.kt`, `AppComponent.kt`, `FirebaseAuthRepository.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Domain-level `AppLoggerRepository` unblocks ViewModel moves; Android-only CSV extension in `AndroidAppLoggerRepository`.

--- a/docs/pr-review/pr-0177.md
+++ b/docs/pr-review/pr-0177.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move `DefaultDoorViewModel` + interface to `usecase/src/commonMain/`. Move `DoorFcmRepository` interface to `domain/src/commonMain/`. Move FCM use cases to `usecase/src/commonMain/`. Both main ViewModels (RemoteButton + Door) now in shared KMP modules.
 
 **Files:** `AndroidGarage/usecase/src/commonMain/kotlin/.../DoorViewModel.kt`, `RegisterFcmUseCase.kt`, `domain/.../DoorFcmRepository.kt` (new), `AppComponent.kt`, UI call sites.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** DoorViewModel + FCM UseCases to shared.

--- a/docs/pr-review/pr-0178.md
+++ b/docs/pr-review/pr-0178.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Extract `Setting<T>` and `AppSettingsRepository` interfaces to `domain/src/commonMain/`. Move `DefaultAppSettingsViewModel` to `usecase/src/commonMain/`. Android `AppSettings` extends domain `AppSettingsRepository`. 3 of 5 ViewModels in shared KMP modules.
 
 **Files:** `AndroidGarage/domain/src/commonMain/kotlin/.../AppSettingsRepository.kt`, `usecase/src/commonMain/kotlin/.../AppSettingsViewModel.kt`, `AppComponent.kt`, settings/AppSettings/SettingManager.kt, several UI files.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** AppSettingsViewModel moved to shared.

--- a/docs/pr-review/pr-0179.md
+++ b/docs/pr-review/pr-0179.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move `DefaultAppLoggerViewModel` + interface to `usecase/src/commonMain/`. Remove `writeCsvToUri` from ViewModel interface (Android-specific). CSV export called directly from Compose layer via `AndroidAppLoggerRepository`. 4 of 5 ViewModels now in shared KMP modules.
 
 **Files:** `AndroidGarage/usecase/src/commonMain/kotlin/.../AppLoggerViewModel.kt`, `AppComponent.kt`, UI call sites.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** VM moved to shared; Android-specific CSV export stays in Compose.

--- a/docs/pr-review/pr-0180.md
+++ b/docs/pr-review/pr-0180.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** New `checkNoFullyQualifiedNames` Gradle task scans all Kotlin source for inline `com.chriscartland.garage.*` and `kotlinx.coroutines.*` FQNs. Fixed 4 violations (use imports instead). Skips string literals (no false positives).
 
 **Files:** `AndroidGarage/buildSrc/src/main/kotlin/codestyle/NoFullyQualifiedNamesTask.kt` (new, 124 lines), `build.gradle.kts`, `scripts/validate.sh`, 4 fixes.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Codestyle lint banning inline FQNs — still active, has been extended (#222).

--- a/docs/pr-review/pr-0181.md
+++ b/docs/pr-review/pr-0181.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move Google One-Tap sign-in from `DefaultAuthViewModel` to a Compose-layer helper (`GoogleSignInState`). Replace deprecated `onActivityResult` + `startIntentSenderForResult` with modern `ActivityResultContracts.StartIntentSenderForResult()`. Simplify `AuthViewModel` interface to just `signInWithGoogle(idToken: GoogleIdToken)` — no Activity, Intent, IntentSender. Remove `onActivityResult` from MainActivity. Delete `AuthConstants.kt`. Unblocks Phase 30.
 
 **Files:** `AndroidGarage/androidApp/.../auth/GoogleSignInState.kt` (new, 142 lines), delete `AuthConstants.kt`, `MainActivity.kt`, `AuthViewModel.kt`, `HomeContent.kt`, `ProfileContent.kt`, `.claude/hooks/git-guardrails.sh`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Removing Activity/Intent/IntentSender from `AuthViewModel` — sign-in orchestration stays in Compose via `ActivityResultContracts` — unblocks the KMP/iOS auth story.
+
+**Still-current lesson:** ViewModels shouldn't take `Activity` or `Intent`. When a platform SDK wants an Activity, put the orchestration in a Compose-layer helper and let the VM consume the result as a domain value (e.g., `GoogleIdToken`).

--- a/docs/pr-review/pr-0182.md
+++ b/docs/pr-review/pr-0182.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move `AuthViewModel` interface and `DefaultAuthViewModel` to `usecase/src/commonMain/`. Replace `@Inject` + `abstract val` with explicit `@Provides` in AppComponent. Update UI imports. Fix FQN violations in `LogSummaryCard.kt`. Completes ViewModel extraction — all 5 ViewModels now in shared KMP modules (Auth, Door, RemoteButton, AppSettings, AppLogger).
 
 **Files:** `AndroidGarage/usecase/src/commonMain/kotlin/.../usecase/AuthViewModel.kt`, `AppComponent.kt`, `HomeContent.kt`, `LogSummaryCard.kt`, `Main.kt`, `ProfileContent.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Last VM moved to usecase/commonMain — caps ViewModel extraction.

--- a/docs/pr-review/pr-0183.md
+++ b/docs/pr-review/pr-0183.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move `DefaultDispatcherProvider` from androidApp to `data/commonMain` (pure coroutines, no Android deps). Move `FirebaseDoorFcmRepository` from androidApp to `data/commonMain` — constructor changes from Android `AppSettings` to shared `AppSettingsRepository` interface. Both classes now KMP-shareable.
 
 **Files:** `AndroidGarage/data/src/commonMain/kotlin/.../coroutines/DefaultDispatcherProvider.kt`, `repository/FirebaseDoorFcmRepository.kt`, `AppComponent.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** KMP module move.

--- a/docs/pr-review/pr-0184.md
+++ b/docs/pr-review/pr-0184.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move `DemoData` (door event fixtures) from androidApp to `presentation-model/commonMain`. Replace `java.time.Instant.parse` with Long constant for KMP. iOS previews can reuse the same fixtures.
 
 **Files:** `AndroidGarage/presentation-model/src/commonMain/kotlin/com/chriscartland/garage/presentation/DemoData.kt`, 3 UI files, `androidApp/build.gradle.kts`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Demo fixtures in commonMain so iOS previews reuse them; ditches `java.time.Instant` for KMP-safe Long.

--- a/docs/pr-review/pr-0185.md
+++ b/docs/pr-review/pr-0185.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Document all Android purity migration phases (19-32) in MIGRATION.md. Update Phase 10 status to COMPLETE (all 5 ViewModels now shared). Add table of what remains in androidApp and why each file requires Android APIs.
 
 **Files:** `AndroidGarage/docs/MIGRATION.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Migration bookkeeping — including the useful "what's left in androidApp and why" table.

--- a/docs/pr-review/pr-0186.md
+++ b/docs/pr-review/pr-0186.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Document remaining work to reach battery-butler parity. Phase 33 (Room → shared data-local; Room is KMP since 2.7.0). Phase 34 (extract shared Compose modules). Phase 35 (SharedPreferences → DataStore, KMP). Phase 36 (`java.time` → `kotlinx-datetime`). Phase 37 (expect/actual for HTTP engine, database factory, config, version). Phase 38 (iOS target, was Phase 13).
 
 **Files:** `AndroidGarage/docs/MIGRATION.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** KMP alignment roadmap; Phases 34 later dropped per #202's SwiftUI clarification.

--- a/docs/pr-review/pr-0187.md
+++ b/docs/pr-review/pr-0187.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Create new `data-local/` KMP module for Room database (Room is KMP since 2.7.0). Move AppDatabase, entities (DoorEventEntity, AppEvent), DAOs, `DatabaseLocalDoorDataSource` from androidApp. Use `@ConstructedBy` + `RoomDatabaseConstructor` for KMP. Add `BundledSQLiteDriver` for cross-platform SQLite. Add `expect/actual currentTimeMillis()`. Android-specific `DatabaseFactory` in androidMain. Remove Room plugin from androidApp.
 
 **Files:** `AndroidGarage/data-local/build.gradle.kts` (new), `data-local/src/commonMain/.../AppDatabase.kt`, `AppEvent.kt`, `DatabaseLocalDoorDataSource.kt`, `DoorEventDao.kt`, `DoorEventEntity.kt`, `data-local/src/androidMain/.../DatabaseFactory.android.kt`, `CurrentTimeMillis.android.kt`, schema JSON, delete androidApp versions, `settings.gradle.kts`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Phase 33 KMP Room — `@ConstructedBy` + `BundledSQLiteDriver` + `expect/actual currentTimeMillis()`. Canonical KMP persistence setup.
+
+**Still-current lesson:** Room is KMP-ready (2.7+). For iOS, `@ConstructedBy` + `RoomDatabaseConstructor` + `BundledSQLiteDriver` gets you the common entities/DAOs with only a per-platform `DatabaseFactory` to provide.

--- a/docs/pr-review/pr-0188.md
+++ b/docs/pr-review/pr-0188.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add `ImportBoundaryCheckTask` to data-local module (allows `androidx.room.*`, `androidx.sqlite.*`). Add data-local to validate.sh import boundary checks. Remove `FirebaseAuthRepository` from test coverage exemptions (has tests since Phase 22).
 
 **Files:** `AndroidGarage/data-local/build.gradle.kts`, `test-coverage-exemptions.txt`, `scripts/validate.sh`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Import boundary for data-local — just Room/SQLite allowed — keeps the module scope tight.

--- a/docs/pr-review/pr-0189.md
+++ b/docs/pr-review/pr-0189.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Remove 7 stale detekt baseline entries for files that moved from androidApp to shared modules during Phases 19-32. Removed: AuthRepository, FcmPayloadParser, 3 Ktor data sources. Kept: AppLoggerRepository (Android Context), FirebaseAuthBridge (Firebase SDK).
 
 **Files:** `AndroidGarage/androidApp/detekt-baseline.xml`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Stale baseline cleanup after module moves.

--- a/docs/pr-review/pr-0190.md
+++ b/docs/pr-review/pr-0190.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** 11 tests for `FirebaseDoorFcmRepository` covering all code paths. Create shared fakes: `FakeMessagingBridge`, `FakeAppSettingsRepository`, `FakeAppLoggerRepository`. `InMemorySetting<T>` provides reusable in-memory `Setting` for tests. Tests in `data/src/commonTest/` (KMP).
 
 **Files:** `AndroidGarage/data/src/commonTest/.../FirebaseDoorFcmRepositoryTest.kt` (new), `testfakes/FakeAppLoggerRepository.kt`, `FakeAppSettingsRepository.kt`, `FakeMessagingBridge.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** FCM repo coverage including `FakeMessagingBridge` — later consolidated into `test-common`.

--- a/docs/pr-review/pr-0191.md
+++ b/docs/pr-review/pr-0191.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add 13 tests for 3 previously-exempt ViewModels (`AuthViewModel`, `AppLoggerViewModel`, `AppSettingsViewModel`). Create shared test fakes: `FakeAuthRepository`, `FakeAppLoggerRepository`, `FakeAppSettingsRepository`, `TestDispatcherProvider`, `InMemorySetting<T>`. Remove 4 exemptions. Only `RoomAppLoggerRepository` remains exempt (Android Context for CSV export).
 
 **Files:** `AndroidGarage/usecase/src/commonTest/.../DefaultAuthViewModelTest.kt` (new), `DefaultAppSettingsViewModelTest.kt` (new), `testfakes/*` (5 new files), `test-coverage-exemptions.txt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Filled exempted coverage gaps; fakes here became the `test-common` module in #218.

--- a/docs/pr-review/pr-0192.md
+++ b/docs/pr-review/pr-0192.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Migrate from Jetpack Navigation 2 to Navigation 3, matching battery-butler. Replace `NavHost` + `composable<Route>` with `NavDisplay` + `entryProvider` + `entry<Screen>`. Replace `NavController` with `mutableStateListOf<Screen>`. `Route` sealed object → `Screen` sealed interface. Tab navigation replaces entire back stack. Add `navigation3-runtime` 1.0.0-alpha02. Bump compileSdk 35→36. New `NoNav2ImportsTask` fails if any Nav2 imports found.
 
 **Files:** `AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt`, `buildSrc/.../NoNav2ImportsTask.kt` (new), `gradle/libs.versions.toml`, many `build.gradle.kts` files, `scripts/validate.sh`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Nav2 → Nav3 migration plus `NoNav2ImportsTask` in the same PR.
+
+**Still-current lesson:** After a library migration, add a lint that fails on imports from the old library in the same wave — otherwise a copy-paste re-introduces the old world one file at a time.

--- a/docs/pr-review/pr-0193.md
+++ b/docs/pr-review/pr-0193.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Mark Phase 33 (Room → data-local KMP) COMPLETE. Mark Phase 12 (Navigation) COMPLETE (Nav2→Nav3). Add PRs #187-#192 to the Android Purity phase table. Update "What remains in androidApp" to reflect Room moved out.
 
 **Files:** `AndroidGarage/docs/MIGRATION.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Phase 33 + Nav3 bookkeeping.

--- a/docs/pr-review/pr-0194.md
+++ b/docs/pr-review/pr-0194.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add 3 tests for `DefaultAppLoggerViewModel` accidentally omitted from PR #191: `logDelegatesToRepository`, `logMultipleKeysDelegatesToRepository`, `countsUpdateAfterLog`.
 
 **Files:** `AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAppLoggerViewModelTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Missing test added.

--- a/docs/pr-review/pr-0195.md
+++ b/docs/pr-review/pr-0195.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move `DoorEventEntityTest` from `androidApp/src/test/` to `data-local/src/commonTest/`. Convert from JUnit to kotlin.test for KMP compatibility. All 8 tests preserved.
 
 **Files:** `AndroidGarage/data-local/src/commonTest/kotlin/com/chriscartland/garage/datalocal/DoorEventEntityTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Test moved to correct module for KMP.

--- a/docs/pr-review/pr-0196.md
+++ b/docs/pr-review/pr-0196.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add three automated build-time architecture enforcement checks. (1) `ArchitectureCheckTask` — module dependency graph (each module only depends on declared allowed modules). (2) `SingletonGuardTask` — critical provider scoping (`@Singleton` required on `provideAppDatabase`, `provideAppSettings`, `provideHttpClient`). (3) `LayerImportCheckTask` — source-level layer boundaries (ViewModel/UseCase files must not import data-layer packages). Pattern-based, future-proof for new files.
 
 **Files:** `AndroidGarage/buildSrc/src/main/kotlin/architecture/ArchitectureCheckTask.kt` (new), `SingletonGuardTask.kt` (new), `LayerImportCheckTask.kt` (new), `build.gradle.kts`, `scripts/validate.sh`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Three architecture lints landed together: module dependency graph, `@Singleton` on critical providers, layer-import boundaries. All three still enforced and expanded over time (#252, #300, #310, #365).
+
+**Still-current lesson:** When migrating to layered architecture, ship three build-time gates together: dependency graph, scoping guard, source-level import boundaries. Any invariant checked only at review time decays.

--- a/docs/pr-review/pr-0197.md
+++ b/docs/pr-review/pr-0197.md
@@ -10,3 +10,15 @@ phase1_reviewed: 2026-04-20
 **Goal:** Replace Android-only SharedPreferences with KMP-compatible `multiplatform-settings` (com.russhwolf 1.3.0). New `MultiplatformAppSettings` in `data-local/commonMain`. Delete old SharedPreferences code. Closed without merging — replaced by PR #199 using DataStore instead (reactive Flow-based API).
 
 **Files:** `data-local/.../MultiplatformAppSettings.kt` (new), delete `androidApp/settings/AppSettings.kt`, `SettingManager.kt`, `libs.versions.toml`.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** [great]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Closed in favor of DataStore (#199) — multiplatform-settings is synchronous and doesn't back reactive UI as well as DataStore's Flow API.
+
+**Superseded by:** #199
+
+**Still-current lesson:** "KMP-compatible" alone doesn't pick a library — pick the one whose API shape matches your UI layer. Reactive UI needs reactive settings.

--- a/docs/pr-review/pr-0198.md
+++ b/docs/pr-review/pr-0198.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Mark Phase 35 (multiplatform-settings) COMPLETE. Document architecture enforcement checks. Update "What remains in androidApp" — settings moved out. Closed without merging — superseded by #200.
 
 **Files:** `AndroidGarage/docs/MIGRATION.md`.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Closed; replaced by #200 (which referenced the DataStore approach instead of multiplatform-settings).
+
+**Superseded by:** #200

--- a/docs/pr-review/pr-0199.md
+++ b/docs/pr-review/pr-0199.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Migrate settings from synchronous SharedPreferences to reactive DataStore (Flow-based). Interface changes (domain `Setting<T>`): `get(): T` → `flow: Flow<T>`, `set(value: T)` → `suspend fun set(value: T)`. New `DataStoreAppSettings` in data-local (KMP-compatible via `PreferenceDataStoreFactory.createWithPath`). `AppSettingsViewModel` collects via `stateIn(Eagerly)`. `FirebaseDoorFcmRepository` uses `flow.first()` in suspend funcs. All test fakes: `InMemorySetting` uses `MutableStateFlow`. Delete old SharedPreferences implementation (180 lines).
 
 **Files:** delete `androidApp/settings/AppSettings.kt`, `SettingManager.kt`. New `data-local/.../DataStoreAppSettings.kt`, `data-local/androidMain/.../DataStoreSettingsFactory.android.kt`. `domain/.../AppSettingsRepository.kt`, `usecase/.../AppSettingsViewModel.kt`, many test files, `AppComponent.kt`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** DataStore (Flow-based) over SharedPreferences (synchronous) — reactive by construction. Still the canonical approach; captured in memory.
+
+**Still-current lesson:** For user settings that back reactive UI, pick DataStore over SharedPreferences — reactive reads let Compose re-render on change without polling. One-shot reads still available via `flow.first()`.

--- a/docs/pr-review/pr-0200.md
+++ b/docs/pr-review/pr-0200.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Mark Phase 35 (DataStore migration) as COMPLETE with implementation details. Document architecture enforcement checks (#196). Update "What remains in androidApp" — settings moved out.
 
 **Files:** `AndroidGarage/docs/MIGRATION.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Phase 35 bookkeeping.

--- a/docs/pr-review/pr-0201.md
+++ b/docs/pr-review/pr-0201.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move HTTP client creation from androidApp to shared `data` module using KMP expect/actual. `expect fun createPlatformHttpEngine()` in `data/commonMain`. `actual` using OkHttp in `data/androidMain`. `createHttpClient(baseUrl, debug)` factory combines platform engine + shared config. Delete `KtorHttpClientProvider.kt` from androidApp. iOS just needs `actual fun createPlatformHttpEngine() = Darwin.create()`.
 
 **Files:** `AndroidGarage/data/src/commonMain/.../ktor/KtorHttpClientFactory.kt` (new), `PlatformHttpEngine.kt` (new), `data/src/androidMain/.../PlatformHttpEngine.android.kt` (new), delete `androidApp/.../KtorHttpClientProvider.kt`, `data/build.gradle.kts`, `androidApp/build.gradle.kts`, `AppComponent.kt`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** HTTP engine via expect/actual is the canonical KMP split — all shared config lives in commonMain; each platform contributes only the engine (`OkHttp` / `Darwin`). Still the shape.
+
+**Still-current lesson:** For a library with cross-platform configuration and platform-specific engines (HTTP, I/O, crypto), use `expect fun createPlatformX()` to isolate the per-platform dependency and keep all common setup in `commonMain`.

--- a/docs/pr-review/pr-0202.md
+++ b/docs/pr-review/pr-0202.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Correct migration roadmap based on clarified goals. Phase 34 SKIPPED (no Compose Multiplatform — UI stays platform-native). Phase 36 simplified (locale formatting stays per-platform, shared modules handle pure math). Phase 37 partially complete (HTTP engine expect/actual done via #201). Phase 38 clarified (iOS uses SwiftUI, Google Sign-In, FCM/APNs). Phase 39 NEW (split PushRepository + audit other names).
 
 **Files:** `AndroidGarage/docs/MIGRATION.md`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Anchored the KMP goal as "SwiftUI for iOS, no Compose Multiplatform" — still the strategic target; saved a lot of work by not taking the CMP path.
+
+**Still-current lesson:** Don't assume KMP + Compose Multiplatform are the same goal. Share business logic in KMP common; keep UI platform-native (SwiftUI on iOS) for best UX on each platform.

--- a/docs/pr-review/pr-0203.md
+++ b/docs/pr-review/pr-0203.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Split `PushRepository` (bad code smell — bundled two unrelated concerns). `RemoteButtonRepository` — garage door button push action (one-shot command, `pushButtonStatus: StateFlow<PushStatus>`, `suspend fun pushButton()`). `SnoozeRepository` — snooze notification management (persisted server-side state, `snoozeRequestStatus`, `snoozeEndTimeSeconds` flows, `fetchSnoozeEndTimeSeconds()`, `snoozeNotifications()`). All layers updated: domain interfaces, data impls, UseCases, ViewModel, DI, tests, fakes.
 
 **Files:** `AndroidGarage/domain/.../RemoteButtonRepository.kt` (new), `SnoozeRepository.kt`, `data/.../NetworkRemoteButtonRepository.kt` (new), `NetworkSnoozeRepository.kt`, `usecase/.../PushRemoteButtonUseCase.kt`, `SnoozeNotificationsUseCase.kt`, `RemoteButtonViewModel.kt`, test fakes + tests, `AppComponent.kt`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Splitting the "X+Y" bundled repo — two semantics (one-shot command vs. persisted state) now grow independently.
+
+**Still-current lesson:** A repository with "and" in its conceptual name is a smell — two semantics in one interface means every impl grows one consistent set of behaviors and one inconsistent set. Split when names start to diverge.


### PR DESCRIPTION
## Summary
Phase 2 session 7 — classified 30 PRs (#203 down through #174).

Category breakdown:
- **great** (9): #203 (split bundled repo), #202 (KMP ≠ CMP), #201 (expect/actual HTTP engine), #199 (DataStore over SharedPreferences), #196 (3 architecture lints), #192 (Nav3 + NoNav2 lint), #187 (KMP Room), #181 (Activity out of VM)
- **ok** (19): KMP module migrations, lint extensions, polish
- **superseded** (2): #198 → #200, #197 → #199

Key still-current lessons:
- Repository with "and" in its concept = split it
- KMP ≠ Compose Multiplatform; share business logic, keep UI native
- `expect/actual createPlatformX()` for platform-engine boundaries
- Reactive-UI settings → DataStore, not SharedPreferences
- Three architecture lints together: deps + scoping + import boundaries
- After library migration, land a lint banning old library imports in same wave
- Room is KMP-ready: `@ConstructedBy` + `BundledSQLiteDriver` + `expect currentTimeMillis()`
- ViewModels don't take Activity/Intent — domain-value inputs only

## Test plan
- [ ] Docs-only — fast-path CI skip applies
- [ ] Phase 2 queue: 381 → 171 remaining (210 assessed, 55% complete)