### PR TITLE
ci: Add opt-in R8 instrumented test step to validate.sh

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -135,6 +135,46 @@ else
     fail "Room schema drift detected"
 fi
 
+# ------------------------------------------------------------------
+# Optional: R8 instrumented tests
+# ------------------------------------------------------------------
+# Runs connectedBenchmarkAndroidTest against an R8-minified APK so the
+# release-only failure class (kotlinx.serialization Companion keeps,
+# proto keepers, etc.) can be reproduced locally before tagging.
+#
+# Opt-in because it needs a connected device/emulator and takes several
+# minutes:
+#   $ VALIDATE_R8=1 ./scripts/validate.sh
+#
+# Without the flag this block is skipped with a short notice so the
+# default run stays fast and device-independent. The release script
+# (`scripts/release-android.sh`) is the place to make this a hard gate
+# when cutting an Android release.
+#
+# Harness background: AndroidGarage/docs/R8_INSTRUMENTED_TESTS.md
+# and ADR-020 (R8 release-build hardening).
+if [ "${VALIDATE_R8:-0}" = "1" ]; then
+    step "R8 instrumented tests (opt-in via VALIDATE_R8=1)"
+    if ! command -v adb >/dev/null 2>&1; then
+        fail "adb not found on PATH — R8 instrumented tests need it"
+    fi
+    if ! adb devices 2>/dev/null | grep -q "device$"; then
+        fail "No device/emulator connected. Plug in a device or start an emulator, then retry."
+    fi
+    $GRADLE \
+        -PtestR8=true \
+        -PdebuggableBenchmark=true \
+        -PVERSION_CODE=99999 \
+        :androidApp:connectedBenchmarkAndroidTest \
+        && pass "connectedBenchmarkAndroidTest (R8 minified)" \
+        || fail "connectedBenchmarkAndroidTest (R8 minified)"
+else
+    step "R8 instrumented tests (skipped — opt-in via VALIDATE_R8=1)"
+    echo "  To reproduce release-only R8 failures locally, run:"
+    echo "    VALIDATE_R8=1 ./scripts/validate.sh"
+    echo "  Requires a connected device/emulator. See docs/R8_INSTRUMENTED_TESTS.md"
+fi
+
 # Record successful validation so git-guardrails hook knows we validated.
 git rev-parse HEAD > "$REPO_ROOT/.claude/.validation-passed"
 


### PR DESCRIPTION
## Summary

Closes Phase 4 audit gap #7. Adds an opt-in R8 instrumented test step to `validate.sh` so release-only failure classes (kotlinx.serialization `$Companion` keep misses, proto keepers, etc.) can be reproduced locally before tagging.

## Usage

```
# Default — no device needed, R8 step skipped with a notice:
./scripts/validate.sh

# With device connected, include R8 instrumented tests:
VALIDATE_R8=1 ./scripts/validate.sh
```

## Design

- **Opt-in** via `VALIDATE_R8=1` env var — the default run stays fast and doesn't require a device.
- **Fails loudly** if `VALIDATE_R8=1` is set but no device is connected (rather than silently skipping).
- **Harness matches** `docs/R8_INSTRUMENTED_TESTS.md` — `-PtestR8=true -PdebuggableBenchmark=true`.
- **`VERSION_CODE=99999`** to avoid `INSTALL_FAILED_UPDATE_INCOMPATIBLE` from a prior benchmark APK.

## Not in scope

Making this a hard gate in `release-android.sh` is a follow-up — the release script is the natural place for that gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)