### PR TITLE
docs: PR review phase 2 batch 2026-04-20 session 8 (PRs #144–#173, 30 assessments)

### DIFF
--- a/docs/pr-review/pr-0144.md
+++ b/docs/pr-review/pr-0144.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Replace silent `Unit` returns with `AppResult<D, FetchError>` on `fetchCurrentDoorEvent()` and `fetchRecentDoorEvents()`. Add `FetchError` sealed interface with `NotReady` and `NetworkFailed` variants for exhaustive `when`. Add ADR-010: Typed API patterns (observation + one-time requests with sealed Result types).
 
 **Files:** `AndroidGarage/domain/src/commonMain/.../FetchError.kt` (new), `DoorRepository.kt`, `data/.../NetworkDoorRepository.kt`, `usecase/.../FetchDoorEventsUseCase.kt`, `DoorViewModel.kt`, `DECISIONS.md`, test files.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** ADR-010 + `AppResult<D, FetchError>` established the typed API pattern that every later repository followed.
+
+**Still-current lesson:** Observation APIs return `Flow<T>`; one-time requests return `AppResult<Data, Error>` with a sealed `Error` — exhaustive `when` on the error; no `else` branch.

--- a/docs/pr-review/pr-0145.md
+++ b/docs/pr-review/pr-0145.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Replace Boolean returns with `AppResult<Unit, ActionError>` on `PushRemoteButtonUseCase` and `SnoozeNotificationsUseCase`. Add `ActionError` sealed interface with `NotAuthenticated` and `MissingData` variants. ViewModel handles each error case with exhaustive `when`.
 
 **Files:** `AndroidGarage/domain/src/commonMain/.../ActionError.kt` (new), `usecase/.../PushRemoteButtonUseCase.kt`, `SnoozeNotificationsUseCase.kt`, `RemoteButtonViewModel.kt`, test files.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** UseCases adopted `AppResult<Unit, ActionError>` — still the pattern; `ActionError` later gained `NetworkFailed` (#256).

--- a/docs/pr-review/pr-0146.md
+++ b/docs/pr-review/pr-0146.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Update MIGRATION.md — Phase 14 marked fully complete with subsections for foundation, DoorRepository, and UseCase migrations.
 
 **Files:** `AndroidGarage/docs/MIGRATION.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Phase 14 bookkeeping.

--- a/docs/pr-review/pr-0147.md
+++ b/docs/pr-review/pr-0147.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Update CLAUDE.md: architecture reflects usecase module + typed errors (AppResult, ADR-010). Session completed Phases 10, 14, 16 + snooze bug fix + validate.sh KMP discovery fix. Released android/138.
 
 **Files:** `CLAUDE.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Session dump.

--- a/docs/pr-review/pr-0148.md
+++ b/docs/pr-review/pr-0148.md
@@ -12,3 +12,13 @@ phase1_reviewed: 2026-04-20
 **Notes:** Later replaced by PR #192 which migrated to Nav3 directly.
 
 **Files:** `AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt`.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Intermediate type-safe Nav2 step; #192 replaced Nav2 entirely with Nav3.
+
+**Superseded by:** #192

--- a/docs/pr-review/pr-0149.md
+++ b/docs/pr-review/pr-0149.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Mark Phase 12.1 (type-safe routes) complete, Nav3 deferred until stable. Update ADR-004: Nav3 still alpha, using Navigation Compose 2.9 type-safe routes instead.
 
 **Files:** `AndroidGarage/docs/DECISIONS.md`, `MIGRATION.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** "Defer Nav3 until stable" was right at the time; Nav3 later landed in #192.

--- a/docs/pr-review/pr-0150.md
+++ b/docs/pr-review/pr-0150.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Replace deprecated tslint (unmaintained since 2019) with ESLint 10 + @typescript-eslint. Map all existing tslint rules to ESLint equivalents in flat config format. Simplify build script (remove platform-specific mac/windows split). Auto-fix 17 trailing comma warnings.
 
 **Files:** `FirebaseServer/eslint.config.js` (new), `package.json`, `package-lock.json`, delete `tslint.json`, 10 source files (trailing commas added).
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** tslint→ESLint — routine deprecation migration.

--- a/docs/pr-review/pr-0151.md
+++ b/docs/pr-review/pr-0151.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Mark Phase 6.1 (tslint→ESLint) as Done (#150) in TESTING.md. Update completed/remaining lists.
 
 **Files:** `AndroidGarage/docs/TESTING.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Bookkeeping.

--- a/docs/pr-review/pr-0152.md
+++ b/docs/pr-review/pr-0152.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** New `AuthBridge` interface in `data/src/commonMain/` abstracting all Firebase Auth SDK calls. `FirebaseAuthBridge` impl wraps `Firebase.auth`. `FirebaseAuthRepository` injects `AuthBridge`. 6 new unit tests for `FirebaseAuthRepository` via `FakeAuthBridge` (previously untestable). Also adds `FakeAppLoggerRepository`.
 
 **Files:** `AndroidGarage/data/src/commonMain/.../AuthBridge.kt` (new), `androidApp/auth/FirebaseAuthBridge.kt` (new), `AuthRepository.kt`, `FirebaseAuthRepositoryTest.kt` (new), `testcommon/FakeAppLoggerRepository.kt`, `FakeAuthBridge.kt`, `AppComponent.kt`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** First platform bridge (AuthBridge) — directly unlocked 6 previously-impossible unit tests for `FirebaseAuthRepository`.

--- a/docs/pr-review/pr-0153.md
+++ b/docs/pr-review/pr-0153.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** New `MessagingBridge` interface in `data/src/commonMain/` abstracting FCM operations. `FirebaseMessagingBridge` impl wraps `Firebase.messaging`. `FirebaseDoorFcmRepository` injects `MessagingBridge` instead of calling Firebase directly. Together with AuthBridge (#152), all Firebase SDK calls now behind injectable interfaces.
 
 **Files:** `AndroidGarage/data/src/commonMain/.../MessagingBridge.kt` (new), `androidApp/fcm/FirebaseMessagingBridge.kt` (new), `DoorFcmRepository.kt`, `AppComponent.kt`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** `MessagingBridge` — Firebase SDK behind a bridge — unlocks unit tests and future APNs on iOS. Still the pattern.
+
+**Still-current lesson:** Any platform SDK that you'd otherwise mock in tests should have a thin bridge interface in `commonMain`. The bridge adapts SDK to domain types; every consumer talks to the bridge, not the SDK.

--- a/docs/pr-review/pr-0154.md
+++ b/docs/pr-review/pr-0154.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Mark Phase 11 (platform abstractions) complete — AuthBridge + MessagingBridge. Mark Phase 3.1 (auth token tests) complete — enabled by AuthBridge extraction. Update test count: 192 across 27 files.
 
 **Files:** `AndroidGarage/docs/MIGRATION.md`, `TESTING.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Phase bookkeeping.

--- a/docs/pr-review/pr-0155.md
+++ b/docs/pr-review/pr-0155.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** New `presentation-model/` KMP module with screen state data classes (`HomeScreenState`, `ProfileScreenState`, `DoorHistoryScreenState`). Pure Kotlin in commonMain, depends only on `:domain`.
 
 **Files:** `AndroidGarage/presentation-model/build.gradle.kts` (new), `src/commonMain/.../HomeScreenState.kt`, `ProfileScreenState.kt`, `DoorHistoryScreenState.kt` (new), `settings.gradle.kts`, `scripts/validate.sh`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** `presentation-model/` KMP module still hosts screen state data classes.

--- a/docs/pr-review/pr-0156.md
+++ b/docs/pr-review/pr-0156.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Replace `java.time.Duration` with `kotlinx.coroutines.delay(millis)` in NetworkPushRepository. Add `java.time.`, `java.text.`, `java.util.Date`, `java.util.Locale` to forbidden import prefixes. Unblocks future iOS builds.
 
 **Files:** `AndroidGarage/buildSrc/src/main/kotlin/importboundary/ImportBoundaryCheckTask.kt`, `data/src/commonMain/.../NetworkPushRepository.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Import boundary forbids JVM-only prefixes in commonMain — keeps future iOS target unblocked.

--- a/docs/pr-review/pr-0157.md
+++ b/docs/pr-review/pr-0157.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Enable `TooGenericExceptionCaught` rule. Tighten `SwallowedException` — only allow CancellationException and InterruptedException. Generate baseline for 9 existing violations. Add ADR-011: No-throw error handling — catch at boundaries, return sealed types, no `else` in `when`.
 
 **Files:** `AndroidGarage/detekt.yml`, `androidApp/detekt-baseline.xml`, `docs/DECISIONS.md`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** ADR-011 "No-throw error handling" anchored the type-first error model: catch at boundaries, return sealed types, no `else` in `when`.
+
+**Still-current lesson:** Pair tightened Detekt rules (`TooGenericExceptionCaught`, `SwallowedException` allow only `CancellationException`) with an ADR — lint catches the easy cases; the ADR resolves the hard ones.

--- a/docs/pr-review/pr-0158.md
+++ b/docs/pr-review/pr-0158.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** New `NetworkResult<T>` sealed interface: `Success<T>`, `HttpError(code)`, `ConnectionFailed`. All 3 data source interfaces return `NetworkResult<T>` instead of nullable/Boolean/Long. Ktor implementations catch at boundary, rethrow CancellationException, map others to typed results. Repositories handle each variant with exhaustive `when` (no `else`). Eliminates silent null/false/0L returns.
 
 **Files:** `AndroidGarage/data/src/commonMain/.../NetworkResult.kt` (new), 3 NetworkDataSource interfaces, 3 Ktor implementations, 2 repositories, test fakes, 18+ tests.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** `NetworkResult<T>` at the data source boundary ended the silent-null era. Every repo now handles `Success/HttpError/ConnectionFailed` via exhaustive `when`.
+
+**Still-current lesson:** Network boundary returns a sealed `NetworkResult<T>` — not `T?`, not `Boolean`. Exhaustive `when` forces callers to decide on every failure mode instead of conflating them.

--- a/docs/pr-review/pr-0159.md
+++ b/docs/pr-review/pr-0159.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Replace global `APP_CONFIG.fetchOnViewModelInit` with constructor parameter `fetchOnInit: Boolean`. DoorViewModel no longer imports global config. New test verifies `fetchOnInit = false` doesn't trigger network fetches.
 
 **Files:** `AndroidGarage/androidApp/.../DoorViewModel.kt`, `DoorViewModelTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Global singleton → constructor param.

--- a/docs/pr-review/pr-0160.md
+++ b/docs/pr-review/pr-0160.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Replace magic numbers in timeout tests with `RemoteButtonStateMachine.DEFAULT_TIMEOUT_MILLIS`. Both `RemoteButtonStateMachineTest` (19 tests) and `RemoteButtonViewModelTest` (26 tests) updated.
 
 **Files:** `AndroidGarage/usecase/src/commonTest/.../RemoteButtonStateMachineTest.kt`, `androidApp/test/.../RemoteButtonViewModelTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** De-magic-numbered timeout tests.

--- a/docs/pr-review/pr-0161.md
+++ b/docs/pr-review/pr-0161.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Use `Dispatchers.Main.immediate` to avoid potential ANR. Add try-catch around `insertDoorEvent()` — prevents service crash on DB error. Remove dead code (`if (false) { scheduleJob() }`) and unused `handleNow` null check. Flatten control flow with early returns.
 
 **Files:** `AndroidGarage/androidApp/.../fcm/FCMService.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Cleanup — concurrency hygiene + dead-code removal.

--- a/docs/pr-review/pr-0162.md
+++ b/docs/pr-review/pr-0162.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Replace fire-and-forget `CoroutineScope(Dispatchers.IO)` with injected scope. AppComponent provides `SupervisorJob() + Dispatchers.IO` application scope. Tests use test dispatcher for deterministic init behavior.
 
 **Files:** `AndroidGarage/androidApp/.../auth/AuthRepository.kt`, `AppComponent.kt`, `FirebaseAuthRepositoryTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Scope injection over fire-and-forget; early version of the externalScope pattern that ADR-019 later codified.

--- a/docs/pr-review/pr-0163.md
+++ b/docs/pr-review/pr-0163.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** On fetch error, transition from `LoadingResult.Loading` back to `LoadingResult.Complete` with previous data. Users no longer see infinite loading spinner on network errors. Error logged with exhaustive `when` on `FetchError` variants.
 
 **Files:** `AndroidGarage/androidApp/.../DoorViewModel.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Loading → Complete(previous data) on fetch error prevents "infinite spinner" UX.

--- a/docs/pr-review/pr-0164.md
+++ b/docs/pr-review/pr-0164.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Replace Mockito mocks in `DoorViewModelTest` with `FakeDoorRepository`, `FakeAppLoggerRepository`, `FakeDoorFcmRepository`. Only `Activity` mock remains. `createViewModel()` no longer needs `suspend`. All 10 tests pass.
 
 **Files:** `AndroidGarage/androidApp/src/test/.../DoorViewModelTest.kt`, `testcommon/FakeDoorFcmRepository.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Phase H mock→fake migration.

--- a/docs/pr-review/pr-0165.md
+++ b/docs/pr-review/pr-0165.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** CLAUDE.md add NetworkResult + platform bridges to architecture section. TESTING.md 192 unit tests across 31 files. MIGRATION.md: Phase 18 complete, hardening phases A-I table added.
 
 **Files:** `CLAUDE.md`, `AndroidGarage/docs/TESTING.md`, `MIGRATION.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Session dump.

--- a/docs/pr-review/pr-0166.md
+++ b/docs/pr-review/pr-0166.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move `SnoozeNotificationsModel.kt` and `DoorFcmModel.kt` to domain/model. Closed — superseded by PR #169.
 
 **Files:** `AndroidGarage/domain/src/commonMain/.../SnoozeNotificationsModel.kt`, `DoorFcmModel.kt`, 4 consuming files.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Closed; replaced by #169.
+
+**Superseded by:** #169

--- a/docs/pr-review/pr-0167.md
+++ b/docs/pr-review/pr-0167.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move 3 Ktor HTTP data sources + FcmPayloadParser from androidApp to data/commonMain. Replace `java.net.URLDecoder` with KMP-compatible `percentDecode`. Closed — superseded by PR #171 which did the same work successfully.
 
 **Files:** `AndroidGarage/data/src/commonMain/.../ktor/*`, `FcmPayloadParser.kt`, `data/build.gradle.kts`.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Closed; replaced by #171.
+
+**Superseded by:** #171

--- a/docs/pr-review/pr-0168.md
+++ b/docs/pr-review/pr-0168.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Extract pure Kotlin config types (`AppConfig`, `Server`, `InitialData`, `FetchOnViewModelInit`) from `androidApp/config/LocalConfig.kt` to `domain/model/AppConfig.kt`. Extract `AppLoggerKeys` to `domain/model/AppLoggerKeys.kt`. `APP_CONFIG` singleton stays in androidApp (depends on `BuildConfig`). Update 10 import sites.
 
 **Files:** `AndroidGarage/domain/src/commonMain/kotlin/.../AppConfig.kt` (new), `AppLoggerKeys.kt` (new), 10 androidApp files.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Config types to domain; platform-bound `APP_CONFIG` singleton stays in androidApp.

--- a/docs/pr-review/pr-0169.md
+++ b/docs/pr-review/pr-0169.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move `SnoozeDurationUIOption`, `SnoozeDurationServerOption`, `toServer()` to `domain/src/commonMain/`. Move `String.toFcmTopic()` to `domain/src/commonMain/`. Update all imports.
 
 **Files:** `AndroidGarage/domain/src/commonMain/kotlin/.../SnoozeNotificationsModel.kt`, `DoorFcmModel.kt`, androidApp imports.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Phase 19 domain model move.

--- a/docs/pr-review/pr-0170.md
+++ b/docs/pr-review/pr-0170.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Remove `Activity` parameter from entire FCM chain (interface → impl → use cases → ViewModel → UI). Activity was declared but never used in any implementation. Eliminates null-Activity checks in Compose callers. FCM use cases are now pure Kotlin — ready for usecase module.
 
 **Files:** `AndroidGarage/androidApp/.../MainActivity.kt`, `DoorViewModel.kt`, `DoorFcmRepository.kt`, `FcmRegistration.kt`, `DoorHistoryContent.kt`, `HomeContent.kt`, `RegisterFcmUseCase.kt`, test files.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** [great]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** "Declared but never used" parameter threading through 7 files is a real smell — removing it made FCM use cases KMP-clean. The general tactic (audit unused plumbed parameters) transfers.

--- a/docs/pr-review/pr-0171.md
+++ b/docs/pr-review/pr-0171.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move 3 Ktor HTTP data sources + `FcmPayloadParser` from androidApp to `data/src/commonMain/`. Replace `java.net.URLDecoder` with KMP-compatible `percentDecode()`. Add Ktor + kotlinx.serialization deps to data module. Import boundary 0 violations.
 
 **Files:** `AndroidGarage/data/src/commonMain/kotlin/.../KtorNetworkButtonDataSource.kt`, `KtorNetworkConfigDataSource.kt`, `KtorNetworkDoorDataSource.kt`, `FcmPayloadParser.kt`, `data/build.gradle.kts`, `AppComponent.kt`, test files.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Phase 21 KMP data-source move; `java.net.URLDecoder` → `percentDecode()` is a typical KMP adaptation.

--- a/docs/pr-review/pr-0172.md
+++ b/docs/pr-review/pr-0172.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** New `AppLoggerDataSource` interface in `data/src/commonMain/` with `log()` and `countKey()`. Android `AppLoggerRepository` extends it, adding `writeCsvToUri()`. Enables shared repositories to depend on logger without Android imports.
 
 **Files:** `AndroidGarage/data/src/commonMain/kotlin/.../AppLoggerDataSource.kt` (new), `androidApp/.../AppLoggerRepository.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Phase 25 extracted shared logger interface; restructured later in #176.

--- a/docs/pr-review/pr-0173.md
+++ b/docs/pr-review/pr-0173.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** New `configureSharedHttpClient()` in `data/src/commonMain/` with JSON, logging, base URL config. Android `provideKtorHttpClient()` picks OkHttp engine and calls shared config. iOS will provide Darwin engine with same shared config.
 
 **Files:** `AndroidGarage/data/src/commonMain/kotlin/.../ktor/KtorHttpClientFactory.kt` (new), `data/build.gradle.kts`, `androidApp/.../KtorHttpClientProvider.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Phase 24 shared HTTP config; expanded by #201 (expect/actual engine).


### PR DESCRIPTION
## Summary
Phase 2 session 8 — classified 30 PRs (#173 down through #144).

Category breakdown:
- **great** (6): #158 (NetworkResult<T> at boundary), #157 (ADR-011 no-throw + detekt), #153 (MessagingBridge), #152 (AuthBridge), #144 (ADR-010 typed returns)
- **ok** (22): KMP module moves, phase docs, cleanups, fixes
- **superseded** (2): #167 → #171, #166 → #169

Key still-current lessons:
- Network boundary returns sealed `NetworkResult<T>` — not `T?` or `Boolean`
- Platform SDK → thin bridge interface in commonMain
- ADR + Detekt rules together (no-throw error handling)
- Observation APIs = `Flow<T>`; one-time requests = `AppResult<Data, Error>`

## Test plan
- [ ] Docs-only — fast-path CI skip applies
- [ ] Phase 2 queue: 381 → 141 remaining (240 assessed, 63% complete)