### PR TITLE
ci: Set up JDK 21 in emulator smoke test job

### DIFF
--- a/.github/workflows/firebase-ci-checks.yml
+++ b/.github/workflows/firebase-ci-checks.yml
@@ -91,6 +91,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+      # firebase-tools requires Java 21+ for the Firestore / Functions
+      # emulators as of firebase-tools 14.x. Without this step the job
+      # fails at `firebase emulators:exec` with:
+      #   "firebase-tools no longer supports Java version before 21"
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
       - name: Install dependencies
         working-directory: FirebaseServer
         run: npm install


### PR DESCRIPTION
## Summary

Fixes the emulator smoke test job that was added in #435. `firebase-tools` 14.x requires Java 21+ for the Firestore / Functions emulators. Without a setup-java step, `firebase emulators:exec` fails immediately with:

```
Error: firebase-tools no longer supports Java version before 21.
Please install a JDK at version 21 or above to get a compatible runtime.
```

## How it surfaced

PR #441 (jws override) hit the newly-landed smoke test job and failed with this error — the safety net caught a setup issue, not a dep regression.

## Change

Adds `actions/setup-java@v4` with `java-version: '21'` between Node setup and the firebase-tools install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)