### PR TITLE
deps: Override jws to 4.0.1 + 3.2.3 (Dependabot #25, #26)

### DIFF
--- a/FirebaseServer/package-lock.json
+++ b/FirebaseServer/package-lock.json
@@ -3670,12 +3670,12 @@
       }
     },
     "node_modules/jsonwebtoken/node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -3737,12 +3737,12 @@
       "license": "MIT"
     },
     "node_modules/jws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^2.0.0",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },

--- a/FirebaseServer/package.json
+++ b/FirebaseServer/package.json
@@ -35,6 +35,12 @@
     "ts-node": "10.9.2",
     "typescript": "4.9.5"
   },
+  "overrides": {
+    "jws": "^4.0.1",
+    "jsonwebtoken": {
+      "jws": "^3.2.3"
+    }
+  },
   "engines": {
     "node": "20"
   },


### PR DESCRIPTION
## Summary

Closes Dependabot alerts **#25** and **#26** — GHSA-869p-cjfg-cm3x (jws improperly verifies HMAC signature; the classic JWT alg-confusion CVE).

**This is the only reachable exploit in the current Dependabot queue.** `firebase.auth().verifyIdToken(googleIdToken)` is called on every authenticated HTTP endpoint (`Snooze.ts:92`, `RemoteButton.ts:162`), and that path transits `jws` for JWT parsing/verification.

## Before → After

| | Path | Before | After |
|---|---|---|---|
| | firebase-admin → google-auth-library → gtoken | jws 4.0.0 | jws 4.0.1 ✓ |
| | firebase-admin → jsonwebtoken | jws 3.2.2 | jws 3.2.3 ✓ |

## Change

```json
"overrides": {
  "jws": "^4.0.1",
  "jsonwebtoken": {
    "jws": "^3.2.3"
  }
}
```

## Verified locally (Node 20)

- `npm install` — lockfile clean
- `npm ls jws` — both copies resolved to patched versions (4.0.1 / 3.2.3)
- `npm run build` — 16 warnings (baseline), 0 errors
- `npm run tests` — 74 passing (no regression; includes the 6 `verifyIdToken` negative-case tests from #433)
- `firebase emulators:exec` smoke test — module loads, `/serverConfig` responds 500 as expected
- `npm audit` — total vulns 25 → 24

## CI safety net

All three safety nets land in this PR's CI run:
- **verifyIdToken library-chain test (#433)** — proves the transitive JWT parsing chain still rejects malformed input after the override.
- **Emulator smoke test (#435)** — proves the compiled bundle loads under Node 20 in the emulator with the new `jws` resolution.
- **`npm audit` warning (#434)** — reports the new count (should drop from 10 → 9 high/critical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)