### PR TITLE
docs: PR review phase 2 batch 2026-04-20 session 10 (PRs #82–#111, 30 assessments)

### DIFF
--- a/docs/pr-review/pr-0082.md
+++ b/docs/pr-review/pr-0082.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Phase 2 complete. Update MIGRATION.md with Phase 2.3 commit hashes and mark Phase 2 done in summary table.
 
 **Files:** `AndroidGarage/docs/MIGRATION.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Phase 2 bookkeeping.

--- a/docs/pr-review/pr-0083.md
+++ b/docs/pr-review/pr-0083.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Delete 5 untracked workflow files from a different project (web hosting, not SmartGarageDoor). Delete `cartland-dev-reference/` directory. Commit `detekt-baseline.xml` (should be tracked). Add `.claude/worktrees/` to `.gitignore`. After: `release-android.sh --check` reports zero warnings.
 
 **Files:** `AndroidGarage/androidApp/detekt-baseline.xml`, `.gitignore`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Cleanup.

--- a/docs/pr-review/pr-0084.md
+++ b/docs/pr-review/pr-0084.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Both release scripts detect and warn about existing tags on HEAD. Latest tag on commit → "version bump, no code change". Older tag on commit → "rollback/rollforward". No tags → no warning. Shown in both `--check` and release mode.
 
 **Files:** `scripts/release-android.sh`, `scripts/release-firebase.sh`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Release script tag-collision warning.

--- a/docs/pr-review/pr-0085.md
+++ b/docs/pr-review/pr-0085.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Permanent migration guide updated with commit hashes as each step completes. Reusable as template for other repos. Hilt inventory, side-by-side migration strategy, step-by-step for add kotlin-inject, migrate ViewModels, bindings, FCMService, remove Hilt. Before/after code examples. Rollback plan.
 
 **Files:** `AndroidGarage/docs/DI-MIGRATION.md` (new, 332 lines).
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** [great]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Living migration guide with commit hashes, reusable template.
+
+**Still-current lesson:** For a long migration, write a living `DI-MIGRATION.md` that lists each concrete step with commit hashes — future Claude sessions need the trail.

--- a/docs/pr-review/pr-0086.md
+++ b/docs/pr-review/pr-0086.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Step 1 of Hilt → kotlin-inject migration. Both DI systems coexist with no behavior change. Add kotlin-inject 0.9.0 (runtime + KSP compiler). Create `@Singleton` scope and empty `AppComponent`. `GarageApplication` lazily creates the kotlin-inject component. Hilt remains fully functional.
 
 **Files:** `AndroidGarage/androidApp/build.gradle.kts`, `GarageApplication.kt`, `di/AppComponent.kt` (new), `Singleton.kt` (new), `libs.versions.toml`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Adding kotlin-inject alongside Hilt as step 1 of a strangler-fig migration — the only way to do a DI rewrite on a shipping app without a breaking-change commit.
+
+**Still-current lesson:** DI migrations ship incrementally: land the new DI system alongside the old, migrate consumers one at a time, delete the old system last. Never try to atomically swap DI frameworks.

--- a/docs/pr-review/pr-0087.md
+++ b/docs/pr-review/pr-0087.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** First ViewModel migrated from Hilt to kotlin-inject (proof of concept). Before: `@HiltViewModel` + `hiltViewModel<AppSettingsViewModelImpl>()`. After: `@Inject` + `viewModel { component.appSettingsViewModel }`. `rememberAppComponent()` composable helper. AppComponent provides `AppSettings` and `AppSettingsViewModelImpl`. Hilt remains for other ViewModels — both systems coexist.
 
 **Files:** `AndroidGarage/androidApp/.../settings/AppSettingsViewModel.kt`, `di/AppComponent.kt`, `ComponentProvider.kt` (new), `AndroidAppInfoCard.kt`, `LogSummaryCard.kt`, `UserInfoCard.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** First kotlin-inject VM migration (strangler-fig POC).

--- a/docs/pr-review/pr-0088.md
+++ b/docs/pr-review/pr-0088.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Before blocking Claude from stopping, dev-mode hook runs `gh pr merge --auto --squash --delete-branch` on all open PRs. Ensures last PR of a session merges once CI passes.
 
 **Files:** `.claude/hooks/dev-mode.sh`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Dev-mode hook enhancement.

--- a/docs/pr-review/pr-0089.md
+++ b/docs/pr-review/pr-0089.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Second ViewModel migrated from Hilt to kotlin-inject. AppComponent provides AuthRepository (+ deps: AppLoggerRepository, AppDatabase, DispatcherProvider). AuthViewModelImpl uses `me.tatarka.inject.annotations.Inject`. 4 composables updated to use `rememberAppComponent()` + `viewModel {}`.
 
 **Files:** `AndroidGarage/androidApp/.../auth/AuthViewModel.kt`, `di/AppComponent.kt`, `MainActivity.kt`, `HomeContent.kt`, `Main.kt`, `ProfileContent.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** AuthViewModel kotlin-inject migration.

--- a/docs/pr-review/pr-0090.md
+++ b/docs/pr-review/pr-0090.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Third ViewModel migrated — the most complex with full FCM + data dependency chain. AppComponent now provides: GarageNetworkService, NetworkDoorDataSource, LocalDoorDataSource, DoorRepository, ServerConfigRepository, DoorFcmRepository, all UseCases. 6 composables updated. `provideGarageNetworkService()` extracted as shared function.
 
 **Files:** `AndroidGarage/androidApp/.../door/DoorViewModel.kt`, `di/AppComponent.kt`, `remotebutton/RemoteButtonViewModel.kt`, `fcm/FcmRegistration.kt`, `internet/GarageNetworkService.kt`, 5 UI files, `MainActivity.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** DoorViewModel kotlin-inject migration.

--- a/docs/pr-review/pr-0091.md
+++ b/docs/pr-review/pr-0091.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Complete kotlin-inject migration (Phase 3.2-3.5). All 5 ViewModels migrated: AppSettings, Auth, Door, RemoteButton, AppLogger. FCMService migrated: `@AndroidEntryPoint` removed, uses lazy component access. No `hiltViewModel<>()` calls, no `javax.inject.Inject` on any ViewModel. Only `@AndroidEntryPoint` on MainActivity and `@HiltAndroidApp` on GarageApplication remain for the final Hilt removal PR (#96).
 
 **Files:** `AndroidGarage/androidApp/.../AppLoggerViewModel.kt`, `MainActivity.kt`, `FCMService.kt`, `di/AppComponent.kt`, 4 UI files.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** All 5 ViewModels + FCMService on kotlin-inject; final step before Hilt removal.

--- a/docs/pr-review/pr-0092.md
+++ b/docs/pr-review/pr-0092.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Dev mode stop hook now detects DIRTY (conflicting) PRs and tells Claude to rebase them before stopping. Ensures auto-merge can succeed after CI passes.
 
 **Files:** `.claude/hooks/dev-mode.sh`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Dev-mode hook refinement.

--- a/docs/pr-review/pr-0093.md
+++ b/docs/pr-review/pr-0093.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Sign-in broke because `signInWithGoogle()` stores `SignInClient` in one ViewModel instance, but `processGoogleSignInResult()` in `onActivityResult` accessed a different instance. Root cause: `component.authViewModel` creates new instance each time; Compose's `viewModel {}` and `ViewModelProvider` use different ViewModelStoreOwners. Fix: create AuthViewModel once in MainActivity's `ViewModelProvider` (Activity-scoped), pass to Compose.
 
 **Files:** `AndroidGarage/androidApp/.../MainActivity.kt`, `HomeContent.kt`, `Main.kt`, `ProfileContent.kt`.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Sign-in fix via Activity-scoped VM; shape changed once sign-in left the VM (#181) and Nav3 landed (#192).
+
+**Superseded by:** #181 + #192

--- a/docs/pr-review/pr-0094.md
+++ b/docs/pr-review/pr-0094.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Rename AAB file: `androidApp-release.aab` → `androidApp-release-129.aab`. GitHub artifact: `release-aab` → `release-aab-129`. Makes each release uniquely identifiable.
 
 **Files:** `.github/workflows/release-android.yml`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Versioned AAB filename.

--- a/docs/pr-review/pr-0095.md
+++ b/docs/pr-review/pr-0095.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Extend the PR #93 auth sign-in fix to all ViewModels used in both MainActivity and Compose: DoorViewModel (`registerFcm` in `onCreate` + UI in Compose), AppLoggerViewModel, AuthViewModel. Create `activityViewModel()` utility wrapping `ViewModelProvider` with kotlin-inject factory.
 
 **Files:** `AndroidGarage/androidApp/.../MainActivity.kt`, `di/ActivityViewModels.kt` (new), `DoorHistoryContent.kt`, `HomeContent.kt`, `Main.kt`.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Activity-scoped VM sharing; later superseded by Nav3 per-entry scoping + singleton repositories (ADR-022).
+
+**Superseded by:** #192 + ADR-021/022

--- a/docs/pr-review/pr-0096.md
+++ b/docs/pr-review/pr-0096.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Hilt is gone. Delete `@HiltAndroidApp`, `@AndroidEntryPoint`, all 15 `@Module` classes (dead code). Remove Hilt Gradle plugin + 3 deps. Remove all `dagger`/`javax.inject` imports. Net -257 lines. Phase 3 DI migration complete.
 
 **Files:** 20+ files across androidApp removing Hilt annotations and imports, `GarageApplication.kt`, `MainActivity.kt`, `AppDatabase.kt`, multiple repositories, DispatcherProvider, delete `LocalDoorDataSource.kt`, delete `DoorRepository.kt`, new `DatabaseLocalDoorDataSource.kt`, `DoorRepositoryImpl.kt`, `AppSettings.kt`, UseCases, `build.gradle.kts`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Hilt fully removed; kotlin-inject is sole DI. Net -257 lines. All Hilt annotations and imports gone — still the case, and it was the prerequisite for every KMP module extraction.

--- a/docs/pr-review/pr-0097.md
+++ b/docs/pr-review/pr-0097.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** MIGRATION.md Phase 3 complete with commit hashes. TESTING.md test count, CI features, DI system. DI-MIGRATION.md steps filled with commits/PRs. CLAUDE.md kotlin-inject noted.
 
 **Files:** `AndroidGarage/docs/MIGRATION.md`, `DI-MIGRATION.md`, `TESTING.md`, `CLAUDE.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Session dump.

--- a/docs/pr-review/pr-0098.md
+++ b/docs/pr-review/pr-0098.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Remove `hilt` and `hiltNavigation` version entries from `libs.versions.toml`. Remove 3 Hilt library aliases, Hilt plugin alias, `libs.plugins.hilt` from root `build.gradle.kts`. Hilt fully removed in #96 — these were leftover catalog entries.
 
 **Files:** `AndroidGarage/build.gradle.kts`, `gradle/libs.versions.toml`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Cleanup of leftover Hilt catalog entries.

--- a/docs/pr-review/pr-0099.md
+++ b/docs/pr-review/pr-0099.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add Ktor HTTP client 3.1.3 + kotlinx-serialization-json 1.8.1. First step of Phase 4. Closed — superseded by PR #100 which included dependencies and the actual Ktor implementations together.
 
 **Files:** `AndroidGarage/androidApp/build.gradle.kts`, `build.gradle.kts`, `libs.versions.toml`.
+
+## Phase 2 assessment
+
+**Primary:** superseded
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Closed; deps rolled into #100.
+
+**Superseded by:** #100

--- a/docs/pr-review/pr-0100.md
+++ b/docs/pr-review/pr-0100.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Create `KtorNetworkDoorDataSource`, `KtorNetworkConfigDataSource`, `KtorNetworkButtonDataSource` each using `@Serializable` DTOs with `ignoreUnknownKeys`. Swap DI wiring in AppComponent from Retrofit to Ktor. Retrofit/Moshi remains but unreferenced (removed in #101). Ktor impls bypass `GarageNetworkService` entirely.
 
 **Files:** `AndroidGarage/androidApp/.../internet/KtorHttpClientProvider.kt` (new, 47 lines), `KtorNetworkButtonDataSource.kt` (new, 123 lines), `KtorNetworkConfigDataSource.kt` (new, 95 lines), `KtorNetworkDoorDataSource.kt` (new, 138 lines), `build.gradle.kts`, `libs.versions.toml`, `AppComponent.kt`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Phase 4.2 — Ktor + kotlinx.serialization replace Retrofit. Still the HTTP stack.

--- a/docs/pr-review/pr-0101.md
+++ b/docs/pr-review/pr-0101.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Delete all Retrofit/Moshi source code (10 files, -841 net lines). Delete `retrofit2.pro` and `moshi.pro`. Remove 7 dependencies. Migrate `GarageNetworkServiceTest` and `RoomSchemaTest` from Moshi to kotlinx.serialization. Zero `retrofit`/`moshi`/`okhttp` imports remain. Phase 4 complete.
 
 **Files:** 10 deleted `internet/Retrofit*.kt` + DTO files, `build.gradle.kts`, `libs.versions.toml`, 2 proguard files deleted, tests migrated, `AppComponent.kt`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** -841 net lines — Retrofit/Moshi/OkHttp fully removed.
+
+**Still-current lesson:** After a library migration, follow up with a PR that *deletes* the old library — not just stops using it. Unused-but-present libraries get re-introduced via auto-import.

--- a/docs/pr-review/pr-0102.md
+++ b/docs/pr-review/pr-0102.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Mark Phase 4 (Retrofit → Ktor) complete in MIGRATION.md. Update ARCHITECTURE.md: DI section from Hilt to kotlin-inject, network from Retrofit to Ktor. Update CLAUDE.md network stack reference.
 
 **Files:** `AndroidGarage/docs/ARCHITECTURE.md`, `MIGRATION.md`, `CLAUDE.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Phase 4 bookkeeping.

--- a/docs/pr-review/pr-0103.md
+++ b/docs/pr-review/pr-0103.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Rename Phase 7.3 from "Hilt DI graph test" to "kotlin-inject component test". Update current state to note Ktor HTTP replacing Retrofit. Update test descriptions.
 
 **Files:** `AndroidGarage/docs/TESTING.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Testing doc update.

--- a/docs/pr-review/pr-0104.md
+++ b/docs/pr-review/pr-0104.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** ADR-002: Update current tech stack (Hilt→kotlin-inject, Retrofit+Moshi→Ktor+kotlinx.serialization). ADR-004: Mark DI and networking targets complete.
 
 **Files:** `AndroidGarage/docs/DECISIONS.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** ADR-002/004 updates.

--- a/docs/pr-review/pr-0105.md
+++ b/docs/pr-review/pr-0105.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Phase 7.1 Gradle Managed Device (Pixel 6, API 34, aosp-atd) + CI workflow. 7.2 `DatabaseSanityTest` — Room DB creates, DAOs accessible, insert/read (6 tests). 7.3 `ComponentGraphTest` — kotlin-inject AppComponent resolves all 5 ViewModels (6 tests). Fix `ExampleInstrumentedTest` package name. CI runs `pixel6Api34DebugAndroidTest` on push to main with KVM acceleration.
 
 **Files:** `.github/workflows/instrumented-tests.yml` (new), `AndroidGarage/androidApp/build.gradle.kts`, `DatabaseSanityTest.kt` (new), `ComponentGraphTest.kt` (new), `ExampleInstrumentedTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** GMD + CI workflow + `ComponentGraphTest` (later load-bearing for DI identity checks in #371).
+
+**Still-current lesson:** A `ComponentGraphTest` asserting DI resolves every `ViewModel`/`Repository` is a high-leverage instrumented test — catches wiring regressions that compile fine.

--- a/docs/pr-review/pr-0106.md
+++ b/docs/pr-review/pr-0106.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** 6 navigation smoke tests using Compose UI testing. Launch MainActivity, navigate via bottom bar tabs. Verify Home, History, Profile screens render without crashing. Sequential navigation test covers all transitions. No new deps. Phase 7 complete.
 
 **Files:** `AndroidGarage/androidApp/src/androidTest/.../NavigationSmokeTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Instrumented smoke tests for navigation.

--- a/docs/pr-review/pr-0107.md
+++ b/docs/pr-review/pr-0107.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** New `android-screenshot-tests` module with AGP Screenshot Plugin 0.0.1-alpha12. `screenshotTest` source set with `@PreviewTest` + `@Preview` pattern. OOM prevention: blocks single-invocation runs, requires sequential script. Auto-generated `SCREENSHOT_GALLERY.md`. 17 previews × light + dark = 34 images. Screens (Home, History, Profile), Components, Garage door states. `/update-android-screenshots` skill.
 
 **Files:** `AndroidGarage/android-screenshot-tests/build.gradle.kts` (new), 3 screenshot test files, scripts, `.claude/skills/update-android-screenshots/SKILL.md` (new), `.github/workflows/ci.yml`, `settings.gradle.kts`, `libs.versions.toml`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Screenshot tests infrastructure — foundational. OOM sequential-script mitigation still in place.
+
+**Still-current lesson:** AGP Screenshot Plugin can OOM when all tests run in one Gradle invocation. A sequential shell script per-test-file avoids it; don't invoke `updateDebug`+`validateDebug` in the same gradle call.

--- a/docs/pr-review/pr-0108.md
+++ b/docs/pr-review/pr-0108.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Reusable `ci-failure-tracker` composite action. On failure: creates issue labeled `ci-failure/<workflow>` with links to failing run/commit/source PR. If issue exists, adds "still failing" comment. On success: finds and closes any open failure issue, adds "fixed by" comment. Applied to `instrumented-tests.yml` with label `ci-failure/instrumented-tests`.
 
 **Files:** `.github/actions/ci-failure-tracker/action.yml` (new, 113 lines), `.github/workflows/instrumented-tests.yml`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Composite action + issue-per-label pattern — reused for Firebase (#382). Still in use.
+
+**Still-current lesson:** Post-merge CI failures deserve an automatic GitHub issue per workflow (label `ci-failure/<workflow>`). Auto-comment on recurrence, auto-close on fix.

--- a/docs/pr-review/pr-0109.md
+++ b/docs/pr-review/pr-0109.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Split CI into pre-submit/post-merge architecture with shared job definitions. New `ci-checks.yml` (workflow_call) — shared jobs. `ci.yml` → PRs only, calls ci-checks + gate job. `ci-post-merge.yml` → push to main, calls ci-checks + instrumented tests + failure tracking. Old `instrumented-tests.yml` merged into post-merge.
 
 **Files:** `.github/workflows/ci-checks.yml` (new, 129 lines), `ci-post-merge.yml` (new, 113 lines), `ci.yml` (simplified), delete `instrumented-tests.yml`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Pre/post-merge split with reusable `ci-checks.yml` — the CI shape every later addition extended.
+
+**Still-current lesson:** Pre-submit and post-merge do different things (block PRs vs. catch main regressions). Use a `workflow_call` yaml for shared steps so one change can't diverge the contexts.

--- a/docs/pr-review/pr-0110.md
+++ b/docs/pr-review/pr-0110.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Two fixes pushed to PR #109 after it auto-merged. (1) `permissions: issues: write` on `ci-post-merge.yml` — required for `ci-failure-tracker` to create labels/issues. (2) `scripts/` in change detection — changes to validate.sh, release scripts, etc. now trigger CI in both PR and post-merge workflows.
 
 **Files:** `.github/workflows/ci-post-merge.yml`, `ci.yml`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Permissions + scripts/ detection fixes.

--- a/docs/pr-review/pr-0111.md
+++ b/docs/pr-review/pr-0111.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** MIGRATION.md: Phase 6 + 7 complete with commit hashes, Phase 5 updated to Android-only. TESTING.md: 18 instrumented tests, CI architecture, failure tracking, screenshot compilation. CLAUDE.md: CI architecture section.
 
 **Files:** `AndroidGarage/docs/MIGRATION.md`, `TESTING.md`, `CLAUDE.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Session dump.


### PR DESCRIPTION
## Summary
Phase 2 session 10 — classified 30 PRs (#111 down through #82).

Category breakdown:
- **great** (7): #109 (pre/post-merge CI split), #108 (auto-issue CI failure tracker), #107 (screenshot infra), #105 (GMD + ComponentGraphTest), #101 (delete Retrofit), #100 (Ktor data sources), #96 (remove Hilt), #91 (all VMs kotlin-inject), #86 (strangler-fig DI add)
- **ok** (19): phase moves, bookkeeping, dev-mode hook tweaks
- **superseded** (4): #99 (→#100), #95/#93 (Activity-scoped VM → Nav3 + ADR-022)

Key still-current lessons:
- Pre-submit + post-merge CI use a reusable `workflow_call` yaml
- Auto-issue per workflow on post-merge failure (label `ci-failure/<workflow>`)
- AGP Screenshot Plugin OOMs on single-invocation; use sequential script
- `ComponentGraphTest` asserting DI resolution is high-leverage
- After library migration, *delete* the old library in a follow-up
- DI migrations ship incrementally (strangler fig), never atomically

## Test plan
- [ ] Docs-only — fast-path CI skip applies
- [ ] Phase 2 queue: 381 → 81 remaining (300 assessed, 79% complete)