### PR TITLE
ci: Add checkNoImplSuffix lint for ADR-008 enforcement

### DIFF
--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -185,6 +185,18 @@ tasks.register<architecture.NoBareTopLevelFunctionsTask>("checkNoBareTopLevelFun
     )
 }
 
+tasks.register<architecture.NoImplSuffixTask>("checkNoImplSuffix") {
+    sourceDirs = listOf(
+        "$rootDir/androidApp/src/main/java",
+        "$rootDir/usecase/src/commonMain/kotlin",
+        "$rootDir/presentation-model/src/commonMain/kotlin",
+        "$rootDir/domain/src/commonMain/kotlin",
+        "$rootDir/data/src/commonMain/kotlin",
+        "$rootDir/data-local/src/commonMain/kotlin",
+        "$rootDir/test-common/src/commonMain/kotlin",
+    )
+}
+
 allprojects {
     apply(plugin = "com.diffplug.spotless")
     apply(plugin = "io.gitlab.arturbosch.detekt")

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/NoImplSuffixTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/NoImplSuffixTask.kt
@@ -1,0 +1,91 @@
+package architecture
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Enforces ADR-008: no `*Impl` suffix on Kotlin class names.
+ *
+ * `*Impl` says nothing about what the implementation actually does.
+ * Prefer descriptive prefixes that name the backing mechanism or role:
+ *
+ *   - `Network*`, `Ktor*` — HTTP data sources
+ *   - `Cached*`, `Room*` — persistence-backed
+ *   - `Firebase*`, `Google*` — platform-specific SDK wrappers
+ *   - `Default*` — the canonical production impl when there's also a
+ *     `Fake*` / `InMemory*` for tests
+ *
+ * This lint had zero violations when added, so it locks the current
+ * state rather than prescribing a migration.
+ */
+abstract class NoImplSuffixTask : DefaultTask() {
+    @get:Input
+    var sourceDirs: List<String> = emptyList()
+
+    /**
+     * File-name patterns to exempt. Generated KSP output or specific
+     * third-party wrappers may need to opt out.
+     */
+    @get:Input
+    var allowedFilePatterns: List<String> = emptyList()
+
+    @TaskAction
+    fun check() {
+        // Matches class declarations whose name ends in "Impl" at word boundary.
+        // Handles the common modifiers: open, abstract, sealed, data, internal,
+        // public, private. Also catches `internal class FooImpl`, `data class BarImpl`,
+        // and plain `class BazImpl`. Does not flag `*Implementation` (that's a
+        // different word), nested class keywords on the same line, or comments.
+        val classPattern = Regex(
+            pattern = """^\s*(?:(?:open|abstract|sealed|data|internal|public|private|inner)\s+)*class\s+(\w+Impl)\b""",
+            option = RegexOption.MULTILINE,
+        )
+        val allowedRegexes = allowedFilePatterns.map { Regex(it) }
+
+        val violations = mutableListOf<String>()
+
+        sourceDirs.forEach { dir ->
+            val rootFile = File(dir)
+            if (!rootFile.exists()) return@forEach
+
+            rootFile
+                .walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .filter { file -> allowedRegexes.none { it.matches(file.name) } }
+                .forEach { file ->
+                    val relativePath = file.relativeTo(rootFile).path
+                    val content = file.readText()
+                    classPattern.findAll(content).forEach { match ->
+                        val className = match.groupValues[1]
+                        val lineNumber = content.substring(0, match.range.first).count { it == '\n' } + 1
+                        violations.add("$relativePath:$lineNumber: class $className")
+                    }
+                }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    append("NoImplSuffix check FAILED: ")
+                    append(violations.size)
+                    append(" class(es) end in `Impl`.\n\n")
+                    violations.forEach { append("  - $it\n") }
+                    append("\n")
+                    append("ADR-008: `*Impl` says nothing about what the implementation does.\n")
+                    append("Rename using a descriptive prefix:\n")
+                    append("  - `Network*`, `Ktor*`       (HTTP data sources)\n")
+                    append("  - `Cached*`, `Room*`        (persistence-backed)\n")
+                    append("  - `Firebase*`, `Google*`    (platform SDK wrappers)\n")
+                    append("  - `Default*`                (canonical production impl)\n")
+                    append("  - `Fake*`, `InMemory*`      (test doubles)\n\n")
+                    append("See AndroidGarage/docs/DECISIONS.md (ADR-008).\n")
+                },
+            )
+        }
+
+        logger.lifecycle("NoImplSuffix check passed: no `*Impl` class names found.")
+    }
+}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -49,6 +49,9 @@ $GRADLE checkNoRawDispatchers && pass "no raw dispatchers" || fail "no raw dispa
 step "No bare top-level functions (ADR-009 — group in object {})"
 $GRADLE checkNoBareTopLevelFunctions && pass "no bare top-level functions" || fail "no bare top-level functions"
 
+step "No *Impl suffix on class names (ADR-008 — use descriptive prefix)"
+$GRADLE checkNoImplSuffix && pass "no *Impl suffix" || fail "no *Impl suffix"
+
 step "Layer imports (ViewModel→UseCase, UseCase→domain)"
 $GRADLE checkLayerImports && pass "layer imports" || fail "layer imports"
 


### PR DESCRIPTION
## Summary

Closes Phase 4 audit gap #8. Locks the \"no \`*Impl\` suffix on class names\" rule (ADR-008). Zero violations today — defensive against regression.

## Verification

\`\`\`
$ grep -rEn '^(open |abstract |sealed |internal |public |private )*class \\w+Impl\\b' AndroidGarage --include='*.kt'
(no output)
\`\`\`

## What's in

- \`AndroidGarage/buildSrc/src/main/kotlin/architecture/NoImplSuffixTask.kt\` — new Gradle task scanning all KMP source modules
- \`AndroidGarage/build.gradle.kts\` — registers \`checkNoImplSuffix\`
- \`scripts/validate.sh\` — invokes after \`checkNoBareTopLevelFunctions\`

Failure message points at ADR-008 with the rename-recipe (Network*, Cached*, Firebase*, Default*, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)