### PR TITLE
ci: Add checkMutexWithLock lint — ban bare Mutex lock/unlock

### DIFF
--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -210,6 +210,17 @@ tasks.register<architecture.NoMockitoImportsTask>("checkNoMockitoImports") {
     )
 }
 
+tasks.register<architecture.MutexWithLockTask>("checkMutexWithLock") {
+    sourceDirs = listOf(
+        "$rootDir/androidApp/src/main/java",
+        "$rootDir/usecase/src/commonMain/kotlin",
+        "$rootDir/presentation-model/src/commonMain/kotlin",
+        "$rootDir/domain/src/commonMain/kotlin",
+        "$rootDir/data/src/commonMain/kotlin",
+        "$rootDir/data-local/src/commonMain/kotlin",
+    )
+}
+
 allprojects {
     apply(plugin = "com.diffplug.spotless")
     apply(plugin = "io.gitlab.arturbosch.detekt")

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/MutexWithLockTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/MutexWithLockTask.kt
@@ -1,0 +1,77 @@
+package architecture
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Enforces: `Mutex` usage must go through `withLock { ... }`, never bare
+ * `.lock()` / `.unlock()` pairs.
+ *
+ * A bare `mutex.lock()` / `mutex.unlock()` is a correctness bug, not a
+ * style preference: a throw between the pair strands the lock for the
+ * rest of the process lifetime, deadlocking everything that ever tries
+ * to acquire it. `withLock { ... }` is the only safe idiom — it uses
+ * `try/finally` internally to guarantee release.
+ *
+ * This lint had zero violations when added (the one `Mutex` in the
+ * codebase already uses `withLock`). It locks the current state.
+ */
+abstract class MutexWithLockTask : DefaultTask() {
+    @get:Input
+    var sourceDirs: List<String> = emptyList()
+
+    @TaskAction
+    fun check() {
+        // Match `.lock()` or `.unlock()` with a name preceding the dot.
+        // `withLock` has a `{ ... }` block and does not match.
+        // `lockInstance.lock()` matches; `mutex.withLock { ... }` does not.
+        val lockPattern = Regex("""\b(\w+)\.lock\s*\(\s*\)""")
+        val unlockPattern = Regex("""\b(\w+)\.unlock\s*\(\s*\)""")
+
+        val violations = mutableListOf<String>()
+
+        sourceDirs.forEach { dir ->
+            val rootFile = File(dir)
+            if (!rootFile.exists()) return@forEach
+
+            rootFile
+                .walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .forEach { file ->
+                    val relativePath = file.relativeTo(rootFile).path
+                    file.readLines().forEachIndexed { index, line ->
+                        val trimmed = line.trim()
+                        if (trimmed.startsWith("//") || trimmed.startsWith("*")) return@forEachIndexed
+                        lockPattern.findAll(line).forEach { match ->
+                            violations.add("$relativePath:${index + 1}: ${match.value}  (use withLock { ... } instead)")
+                        }
+                        unlockPattern.findAll(line).forEach { match ->
+                            violations.add("$relativePath:${index + 1}: ${match.value}  (use withLock { ... } instead)")
+                        }
+                    }
+                }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    append("MutexWithLock check FAILED: ")
+                    append(violations.size)
+                    append(" bare lock/unlock call(s).\n\n")
+                    violations.forEach { append("  - $it\n") }
+                    append("\n")
+                    append("Bare `mutex.lock()` / `mutex.unlock()` strands the lock for the\n")
+                    append("rest of the process if anything between them throws. Use:\n")
+                    append("  import kotlinx.coroutines.sync.withLock\n")
+                    append("  mutex.withLock { /* critical section */ }\n\n")
+                    append("`withLock` wraps in try/finally and guarantees release.\n")
+                },
+            )
+        }
+
+        logger.lifecycle("MutexWithLock check passed: no bare .lock()/.unlock() calls found.")
+    }
+}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -55,6 +55,9 @@ $GRADLE checkNoImplSuffix && pass "no *Impl suffix" || fail "no *Impl suffix"
 step "No Mockito imports (ADR-003 — fakes over mocks)"
 $GRADLE checkNoMockitoImports && pass "no Mockito imports" || fail "no Mockito imports"
 
+step "Mutex withLock (no bare .lock()/.unlock())"
+$GRADLE checkMutexWithLock && pass "mutex withLock" || fail "mutex withLock"
+
 step "Layer imports (ViewModel→UseCase, UseCase→domain)"
 $GRADLE checkLayerImports && pass "layer imports" || fail "layer imports"
 


### PR DESCRIPTION
## Summary

Closes Phase 4 audit gap #9. Bans bare \`mutex.lock()\` / \`mutex.unlock()\` call patterns. Zero violations today — the one \`Mutex\` in the codebase (\`CachedServerConfigRepository.fetchMutex\`) already uses \`withLock\`.

## Why this is a correctness rule

A bare pair strands the lock if anything between them throws. \`withLock { ... }\` wraps in try/finally and guarantees release. This isn't a style preference; it's the difference between a deadlock lasting the rest of the process lifetime and a safe critical section.

## What's in

- \`AndroidGarage/buildSrc/src/main/kotlin/architecture/MutexWithLockTask.kt\` — scans all KMP source modules for \`foo.lock()\` or \`foo.unlock()\` patterns (word-boundary)
- \`AndroidGarage/build.gradle.kts\` — registers \`checkMutexWithLock\`
- \`scripts/validate.sh\` — invokes after \`checkNoBareTopLevelFunctions\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)