### PR TITLE
ci: Add checkSingletonCaching to catch kotlin-inject @Singleton regressions

### DIFF
--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -157,6 +157,15 @@ tasks.register<testcoverage.TestCoverageCheckTask>("checkTestCoverage") {
     patterns = listOf("ViewModel", "Repository")
 }
 
+tasks.register<architecture.SingletonCachingCheckTask>("checkSingletonCaching") {
+    appComponentPath = "$rootDir/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt"
+    generatedComponentPath =
+        "$rootDir/androidApp/build/generated/ksp/debug/kotlin/com/chriscartland/garage/di/InjectAppComponent.kt"
+    // The generated file only exists after KSP runs. Depend on the debug KSP task
+    // so `./gradlew checkSingletonCaching` works standalone.
+    dependsOn(":androidApp:kspDebugKotlin")
+}
+
 allprojects {
     apply(plugin = "com.diffplug.spotless")
     apply(plugin = "io.gitlab.arturbosch.detekt")

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/SingletonCachingCheckTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/SingletonCachingCheckTask.kt
@@ -1,0 +1,183 @@
+package architecture
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Verifies that every `@Singleton` provider in `AppComponent.kt`
+ * produces matching `_scoped.get(...)` caching in the generated
+ * `InjectAppComponent.kt`.
+ *
+ * kotlin-inject's `@Singleton` is annotation-shaped — the compiler
+ * accepts any declaration shape, and only *abstract-entry-point
+ * overrides with parameter-based `@Provides fun` bodies* emit
+ * caching. Concrete `val x: T @Provides @Singleton get() = ...`
+ * declarations silently bypass the cache: every consumer receives a
+ * fresh instance, tests still pass, and the feature-specific symptom
+ * may take months to isolate. That was the shape of the android/170
+ * snooze regression.
+ *
+ * This check reads the generated file (the only authoritative source
+ * for what kotlin-inject actually emitted) and fails the build if any
+ * `@Singleton` provider in source is missing a corresponding
+ * `_scoped.get(...) { provideX() }` call in the generated output.
+ *
+ * See `AndroidGarage/docs/DI_SINGLETON_REQUIREMENTS.md` and
+ * `AndroidGarage/docs/POSTMORTEM_ANDROID_170.md` for context.
+ */
+abstract class SingletonCachingCheckTask : DefaultTask() {
+    @get:Input
+    var appComponentPath: String = ""
+
+    /**
+     * Path to the generated `InjectAppComponent.kt`. KSP emits one
+     * per variant; checking debug is sufficient because all variants
+     * generate identical scoping code from the same source.
+     */
+    @get:Input
+    var generatedComponentPath: String = ""
+
+    @TaskAction
+    fun check() {
+        val appComponentFile = File(appComponentPath)
+        if (!appComponentFile.exists()) {
+            throw GradleException(
+                "Singleton caching check: AppComponent.kt not found at $appComponentPath",
+            )
+        }
+
+        val generatedFile = File(generatedComponentPath)
+        if (!generatedFile.exists()) {
+            throw GradleException(
+                "Singleton caching check: generated InjectAppComponent.kt not found at " +
+                    "$generatedComponentPath. Ensure this task runs after :androidApp:kspDebugKotlin.",
+            )
+        }
+
+        val sourceContent = appComponentFile.readText()
+        val generatedContent = generatedFile.readText()
+
+        val singletonProviders = extractSingletonProviders(sourceContent)
+
+        if (singletonProviders.isEmpty()) {
+            throw GradleException(
+                "Singleton caching check: no @Singleton providers found in AppComponent.kt. " +
+                    "Either the file shape changed or the regex needs updating.",
+            )
+        }
+
+        // Check 1: each well-shaped @Singleton fun has a matching _scoped.get entry.
+        val missingCaching = singletonProviders.filter { providerName ->
+            !isCachedInGenerated(providerName, generatedContent)
+        }
+
+        // Check 2: the total count of @Singleton annotations on providers (any shape)
+        // matches the count of _scoped.get(...) entries in the generated file. This
+        // catches the regression where a provider is marked @Singleton but written in a
+        // shape that bypasses caching (e.g., `val x: T @Provides @Singleton get() = ...`)
+        // — that shape isn't picked up by extractSingletonProviders above, so the name
+        // check alone would miss it.
+        val providerScopeAnnotations = countProviderScopeAnnotations(sourceContent)
+        val cachedEntries = countCachedEntries(generatedContent)
+
+        val errors = buildList {
+            if (missingCaching.isNotEmpty()) {
+                add(
+                    buildString {
+                        append("${missingCaching.size} @Singleton provider(s) marked correctly but not cached:\n")
+                        missingCaching.forEach { append("  - $it\n") }
+                    },
+                )
+            }
+            if (providerScopeAnnotations != cachedEntries) {
+                add(
+                    "@Singleton provider count ($providerScopeAnnotations) does not match " +
+                        "generated _scoped.get(...) count ($cachedEntries). A provider is likely " +
+                        "declared in a shape that bypasses caching — see fix guidance below.",
+                )
+            }
+        }
+
+        if (errors.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    append("Singleton caching check FAILED:\n\n")
+                    errors.forEach { append("$it\n") }
+                    append("\n")
+                    append("These @Singleton providers are not being cached by kotlin-inject.\n")
+                    append("Every consumer will get a fresh instance; shared state will break.\n\n")
+                    append("Root cause is usually provider shape. Fix:\n")
+                    append("  - Prefer: @Provides @Singleton fun provideX(...): T = ...\n")
+                    append("  - Avoid:  val x: T @Provides @Singleton get() = ...\n")
+                    append("    (concrete getters bypass caching)\n")
+                    append("  - The abstract entry point `abstract val X: T` must be declared in\n")
+                    append("    AppComponent so the generator has something to override.\n\n")
+                    append("See docs/DI_SINGLETON_REQUIREMENTS.md and docs/POSTMORTEM_ANDROID_170.md.\n")
+                    append("This is the shape of the android/170 snooze regression.\n")
+                },
+            )
+        }
+
+        logger.lifecycle(
+            "Singleton caching check passed: ${singletonProviders.size} @Singleton providers " +
+                "verified; $cachedEntries generated _scoped.get(...) entries match.",
+        )
+    }
+
+    private fun extractSingletonProviders(sourceContent: String): List<String> {
+        // Match indented `@Provides` and `@Singleton` annotations (in either order)
+        // preceding a `fun provideX(` declaration. Whitespace between annotations
+        // may include newlines. The provider name is captured in group 1.
+        //
+        // Class-level `@Singleton` on `abstract class AppComponent` is ignored
+        // because it isn't followed by `fun provideX(`.
+        val regex = Regex(
+            pattern = """(?:@Provides\s+@Singleton|@Singleton\s+@Provides)\s+fun\s+(\w+)\s*\(""",
+            option = RegexOption.MULTILINE,
+        )
+        return regex.findAll(sourceContent).map { it.groupValues[1] }.toList()
+    }
+
+    private fun isCachedInGenerated(
+        providerName: String,
+        generatedContent: String,
+    ): Boolean {
+        // The generator emits: `_scoped.get("FQN") { provideX() }` or
+        // `_scoped.get("FQN") { provideX(arg = ...) }`. We search for the
+        // lexical proximity of `_scoped.get(` and the specific `provideX(`
+        // call within a small window — the generator always puts them on
+        // adjacent lines.
+        val cachedCallPattern = Regex(
+            pattern = """_scoped\.get\s*\([^)]*\)\s*\{\s*$providerName\s*\(""",
+            option = RegexOption.MULTILINE,
+        )
+        return cachedCallPattern.containsMatchIn(generatedContent)
+    }
+
+    /**
+     * Counts `@Singleton` annotations that are declaration annotations (on
+     * their own line, optionally indented), excluding the class-level
+     * `@Singleton` on `AppComponent`. This catches the annotation whether
+     * it precedes `fun provideX(` (good shape) or a getter of a concrete
+     * `val` property (bad shape — the android/170 regression). Matches on
+     * own-line only so `@Singleton` mentions inside KDoc/comments are
+     * ignored.
+     */
+    private fun countProviderScopeAnnotations(sourceContent: String): Int {
+        val standaloneAnnotationLines =
+            Regex("""^\s*@Singleton\s*$""", RegexOption.MULTILINE)
+                .findAll(sourceContent)
+                .count()
+        // The class-level `@Singleton` is also on its own line (directly
+        // above `abstract class AppComponent`). Subtract one for it.
+        val hasClassLevelSingleton =
+            Regex("""@Singleton\s+abstract\s+class\s+AppComponent\b""")
+                .containsMatchIn(sourceContent)
+        return standaloneAnnotationLines - (if (hasClassLevelSingleton) 1 else 0)
+    }
+
+    private fun countCachedEntries(generatedContent: String): Int = Regex("""_scoped\.get\s*\(""").findAll(generatedContent).count()
+}

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/SingletonCachingCheckTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/SingletonCachingCheckTask.kt
@@ -25,6 +25,18 @@ import java.io.File
  * `@Singleton` provider in source is missing a corresponding
  * `_scoped.get(...) { provideX() }` call in the generated output.
  *
+ * # Library-version fragility
+ *
+ * This check depends on kotlin-inject's generated-code shape: the
+ * class name (`InjectAppComponent`), the scope-map field name
+ * (`_scoped`), and the call shape (`_scoped.get("FQN") { provideX() }`).
+ * If kotlin-inject upgrades its codegen, the regexes below will stop
+ * matching and the check will fire with the
+ * "unrecognized codegen shape" branch in the failure message, which
+ * tells the maintainer what to do: inspect the generated file,
+ * update the regexes here, or retire this static check in favor of
+ * the runtime `ComponentGraphTest` identity asserts.
+ *
  * See `AndroidGarage/docs/DI_SINGLETON_REQUIREMENTS.md` and
  * `AndroidGarage/docs/POSTMORTEM_ANDROID_170.md` for context.
  */
@@ -69,6 +81,50 @@ abstract class SingletonCachingCheckTask : DefaultTask() {
             )
         }
 
+        val providerScopeAnnotations = countProviderScopeAnnotations(sourceContent)
+        val cachedEntries = countCachedEntries(generatedContent)
+
+        // Pre-check: if the source has @Singleton providers but the generated
+        // file has zero `_scoped.get(...)` calls, the regex no longer recognizes
+        // the codegen shape. This is almost always a kotlin-inject library
+        // upgrade, not a source-code bug. Fail loudly with a distinct message
+        // so the maintainer doesn't waste time hunting for a phantom source
+        // regression.
+        if (providerScopeAnnotations > 0 && cachedEntries == 0) {
+            throw GradleException(
+                buildString {
+                    append("Singleton caching check FAILED — unrecognized codegen shape.\n\n")
+                    append("Source has $providerScopeAnnotations @Singleton provider(s) but the generated\n")
+                    append("InjectAppComponent.kt has ZERO `_scoped.get(...)` calls.\n\n")
+                    append("This has two possible causes:\n\n")
+                    append("  (A) Real bug — the android/170 regression shape.\n")
+                    append("      kotlin-inject produced an empty subclass (~15 lines). Every\n")
+                    append("      consumer gets a fresh instance. Fix by converting providers to\n")
+                    append("      `@Provides @Singleton fun provideX(...): T = ...` and ensuring\n")
+                    append("      each is reachable via an abstract entry point.\n\n")
+                    append("  (B) kotlin-inject was upgraded and changed its codegen.\n")
+                    append("      This task's regex expects the library to emit\n")
+                    append("      `_scoped.get(\"FQN\") { provideX(...) }` in\n")
+                    append("      InjectAppComponent.kt. If the library renamed `_scoped`,\n")
+                    append("      restructured the generated class, or moved caching to a\n")
+                    append("      different primitive (e.g. `_cache.getOrPut`), this check will\n")
+                    append("      no longer find any matches.\n\n")
+                    append("How to tell which case:\n")
+                    append("  1. Open $generatedComponentPath\n")
+                    append("  2. If it's short (~15 lines) with no scoping calls at all → case (A).\n")
+                    append("     Read docs/POSTMORTEM_ANDROID_170.md and fix the provider shapes.\n")
+                    append("  3. If it has scoping calls under a different name/shape → case (B).\n")
+                    append("     Update the regexes in:\n")
+                    append("     AndroidGarage/buildSrc/src/main/kotlin/architecture/SingletonCachingCheckTask.kt\n")
+                    append("     (specifically `countCachedEntries` and `isCachedInGenerated`).\n")
+                    append("     If the library no longer exposes caching textually, retire this\n")
+                    append("     static check and rely on the runtime ComponentGraphTest\n")
+                    append("     `*IsSingleton` assertions as the sole guard.\n\n")
+                    append("See docs/DI_SINGLETON_REQUIREMENTS.md for background.\n")
+                },
+            )
+        }
+
         // Check 1: each well-shaped @Singleton fun has a matching _scoped.get entry.
         val missingCaching = singletonProviders.filter { providerName ->
             !isCachedInGenerated(providerName, generatedContent)
@@ -80,9 +136,6 @@ abstract class SingletonCachingCheckTask : DefaultTask() {
         // shape that bypasses caching (e.g., `val x: T @Provides @Singleton get() = ...`)
         // — that shape isn't picked up by extractSingletonProviders above, so the name
         // check alone would miss it.
-        val providerScopeAnnotations = countProviderScopeAnnotations(sourceContent)
-        val cachedEntries = countCachedEntries(generatedContent)
-
         val errors = buildList {
             if (missingCaching.isNotEmpty()) {
                 add(
@@ -109,12 +162,16 @@ abstract class SingletonCachingCheckTask : DefaultTask() {
                     append("\n")
                     append("These @Singleton providers are not being cached by kotlin-inject.\n")
                     append("Every consumer will get a fresh instance; shared state will break.\n\n")
-                    append("Root cause is usually provider shape. Fix:\n")
+                    append("Most likely cause — provider shape in AppComponent.kt:\n")
                     append("  - Prefer: @Provides @Singleton fun provideX(...): T = ...\n")
                     append("  - Avoid:  val x: T @Provides @Singleton get() = ...\n")
                     append("    (concrete getters bypass caching)\n")
                     append("  - The abstract entry point `abstract val X: T` must be declared in\n")
                     append("    AppComponent so the generator has something to override.\n\n")
+                    append("Less likely — kotlin-inject codegen changed across a library upgrade.\n")
+                    append("If AppComponent.kt looks correct, inspect $generatedComponentPath\n")
+                    append("and compare against the patterns in this task\n")
+                    append("(SingletonCachingCheckTask.kt — `isCachedInGenerated`, `countCachedEntries`).\n\n")
                     append("See docs/DI_SINGLETON_REQUIREMENTS.md and docs/POSTMORTEM_ANDROID_170.md.\n")
                     append("This is the shape of the android/170 snooze regression.\n")
                 },

--- a/AndroidGarage/docs/DI_SINGLETON_REQUIREMENTS.md
+++ b/AndroidGarage/docs/DI_SINGLETON_REQUIREMENTS.md
@@ -95,6 +95,18 @@ C1-C3 apply.
 
 ## How to detect this bug
 
+### Automated: `checkSingletonCaching`
+
+`validate.sh` runs `./gradlew checkSingletonCaching`, a build-time check
+that parses every `@Provides @Singleton fun provideX(...)` in
+`AppComponent.kt` and verifies a matching `_scoped.get(...) { provideX() }`
+call exists in the generated `InjectAppComponent.kt`. If any provider is
+marked `@Singleton` but not cached, the task fails with a list of the
+offenders and a pointer back to this doc. Runs on every local validation
+and every PR — the android/170 regression shape cannot land silently.
+
+The task source is `AndroidGarage/buildSrc/src/main/kotlin/architecture/SingletonCachingCheckTask.kt`.
+
 ### Mechanical: inspect the generated component
 
 ```bash
@@ -105,11 +117,8 @@ Read the file. Healthy generation for an app of this size produces
 **hundreds of lines** — one override per abstract entry, each calling
 `_scoped.get(...)` or computing the instance directly. If the file is
 **under 20 lines** and has no `override val <provider>` lines, scoping
-is broken.
-
-Commit the first non-trivial `InjectAppComponent.kt` line count as a
-check: `validate.sh` can grep `build/generated/ksp/*/kotlin/**/Inject*.kt`
-and fail if the count is suspiciously small.
+is broken. (Use this if `checkSingletonCaching` reported a failure and
+you want to see the exact missing overrides.)
 
 ### Static: run a reference-identity test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,14 +189,19 @@ during the android/170 snooze regression (see ADR-022 timeline and
 
 **When modifying `AppComponent.kt`:**
 1. Make the change.
-2. Run `./gradlew :androidApp:kspDebugKotlin` to regenerate.
-3. Read `androidApp/build/generated/ksp/debug/kotlin/com/chriscartland/garage/di/InjectAppComponent.kt`.
-   Healthy file is ~300 lines with one `override val X: T get() = _scoped.get(...)`
-   per `@Singleton` entry. If it's under 20 lines or missing `_scoped.get(...)`
-   for your new provider, scoping is broken.
+2. Run `./gradlew -p AndroidGarage checkSingletonCaching` — this regenerates
+   `InjectAppComponent.kt` via KSP and fails the build if any `@Singleton`
+   provider is not wrapped in `_scoped.get(...)` in the generated code.
+   This is the automated version of the manual inspection step and runs
+   in `validate.sh`.
+3. Read `androidApp/build/generated/ksp/debug/kotlin/com/chriscartland/garage/di/InjectAppComponent.kt`
+   if the check failed — the error message lists which providers are missing
+   caching. Healthy file is ~300 lines with one
+   `override val X: T get() = _scoped.get(...)` per `@Singleton` entry.
 4. Run the identity tests: `./gradlew :androidApp:connectedDebugAndroidTest
    -Pandroid.testInstrumentationRunnerArguments.class=com.chriscartland.garage.di.ComponentGraphTest`.
-   All `*IsSingleton` tests must pass.
+   All `*IsSingleton` tests must pass. This is the runtime counterpart to
+   `checkSingletonCaching` (which is a static check on generated code).
 5. If you add a new `@Singleton` state-owning provider, add a matching
    `abstract val` entry + an `assertSame` identity test in
    `ComponentGraphTest`.

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -40,6 +40,9 @@ $GRADLE checkArchitecture && pass "architecture" || fail "architecture"
 step "Singleton guard (Database, Settings, HttpClient)"
 $GRADLE checkSingletonGuard && pass "singleton guard" || fail "singleton guard"
 
+step "Singleton caching (kotlin-inject generated _scoped.get matches @Singleton)"
+$GRADLE checkSingletonCaching && pass "singleton caching" || fail "singleton caching"
+
 step "Layer imports (ViewModel→UseCase, UseCase→domain)"
 $GRADLE checkLayerImports && pass "layer imports" || fail "layer imports"
 


### PR DESCRIPTION
## Summary

Closes Phase 4 audit gap #1 — automates the generated-code inspection step that would have caught the android/170 snooze regression in 5 minutes instead of 5 months.

## What it does

Adds \`./gradlew -p AndroidGarage checkSingletonCaching\` — a Gradle task that reads the kotlin-inject-generated \`InjectAppComponent.kt\` and fails the build if any \`@Singleton\` provider in source is not actually cached in the generated output.

## Why

kotlin-inject's \`@Singleton\` is annotation-shaped. The compiler accepts any declaration shape, but only **abstract-entry-point overrides with parameter-based \`@Provides fun\` bodies** emit \`_scoped.get(...)\` caching. The shape \`val x: T @Provides @Singleton get() = ...\` compiles fine, passes unit tests, and silently produces a fresh instance on every access.

That was the shape of the android/170 regression. Investigation took 5 months because the only authoritative source — the generated file — was read by hand after everything else had been ruled out.

## How it catches regressions

Two complementary checks in one task:

1. **Name match.** For every \`@Provides @Singleton fun provideX(...)\` in \`AppComponent.kt\`, verify a \`_scoped.get(...) { provideX(...) }\` block exists in the generated file. Catches new well-shaped providers that somehow don't cache.

2. **Count match.** Count standalone \`@Singleton\` annotations (minus the class-level one) and compare to the count of \`_scoped.get(...)\` entries in generated code. Catches the regression of converting an existing \`fun provideX(\` to the bad getter shape — the name check alone would miss this because the new shape isn't a \`fun\`.

## Wiring

- New task registered in \`AndroidGarage/build.gradle.kts\`, \`dependsOn(\":androidApp:kspDebugKotlin\")\` so the generated file always exists at check time.
- Invoked in \`scripts/validate.sh\` after the existing \`checkSingletonGuard\` step.
- \`CLAUDE.md\` AppComponent safety checklist updated to reference the new task (step 2 in \"When modifying AppComponent.kt\" now runs the check; step 3 points readers at the generated file only if the check failed).
- \`AndroidGarage/docs/DI_SINGLETON_REQUIREMENTS.md\` \"How to detect this bug\" section updated to document the automated check.

## Tested

\`\`\`
\$ ./gradlew -p AndroidGarage checkSingletonCaching
Singleton caching check passed: 23 @Singleton providers verified;
23 generated _scoped.get(...) entries match.
BUILD SUCCESSFUL
\`\`\`

Both checks cover the shape; spotless + the surrounding Gradle tasks still pass.

## Test plan

- [x] \`./gradlew -p AndroidGarage checkSingletonCaching\` passes
- [x] \`./gradlew -p AndroidGarage spotlessCheck\` passes
- [x] Full \`validate.sh\` run (via CI)

## Not in scope

- Runtime identity tests (\`ComponentGraphTest\`) still run manually on device. A follow-up can gate push to branches touching \`AppComponent.kt\` on having run them.
- Phase 4 gap #2 (auto-run \`ComponentGraphTest\` on AppComponent changes) — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)