### PR TITLE
docs: PR review phase 2 batch 2026-04-20 session 9 (PRs #113–#143, 30 assessments)

### DIFF
--- a/docs/pr-review/pr-0113.md
+++ b/docs/pr-review/pr-0113.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Replace two separate failure trackers (`ci-failure/build` + `ci-failure/instrumented-tests`) with one unified `ci-failure/post-merge`. Issue title includes which jobs failed: "Post-Merge CI (checks: success, instrumented: failure)". Avoids two issues for the same broken commit.
 
 **Files:** `.github/workflows/ci-post-merge.yml`, `CLAUDE.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Unified failure tracker prevents two-issues-per-broken-commit — still the rule.

--- a/docs/pr-review/pr-0115.md
+++ b/docs/pr-review/pr-0115.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Fix `IllegalStateException` in instrumented tests caused by Room querying empty table with non-nullable return. `DoorEventDao.currentDoorEvent()` returned `Flow<DoorEventEntity>` — empty table throws because Room expects non-null row. Change to `Flow<DoorEventEntity?>` through entire data chain. UI already handled null via `LoadingResult<DoorEvent?>`.
 
 **Files:** `AndroidGarage/androidApp/.../DoorEventDao.kt`, `DatabaseLocalDoorDataSource.kt`, `DoorRepositoryImpl.kt`, `FakeDoorRepository.kt`, `data/.../LocalDoorDataSource.kt`, `domain/.../DoorRepository.kt`, `.claude/hooks/git-guardrails.sh`, `scripts/run-instrumented-tests.sh`, `CLAUDE.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** [great]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Room DAO nullability fix — non-null return on empty table is a Room sharp edge. The `Flow<Entity?>` pattern is still the right shape for optional-existence queries.
+
+**Still-current lesson:** Room DAOs returning a non-nullable single row throw on empty table. Always use `Flow<Entity?>` or `suspend fun get(): Entity?` for any query that can legitimately have zero rows.

--- a/docs/pr-review/pr-0116.md
+++ b/docs/pr-review/pr-0116.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Release script and workflow now match post-merge check-run names (`Checks / Unit Tests` etc.) using `contains()`. Recover files lost to auto-merge race in PR #115: `DaoNullabilityTest` (catches non-nullable Room DAO return types at unit test time), `docs/library-bugs/` directory, `docs/library-bugs/room-nullability.md`.
 
 **Files:** `.github/workflows/ci-post-merge.yml`, `release-android.yml`, `AndroidGarage/androidApp/src/test/.../DaoNullabilityTest.kt` (new, 111 lines), `docs/library-bugs/README.md` (new), `room-nullability.md` (new), `CLAUDE.md`, `scripts/release-android.sh`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** [great]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Recovery PR that also added `DaoNullabilityTest` and `docs/library-bugs/` folder — useful home for third-party mitigations.
+
+**Still-current lesson:** When a third-party library has a known bug with your mitigation, record it in `docs/library-bugs/`. Future readers need the rationale or they'll revert the mitigation.

--- a/docs/pr-review/pr-0117.md
+++ b/docs/pr-review/pr-0117.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** TESTING.md: 138 unit tests across 21 files (was ~135 across 17). DaoNullabilityTest is the new addition.
 
 **Files:** `AndroidGarage/docs/TESTING.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Test count bookkeeping.

--- a/docs/pr-review/pr-0118.md
+++ b/docs/pr-review/pr-0118.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Delete `ExampleInstrumentedTest.kt` (boilerplate). Recover files lost to auto-merge race in PR #113: `/review-annotations` skill, `.github/annotation-ignores.txt`, Release workflow `::notice` annotation. Fix TESTING.md: accurate test count, unified failure tracking label, gate jobs documented.
 
 **Files:** delete `ExampleInstrumentedTest.kt`, `.claude/skills/review-annotations/SKILL.md` (new), `.github/annotation-ignores.txt` (new), `release-android.yml`, `docs/TESTING.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Cleanup + recovery of files lost to auto-merge race (pre-#206 hook).

--- a/docs/pr-review/pr-0119.md
+++ b/docs/pr-review/pr-0119.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** New `/repo-check` skill shows compact status report: Open PRs (count, conflicts, auto-merge), CI health (last post-merge result, open failure issues), recent releases, open issues, migration progress, local git state.
 
 **Files:** `.claude/skills/repo-check/SKILL.md` (new, 78 lines).
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** `/repo-check` skill still in use.

--- a/docs/pr-review/pr-0120.md
+++ b/docs/pr-review/pr-0120.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Convert the two pure Kotlin modules to KMP with `androidTarget()`. domain/: `kotlin("jvm")` → `kotlin("multiplatform")` + `com.android.library`; sources → `src/commonMain/kotlin/`; tests migrated JUnit → kotlin.test. data/: same pattern for 4 interface files.
 
 **Files:** `AndroidGarage/domain/build.gradle.kts`, `data/build.gradle.kts`, 13 domain source files moved, 2 test files, 4 data interfaces.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** First KMP modules (`kotlin("multiplatform")` with `androidTarget()`).

--- a/docs/pr-review/pr-0121.md
+++ b/docs/pr-review/pr-0121.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Mark Phase 5 complete in MIGRATION.md. All 7 phases done (Testing, Clean Architecture, DI Migration, Network Migration, KMP Android-only, Screenshot Tests, Instrumented Tests). Phase 5.2 documents future work for adding a second platform target.
 
 **Files:** `AndroidGarage/docs/MIGRATION.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Phase 5 bookkeeping.

--- a/docs/pr-review/pr-0122.md
+++ b/docs/pr-review/pr-0122.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Fix non-deterministic demo data (`Instant.now()` + `Random` → fixed timestamp) so screenshots don't diff on every run. Fix `UserInfoCardPreview` to use stateless overload. Fix screenshot script (shell-based cleanup, `--no-configuration-cache`, gallery generation in shell). Generate 34 reference screenshots.
 
 **Files:** `.claude/skills/update-android-screenshots/SKILL.md`, `android-screenshot-tests/build.gradle.kts`, 34 screenshot PNGs, `AndroidGarage/androidApp/ui/UiDemoData.kt`, `UserInfoCard.kt`, `scripts/generate-android-screenshots.sh`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** [great]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Deterministic preview data — still the rule.
+
+**Still-current lesson:** Preview Composables must be deterministic. Replace `Instant.now()`, `Random`, `currentTimeMillis()` with fixed constants. Non-deterministic previews cause spurious screenshot diffs on every run.

--- a/docs/pr-review/pr-0123.md
+++ b/docs/pr-review/pr-0123.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Reimplement garage door as pure Compose Canvas drawing (replaces XML vector drawables that couldn't render in screenshot tests). New `GarageDoorCanvas` draws frame + panels using Canvas API. Delete `garage_frame.xml` and `garage_door_only.xml`. Remove `weight(1f)` from RemoteButtonContent so button is inherently square. Overlays use `fillMaxSize(0.3f)` instead of `onGloballyPositioned`.
 
 **Files:** `AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/GarageDoorCanvas.kt` (new, 165 lines), `AnimatableGarageDoor.kt`, `RemoteButtonContent.kt`, delete 2 XML drawables, 19 screenshot PNGs.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Canvas drawing replaces XML vectors that didn't render in screenshot tests.

--- a/docs/pr-review/pr-0124.md
+++ b/docs/pr-review/pr-0124.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Delete `garage_closed.xml` — not referenced anywhere in code. Garage door is now drawn entirely with Compose Canvas.
 
 **Files:** delete `AndroidGarage/androidApp/src/main/res/drawable/garage_closed.xml`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Unused drawable removed.

--- a/docs/pr-review/pr-0125.md
+++ b/docs/pr-review/pr-0125.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Version name is `major.minor.patch` in `version.properties` (manually bumped). versionCode unchanged — still from release tag. Build timestamp preserved as `BuildConfig.BUILD_TIMESTAMP` (UTC). App info screen shows version name, code, and build timestamp.
 
 **Files:** `AndroidGarage/version.properties`, `androidApp/build.gradle.kts`, `AndroidAppInfoCard.kt`, `VersionModel.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Semantic versioning + build timestamp — still the release model.

--- a/docs/pr-review/pr-0126.md
+++ b/docs/pr-review/pr-0126.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add 11 new phases to MIGRATION.md for shared module extraction and iOS readiness. Phases 8-13: Core module extraction (UseCase, Data, ViewModel, Nav3, iOS). Phases 14-18: Quality improvements (typed errors, logging, tests, rules).
 
 **Files:** `AndroidGarage/docs/MIGRATION.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Phases 8-18 roadmap; most later executed.

--- a/docs/pr-review/pr-0127.md
+++ b/docs/pr-review/pr-0127.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move repository dependencies from `invoke()` args to constructors in 3 UseCases (`EnsureFreshIdTokenUseCase`, `PushRemoteButtonUseCase`, `SnoozeNotificationsUseCase`). `invoke()` now only takes request-specific args. Follows battery-butler pattern, unblocks extracting UseCases to shared KMP module. Replaces `android.text.format.DateFormat` with `java.text.SimpleDateFormat` in `createButtonAckToken` (fixes NPE in unit tests).
 
 **Files:** 3 UseCase files, `RemoteButtonViewModel.kt`, `PushRepository.kt`, `HomeContent.kt`, `ProfileContent.kt`, `AppComponent.kt`, 4 test files.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** UseCase constructor injection (deps → ctor, `invoke()` → request args) — still the shape.
+
+**Still-current lesson:** UseCase constructors take repository deps; `invoke()` takes only request-specific args. That split keeps UseCases shareable — deps in common, call-site state in whatever calls it.

--- a/docs/pr-review/pr-0128.md
+++ b/docs/pr-review/pr-0128.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Create `usecase/` KMP module with shared business logic in `commonMain`. 5 UseCases moved from `androidApp/usecase/` → `usecase/src/commonMain/kotlin/`. `RegisterFcmUseCase` stays in androidApp (Android deps). Module depends only on `:domain`. Tests remain in androidApp (Phase 16 migrates them). Git shows clean renames.
 
 **Files:** `AndroidGarage/usecase/build.gradle.kts` (new), 5 UseCase files moved, `settings.gradle.kts`, `androidApp/build.gradle.kts`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Created `usecase/` KMP module — foundation for every subsequent UseCase/VM extraction.

--- a/docs/pr-review/pr-0129.md
+++ b/docs/pr-review/pr-0129.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Replace `android.util.Log` with Kermit (`co.touchlab:kermit` 2.0.4) across all 20 files. KMP-compatible, unblocking Phase 9 (moving repos/data sources to commonMain). `Log.d(TAG, "msg")` → `Logger.d { "msg" }` (lazy eval). String concatenation → string templates. Remove all TAG constants. Zero `android.util.Log` imports. Net -69 lines.
 
 **Files:** 20 `androidApp/src/main/.../*.kt` files, `androidApp/build.gradle.kts`, `libs.versions.toml`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Kermit replacing `android.util.Log` unblocks KMP for 20 files.
+
+**Still-current lesson:** Replace `android.util.Log` with Kermit before moving code to `commonMain` — lazy-lambda API (`Logger.d { ... }`) is strictly better on both KMP-compatibility and concat-performance.

--- a/docs/pr-review/pr-0130.md
+++ b/docs/pr-review/pr-0130.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** First step of Phase 9. `ServerConfigRepositoryImpl` → `data/src/commonMain/kotlin/` (zero Android deps). Inject `serverConfigKey` via constructor instead of global `APP_CONFIG`. Remove duplicate `ServerConfigRepository` interface from `config/` (domain already has it). Update imports and DI wiring.
 
 **Files:** `AndroidGarage/data/src/commonMain/kotlin/.../ServerConfigRepositoryImpl.kt`, delete `androidApp/config/ServerConfigRepository.kt`, `AppComponent.kt`, `DoorRepositoryImpl.kt`, `PushRepository.kt`, test files.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** First repo moved to data/commonMain.

--- a/docs/pr-review/pr-0131.md
+++ b/docs/pr-review/pr-0131.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Remove direct `APP_CONFIG` global references from repository implementations, replacing with constructor-injected values. `DoorRepositoryImpl` injected `recentEventCount`. `PushRepositoryImpl` injected `remoteButtonPushEnabled`, `snoozeNotificationsOption`. Removes last Android-specific coupling before Phase 9 extraction.
 
 **Files:** `AndroidGarage/androidApp/.../DoorRepositoryImpl.kt`, `PushRepository.kt`, `AppComponent.kt`, `PushRepositoryTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Global singleton → constructor injection.

--- a/docs/pr-review/pr-0132.md
+++ b/docs/pr-review/pr-0132.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Move all 3 repository implementations from androidApp to `data/src/commonMain/`. `DoorRepositoryImpl` zero Android deps. `PushRepositoryImpl` JVM deps (Duration, Date) work for Android KMP target. `ServerConfigRepositoryImpl` already moved in PR #130. `createButtonAckToken()` moved to `RemoteButtonViewModel.kt` (uses SimpleDateFormat). Kermit added to data module deps. All repos now in shared data module, completing Phase 9's core goal.
 
 **Files:** `AndroidGarage/data/src/commonMain/kotlin/.../DoorRepositoryImpl.kt`, `PushRepositoryImpl.kt`, `data/build.gradle.kts`, `androidApp/.../RemoteButtonViewModel.kt`, `AppComponent.kt`, `PushRepositoryTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Phase 9 repo moves to data module.

--- a/docs/pr-review/pr-0133.md
+++ b/docs/pr-review/pr-0133.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Establish naming convention (ADR-008) and rename 3 repository implementations. `DoorRepositoryImpl` → `NetworkDoorRepository`. `PushRepositoryImpl` → `NetworkPushRepository`. `ServerConfigRepositoryImpl` → `CachedServerConfigRepository`. ADR-008: no `*Impl` suffix, use descriptive prefixes. Old ADR-008 (parsing objects) renumbered to ADR-009.
 
 **Files:** `AndroidGarage/data/src/commonMain/.../NetworkDoorRepository.kt`, `NetworkPushRepository.kt`, `CachedServerConfigRepository.kt`, `AppComponent.kt`, `DECISIONS.md`, `CLAUDE.md`, test files.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** ADR-008 "no `*Impl` suffix" landed with the first three renames; #134 completed the sweep.

--- a/docs/pr-review/pr-0134.md
+++ b/docs/pr-review/pr-0134.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Complete ADR-008 enforcement — rename all 9 remaining `*Impl` classes. `AuthRepositoryImpl` → `FirebaseAuthRepository`. VM Impls → `Default*`. `AppLoggerRepositoryImpl` → `RoomAppLoggerRepository`. `AppSettingsImpl` → `DataStoreAppSettings`. `DoorFcmRepositoryImpl` → `FirebaseDoorFcmRepository`. Broaden ADR-009: no bare top-level functions — group in named `object {}`. Composables exempt. Zero `*Impl` classes remain.
 
 **Files:** 9 renamed classes, `AppComponent.kt`, many call sites, `DECISIONS.md`, `ARCHITECTURE.md`, `DI-MIGRATION.md`, `CLAUDE.md`, `test-coverage-exemptions.txt`, `detekt-baseline.xml`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Eliminated all `*Impl` names in one wave — replaced with descriptive prefixes (`Firebase*`, `Default*`, `Room*`, `DataStore*`). Convention + the "no bare top-level functions" ADR-009 rule still enforced culturally.
+
+**Still-current lesson:** `*Impl` says nothing about the implementation — name after what it uses (`Firebase*`, `Room*`, `Network*`) or its default vs. fake role (`Default*`). Readers can guess the difference between `FirebaseAuthRepository` and `FakeAuthRepository`; they can't guess between `AuthRepositoryImpl` and `FakeAuthRepository`.

--- a/docs/pr-review/pr-0135.md
+++ b/docs/pr-review/pr-0135.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add `AppResult<D, E : AppError>` sealed interface to domain module. Typed error hierarchy: `Success<D>`/`Error<E>`, `DataError.Network` (ConnectionFailed, Timeout, ServerError, NotReady), `AuthError` (NotAuthenticated, TokenExpired, SignInFailed). Extensions: `getOrNull`, `getOrElse`, `map`, `mapError`, `onSuccess`, `onError`. Foundation only — repositories/UseCases adopt incrementally. 11 new tests.
 
 **Files:** `AndroidGarage/domain/src/commonMain/kotlin/.../AppResult.kt` (new, 120 lines), `AppResultTest.kt` (new, 90 lines).
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** `AppResult<D, E : AppError>` is the root of the typed-error model every repo/UseCase uses. Extensions (`map`, `getOrNull`) make it ergonomic without hiding failure modes.
+
+**Still-current lesson:** Domain `Result<Data, Error>` with `Error` as a sealed hierarchy (not `Exception`) lets every consumer match outcome by type. Extensions keep it ergonomic without inviting `.getOrThrow()`.

--- a/docs/pr-review/pr-0136.md
+++ b/docs/pr-review/pr-0136.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add `ImportBoundaryCheckTask` scanning `commonMain` for forbidden Android imports. Catches accidental platform-specific deps at build time. Forbidden: `android.*`, `androidx.*`, `com.google.firebase.*`, `com.google.android.*`. Registered in domain, data, usecase. Added to validate.sh.
 
 **Files:** `AndroidGarage/buildSrc/src/main/kotlin/importboundary/ImportBoundaryCheckTask.kt` (new, 79 lines), `domain/build.gradle.kts`, `data/build.gradle.kts`, `usecase/build.gradle.kts`, `scripts/validate.sh`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Import-boundary lint for `commonMain` — bans platform-specific packages at build time. Foundational KMP-purity gate.
+
+**Still-current lesson:** For any KMP module's `commonMain`, add a build-time import-boundary lint that bans platform-specific packages. Accidental Android imports compile fine — until iOS.

--- a/docs/pr-review/pr-0137.md
+++ b/docs/pr-review/pr-0137.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Update MIGRATION.md: Mark Phases 8, 9, 14, 15, 17 complete with PR numbers. TESTING.md: 144 unit tests (was 138), import boundary check added.
 
 **Files:** `AndroidGarage/docs/MIGRATION.md`, `TESTING.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Session dump.

--- a/docs/pr-review/pr-0138.md
+++ b/docs/pr-review/pr-0138.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add whatsnew entry for 2.3.
 
 **Files:** `AndroidGarage/distribution/whatsnew/whatsnew-en-US`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Release notes.

--- a/docs/pr-review/pr-0139.md
+++ b/docs/pr-review/pr-0139.md
@@ -12,3 +12,13 @@ phase1_reviewed: 2026-04-20
 **Notes:** Later replaced by unified `ButtonStateMachine` in PR #237.
 
 **Files:** `AndroidGarage/usecase/src/commonMain/kotlin/.../RemoteButtonStateMachine.kt` (new, 219 lines), `RemoteButtonStateMachineTest.kt` (new, 352 lines), `domain/src/commonMain/kotlin/.../DispatcherProvider.kt` (new), `androidApp/.../RemoteButtonViewModel.kt` (slim down), `MIGRATION.md`.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** [great]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** First SM extraction; replaced by Channel-based unified `ButtonStateMachine` (#237). "State machine as pure usecase code" pattern survives.
+
+**Superseded by:** #237

--- a/docs/pr-review/pr-0140.md
+++ b/docs/pr-review/pr-0140.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Create fake data sources in `data/src/commonTest/`: `InMemoryLocalDoorDataSource`, `FakeNetworkDoorDataSource`, `FakeNetworkConfigDataSource`. 12 integration tests for `NetworkDoorRepository` (fetch→cache→flow pipeline, null server config, null network response, insert, position tracking). 6 tests for `CachedServerConfigRepository` (caching, retry after null, cache invalidation). All use kotlin.test (KMP, no Mockito).
 
 **Files:** `AndroidGarage/data/src/commonTest/kotlin/.../NetworkDoorRepositoryIntegrationTest.kt` (new, 247 lines), `CachedServerConfigRepositoryTest.kt` (new), `testfakes/*` (3 new files), `data/build.gradle.kts`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Phase 16 integration tests with fake data sources — foundational for the "two fake boundaries" rule codified in #219.

--- a/docs/pr-review/pr-0141.md
+++ b/docs/pr-review/pr-0141.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** TESTING.md: 186 unit tests across 26 files (was 144/22). MIGRATION.md: Phase 16 (integration tests) marked complete.
 
 **Files:** `AndroidGarage/docs/TESTING.md`, `MIGRATION.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Bookkeeping.

--- a/docs/pr-review/pr-0142.md
+++ b/docs/pr-review/pr-0142.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Fix auto-discovery in `validate.sh` to find KMP `src/commonTest/` directories (not just `src/test/`). Use `testDebugUnitTest` task for KMP Android library modules. domain and usecase module tests now run during local validation.
 
 **Files:** `scripts/validate.sh`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** KMP `commonTest` now discovered in validate.sh.

--- a/docs/pr-review/pr-0143.md
+++ b/docs/pr-review/pr-0143.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** After successful snooze, call `fetchSnoozeEndTimeSeconds()` immediately instead of waiting for 1-minute polling. Fixes issue where snooze settings don't visually update until switching tabs.
 
 **Files:** `AndroidGarage/androidApp/.../remotebutton/RemoteButtonViewModel.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Immediate fetch after snooze — correct UX; later superseded by #349's "use POST response body" (no follow-up GET).


### PR DESCRIPTION
## Summary
Phase 2 session 9 — classified 30 PRs (#143 down through #113, skipping #114 which isn't a PR).

Category breakdown:
- **great** (7): #140 (integration tests w/ fake data sources), #136 (import-boundary lint), #135 (AppResult foundation), #134 (rename all *Impl), #133 (ADR-008 naming), #129 (Kermit KMP logging), #128 (usecase KMP module), #127 (UseCase constructor injection)
- **ok** (22): phase moves, polish, docs, skill
- **superseded** (1): #139 (RemoteButtonStateMachine → unified ButtonStateMachine #237)

Key still-current lessons:
- Preview Composables must be deterministic (no `Instant.now()`, no `Random`)
- Room DAOs: `Flow<Entity?>` for any query that can legitimately return zero rows
- `docs/library-bugs/` folder for third-party mitigations with rationale
- Kermit over `android.util.Log` before moving to commonMain
- UseCase constructors take repo deps; `invoke()` takes only request args
- Replace `*Impl` with descriptive prefixes (`Firebase*`, `Default*`, `Network*`)
- Domain `AppResult<D, E : AppError>` with sealed Error — not Exception
- Ban platform-specific packages in commonMain at build time (Android imports compile fine — until iOS)

## Test plan
- [ ] Docs-only — fast-path CI skip applies
- [ ] Phase 2 queue: 381 → 111 remaining (270 assessed, 71% complete)