### PR TITLE
deps: Add qs + path-to-regexp overrides (Express transitives)

### DIFF
--- a/FirebaseServer/package-lock.json
+++ b/FirebaseServer/package-lock.json
@@ -4344,9 +4344,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/pathval": {
@@ -4450,12 +4450,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"

--- a/FirebaseServer/package.json
+++ b/FirebaseServer/package.json
@@ -39,7 +39,9 @@
     "jws": "^4.0.1",
     "jsonwebtoken": {
       "jws": "^3.2.3"
-    }
+    },
+    "qs": "^6.14.2",
+    "path-to-regexp": "0.1.13"
   },
   "engines": {
     "node": "20"


### PR DESCRIPTION
## Summary

Closes 3 Dependabot alerts in Express transitives:
- **#27** (qs, medium) — arrayLimit bypass via bracket notation DoS
- **#34** (qs, low) — arrayLimit bypass via comma parsing DoS
- **#60** (path-to-regexp, high) — ReDoS via multiple route parameters

## Changes

- Added `qs: ^6.14.2` and `path-to-regexp: 0.1.13` to `overrides` in `FirebaseServer/package.json`
- After `npm install`: qs 6.13.0 → 6.15.1 (satisfies ^6.14.2), path-to-regexp 0.1.12 → 0.1.13

## Test plan

- [x] 74 mocha tests pass locally (Node 20)
- [x] `npm run build` passes (0 errors)
- [ ] CI: pre-submit checks (includes emulator smoke test that hits /serverConfig via real Express routing)
- [ ] Post-merge: next `server/N` tag will deploy — verifyIdToken contract tests guard the JWT path (unaffected by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)