### PR TITLE
refactor(fb-db): Phase 1a — centralize RemoteButton databases

### DIFF
--- a/FirebaseServer/src/controller/DatabaseCleaner.ts
+++ b/FirebaseServer/src/controller/DatabaseCleaner.ts
@@ -17,11 +17,11 @@
 import { Config } from '../database/ServerConfigDatabase';
 
 import { TimeSeriesDatabase } from '../database/TimeSeriesDatabase';
+import { DATABASE as REMOTE_REQUEST_DATABASE } from '../database/RemoteButtonRequestDatabase';
+import { DATABASE as REMOTE_COMMAND_DATABASE } from '../database/RemoteButtonCommandDatabase';
 
 const UPDATE_DATABASE = new TimeSeriesDatabase('updateCurrent', 'updateAll');
 const EVENT_DATABASE = new TimeSeriesDatabase('eventsCurrent', 'eventsAll');
-const REMOTE_REQUEST_DATABASE = new TimeSeriesDatabase('remoteButtonRequestCurrent', 'remoteButtonRequestAll');
-const REMOTE_COMMAND_DATABASE = new TimeSeriesDatabase('remoteButtonCommandCurrent', 'remoteButtonCommandAll');
 
 export async function deleteOldData(cutoffTimestampSeconds: number, dryRunRequested: boolean): Promise<object> {
   const config = await Config.get();

--- a/FirebaseServer/src/database/RemoteButtonCommandDatabase.ts
+++ b/FirebaseServer/src/database/RemoteButtonCommandDatabase.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { TimeSeriesDatabase } from './TimeSeriesDatabase';
+
+// Canonical collection strings for this database. Pinned by
+// test/database/RemoteButtonCommandDatabaseTest.ts. Changing them
+// requires a Firestore data migration in production — see
+// docs/FIREBASE_DATABASE_REFACTOR.md.
+export const COLLECTION_CURRENT = 'remoteButtonCommandCurrent';
+export const COLLECTION_ALL = 'remoteButtonCommandAll';
+
+export interface RemoteButtonCommandDatabase {
+  save(buildTimestamp: string, data: any): Promise<void>;
+  getCurrent(buildTimestamp: string): Promise<any>;
+  deleteAllBefore(cutoffTimestampSeconds: number, dryRun: boolean): Promise<number>;
+}
+
+class FirestoreRemoteButtonCommandDatabase implements RemoteButtonCommandDatabase {
+  private readonly db = new TimeSeriesDatabase(COLLECTION_CURRENT, COLLECTION_ALL);
+  save(t: string, d: any) { return this.db.save(t, d); }
+  getCurrent(t: string) { return this.db.getCurrent(t); }
+  deleteAllBefore(c: number, dry: boolean) { return this.db.deleteAllBefore(c, dry); }
+}
+
+let _instance: RemoteButtonCommandDatabase = new FirestoreRemoteButtonCommandDatabase();
+
+export const DATABASE: RemoteButtonCommandDatabase = {
+  save: (t, d) => _instance.save(t, d),
+  getCurrent: (t) => _instance.getCurrent(t),
+  deleteAllBefore: (c, dry) => _instance.deleteAllBefore(c, dry),
+};
+
+/** TEST-ONLY: swap in a fake implementation. */
+export function setImpl(impl: RemoteButtonCommandDatabase): void { _instance = impl; }
+
+/** TEST-ONLY: restore the Firestore implementation. */
+export function resetImpl(): void { _instance = new FirestoreRemoteButtonCommandDatabase(); }

--- a/FirebaseServer/src/database/RemoteButtonRequestDatabase.ts
+++ b/FirebaseServer/src/database/RemoteButtonRequestDatabase.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { TimeSeriesDatabase } from './TimeSeriesDatabase';
+
+// Canonical collection strings for this database. Pinned by
+// test/database/RemoteButtonRequestDatabaseTest.ts. Changing them
+// requires a Firestore data migration in production — see
+// docs/FIREBASE_DATABASE_REFACTOR.md.
+export const COLLECTION_CURRENT = 'remoteButtonRequestCurrent';
+export const COLLECTION_ALL = 'remoteButtonRequestAll';
+
+export interface RemoteButtonRequestDatabase {
+  save(buildTimestamp: string, data: any): Promise<void>;
+  getCurrent(buildTimestamp: string): Promise<any>;
+  deleteAllBefore(cutoffTimestampSeconds: number, dryRun: boolean): Promise<number>;
+}
+
+class FirestoreRemoteButtonRequestDatabase implements RemoteButtonRequestDatabase {
+  private readonly db = new TimeSeriesDatabase(COLLECTION_CURRENT, COLLECTION_ALL);
+  save(t: string, d: any) { return this.db.save(t, d); }
+  getCurrent(t: string) { return this.db.getCurrent(t); }
+  deleteAllBefore(c: number, dry: boolean) { return this.db.deleteAllBefore(c, dry); }
+}
+
+let _instance: RemoteButtonRequestDatabase = new FirestoreRemoteButtonRequestDatabase();
+
+export const DATABASE: RemoteButtonRequestDatabase = {
+  save: (t, d) => _instance.save(t, d),
+  getCurrent: (t) => _instance.getCurrent(t),
+  deleteAllBefore: (c, dry) => _instance.deleteAllBefore(c, dry),
+};
+
+/** TEST-ONLY: swap in a fake implementation. */
+export function setImpl(impl: RemoteButtonRequestDatabase): void { _instance = impl; }
+
+/** TEST-ONLY: restore the Firestore implementation. */
+export function resetImpl(): void { _instance = new FirestoreRemoteButtonRequestDatabase(); }

--- a/FirebaseServer/src/database/RemoteButtonRequestErrorDatabase.ts
+++ b/FirebaseServer/src/database/RemoteButtonRequestErrorDatabase.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { TimeSeriesDatabase } from './TimeSeriesDatabase';
+
+// Canonical collection strings for this database. Pinned by
+// test/database/RemoteButtonRequestErrorDatabaseTest.ts. Changing them
+// requires a Firestore data migration in production — see
+// docs/FIREBASE_DATABASE_REFACTOR.md.
+//
+// This database stores health-monitoring entries written by the
+// pubsub cron (`pubsubCheckForRemoteButtonErrors`) when it detects
+// that the request pipeline has gone stale (device offline, missing
+// config, etc.). It is NOT a per-request error log for the HTTP
+// handler — those failures are logged to console and returned to the
+// client.
+export const COLLECTION_CURRENT = 'remoteButtonRequestErrorCurrent';
+export const COLLECTION_ALL = 'remoteButtonRequestErrorAll';
+
+export interface RemoteButtonRequestErrorDatabase {
+  save(buildTimestamp: string, data: any): Promise<void>;
+}
+
+class FirestoreRemoteButtonRequestErrorDatabase implements RemoteButtonRequestErrorDatabase {
+  private readonly db = new TimeSeriesDatabase(COLLECTION_CURRENT, COLLECTION_ALL);
+  save(t: string, d: any) { return this.db.save(t, d); }
+}
+
+let _instance: RemoteButtonRequestErrorDatabase = new FirestoreRemoteButtonRequestErrorDatabase();
+
+export const DATABASE: RemoteButtonRequestErrorDatabase = {
+  save: (t, d) => _instance.save(t, d),
+};
+
+/** TEST-ONLY: swap in a fake implementation. */
+export function setImpl(impl: RemoteButtonRequestErrorDatabase): void { _instance = impl; }
+
+/** TEST-ONLY: restore the Firestore implementation. */
+export function resetImpl(): void { _instance = new FirestoreRemoteButtonRequestErrorDatabase(); }

--- a/FirebaseServer/src/functions/http/RemoteButton.ts
+++ b/FirebaseServer/src/functions/http/RemoteButton.ts
@@ -19,15 +19,12 @@ import { v4 as uuidv4 } from 'uuid';
 import * as firebase from 'firebase-admin';
 import * as functions from 'firebase-functions/v1';
 
-import { TimeSeriesDatabase } from '../../database/TimeSeriesDatabase';
-
 import { Config } from '../../database/ServerConfigDatabase';
+import { DATABASE as REMOTE_BUTTON_COMMAND_DATABASE } from '../../database/RemoteButtonCommandDatabase';
+import { DATABASE as REMOTE_BUTTON_REQUEST_DATABASE } from '../../database/RemoteButtonRequestDatabase';
 import { isAuthorizedToPushRemoteButton } from '../../controller/Auth';
 
 import { RemoteButtonCommand } from '../../model/RemoteButtonCommand';
-
-const REMOTE_BUTTON_COMMAND_DATABASE = new TimeSeriesDatabase('remoteButtonCommandCurrent', 'remoteButtonCommandAll');
-const REMOTE_BUTTON_REQUEST_DATABASE = new TimeSeriesDatabase('remoteButtonRequestCurrent', 'remoteButtonRequestAll');
 
 const DATABASE_TIMESTAMP_SECONDS_KEY = 'FIRESTORE_databaseTimestampSeconds';
 const SESSION_PARAM_KEY = "session";

--- a/FirebaseServer/src/functions/pubsub/RemoteButton.ts
+++ b/FirebaseServer/src/functions/pubsub/RemoteButton.ts
@@ -17,14 +17,12 @@
 import * as firebase from 'firebase-admin';
 import * as functions from 'firebase-functions/v1';
 
-import { TimeSeriesDatabase } from '../../database/TimeSeriesDatabase';
-
-const REMOTE_BUTTON_REQUEST_DATABASE = new TimeSeriesDatabase('remoteButtonRequestCurrent', 'remoteButtonRequestAll');
+import { DATABASE as REMOTE_BUTTON_REQUEST_DATABASE } from '../../database/RemoteButtonRequestDatabase';
+import { DATABASE as REMOTE_BUTTON_REQUEST_ERROR_DATABASE } from '../../database/RemoteButtonRequestErrorDatabase';
 
 const DATABASE_TIMESTAMP_SECONDS_KEY = 'FIRESTORE_databaseTimestampSeconds';
 
 const REMOTE_BUTTON_REQUEST_ERROR_SECONDS = 60 * 10;
-const REMOTE_BUTTON_REQUEST_ERROR_DATABASE = new TimeSeriesDatabase('remoteButtonRequestErrorCurrent', 'remoteButtonRequestErrorAll');
 
 export const pubsubCheckForRemoteButtonErrors = functions.pubsub
   .schedule('every 10 minutes').timeZone('America/Los_Angeles') // California after midnight every day.

--- a/FirebaseServer/test/database/RemoteButtonCommandDatabaseTest.ts
+++ b/FirebaseServer/test/database/RemoteButtonCommandDatabaseTest.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { expect } from 'chai';
+import {
+  COLLECTION_CURRENT,
+  COLLECTION_ALL,
+} from '../../src/database/RemoteButtonCommandDatabase';
+
+describe('RemoteButtonCommandDatabase: collection-name contract', () => {
+  // These strings MUST match what http/RemoteButton.ts wrote before
+  // centralization. A mismatch means new code writes to a different
+  // Firestore collection than existing production data — the app
+  // appears to work while historical data becomes unreachable.
+  //
+  // Intentional change requires a full data migration:
+  //   1. Copy documents from old collection to new in production.
+  //   2. Update this test.
+  //   3. Update the data-retention cron.
+  //   4. Update any dashboards or alerts.
+  //   5. Deploy atomically.
+
+  it('current collection is pinned', () => {
+    expect(COLLECTION_CURRENT).to.equal('remoteButtonCommandCurrent');
+  });
+
+  it('all collection is pinned', () => {
+    expect(COLLECTION_ALL).to.equal('remoteButtonCommandAll');
+  });
+});

--- a/FirebaseServer/test/database/RemoteButtonRequestDatabaseTest.ts
+++ b/FirebaseServer/test/database/RemoteButtonRequestDatabaseTest.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { expect } from 'chai';
+import {
+  COLLECTION_CURRENT,
+  COLLECTION_ALL,
+} from '../../src/database/RemoteButtonRequestDatabase';
+
+describe('RemoteButtonRequestDatabase: collection-name contract', () => {
+  // These strings MUST match what pubsub/RemoteButton.ts and
+  // http/RemoteButton.ts wrote before centralization. A mismatch means
+  // new code writes to a different Firestore collection than existing
+  // production data — the app appears to work while historical data
+  // becomes unreachable.
+  //
+  // Intentional change requires a full data migration:
+  //   1. Copy documents from old collection to new in production.
+  //   2. Update this test.
+  //   3. Update the data-retention cron.
+  //   4. Update any dashboards or alerts.
+  //   5. Deploy atomically.
+
+  it('current collection is pinned', () => {
+    expect(COLLECTION_CURRENT).to.equal('remoteButtonRequestCurrent');
+  });
+
+  it('all collection is pinned', () => {
+    expect(COLLECTION_ALL).to.equal('remoteButtonRequestAll');
+  });
+});

--- a/FirebaseServer/test/database/RemoteButtonRequestErrorDatabaseTest.ts
+++ b/FirebaseServer/test/database/RemoteButtonRequestErrorDatabaseTest.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { expect } from 'chai';
+import {
+  COLLECTION_CURRENT,
+  COLLECTION_ALL,
+} from '../../src/database/RemoteButtonRequestErrorDatabase';
+
+describe('RemoteButtonRequestErrorDatabase: collection-name contract', () => {
+  // These strings MUST match what pubsub/RemoteButton.ts wrote before
+  // centralization. A mismatch means new code writes to a different
+  // Firestore collection than existing production data — error
+  // monitoring dashboards and alerts would stop firing while the
+  // pipeline silently accumulates entries in the wrong place.
+  //
+  // Intentional change requires a full data migration:
+  //   1. Copy documents from old collection to new in production.
+  //   2. Update this test.
+  //   3. Update any dashboards or alerts querying the error collection.
+  //   4. Deploy atomically.
+
+  it('current collection is pinned', () => {
+    expect(COLLECTION_CURRENT).to.equal('remoteButtonRequestErrorCurrent');
+  });
+
+  it('all collection is pinned', () => {
+    expect(COLLECTION_ALL).to.equal('remoteButtonRequestErrorAll');
+  });
+});

--- a/FirebaseServer/test/fakes/FakeRemoteButtonCommandDatabase.ts
+++ b/FirebaseServer/test/fakes/FakeRemoteButtonCommandDatabase.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { RemoteButtonCommandDatabase } from '../../src/database/RemoteButtonCommandDatabase';
+
+export class FakeRemoteButtonCommandDatabase implements RemoteButtonCommandDatabase {
+  private readonly store = new Map<string, any>();
+
+  /** Audit log of all save() calls. */
+  readonly saved: Array<[string, any]> = [];
+
+  /** Audit log of all deleteAllBefore() calls. */
+  readonly deleteCalls: Array<{ cutoff: number, dryRun: boolean }> = [];
+
+  async save(buildTimestamp: string, data: any): Promise<void> {
+    this.store.set(buildTimestamp, data);
+    this.saved.push([buildTimestamp, data]);
+  }
+
+  async getCurrent(buildTimestamp: string): Promise<any> {
+    return this.store.get(buildTimestamp) ?? null;
+  }
+
+  async deleteAllBefore(cutoffTimestampSeconds: number, dryRun: boolean): Promise<number> {
+    this.deleteCalls.push({ cutoff: cutoffTimestampSeconds, dryRun });
+    return 0;
+  }
+
+  /** Test-only helper: pre-populate storage without recording in saved[]. */
+  seed(buildTimestamp: string, data: any): void {
+    this.store.set(buildTimestamp, data);
+  }
+
+  /** Test-only helper: wipe storage and audit logs. */
+  clear(): void {
+    this.store.clear();
+    this.saved.length = 0;
+    this.deleteCalls.length = 0;
+  }
+}

--- a/FirebaseServer/test/fakes/FakeRemoteButtonRequestDatabase.ts
+++ b/FirebaseServer/test/fakes/FakeRemoteButtonRequestDatabase.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { RemoteButtonRequestDatabase } from '../../src/database/RemoteButtonRequestDatabase';
+
+export class FakeRemoteButtonRequestDatabase implements RemoteButtonRequestDatabase {
+  private readonly store = new Map<string, any>();
+
+  /** Audit log of all save() calls. */
+  readonly saved: Array<[string, any]> = [];
+
+  /** Audit log of all deleteAllBefore() calls. */
+  readonly deleteCalls: Array<{ cutoff: number, dryRun: boolean }> = [];
+
+  async save(buildTimestamp: string, data: any): Promise<void> {
+    this.store.set(buildTimestamp, data);
+    this.saved.push([buildTimestamp, data]);
+  }
+
+  async getCurrent(buildTimestamp: string): Promise<any> {
+    return this.store.get(buildTimestamp) ?? null;
+  }
+
+  async deleteAllBefore(cutoffTimestampSeconds: number, dryRun: boolean): Promise<number> {
+    this.deleteCalls.push({ cutoff: cutoffTimestampSeconds, dryRun });
+    return 0;
+  }
+
+  /** Test-only helper: pre-populate storage without recording in saved[]. */
+  seed(buildTimestamp: string, data: any): void {
+    this.store.set(buildTimestamp, data);
+  }
+
+  /** Test-only helper: wipe storage and audit logs. */
+  clear(): void {
+    this.store.clear();
+    this.saved.length = 0;
+    this.deleteCalls.length = 0;
+  }
+}

--- a/FirebaseServer/test/fakes/FakeRemoteButtonRequestErrorDatabase.ts
+++ b/FirebaseServer/test/fakes/FakeRemoteButtonRequestErrorDatabase.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { RemoteButtonRequestErrorDatabase } from '../../src/database/RemoteButtonRequestErrorDatabase';
+
+export class FakeRemoteButtonRequestErrorDatabase implements RemoteButtonRequestErrorDatabase {
+  /** Audit log of all save() calls. This DB is write-only in production. */
+  readonly saved: Array<[string, any]> = [];
+
+  async save(buildTimestamp: string, data: any): Promise<void> {
+    this.saved.push([buildTimestamp, data]);
+  }
+
+  /** Test-only helper: wipe audit log. */
+  clear(): void {
+    this.saved.length = 0;
+  }
+}


### PR DESCRIPTION
## Summary

Pilot of the database refactor documented in [\`docs/FIREBASE_DATABASE_REFACTOR.md\`](../blob/main/docs/FIREBASE_DATABASE_REFACTOR.md). Centralizes 7 inline \`new TimeSeriesDatabase(...)\` calls for RemoteButton-family collections into 3 per-collection singletons. Zero behavioral change.

## What's new

**3 DB modules in \`src/database/\`** (interface + FirestoreImpl + singleton + \`setImpl\`/\`resetImpl\`):
- \`RemoteButtonRequestDatabase.ts\`
- \`RemoteButtonCommandDatabase.ts\`
- \`RemoteButtonRequestErrorDatabase.ts\`

**3 fakes in \`test/fakes/\`** — Map-backed in-memory impls with \`saved[]\` / \`deleteCalls[]\` audit logs and \`seed()\` / \`clear()\` helpers.

**3 contract tests in \`test/database/\`** — pin the \`COLLECTION_CURRENT\` / \`COLLECTION_ALL\` strings. A typo in a collection name now fails the build.

## Migrated callers

| File | Change |
|---|---|
| \`pubsub/RemoteButton.ts\` | 2 inline instances → imports |
| \`http/RemoteButton.ts\` | 2 inline instances → imports |
| \`controller/DatabaseCleaner.ts\` | 2 inline instances → imports (Update + Event remain, Phase 2/3) |

## Backward compatibility

- Grep of \`'[a-z][a-zA-Z]+(Current|All)'\` across migrated files — strings are now owned by the 3 new DB modules, not removed.
- \`TimeSeriesDatabase.ts\` not modified (scope rule).
- No document shape changes.
- Singleton proxy forwards every call identically to the previous inline instances.

## Test plan

- [x] \`npm run build\` — 0 errors, 0 warnings.
- [x] \`npm run tests\` — **80 passing** (74 previous + 6 new contract tests).
- [x] Grep audit confirms unchanged string set.
- [ ] CI pre-submit checks (includes emulator smoke test).
- [ ] After merge: cut server/8 to confirm production deploy.

## Next

**Phase 1b** — extract \`pubsub/RemoteButton\` and \`http/RemoteButton\` handler logic into testable controller functions, add behavior tests using the fakes from this PR. Separate PR, not blocking.

**Phase 2** — \`'eventsCurrent'\` consolidation (5 duplicates → 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)