### PR TITLE
ci: Add FCM Contract Tests as a distinct check-run

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -75,6 +75,41 @@ jobs:
           name: test-reports
           path: AndroidGarage/androidApp/build/reports/tests/
 
+  fcm_contract_tests:
+    # Dedicated job that names the FCM contract tests as a distinct
+    # check-run in the PR UI. FCM is the canonical silent-failure class
+    # in this repo — topic format or payload key changes produce no
+    # visible error; users' push notifications just stop working. The
+    # contract tests (FcmTopicTest, FcmPayloadParsingTest,
+    # FcmMessageHandlerTest) pin the wire format. They also run as part
+    # of the main unit_tests job; this job makes their existence and
+    # pass/fail state visible to reviewers, and is a natural candidate
+    # for branch protection "required check" status.
+    name: FCM Contract Tests
+    if: inputs.android == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-android
+        with:
+          encrypt-key: ${{ secrets.ENCRYPT_KEY }}
+      - name: FcmTopicTest (domain)
+        working-directory: AndroidGarage
+        run: ./gradlew :domain:testDebugUnitTest --tests 'com.chriscartland.garage.domain.model.FcmTopicTest'
+      - name: FcmPayloadParsingTest (data)
+        working-directory: AndroidGarage
+        run: ./gradlew :data:testDebugUnitTest --tests 'com.chriscartland.garage.data.FcmPayloadParsingTest'
+      - name: FcmMessageHandlerTest (androidApp)
+        working-directory: AndroidGarage
+        env:
+          SERVER_CONFIG_KEY: ${{ secrets.SERVER_CONFIG_KEY }}
+          GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
+        run: ./gradlew :androidApp:testDebugUnitTest --tests 'com.chriscartland.garage.fcm.FcmMessageHandlerTest' -PSERVER_CONFIG_KEY="$SERVER_CONFIG_KEY" -PGOOGLE_WEB_CLIENT_ID="$GOOGLE_WEB_CLIENT_ID"
+      - name: Clean secrets
+        if: always()
+        working-directory: AndroidGarage
+        run: ./release/clean-secrets.sh
+
   build_debug:
     name: Build Debug APK
     if: inputs.android == 'true'


### PR DESCRIPTION
## Summary

Closes Phase 4 audit gap #3 — the FCM contract tests (FcmTopicTest, FcmPayloadParsingTest, FcmMessageHandlerTest) already ran as part of the main unit_tests job, but their pass/fail state was invisible in the PR UI. This adds a dedicated \"FCM Contract Tests\" job so the contract's existence is visible to reviewers and the check can be marked individually required in branch protection.

## Why this matters

FCM is the canonical silent-failure class in this repo: a topic format change or payload key change produces no visible error; users' push notifications just stop working. The contract tests pin the exact wire format. Reviewers need to see that the contract is being exercised on every PR — otherwise it's easy to accept a change that breaks the contract alongside the tests that enforce it.

## Test plan

- [x] \`./gradlew :domain:testDebugUnitTest --tests 'com.chriscartland.garage.domain.model.FcmTopicTest'\` passes locally
- [x] \`./gradlew :data:testDebugUnitTest --tests 'com.chriscartland.garage.data.FcmPayloadParsingTest'\` passes locally
- [x] \`./gradlew :androidApp:testDebugUnitTest --tests 'com.chriscartland.garage.fcm.FcmMessageHandlerTest'\` passes locally
- [ ] New job appears in CI as \"FCM Contract Tests\"

## Not in scope

- Marking the new check required in branch protection — that's a GitHub UI step on the repo settings page.
- CODEOWNERS for FCM source files — separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)