### PR TITLE
ci: Add checkNoMockitoImports lint — ADR-003 enforcement

### DIFF
--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -197,6 +197,19 @@ tasks.register<architecture.NoImplSuffixTask>("checkNoImplSuffix") {
     )
 }
 
+tasks.register<architecture.NoMockitoImportsTask>("checkNoMockitoImports") {
+    sourceDirs = listOf(
+        "$rootDir/androidApp/src/test/java",
+        "$rootDir/androidApp/src/androidTest/java",
+        "$rootDir/usecase/src/commonTest/kotlin",
+        "$rootDir/data/src/commonTest/kotlin",
+        "$rootDir/data-local/src/commonTest/kotlin",
+        "$rootDir/domain/src/commonTest/kotlin",
+        "$rootDir/presentation-model/src/commonTest/kotlin",
+        "$rootDir/test-common/src/commonMain/kotlin",
+    )
+}
+
 allprojects {
     apply(plugin = "com.diffplug.spotless")
     apply(plugin = "io.gitlab.arturbosch.detekt")

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/NoMockitoImportsTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/NoMockitoImportsTask.kt
@@ -1,0 +1,63 @@
+package architecture
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Enforces ADR-003 (testing philosophy): no Mockito imports in test files.
+ *
+ * The codebase uses fakes over mocks — shared `Fake*` / `InMemory*`
+ * implementations in `test-common/` that every test depends on. Mockito
+ * was fully removed in PR #215; this lint prevents accidental
+ * re-introduction via auto-import.
+ *
+ * Zero violations today. Scope is all test source directories.
+ */
+abstract class NoMockitoImportsTask : DefaultTask() {
+    @get:Input
+    var sourceDirs: List<String> = emptyList()
+
+    @TaskAction
+    fun check() {
+        val importPattern = Regex("""^\s*import\s+org\.mockito(\.|$)""")
+        val violations = mutableListOf<String>()
+
+        sourceDirs.forEach { dir ->
+            val rootFile = File(dir)
+            if (!rootFile.exists()) return@forEach
+
+            rootFile
+                .walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .forEach { file ->
+                    val relativePath = file.relativeTo(rootFile).path
+                    file.readLines().forEachIndexed { index, line ->
+                        if (importPattern.containsMatchIn(line)) {
+                            violations.add("$relativePath:${index + 1}: ${line.trim()}")
+                        }
+                    }
+                }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    append("NoMockitoImports check FAILED: ")
+                    append(violations.size)
+                    append(" Mockito import(s).\n\n")
+                    violations.forEach { append("  - $it\n") }
+                    append("\n")
+                    append("ADR-003: fakes over mocks. Mockito was fully removed in PR #215.\n")
+                    append("Fix: replace the Mockito usage with a fake from `test-common/`, or\n")
+                    append("create a new fake that implements the same interface.\n")
+                    append("See AndroidGarage/docs/DECISIONS.md (ADR-003) and `test-common/src/`.\n")
+                },
+            )
+        }
+
+        logger.lifecycle("NoMockitoImports check passed: no org.mockito.* imports found.")
+    }
+}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -52,6 +52,9 @@ $GRADLE checkNoBareTopLevelFunctions && pass "no bare top-level functions" || fa
 step "No *Impl suffix on class names (ADR-008 — use descriptive prefix)"
 $GRADLE checkNoImplSuffix && pass "no *Impl suffix" || fail "no *Impl suffix"
 
+step "No Mockito imports (ADR-003 — fakes over mocks)"
+$GRADLE checkNoMockitoImports && pass "no Mockito imports" || fail "no Mockito imports"
+
 step "Layer imports (ViewModel→UseCase, UseCase→domain)"
 $GRADLE checkLayerImports && pass "layer imports" || fail "layer imports"
 


### PR DESCRIPTION
## Summary

Closes Phase 4 audit gap #10. Bans \`import org.mockito.*\` in test files. Mockito was fully removed in PR #215 (zero imports today); this lint prevents accidental re-introduction via auto-import.

## What's in

- \`AndroidGarage/buildSrc/src/main/kotlin/architecture/NoMockitoImportsTask.kt\` — scans all test source directories
- \`AndroidGarage/build.gradle.kts\` — registers \`checkNoMockitoImports\`
- \`scripts/validate.sh\` — invokes after \`checkNoImplSuffix\`

Failure message points at ADR-003 and the \`test-common/\` fakes module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)