### PR TITLE
chore: Clean up 16 ESLint unused-var warnings in FirebaseServer

### DIFF
--- a/FirebaseServer/src/functions/firestore/Events.ts
+++ b/FirebaseServer/src/functions/firestore/Events.ts
@@ -20,7 +20,7 @@ import { updateEvent } from '../../controller/EventUpdates';
 
 export const firestoreUpdateEvents = functions.firestore
   .document('updateAll/{docId}')
-  .onWrite(async (change, context) => {
+  .onWrite(async (change, _context) => {
     const data = change.after.data();
     const scheduledJob = false;
     await updateEvent(data, scheduledJob);

--- a/FirebaseServer/src/functions/http/RemoteButton.ts
+++ b/FirebaseServer/src/functions/http/RemoteButton.ts
@@ -38,9 +38,6 @@ const EMAIL_PARAM_KEY = "email";
 const REMOTE_BUTTON_MIN_PERIOD_SECONDS = 10;
 const REMOTE_BUTTON_COMMAND_TIMEOUT_SECONDS = 60;
 
-const REMOTE_BUTTON_REQUEST_ERROR_SECONDS = 60 * 10;
-const REMOTE_BUTTON_REQUEST_ERROR_DATABASE = new TimeSeriesDatabase('remoteButtonRequestErrorCurrent', 'remoteButtonRequestErrorAll');
-
 /**
  * curl -H "Content-Type: application/json" http://localhost:5000/PROJECT-ID/us-central1/remoteButton?buildTimestamp=buildTimestamp&buttonAckToken=buttonAckToken
  */
@@ -183,7 +180,6 @@ export const httpAddRemoteButtonCommand = functions.https.onRequest(async (reque
     // If the client does not send a session ID, create a session ID.
     data[SESSION_PARAM_KEY] = uuidv4();
   }
-  const session = data[SESSION_PARAM_KEY];
   if (BUTTON_ACK_TOKEN_PARAM_KEY in request.query) {
     // Button ack token needs to be unique for each request (prefer random).
     data[BUTTON_ACK_TOKEN_PARAM_KEY] = request.query[BUTTON_ACK_TOKEN_PARAM_KEY];

--- a/FirebaseServer/src/functions/http/ServerConfig.ts
+++ b/FirebaseServer/src/functions/http/ServerConfig.ts
@@ -19,10 +19,6 @@ import * as functions from 'firebase-functions/v1';
 import { Config } from '../../database/ServerConfigDatabase';
 
 export const httpServerConfig = functions.https.onRequest(async (request, response) => {
-  const data = {
-    queryParams: request.query,
-    body: request.body,
-  };
   const functionConfig = functions.config();
   if (!functionConfig
     || !('serverconfig' in functionConfig)

--- a/FirebaseServer/src/functions/http/Snooze.ts
+++ b/FirebaseServer/src/functions/http/Snooze.ts
@@ -115,7 +115,7 @@ export const httpSnoozeNotificationsRequest = functions.https.onRequest(async (r
             snoozeDuration: request.query[SNOOZE_DURATION_PARAM_KEY] as string,
             snoozeEventTimestamp: request.query[SNOOZE_EVENT_TIMESTAMP_KEY] as string,
         };
-    } catch (error) {
+    } catch {
         const result = {
             error: 'Could not parse parameters: '
                 + BUILD_TIMESTAMP_PARAM_KEY + ', ' + SNOOZE_DURATION_PARAM_KEY + ', ' + SNOOZE_EVENT_TIMESTAMP_KEY,
@@ -194,7 +194,7 @@ export const httpSnoozeNotificationsLatest = functions.https.onRequest(async (re
         params = <SnoozeLatestParams>{
             buildTimestamp: request.query[BUILD_TIMESTAMP_PARAM_KEY] as string,
         };
-    } catch (error) {
+    } catch {
         console.error('No build timestamp in request');
         const result = { error: 'Missing required parameter: ' + BUILD_TIMESTAMP_PARAM_KEY };
         response.status(400).send(result);

--- a/FirebaseServer/src/functions/pubsub/DataRetentionPolicy.ts
+++ b/FirebaseServer/src/functions/pubsub/DataRetentionPolicy.ts
@@ -21,7 +21,7 @@ import { deleteOldData } from '../../controller/DatabaseCleaner';
 
 export const pubsubDataRetentionPolicy = functions.pubsub
   .schedule('0 0 * * *').timeZone('America/Los_Angeles') // California midnight every day.
-  .onRun(async (context) => {
+  .onRun(async (_context) => {
     const config = await Config.get();
     if (!Config.isDeleteOldDataEnabled(config)) {
       console.log('Deleting data is disabled');
@@ -30,6 +30,6 @@ export const pubsubDataRetentionPolicy = functions.pubsub
     const cutoffMillis = new Date().getTime() - 1000 * 60 * 60 * 24 * 14; // 2 weeks.
     const cutoffSeconds = cutoffMillis / 1000;
     const dryRunRequested = false;
-    const deleteCount = await deleteOldData(cutoffSeconds, dryRunRequested);
+    await deleteOldData(cutoffSeconds, dryRunRequested);
     return null;
   });

--- a/FirebaseServer/src/functions/pubsub/DoorErrors.ts
+++ b/FirebaseServer/src/functions/pubsub/DoorErrors.ts
@@ -18,7 +18,7 @@ import * as functions from 'firebase-functions/v1';
 
 import { updateEvent } from '../../controller/EventUpdates';
 
-export const pubsubCheckForDoorErrors = functions.pubsub.schedule('every 1 minutes').onRun(async (context) => {
+export const pubsubCheckForDoorErrors = functions.pubsub.schedule('every 1 minutes').onRun(async (_context) => {
   const BUILD_TIMESTAMP_PARAM_KEY = "buildTimestamp";
   const buildTimestampString = 'Sat Mar 13 14:45:00 2021'; // TODO: Use config.
   const scheduledJob = true;

--- a/FirebaseServer/src/functions/pubsub/OpenDoor.ts
+++ b/FirebaseServer/src/functions/pubsub/OpenDoor.ts
@@ -22,7 +22,7 @@ import { TimeSeriesDatabase } from '../../database/TimeSeriesDatabase';
 const EVENT_DATABASE = new TimeSeriesDatabase('eventsCurrent', 'eventsAll');
 
 // TODO: Add Snooze option to delay notifications.
-export const pubsubCheckForOpenDoorsJob = functions.pubsub.schedule('every 5 minutes').onRun(async (context) => {
+export const pubsubCheckForOpenDoorsJob = functions.pubsub.schedule('every 5 minutes').onRun(async (_context) => {
   const buildTimestamp = 'Sat Mar 13 14:45:00 2021'; // TODO: Use config.
   const eventData = await EVENT_DATABASE.getCurrent(buildTimestamp);
   await sendFCMForOldData(buildTimestamp, eventData);

--- a/FirebaseServer/src/functions/pubsub/RemoteButton.ts
+++ b/FirebaseServer/src/functions/pubsub/RemoteButton.ts
@@ -28,7 +28,7 @@ const REMOTE_BUTTON_REQUEST_ERROR_DATABASE = new TimeSeriesDatabase('remoteButto
 
 export const pubsubCheckForRemoteButtonErrors = functions.pubsub
   .schedule('every 10 minutes').timeZone('America/Los_Angeles') // California after midnight every day.
-  .onRun(async (context) => {
+  .onRun(async (_context) => {
     // TODO: Use config.
     // const config = await Config.get();
     // const buildTimestamp = Config.getRemoteButtonBuildTimestamp(config);

--- a/FirebaseServer/test/controller/SnoozeNotificationsTest.ts
+++ b/FirebaseServer/test/controller/SnoozeNotificationsTest.ts
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-import * as firebase from 'firebase-admin';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 
 import { getSnoozeStatus, submitSnoozeNotificationsRequest } from '../../src/controller/SnoozeNotifications';
 import { DATABASE as SnoozeNotificationsDatabase } from '../../src/database/SnoozeNotificationsDatabase';
 import { DATABASE as SensorEventDatabase } from '../../src/database/SensorEventDatabase';
-import { SnoozeRequest, SnoozeStatus } from '../../src/model/SnoozeRequest';
-import { SensorEvent } from '../../src/model/SensorEvent';
+import { SnoozeStatus } from '../../src/model/SnoozeRequest';
 
 describe('SnoozeNotifications', () => {
   afterEach(() => {

--- a/FirebaseServer/test/controller/fcm/OldDataFCMTest.ts
+++ b/FirebaseServer/test/controller/fcm/OldDataFCMTest.ts
@@ -1,6 +1,5 @@
 
 import { expect } from 'chai';
-import { getFCMDataFromEvent } from '../../../src/controller/fcm/EventFCM';
 import { SensorEvent, SensorEventType } from '../../../src/model/SensorEvent';
 import { AndroidMessagePriority, NotificationPriority, TopicMessage } from '../../../src/model/FCM';
 import { getDoorNotClosedMessageFromEvent } from '../../../src/controller/fcm/OldDataFCM';


### PR DESCRIPTION
## Summary

Zero behavioral changes — just cleans up 16 pre-existing ESLint warnings that appeared in the deploy log.

## Changes by category

- **6 pubsub/firestore handlers:** rename unused \`context\` → \`_context\`. The ESLint rule already honors \`_\`-prefix (\"Allowed unused args must match /^_/u\"), so this signals intent and silences the warning.
- **2 catch blocks in Snooze.ts:** \`catch (error)\` → \`catch\` (TS 4.4+ syntax). The error binding was never used.
- **Delete copy-paste leftovers** \`REMOTE_BUTTON_REQUEST_ERROR_SECONDS\` and \`REMOTE_BUTTON_REQUEST_ERROR_DATABASE\` in \`http/RemoteButton.ts\`. The real copies live in \`pubsub/RemoteButton.ts\` where they're actually used.
- **Delete unused locals:** \`session\` (RemoteButton.ts line 183 in the second handler — the first handler uses its own \`session\`), \`data\` wrapper (ServerConfig.ts httpServerConfig only — httpServerConfigUpdate still uses its copy), \`deleteCount\` (DataRetentionPolicy.ts — function was called for side-effect).
- **Delete unused imports** in two test files.

## Test plan

- [x] \`npm run build\` — 0 errors, **0 warnings** (was 16 warnings)
- [x] 74 mocha tests pass (Node 20)
- [ ] CI: pre-submit checks
- [ ] Emulator smoke test in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)