### PR TITLE
ci: Add checkNoRawDispatchers lint for ADR-005 enforcement

### DIFF
--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -166,6 +166,14 @@ tasks.register<architecture.SingletonCachingCheckTask>("checkSingletonCaching") 
     dependsOn(":androidApp:kspDebugKotlin")
 }
 
+tasks.register<architecture.NoRawDispatchersTask>("checkNoRawDispatchers") {
+    sourceDirs = listOf(
+        "$rootDir/androidApp/src/main/java",
+        "$rootDir/usecase/src/commonMain/kotlin",
+        "$rootDir/presentation-model/src/commonMain/kotlin",
+    )
+}
+
 allprojects {
     apply(plugin = "com.diffplug.spotless")
     apply(plugin = "io.gitlab.arturbosch.detekt")

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/NoRawDispatchersTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/NoRawDispatchersTask.kt
@@ -1,0 +1,99 @@
+package architecture
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Enforces ADR-005: ViewModels and UseCases must inject `DispatcherProvider`,
+ * not reference `Dispatchers.IO`, `Dispatchers.Main`, `Dispatchers.Default`,
+ * or `Dispatchers.Unconfined` directly.
+ *
+ * Rationale: hardcoded dispatchers are untestable. Production gets real
+ * dispatchers; tests get `TestDispatcher` (virtual time). A single file
+ * that references `Dispatchers.IO` directly breaks the chain — its tests
+ * can't use virtual time, flake timing assertions, and the rule is
+ * silently eroded.
+ *
+ * Scope: `*ViewModel*.kt` and `*UseCase*.kt` in `androidApp/` +
+ * `usecase/` + `presentation-model/` source trees. The
+ * `DefaultDispatcherProvider` implementation is explicitly allowlisted
+ * because it IS the provider — it necessarily references raw
+ * Dispatchers.
+ *
+ * This lint had zero violations when added, so it locks the current
+ * state rather than prescribing a migration.
+ */
+abstract class NoRawDispatchersTask : DefaultTask() {
+    @get:Input
+    var sourceDirs: List<String> = emptyList()
+
+    @get:Input
+    var allowedFilePatterns: List<String> = listOf(
+        // The provider implementation is the only legitimate site of
+        // raw Dispatchers references.
+        "DefaultDispatcherProvider\\.kt",
+    )
+
+    @get:Input
+    var targetFilePatterns: List<String> = listOf(
+        ".*ViewModel.*\\.kt",
+        ".*UseCase.*\\.kt",
+    )
+
+    @TaskAction
+    fun check() {
+        val pattern = Regex("""\bDispatchers\.(IO|Main|Default|Unconfined)\b""")
+        val allowedRegexes = allowedFilePatterns.map { Regex(it) }
+        val targetRegexes = targetFilePatterns.map { Regex(it) }
+
+        val violations = mutableListOf<String>()
+
+        sourceDirs.forEach { dir ->
+            val rootFile = File(dir)
+            if (!rootFile.exists()) return@forEach
+
+            rootFile
+                .walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .filter { file -> targetRegexes.any { it.matches(file.name) } }
+                .filter { file -> allowedRegexes.none { it.matches(file.name) } }
+                .forEach { file ->
+                    val relativePath = file.relativeTo(rootFile).path
+                    file.readLines().forEachIndexed { index, line ->
+                        val trimmed = line.trim()
+                        // Skip comments and KDoc mentions.
+                        if (trimmed.startsWith("//") || trimmed.startsWith("*")) return@forEachIndexed
+                        if (pattern.containsMatchIn(line)) {
+                            violations.add("$relativePath:${index + 1}: ${line.trim()}")
+                        }
+                    }
+                }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    append("NoRawDispatchers check FAILED: ")
+                    append(violations.size)
+                    append(" violation(s).\n\n")
+                    violations.forEach { append("  - $it\n") }
+                    append("\n")
+                    append("ViewModels and UseCases must inject `DispatcherProvider` (ADR-005),\n")
+                    append("never reference `Dispatchers.IO`/`Main`/`Default`/`Unconfined` directly.\n\n")
+                    append("Fix:\n")
+                    append("  - Add `dispatchers: DispatcherProvider` as a constructor parameter.\n")
+                    append("  - Use `dispatchers.io`, `dispatchers.main`, `dispatchers.default` at call sites.\n")
+                    append("  - The AppComponent already provides `DispatcherProvider` as a singleton.\n\n")
+                    append("Rationale: tests inject `TestDispatcher` for virtual-time assertions.\n")
+                    append("A hardcoded Dispatchers.IO silently flakes tests and erodes the rule.\n")
+                    append("See AndroidGarage/docs/DECISIONS.md (ADR-005).\n")
+                },
+            )
+        }
+
+        logger.lifecycle("NoRawDispatchers check passed: no ViewModel/UseCase files reference raw Dispatchers.")
+    }
+}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -43,6 +43,9 @@ $GRADLE checkSingletonGuard && pass "singleton guard" || fail "singleton guard"
 step "Singleton caching (kotlin-inject generated _scoped.get matches @Singleton)"
 $GRADLE checkSingletonCaching && pass "singleton caching" || fail "singleton caching"
 
+step "No raw Dispatchers (ADR-005 — VM/UseCase must inject DispatcherProvider)"
+$GRADLE checkNoRawDispatchers && pass "no raw dispatchers" || fail "no raw dispatchers"
+
 step "Layer imports (ViewModel→UseCase, UseCase→domain)"
 $GRADLE checkLayerImports && pass "layer imports" || fail "layer imports"
 


### PR DESCRIPTION
## Summary

Closes Phase 4 audit gap #4 — locks in ADR-005 (inject \`DispatcherProvider\`, never reference \`Dispatchers.IO\`/\`Main\`/\`Default\`/\`Unconfined\` directly in ViewModels or UseCases).

## Verification

Scanned the current codebase before adding the lint:
\`\`\`
$ grep -rEn \"Dispatchers\\.(IO|Main|Default|Unconfined)\" --include=\"*ViewModel*.kt\" --include=\"*UseCase*.kt\" AndroidGarage/
(no output)
\`\`\`

**Zero violations.** This PR locks the current state rather than prescribing a migration.

## What's in

- \`AndroidGarage/buildSrc/src/main/kotlin/architecture/NoRawDispatchersTask.kt\` — new Gradle task scanning \`*ViewModel*.kt\` and \`*UseCase*.kt\` files across \`androidApp/\`, \`usecase/commonMain\`, and \`presentation-model/commonMain\`. Allowlists \`DefaultDispatcherProvider.kt\` (the sole legitimate site).
- \`AndroidGarage/build.gradle.kts\` — registers \`checkNoRawDispatchers\`.
- \`scripts/validate.sh\` — invokes the task after \`checkSingletonCaching\`.

## Failure message

On violation, the task fails with a line-by-line list, the fix recipe (constructor-inject \`DispatcherProvider\`, use \`dispatchers.io\`/\`main\`/\`default\`), and a pointer to ADR-005.

## Test plan

- [x] \`./gradlew -p AndroidGarage checkNoRawDispatchers\` passes
- [x] \`./gradlew -p AndroidGarage spotlessCheck\` passes
- [x] Full validate.sh run (via CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)