### PR TITLE
docs: PR review phase 2 batch 2026-04-20 session 11 (PRs #52–#81, 30 assessments)

### DIFF
--- a/docs/pr-review/pr-0052.md
+++ b/docs/pr-review/pr-0052.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Apply ADR-008: replace `Map<K, V>.asDoorEvent()` extension with `FcmPayloadParser.parseDoorEvent(Map<String, String>)`. Parser object makes parsing logic discoverable and input type explicit. All 17 FCM contract tests pass unchanged.
 
 **Files:** `AndroidGarage/androidApp/.../fcm/FCMService.kt`, `FcmPayloadParser.kt` (new, 63 lines), `FcmPayloadParsingTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Extension → named parser object (ADR-008/009).

--- a/docs/pr-review/pr-0053.md
+++ b/docs/pr-review/pr-0053.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** `refreshFirebaseAuthState()` used `suspendCancellableCoroutine` with `addOnSuccessListener` but no `addOnFailureListener`. If Firebase token fetch failed, the coroutine hung forever, blocking the ViewModel. Now resumes with `null` on failure, triggering the existing `Unauthenticated` fallback. Known bug from TESTING.md Phase 3.1.
 
 **Files:** `AndroidGarage/androidApp/.../auth/AuthRepository.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** [great]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Missing failure listener hung the coroutine. Classic coroutine+callback bug.
+
+**Still-current lesson:** Any `suspendCancellableCoroutine` wrapping a callback API must register BOTH success and failure callbacks — a missing failure callback doesn't throw, it silently hangs the coroutine forever.

--- a/docs/pr-review/pr-0054.md
+++ b/docs/pr-review/pr-0054.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Mark Phase 2.2 as in progress, document EnsureFreshIdTokenUseCase completion. Update Phase 3.1 to reflect auth token hang fix (#53).
 
 **Files:** `AndroidGarage/docs/MIGRATION.md`, `TESTING.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Bookkeeping.

--- a/docs/pr-review/pr-0055.md
+++ b/docs/pr-review/pr-0055.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Close gap between local validation and CI that caused PR #45 to pass locally but fail in CI. `spotlessCheck` now runs at root level (covers `:domain` not just `:androidApp`). Add `:domain:test`.
 
 **Files:** `scripts/validate.sh`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Closes local↔CI gap.

--- a/docs/pr-review/pr-0056.md
+++ b/docs/pr-review/pr-0056.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Room schema changes break at runtime, not compile time. Three layers: (1) validate.sh schema drift check — compares generated schema JSON vs committed; (2) git guardrails warns when committing Room entity/DAO/database files; (3) `RoomSchemaTest` (5 tests): schema file exists, DoorEvent columns, DoorPosition enum stability, AppEvent, version self-consistency. Document Room safety workflow in CLAUDE.md.
 
 **Files:** `.claude/hooks/git-guardrails.sh`, `AndroidGarage/androidApp/src/test/.../RoomSchemaTest.kt` (new, 157 lines), `CLAUDE.md`, `scripts/validate.sh`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Three-layer Room schema safety (drift check, git-hook warning, schema contract tests).
+
+**Still-current lesson:** Room schema changes break at runtime, not compile time. Ship three guards in one wave: schema JSON drift check in CI, git hook warning on entity/DAO/DB edits, schema contract tests asserting column+enum stability.

--- a/docs/pr-review/pr-0057.md
+++ b/docs/pr-review/pr-0057.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add Claude Code skill for guided Android releases. Documents pre-flight checks, tag computation, deployment verification.
 
 **Files:** `.claude/skills/release-android/SKILL.md` (new, 60 lines).
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** /release-android skill.

--- a/docs/pr-review/pr-0058.md
+++ b/docs/pr-review/pr-0058.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Update all documentation after 12+ PRs. MIGRATION.md: fix stale summary table (Phase 2 is IN PROGRESS). TESTING.md: 125 tests, Phase 3 complete, document safety guardrails. ARCHITECTURE.md: domain module section, package inventory update.
 
 **Files:** `AndroidGarage/docs/ARCHITECTURE.md`, `MIGRATION.md`, `TESTING.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Docs consolidation.

--- a/docs/pr-review/pr-0059.md
+++ b/docs/pr-review/pr-0059.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Delete duplicate interface definitions from androidApp (AuthRepository, DoorRepository). Both had identical signatures in androidApp and domain — now one source of truth in `domain/repository/`. Updates all imports across 11 files. Unblocks UseCase extraction.
 
 **Files:** `AndroidGarage/androidApp/.../auth/AuthRepository.kt`, `door/DoorRepository.kt`, many callers.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Interface consolidation to domain module.

--- a/docs/pr-review/pr-0060.md
+++ b/docs/pr-review/pr-0060.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Last repository interface alignment. Replace Android-specific wrapper types with plain types. `push(IdToken)` → `push(String)`. Complex snooze types → plain `String`/`Long`. Wrapper conversion moves into PushRepositoryImpl. After this, all three repository interfaces (Auth, Door, Push) use domain-compatible types.
 
 **Files:** `AndroidGarage/androidApp/.../PushRepository.kt`, `RemoteButtonViewModel.kt`, `FakePushRepository.kt`, `PushRepositoryTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Repo interface uses plain types.

--- a/docs/pr-review/pr-0061.md
+++ b/docs/pr-review/pr-0061.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** New PreToolUse hook prompts for user confirmation when Bash commands contain `$(...)` command substitution. Uses `permissionDecision: "ask"` — user can still approve.
 
 **Files:** `.claude/hooks/warn-command-substitution.sh` (new), `.claude/settings.json`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** PreToolUse hook asks confirmation for `$(...)` substitution.

--- a/docs/pr-review/pr-0062.md
+++ b/docs/pr-review/pr-0062.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Delete duplicate PushRepository interface from androidApp. All three repository interfaces now have single source of truth in `domain/repository/`. Completes repository interface alignment from Phase 2.1.
 
 **Files:** `AndroidGarage/androidApp/.../remotebutton/PushRepository.kt`, `RemoteButtonViewModel.kt`, `RemoteButtonViewModelTest.kt`, `FakePushRepository.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Interface consolidation — single source of truth in domain.

--- a/docs/pr-review/pr-0063.md
+++ b/docs/pr-review/pr-0063.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Mirror Android release infrastructure for Firebase. `firebase-deploy.yml` triggers on `server/N` tags (not `workflow_dispatch`). Verifies Firebase CI passed. Fixes broken `credentials_json` string. `scripts/release-firebase.sh` same UX as `release-android.sh`. `/release-firebase` skill. Updated guardrails.
 
 **Files:** `.github/workflows/firebase-deploy.yml`, `scripts/release-firebase.sh` (new, 122 lines), `.claude/skills/release-firebase/SKILL.md` (new), `.claude/hooks/git-guardrails.sh`, `CLAUDE.md`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Tag-triggered Firebase deploy mirrors Android — consistent UX across platforms pays off.

--- a/docs/pr-review/pr-0064.md
+++ b/docs/pr-review/pr-0064.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Android CI and Firebase CI skip irrelevant checks based on which files changed. Docs-only PRs → CI completes in ~30s. Firebase-only → Android CI skipped. Android-only → Firebase CI skipped. workflow_dispatch/unknown diffs → always run. `changes` job diffs HEAD against base. `CI Complete` gate job runs `if: always()`. Branch protection uses only gate jobs.
 
 **Files:** `.github/workflows/ci.yml`, `firebase-ci.yml`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Path-based CI skipping + `if: always()` gate jobs — foundational CI architecture every later addition extends.
+
+**Still-current lesson:** A single gate job with `if: always()` that downstream branch protection uses is the right pattern for "skip when unchanged" CI. The gate must always run even when the checks are skipped.

--- a/docs/pr-review/pr-0065.md
+++ b/docs/pr-review/pr-0065.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** `release-firebase.sh --check` showed `server/0` when no tags existed. Now shows `(none)` to match `release-android.sh` behavior.
 
 **Files:** `scripts/release-firebase.sh`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Cosmetic release-script fix.

--- a/docs/pr-review/pr-0066.md
+++ b/docs/pr-review/pr-0066.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Firebase deploy failed because `npm run build` has TypeScript errors. Root cause: `firebase-functions@6.4.0` exports v2 APIs by default, but code uses v1-style (`functions.firestore.document()`, `functions.pubsub.schedule()`). Fix: import from `firebase-functions/v1` in all 12 source files. Update `@types/node` to `^20`. `tsconfig.json`: `es6` → `es2020`, add `skipLibCheck`.
 
 **Files:** `FirebaseServer/tsconfig.json`, `package.json`, 12 source files changing imports.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** firebase-functions/v1 imports for v6 SDK.

--- a/docs/pr-review/pr-0067.md
+++ b/docs/pr-review/pr-0067.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** Floating semver ranges caused silent breakage when transitive deps changed. Pin all deps to exact versions. Remove `^` prefix from all deps in `package.json`. Add `npm run outdated` script. Add `npm run build` step to Firebase CI.
 
 **Files:** `FirebaseServer/package.json`, `package-lock.json`, `.github/workflows/firebase-ci.yml`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** [great]
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Pinning exact versions avoids silent breakage from transitive dep drift.
+
+**Still-current lesson:** In npm projects, pin deps to exact versions (no `^`, no `~`) — floating ranges break silently when a transitive dep changes.

--- a/docs/pr-review/pr-0068.md
+++ b/docs/pr-review/pr-0068.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Second UseCase extraction. Extract push button logic from RemoteButtonViewModel. Auth verification + token refresh + PushRepository delegation. 6 new tests via FakeAuthRepository and FakePushRepository. ViewModel retains early auth check to avoid Android API call when unauthenticated.
 
 **Files:** `AndroidGarage/androidApp/.../usecase/PushRemoteButtonUseCase.kt` (new, 56 lines), `PushRemoteButtonUseCaseTest.kt` (new, 121 lines), `RemoteButtonViewModel.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Push UseCase extraction.

--- a/docs/pr-review/pr-0069.md
+++ b/docs/pr-review/pr-0069.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Third UseCase extraction. Extract snooze logic from RemoteButtonViewModel. 6 new tests: auth check, null timestamp guard, token refresh. Remove `EnsureFreshIdTokenUseCase` from ViewModel constructor (both UseCases inject it themselves).
 
 **Files:** `AndroidGarage/androidApp/.../usecase/SnoozeNotificationsUseCase.kt` (new, 62 lines), `SnoozeNotificationsUseCaseTest.kt` (new, 118 lines), `RemoteButtonViewModel.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Snooze UseCase extraction.

--- a/docs/pr-review/pr-0070.md
+++ b/docs/pr-review/pr-0070.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** 4th and 5th UseCase extractions. `FetchCurrentDoorEventUseCase` delegates to `DoorRepository.fetchCurrentDoorEvent()`. `FetchRecentDoorEventsUseCase` delegates to `fetchRecentDoorEvents()`. Thin wrappers establishing pattern: all data fetching goes through UseCases. 5 of 6 UseCases done (only RegisterFcmUseCase remains, blocked on Activity dep).
 
 **Files:** `AndroidGarage/androidApp/.../usecase/FetchDoorEventsUseCase.kt` (new), `DoorViewModel.kt`, test files.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Fetch UseCase extraction.

--- a/docs/pr-review/pr-0071.md
+++ b/docs/pr-review/pr-0071.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Final UseCase extraction — completes Phase 2.2. `FetchFcmStatusUseCase` (fetches FCM registration status). `RegisterFcmUseCase` (build timestamp → topic → registration). `DeregisterFcmUseCase`. `DoorFcmState.toRegistrationStatus()` shared mapping. DoorViewModel no longer depends on DoorFcmRepository directly. Phase 2.2 complete: all 8 UseCases extracted.
 
 **Files:** `AndroidGarage/androidApp/.../door/DoorViewModel.kt`, `usecase/RegisterFcmUseCase.kt` (new, 80 lines), `RegisterFcmUseCaseTest.kt` (new, 132 lines), `DoorViewModelTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** FCM UseCase extraction caps Phase 2.2.

--- a/docs/pr-review/pr-0072.md
+++ b/docs/pr-review/pr-0072.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Add instrumented test plan using Gradle Managed Devices. Post-merge only, separate workflow not on PRs. Gradle Managed Device (Pixel 6, API 34, aosp-atd). Room sanity, Hilt DI graph, Navigation smoke. Phase 5.1 (ProGuard smoke test) now covered by Phase 7.
 
 **Files:** `AndroidGarage/docs/TESTING.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Phase 7 plan (later executed as #105-#107).

--- a/docs/pr-review/pr-0073.md
+++ b/docs/pr-review/pr-0073.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Mark Phase 2.2 as complete with all 8 UseCases and commit hashes. Note repository interface consolidation (#59, #60, #62). Document next step: ViewModels should only depend on UseCases (Phase 3).
 
 **Files:** `AndroidGarage/docs/MIGRATION.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Phase 2.2 bookkeeping.

--- a/docs/pr-review/pr-0074.md
+++ b/docs/pr-review/pr-0074.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** First step of Phase 2.3 — create `data` module as pure Kotlin abstraction layer. data/ is pure Kotlin (no Android deps), depends only on domain. `LocalDoorDataSource` interface moved from `androidApp/db/` to `data/`. `DatabaseLocalDoorDataSource` (Room impl) stays in androidApp. Repositories import from data, never from Room directly.
 
 **Files:** `AndroidGarage/data/build.gradle.kts` (new), `data/src/main/kotlin/.../LocalDoorDataSource.kt`, `settings.gradle.kts`, delete `androidApp/.../LocalDoorDataSource.kt`, `DoorRepository.kt`, `DoorRepositoryTest.kt`, `androidApp/build.gradle.kts`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Created the `data/` module — Kotlin-only, depends on domain. Foundation for later KMP conversion.

--- a/docs/pr-review/pr-0075.md
+++ b/docs/pr-review/pr-0075.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Define pure data source interfaces for all network operations in data module. `NetworkDoorDataSource` (current/recent door events → `DoorEvent`), `NetworkConfigDataSource` (server config → `ServerConfig`), `NetworkButtonDataSource` (push button, snooze, fetch snooze time → `Boolean`/`Long`). No Retrofit, Moshi, HTTP types. Contract Repositories depend on; implementations (Retrofit today, Ktor later) live in app or data-network module.
 
 **Files:** `AndroidGarage/data/src/main/kotlin/.../NetworkButtonDataSource.kt`, `NetworkConfigDataSource.kt`, `NetworkDoorDataSource.kt`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Three `NetworkXDataSource` interfaces — the abstraction that made the Retrofit→Ktor swap possible without touching repos.

--- a/docs/pr-review/pr-0076.md
+++ b/docs/pr-review/pr-0076.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Replace hardcoded `:domain:test` with auto-discovery. Scan for all pure Kotlin modules with `src/test/` directories. New modules get test coverage automatically.
 
 **Files:** `scripts/validate.sh`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Auto-discovery of module tests.

--- a/docs/pr-review/pr-0077.md
+++ b/docs/pr-review/pr-0077.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Update CLAUDE.md to reflect current architecture: domain module, data module, UseCases, and layering.
 
 **Files:** `CLAUDE.md`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** CLAUDE.md architecture update.

--- a/docs/pr-review/pr-0078.md
+++ b/docs/pr-review/pr-0078.md
@@ -10,3 +10,13 @@ phase1_reviewed: 2026-04-20
 **Goal:** DoorRepository no longer depends on Retrofit directly. Before: `DoorRepository → GarageNetworkService` (Retrofit Response, null checks, HTTP codes). After: `DoorRepository → NetworkDoorDataSource` (returns `DoorEvent?`). Create `RetrofitNetworkDoorDataSource` — moves all Retrofit/DTO logic out of Repository. Tests use `FakeNetworkDoorDataSource` instead of mocking Retrofit. Key pattern for Phase 4 (Ktor migration).
 
 **Files:** `AndroidGarage/androidApp/.../internet/RetrofitNetworkDoorDataSource.kt` (new, 106 lines), `door/DoorRepository.kt`, delete `DoorRepositoryTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** great
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** First repo decoupled from Retrofit via data-source interface — template for the Ktor swap.
+
+**Still-current lesson:** Keep HTTP-library types (Retrofit Response, Ktor HttpResponse) inside the data-source impl. Repositories take plain domain types in, plain types out — the HTTP library becomes swappable.

--- a/docs/pr-review/pr-0079.md
+++ b/docs/pr-review/pr-0079.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Same pattern as #78 — decouple PushRepository from Retrofit. Create `RetrofitNetworkButtonDataSource` implementing `data.NetworkButtonDataSource`. PushRepository uses plain types (Boolean, Long), never sees Retrofit. Test updated to mock `NetworkButtonDataSource`.
 
 **Files:** `AndroidGarage/androidApp/.../internet/RetrofitNetworkButtonDataSource.kt` (new, 108 lines), `remotebutton/PushRepository.kt`, `PushRepositoryTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** PushRepository decoupled from Retrofit.

--- a/docs/pr-review/pr-0080.md
+++ b/docs/pr-review/pr-0080.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Last repository to decouple from Retrofit. Create `RetrofitNetworkConfigDataSource` implementing `data.NetworkConfigDataSource`. ServerConfigRepository uses `NetworkConfigDataSource` (returns `ServerConfig?`). Consolidate `config.model.ServerConfig` into `domain.model.ServerConfig`. Test rewritten with `FakeNetworkConfigDataSource` — no more Retrofit Response mocking. All 3 repositories now depend on data interfaces.
 
 **Files:** `AndroidGarage/androidApp/.../config/ServerConfigRepository.kt`, `internet/RetrofitNetworkConfigDataSource.kt` (new), delete `config/model/ServerConfig.kt`, `ServerConfigRepositoryTest.kt`, `PushRepositoryTest.kt`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Last repo decoupled from Retrofit; tests now use fake data source.

--- a/docs/pr-review/pr-0081.md
+++ b/docs/pr-review/pr-0081.md
@@ -10,3 +10,11 @@ phase1_reviewed: 2026-04-20
 **Goal:** Both release scripts warn about untracked files that could affect the build. `--check` reports count of untracked + uncommitted. Release mode shows file list, prompts to continue (interactive) or proceeds with warning (non-interactive).
 
 **Files:** `scripts/release-android.sh`, `scripts/release-firebase.sh`.
+
+## Phase 2 assessment
+
+**Primary:** ok
+**Secondary:** []
+**Phase 2 reviewed:** 2026-04-20
+
+**Rationale:** Release script warns on untracked files.


### PR DESCRIPTION
## Summary
Phase 2 session 11 — classified 30 PRs (#81 down through #52).

Category breakdown:
- **great** (6): #78 (data-source interface decouples repo from Retrofit), #75 (NetworkXDataSource), #74 (data/ module), #64 (path-based CI + gate jobs), #63 (Firebase release script mirror), #56 (Room schema 3-layer safety)
- **ok** (24): Phase 2.2 UseCase extractions, repo interface consolidation, Firebase infra, docs

No superseded/buggy/outdated/abandoned in this batch.

Key still-current lessons:
- Keep HTTP-library types inside data-source impl; repos take plain domain types
- Pin npm deps to exact versions — `^` floats break silently
- Gate jobs with `if: always()` so branch protection works with skipped checks
- Room schema safety needs three guards: drift check + git hook + contract tests
- `suspendCancellableCoroutine` wrapping callbacks needs BOTH onSuccess and onFailure

## Test plan
- [ ] Docs-only — fast-path CI skip applies
- [ ] Phase 2 queue: 381 → 51 remaining (330 assessed, 87% complete)