### PR TITLE
ci: Add npm audit warning step to Firebase CI

### DIFF
--- a/.github/workflows/firebase-ci-checks.yml
+++ b/.github/workflows/firebase-ci-checks.yml
@@ -42,3 +42,21 @@ jobs:
           if [ "$OUTDATED" != "{}" ]; then
             echo "::warning::Some dependencies have newer versions available. Run 'npm outdated' locally to review."
           fi
+
+      # Surfaces known vulnerabilities inline on the PR as warnings so new
+      # introductions are visible on every CI run. Currently non-blocking
+      # because the repo has open alerts being worked through — once the
+      # Dependabot cleanup PRs land and `npm audit --audit-level=high` is
+      # clean, remove `continue-on-error` and tighten the audit level to
+      # make it a hard gate against regression.
+      - name: npm audit (warn on high/critical)
+        working-directory: FirebaseServer
+        continue-on-error: true
+        run: |
+          echo "::group::npm audit (production + dev)"
+          npm audit || true
+          echo "::endgroup::"
+          HIGH=$(npm audit --json 2>/dev/null | jq -r '((.metadata.vulnerabilities.high // 0) + (.metadata.vulnerabilities.critical // 0))' 2>/dev/null || echo 0)
+          if [ "${HIGH:-0}" -gt 0 ]; then
+            echo "::warning::npm audit reports $HIGH high/critical vulnerabilities. Triage with: gh api repos/$GITHUB_REPOSITORY/dependabot/alerts"
+          fi


### PR DESCRIPTION
## Summary

Adds an \`npm audit\` step to \`firebase-ci-checks.yml\` that surfaces high/critical vulnerability counts as PR warnings on every Firebase CI run.

**Non-blocking today.** The repo currently has 10 high/critical alerts (per local \`npm audit\`), so a hard gate would block every PR until they're resolved. \`continue-on-error: true\` + \`::warning::\` lets us see the count on every run without blocking.

**After the Dependabot cleanup PRs land** (jws, node-forge/firebase-admin bump, fast-xml-parser+protobufjs, Express overrides, serialize-javascript), remove \`continue-on-error\` and add \`--audit-level=high\` so any new high/critical vuln fails the build. That's the proper regression guard.

## Fast skip

Inherits the existing \`inputs.firebase == 'true'\` gate on the \`test\` job — non-Firebase and docs-only PRs skip automatically via the \`changes\` path-detection in \`firebase-ci.yml\`.

## Test plan

- [x] Local sanity: \`npm --prefix FirebaseServer audit --json | jq ...\` returns 10 (8 high + 2 critical) — matches expected
- [ ] CI green (warning visible in PR annotations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)