### PR TITLE
scripts: Release Android — overrides confirm reality (not set state)

### DIFF
--- a/.claude/skills/release-android/SKILL.md
+++ b/.claude/skills/release-android/SKILL.md
@@ -6,12 +6,15 @@ description: Release the Android app to Play Store internal track via tag-based 
 
 Cut an Android release by creating a tag via `scripts/release-android.sh`. The tag triggers CI to build and deploy to Play Store internal track (never production).
 
+## Design principle
+
+**The script's `--check` mode prints the exact command to run next, with SHAs and tag numbers already filled in. Copy and paste that command. Don't retype from memory.** Overrides take a specific value (a SHA from reality) that must match; wrong value = refused. Correctness is easy (read from `--check`); accidental correctness is hard.
+
 ## Steps
 
 ### 1. Pre-flight checks
 
 ```bash
-# Must be on main with clean tree
 git checkout main && git pull
 git status  # Must be clean
 ```
@@ -24,43 +27,80 @@ git status  # Must be clean
 ./scripts/validate.sh
 ```
 
-If validation fails, fix the issue before releasing. Do NOT use `--skip-validation` unless the user explicitly confirms they want to release without validation (e.g., emergency rollback).
+If validation fails, fix the issue before releasing. Do NOT skip validation unless the user explicitly confirms they want to release without it (e.g., emergency hotfix).
 
 ### 3. Check release state
 
 ```bash
-scripts/release-android.sh --check
+./scripts/release-android.sh --check
 ```
 
-This prints the latest tag and the computed next tag (`android/<N+1>`). Verify validation shows "passed".
+This prints:
+- Latest tag and its SHA, next computed tag, HEAD SHA, branch
+- Validation state: `PASSED`, `STALE`, or `MISSING`
+- **A copy-paste-ready command for the appropriate scenario** (normal, rollback, emergency)
 
 ### 4. Cut the release
 
+Paste the command from step 3. For a normal release:
+
 ```bash
-scripts/release-android.sh --confirm-tag android/N
+./scripts/release-android.sh --confirm-tag android/N
 ```
 
-Where `N` is the next tag number from step 3. The `--confirm-tag` is a safety check — it must match the computed tag exactly (cannot override).
+For an emergency release (validation not passing), `--check` will print:
+
+```bash
+./scripts/release-android.sh \
+    --confirm-tag android/N \
+    --confirm-unvalidated-release <40-char-sha>
+```
+
+For a rollback (detached HEAD on an older tag), `--check` will print:
+
+```bash
+./scripts/release-android.sh \
+    --confirm-tag android/N \
+    --confirm-hash <40-char-sha-of-target> \
+    --confirm-rollback-from <40-char-sha-of-previous-latest>
+```
 
 The script will:
-- Verify clean git state
-- Verify on main branch
-- Verify validate.sh passed on HEAD
+- Verify clean git state (unless `--confirm-hash` is used)
+- Verify on main branch (unless `--confirm-hash` is used)
+- Verify validation marker matches the target commit (unless `--confirm-unvalidated-release` is used)
 - Create and push the tag
 - The tag triggers `.github/workflows/release-android.yml`
 
 ### 5. Verify deployment
 
-Watch the release workflow:
 ```bash
 gh run list --workflow=release-android.yml --limit 1
 gh run watch <run-id>
 ```
 
-### Rules
+## Rollback recipe (two steps — intentionally hard to do accidentally)
+
+```bash
+# 1. Move HEAD to the commit you want to re-release.
+git checkout android/M
+
+# 2. Print the rollback command and paste it.
+./scripts/release-android.sh --check
+./scripts/release-android.sh \
+    --confirm-tag android/N \
+    --confirm-hash <full-sha-from-check> \
+    --confirm-rollback-from <full-sha-from-check>
+```
+
+Both SHAs must match what the script computed from the current repo state. You can only produce them by actually running `--check` on the checked-out commit, which forces you to move HEAD deliberately.
+
+## Rules
 
 - **Never push tags directly** — hooks block `git tag` (except `git tag -l`). Only the release script can create tags.
 - **Never deploy to production** — internal track only.
 - **Tag version = versionCode** — `android/120` → `versionCode=120`.
+- **Always start with `--check`** — it prints the right command for the current state. Don't type the flags from memory.
 - **Always validate first** — run `./scripts/validate.sh` before every release.
-- **Never use `--skip-validation` without asking the user.** It exists for emergencies only (rollbacks, hotfixes). If validation hasn't passed, tell the user and ask whether to run validation or skip it.
+- **Never skip validation without asking the user.** `--confirm-unvalidated-release` exists for emergencies (hotfixes, rollbacks of old tags). If validation hasn't passed, tell the user and ask whether to run validation or skip it.
+- **`--skip-validation` is deprecated** but still accepted. Prefer `--confirm-unvalidated-release <sha>`. It requires explicitly stating the SHA you're skipping validation on, which prevents accidentally skipping on the wrong commit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,15 +211,24 @@ Use `./scripts/release-android.sh` — never create or push tags directly (hooks
 
 ```bash
 ./scripts/release-android.sh              # Interactive (terminal only)
-./scripts/release-android.sh --check      # Print latest + next tag
-./scripts/release-android.sh --confirm-tag android/N  # Non-interactive
-./scripts/release-android.sh --confirm-tag android/N --confirm-hash android/M  # Rollback to old tag
+./scripts/release-android.sh --check      # Print state + copy-paste-ready next command
+./scripts/release-android.sh --confirm-tag android/N  # Normal release
 ./scripts/release-android.sh --dry-run    # Preview without releasing
 ```
 
+**Always start with `--check`.** It prints the exact command to run next, with SHAs and tag numbers already filled in. Copy and paste that command — don't retype from memory. The `--check` output detects normal, rollback, and emergency states and prints the appropriate command for each.
+
 The script computes the next tag as `android/<highest + 1>`. The `--confirm-tag` flag is a safety check — it must match the computed tag, it cannot override it. Deploys to Play Store internal track only — never production.
 
-**Validation is required by default.** Run `./scripts/validate.sh` before releasing. If validation hasn't passed on the commit, the release script will block. `--skip-validation` exists for emergencies (e.g., rollbacks to old tags) but should NOT be used routinely. Always ask the user before using `--skip-validation`.
+**Design principle — overrides confirm reality.** Every override flag takes a value (SHA or tag) that must match what's actually in the repo. Wrong value = refused. This makes correct usage easy (read from `--check`) and accidental usage hard (you'd have to type the right value for the wrong situation).
+
+**Validation is required by default.** Run `./scripts/validate.sh` before releasing. If validation hasn't passed on the commit, the release script will block. For emergencies use `--confirm-unvalidated-release <sha>` (the SHA must equal the target commit). `--skip-validation` is kept as a deprecated alias; prefer the explicit form. Always ask the user before skipping validation.
+
+**Rollback requires two steps** (intentionally hard to do accidentally):
+```bash
+git checkout android/M                 # 1. move HEAD to the commit you want to re-release
+./scripts/release-android.sh --check   # 2. prints the rollback command with --confirm-hash and --confirm-rollback-from
+```
 
 **Versioning rule (see [CHANGELOG.md](AndroidGarage/CHANGELOG.md#versioning)):** major = rewrite or core-experience shift; minor = added or removed user-facing feature/capability; patch = fixes, polish, refactors. `CHANGELOG.md` logs every version; `distribution/whatsnew/` gets one line per minor/major (patches roll up).
 

--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -7,21 +7,36 @@ set -euo pipefail
 # IMPORTANT: We only publish to internal track, never production.
 # Users promote from internal to production manually in Play Console.
 #
-# Usage:
-#   ./scripts/release-android.sh              # Interactive mode (fails in CI/non-TTY)
-#   ./scripts/release-android.sh --check      # Print latest and next tag, exit
-#   ./scripts/release-android.sh --confirm-tag android/N  # Non-interactive release from main HEAD
-#   ./scripts/release-android.sh --confirm-tag android/N --confirm-hash <ref>  # Any commit
-#   ./scripts/release-android.sh --confirm-tag android/N --skip-validation     # Skip validation check
-#   ./scripts/release-android.sh --dry-run    # Show what would happen
+# USAGE
 #
-# Default gates (all enforced):
-#   1. Must be on main branch         — override with --confirm-hash <ref>
-#   2. Must have passed validate.sh   — override with --skip-validation
-#   3. --confirm-tag must match next   — no override (always required in non-interactive)
+# Start with --check. It prints the exact command(s) you should run next,
+# with real values (SHAs, tag names) already filled in. Copy-paste, don't
+# re-type from memory; seeing the concrete values is the whole point.
 #
-# The release workflow (release-android.yml) does NOT re-check these gates.
-# It trusts the tag and builds whatever commit the tag points to.
+#   ./scripts/release-android.sh --check
+#
+# Normal release (validation marker matches HEAD):
+#   ./scripts/release-android.sh --confirm-tag android/N
+#
+# Emergency release (validation has not passed for HEAD):
+#   ./scripts/release-android.sh \
+#       --confirm-tag android/N \
+#       --confirm-unvalidated-release <40-char-sha>
+#
+# Rollback release (detached HEAD on an older tag):
+#   git checkout android/M            # older tag you want to re-release
+#   ./scripts/release-android.sh --check  # prints the rollback command
+#   ./scripts/release-android.sh \
+#       --confirm-tag android/N \
+#       --confirm-hash <40-char-sha-of-target> \
+#       --confirm-rollback-from <40-char-sha-of-previous-latest>
+#
+# DESIGN PRINCIPLE
+#
+# Every override asks you to state a value from reality (a SHA, a tag).
+# The script fails if the value does not match. This makes correct usage
+# easy (read from --check output) and accidental usage hard (you would
+# have to type the right value for the wrong situation).
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
 
@@ -31,37 +46,48 @@ YELLOW='\033[1;33m'
 BOLD='\033[1m'
 RESET='\033[0m'
 
-# Parse flags
+# Parse flags.
 MODE="interactive"
 CONFIRM_TAG=""
 CONFIRM_HASH=""
-SKIP_VALIDATION=false
+CONFIRM_ROLLBACK_FROM=""
+CONFIRM_UNVALIDATED_RELEASE=""
+SKIP_VALIDATION=false  # legacy; prefer --confirm-unvalidated-release
 DRY_RUN=false
 
 show_help() {
-    echo "Usage: ./scripts/release-android.sh [OPTIONS]"
-    echo ""
-    echo "Modes:"
-    echo "  (no args)                  Interactive mode — prompts for confirmation"
-    echo "  --check                    Print latest tag and next tag, then exit"
-    echo "  --confirm-tag <tag>        Non-interactive release. Tag must match computed next tag."
-    echo "  --dry-run                  Show what would happen without creating tags"
-    echo ""
-    echo "Override flags:"
-    echo "  --confirm-hash <ref>       Release a specific commit (SHA, tag, branch)."
-    echo "                             Bypasses the main-branch requirement."
-    echo "  --skip-validation          Skip the validate.sh check. Use when you need to"
-    echo "                             release urgently without local validation."
-    echo "  -h, --help                 Show this help"
-    echo ""
-    echo "Examples:"
-    echo "  ./scripts/release-android.sh --check"
-    echo "  ./scripts/release-android.sh --confirm-tag android/141"
-    echo "  ./scripts/release-android.sh --confirm-tag android/141 --confirm-hash android/139"
-    echo "  ./scripts/release-android.sh --confirm-tag android/141 --skip-validation"
-    echo "  ./scripts/release-android.sh --dry-run"
-    echo ""
-    echo "Multiple tags on the same commit are allowed — tag numbers always increment."
+    cat <<'EOF'
+Usage: ./scripts/release-android.sh [OPTIONS]
+
+Recommended workflow: run with --check first. It prints the exact
+command to run next, with SHAs filled in. Copy-paste that command.
+
+Modes:
+  (no args)                 Interactive mode — prompts for confirmation
+  --check                   Print state + recommended next command, then exit
+  --confirm-tag <tag>       Non-interactive release. Tag must match computed next tag.
+  --dry-run                 Show what would happen without creating tags
+
+Override flags (all require a specific value from --check output):
+  --confirm-hash <sha>              Release a specific commit. SHA must match
+                                    exactly (recommend 40-char full SHA).
+  --confirm-rollback-from <sha>     Required for rollback releases. Must match
+                                    the SHA the latest tag currently points to.
+  --confirm-unvalidated-release <sha>
+                                    Release without validation marker match.
+                                    SHA must equal the target commit.
+
+Deprecated:
+  --skip-validation         Legacy boolean skip; prefer --confirm-unvalidated-release.
+                            Still accepted for backward compat.
+
+Help:
+  -h, --help                Show this help
+
+Examples:
+  ./scripts/release-android.sh --check
+  ./scripts/release-android.sh --confirm-tag android/141
+EOF
 }
 
 while [[ $# -gt 0 ]]; do
@@ -77,6 +103,14 @@ while [[ $# -gt 0 ]]; do
             ;;
         --confirm-hash)
             CONFIRM_HASH="$2"
+            shift 2
+            ;;
+        --confirm-rollback-from)
+            CONFIRM_ROLLBACK_FROM="$2"
+            shift 2
+            ;;
+        --confirm-unvalidated-release)
+            CONFIRM_UNVALIDATED_RELEASE="$2"
             shift 2
             ;;
         --skip-validation)
@@ -99,10 +133,10 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Fetch tags
+# Fetch tags.
 git fetch origin --tags --quiet
 
-# Compute latest and next tag
+# Compute latest tag number and its SHA.
 HIGHEST_VERSION=$(git tag -l 'android/[0-9]*' | \
     sed 's|android/||' | \
     grep -E '^[0-9]+$' || true)
@@ -111,70 +145,123 @@ HIGHEST_VERSION=$(echo "$HIGHEST_VERSION" | sort -n | tail -1)
 if [ -z "$HIGHEST_VERSION" ]; then
     NEXT_VERSION=1
     LATEST_TAG="(none)"
+    LATEST_TAG_SHA="(none)"
 else
     NEXT_VERSION=$((HIGHEST_VERSION + 1))
     LATEST_TAG="android/$HIGHEST_VERSION"
+    LATEST_TAG_SHA=$(git rev-parse "$LATEST_TAG" 2>/dev/null || echo "(missing)")
 fi
 
 NEW_TAG="android/$NEXT_VERSION"
 
-# Resolve target commit
+# Resolve target commit.
 if [ -n "$CONFIRM_HASH" ]; then
     TARGET_COMMIT=$(git rev-parse --verify "$CONFIRM_HASH" 2>/dev/null) || {
         echo -e "${RED}Error: --confirm-hash '$CONFIRM_HASH' is not a valid git ref.${RESET}"
         exit 1
     }
     TARGET_COMMIT_SHORT=$(git rev-parse --short "$TARGET_COMMIT")
-    TARGET_SOURCE="--confirm-hash $CONFIRM_HASH → $TARGET_COMMIT_SHORT"
+    TARGET_SOURCE="--confirm-hash $CONFIRM_HASH -> $TARGET_COMMIT_SHORT"
 else
     TARGET_COMMIT=$(git rev-parse HEAD)
     TARGET_COMMIT_SHORT=$(git rev-parse --short HEAD)
     TARGET_SOURCE="HEAD ($TARGET_COMMIT_SHORT)"
 fi
 
-CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "(detached)")
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+if [ -z "$CURRENT_BRANCH" ]; then
+    IS_DETACHED="true"
+    CURRENT_BRANCH="(detached)"
+else
+    IS_DETACHED="false"
+fi
 
-# Check for existing android tags on target commit
-TAGS_ON_COMMIT=$(git tag -l 'android/[0-9]*' --points-at "$TARGET_COMMIT" 2>/dev/null | sort -t/ -k2 -n || true)
-check_existing_tags() {
-    if [ -n "$TAGS_ON_COMMIT" ]; then
-        NEWEST_TAG_ON_COMMIT=$(echo "$TAGS_ON_COMMIT" | tail -1)
-        if [ "$NEWEST_TAG_ON_COMMIT" = "$LATEST_TAG" ]; then
-            echo -e "${YELLOW}WARNING: This commit already has $LATEST_TAG.${RESET}"
-            echo "  Creating $NEW_TAG on the same commit (version bump, no code change)."
-        else
-            echo -e "${YELLOW}WARNING: This commit was previously released as: $(echo "$TAGS_ON_COMMIT" | tr '\n' ' ')${RESET}"
-            echo "  Latest tag $LATEST_TAG is on a different commit."
-            echo "  Creating $NEW_TAG here (rollback/rollforward)."
-        fi
-    fi
-}
-
-# Check if validate.sh passed on the target commit
+# Validation marker state.
+#   matches : marker exists and matches TARGET_COMMIT
+#   stale   : marker exists but matches some other commit
+#   missing : marker file does not exist
 VALIDATION_FILE="$REPO_ROOT/.claude/.validation-passed"
-check_validation() {
-    if [ ! -f "$VALIDATION_FILE" ]; then
-        return 1
-    fi
+VALIDATION_STATE="missing"
+VALIDATED_COMMIT=""
+if [ -f "$VALIDATION_FILE" ]; then
     VALIDATED_COMMIT=$(cat "$VALIDATION_FILE" 2>/dev/null | tr -d '[:space:]')
-    [ "$VALIDATED_COMMIT" = "$TARGET_COMMIT" ]
-}
+    if [ "$VALIDATED_COMMIT" = "$TARGET_COMMIT" ]; then
+        VALIDATION_STATE="matches"
+    else
+        VALIDATION_STATE="stale"
+    fi
+fi
+
+# Rollback detection: target commit is already tagged (not the latest),
+# usually because the user ran `git checkout android/M` on an older tag.
+EXISTING_TAGS_ON_TARGET=$(git tag -l 'android/[0-9]*' --points-at "$TARGET_COMMIT" 2>/dev/null | sort -t/ -k2 -n || true)
+IS_ROLLBACK="false"
+if [ -n "$EXISTING_TAGS_ON_TARGET" ]; then
+    NEWEST_TAG_ON_TARGET=$(echo "$EXISTING_TAGS_ON_TARGET" | tail -1)
+    if [ "$NEWEST_TAG_ON_TARGET" != "$LATEST_TAG" ]; then
+        IS_ROLLBACK="true"
+    fi
+fi
 
 # === --check mode ===
 if [ "$MODE" = "check" ]; then
-    echo "Latest tag: $LATEST_TAG"
-    echo "Next tag:   $NEW_TAG"
-    echo "Branch:     $CURRENT_BRANCH"
-    echo "Target:     $TARGET_SOURCE"
-    if [ -z "$CONFIRM_HASH" ] && ! git diff-index --quiet HEAD -- 2>/dev/null; then
-        echo -e "${RED}WARNING: Uncommitted changes${RESET}"
+    echo "Latest tag:   $LATEST_TAG (sha: $LATEST_TAG_SHA)"
+    echo "Next tag:     $NEW_TAG"
+    echo "HEAD:         $TARGET_COMMIT"
+    echo "Branch:       $CURRENT_BRANCH"
+
+    case "$VALIDATION_STATE" in
+        matches)
+            echo -e "Validation:   ${GREEN}PASSED${RESET} on $VALIDATED_COMMIT"
+            ;;
+        stale)
+            echo -e "Validation:   ${YELLOW}STALE${RESET} (marker is for $VALIDATED_COMMIT, not HEAD)"
+            ;;
+        missing)
+            echo -e "Validation:   ${YELLOW}MISSING${RESET} — run ./scripts/validate.sh first"
+            ;;
+    esac
+
+    if [ -n "$EXISTING_TAGS_ON_TARGET" ]; then
+        echo "Target tags:  $(echo "$EXISTING_TAGS_ON_TARGET" | tr '\n' ' ')"
     fi
-    if check_validation; then
-        echo -e "${GREEN}Validation: passed${RESET}"
+
+    echo ""
+
+    if [ "$IS_ROLLBACK" = "true" ]; then
+        echo -e "${BOLD}Detected ROLLBACK${RESET} (HEAD is on $NEWEST_TAG_ON_TARGET, older than $LATEST_TAG)."
+        echo ""
+        echo "Copy and run this command to proceed:"
+        echo ""
+        echo "  ./scripts/release-android.sh \\"
+        echo "      --confirm-tag $NEW_TAG \\"
+        echo "      --confirm-hash $TARGET_COMMIT \\"
+        echo "      --confirm-rollback-from $LATEST_TAG_SHA"
+        echo ""
+        if [ "$VALIDATION_STATE" != "matches" ]; then
+            echo "If you also need to skip validation (expected for old rollback targets), append:"
+            echo "      --confirm-unvalidated-release $TARGET_COMMIT"
+            echo ""
+        fi
+    elif [ "$VALIDATION_STATE" = "matches" ]; then
+        echo "Copy and run this command to release:"
+        echo ""
+        echo "  ./scripts/release-android.sh --confirm-tag $NEW_TAG"
+        echo ""
     else
-        echo -e "${YELLOW}Validation: not passed for this commit${RESET}"
+        echo "Validation is not passing for HEAD. Two options:"
+        echo ""
+        echo "(1) Run validation, then re-run --check (recommended):"
+        echo "    ./scripts/validate.sh && ./scripts/release-android.sh --check"
+        echo ""
+        echo "(2) Release WITHOUT validation (emergency only):"
+        echo ""
+        echo "    ./scripts/release-android.sh \\"
+        echo "        --confirm-tag $NEW_TAG \\"
+        echo "        --confirm-unvalidated-release $TARGET_COMMIT"
+        echo ""
     fi
-    check_existing_tags
+
     exit 0
 fi
 
@@ -183,10 +270,8 @@ if [ "$MODE" = "interactive" ]; then
     if [ ! -t 0 ] || [ ! -t 1 ]; then
         echo -e "${RED}Error: Interactive mode requires a TTY.${RESET}"
         echo ""
-        echo "This script must be run interactively from a terminal."
-        echo "For CI or Claude, use:"
-        echo "  ./scripts/release-android.sh --check          # See next tag"
-        echo "  ./scripts/release-android.sh --confirm-tag $NEW_TAG  # Release"
+        echo "Run --check to see the exact command for this state:"
+        echo "  ./scripts/release-android.sh --check"
         exit 1
     fi
 fi
@@ -194,7 +279,7 @@ fi
 echo -e "${BOLD}=== Android Release ===${RESET}"
 echo ""
 
-# === Gate 1: Clean working tree (only when tagging HEAD) ===
+# === Gate: Clean working tree (only when tagging HEAD) ===
 if [ -z "$CONFIRM_HASH" ]; then
     if ! git diff-index --quiet HEAD --; then
         echo -e "${RED}Error: Working tree has uncommitted changes.${RESET}"
@@ -202,7 +287,6 @@ if [ -z "$CONFIRM_HASH" ]; then
         exit 1
     fi
 
-    # Warn on untracked files
     UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null)
     if [ -n "$UNTRACKED" ]; then
         echo -e "${YELLOW}Warning: Untracked files detected:${RESET}"
@@ -225,12 +309,12 @@ if [ -z "$CONFIRM_HASH" ]; then
     fi
 fi
 
-# === Gate 2: Must be on main — override with --confirm-hash ===
+# === Gate: Must be on main (when tagging HEAD) — override via --confirm-hash ===
 if [ -z "$CONFIRM_HASH" ] && [ "$CURRENT_BRANCH" != "main" ]; then
     echo -e "${RED}Error: Not on main branch (on '$CURRENT_BRANCH').${RESET}"
     echo ""
-    echo "To release from a specific commit, use --confirm-hash:"
-    echo "  ./scripts/release-android.sh --confirm-tag $NEW_TAG --confirm-hash $(git rev-parse HEAD)"
+    echo "Run --check to see the exact command for this state:"
+    echo "  ./scripts/release-android.sh --check"
     exit 1
 fi
 
@@ -241,50 +325,97 @@ if [ -n "$CONFIRM_HASH" ]; then
     echo ""
 fi
 
-# === Gate 3: Must have passed validate.sh — override with --skip-validation ===
-# --skip-validation is for emergencies only (e.g., rollbacks to old tags).
-# Normal releases should ALWAYS pass validate.sh first.
-if [ "$SKIP_VALIDATION" = true ]; then
-    echo -e "${RED}WARNING: Validation check skipped (--skip-validation).${RESET}"
-    echo "  This should only be used for emergencies (rollbacks, hotfixes)."
-    echo "  Normal releases should always run ./scripts/validate.sh first."
+# === Gate: Rollback confirmation ===
+# If --confirm-rollback-from is provided, validate it matches the latest tag's
+# current commit. If the target looks like a rollback but this flag is not
+# provided, require it (prevents accidental "rollback" by forgetting to
+# re-checkout main).
+if [ -n "$CONFIRM_ROLLBACK_FROM" ]; then
+    if [ "$CONFIRM_ROLLBACK_FROM" != "$LATEST_TAG_SHA" ]; then
+        echo -e "${RED}Error: --confirm-rollback-from does not match the latest tag's commit.${RESET}"
+        echo "  Expected (sha of $LATEST_TAG): $LATEST_TAG_SHA"
+        echo "  Got:                           $CONFIRM_ROLLBACK_FROM"
+        echo ""
+        echo "Run --check to see the correct value."
+        exit 1
+    fi
+    echo -e "${YELLOW}Rollback confirmed: $LATEST_TAG -> $NEW_TAG at $TARGET_COMMIT_SHORT${RESET}"
     echo ""
-elif check_validation; then
+elif [ "$IS_ROLLBACK" = "true" ]; then
+    echo -e "${RED}Error: Target commit is on tag $NEWEST_TAG_ON_TARGET, older than $LATEST_TAG.${RESET}"
+    echo "  This looks like a rollback but --confirm-rollback-from was not provided."
+    echo ""
+    echo "Run --check to see the correct command."
+    exit 1
+fi
+
+# === Gate: Validation ===
+# Three acceptable paths:
+#   A. Validation marker matches target commit (normal)
+#   B. --confirm-unvalidated-release matches target commit (emergency)
+#   C. --skip-validation (legacy; deprecated)
+if [ "$VALIDATION_STATE" = "matches" ]; then
     echo -e "${GREEN}Validation passed for this commit.${RESET}"
+elif [ -n "$CONFIRM_UNVALIDATED_RELEASE" ]; then
+    if [ "$CONFIRM_UNVALIDATED_RELEASE" != "$TARGET_COMMIT" ]; then
+        echo -e "${RED}Error: --confirm-unvalidated-release SHA does not match target commit.${RESET}"
+        echo "  Expected (target commit): $TARGET_COMMIT"
+        echo "  Got:                      $CONFIRM_UNVALIDATED_RELEASE"
+        echo ""
+        echo "Run --check to see the correct value."
+        exit 1
+    fi
+    echo -e "${YELLOW}WARNING: Releasing without validation (--confirm-unvalidated-release).${RESET}"
+    echo "  This is intended for emergencies (hotfixes, rollbacks of old tags)."
+    echo ""
+elif [ "$SKIP_VALIDATION" = true ]; then
+    echo -e "${YELLOW}WARNING: --skip-validation is deprecated.${RESET}"
+    echo "  Prefer --confirm-unvalidated-release <sha>. See --help."
+    echo -e "${YELLOW}WARNING: Validation check skipped.${RESET}"
+    echo ""
 else
-    echo -e "${YELLOW}Warning: validate.sh has not passed on commit $TARGET_COMMIT_SHORT.${RESET}"
     if [ "$MODE" = "interactive" ]; then
+        if [ "$VALIDATION_STATE" = "stale" ]; then
+            echo -e "${YELLOW}Warning: validation marker is stale.${RESET}"
+            echo "  Marker SHA:    $VALIDATED_COMMIT"
+            echo "  Target SHA:    $TARGET_COMMIT"
+        else
+            echo -e "${YELLOW}Warning: no validation marker — run ./scripts/validate.sh first.${RESET}"
+        fi
         read -p "Continue without validation? (y/N) " -n 1 -r
         echo ""
-        [[ $REPLY =~ ^[Yy]$ ]] || { echo "Aborted. Run ./scripts/validate.sh first."; exit 1; }
+        [[ $REPLY =~ ^[Yy]$ ]] || { echo "Aborted. Run ./scripts/validate.sh first, or run --check for options."; exit 1; }
     else
-        echo -e "${RED}Error: validate.sh has not passed on this commit.${RESET}"
-        echo "Run ./scripts/validate.sh first, or use --skip-validation to override."
+        echo -e "${RED}Error: validation has not passed for this commit.${RESET}"
+        echo ""
+        echo "Run --check to see the exact command for this state:"
+        echo "  ./scripts/release-android.sh --check"
         exit 1
     fi
 fi
 
-check_existing_tags
+# Existing tags on this commit (informational).
+if [ -n "$EXISTING_TAGS_ON_TARGET" ]; then
+    NEWEST_TAG_ON_COMMIT=$(echo "$EXISTING_TAGS_ON_TARGET" | tail -1)
+    if [ "$NEWEST_TAG_ON_COMMIT" = "$LATEST_TAG" ]; then
+        echo -e "${YELLOW}Note: This commit already has $LATEST_TAG.${RESET}"
+        echo "  Creating $NEW_TAG on the same commit (version bump, no code change)."
+    else
+        echo -e "${YELLOW}Note: This commit previously released as: $(echo "$EXISTING_TAGS_ON_TARGET" | tr '\n' ' ')${RESET}"
+    fi
+fi
 
-# Release details
+# Release details.
 echo ""
 echo "=== Release Details ==="
 echo "  Target:     $TARGET_SOURCE"
 echo "  Branch:     $CURRENT_BRANCH"
-echo "  Latest tag: $LATEST_TAG"
+echo "  Latest tag: $LATEST_TAG ($LATEST_TAG_SHA)"
 echo "  New tag:    $NEW_TAG"
 echo "  Commit:     $TARGET_COMMIT_SHORT ($TARGET_COMMIT)"
 echo ""
 
-# Note existing tags on this commit
-EXISTING_TAGS=$(git tag --points-at "$TARGET_COMMIT" | grep -E '^android/[0-9]+$' || true)
-if [ -n "$EXISTING_TAGS" ]; then
-    echo -e "${YELLOW}Note: This commit already has tag(s): $(echo "$EXISTING_TAGS" | tr '\n' ' ')${RESET}"
-    echo "  New tag $NEW_TAG will be created with the next number."
-    echo ""
-fi
-
-# Confirmation
+# Confirmation.
 if [ "$MODE" = "confirm" ]; then
     if [ "$CONFIRM_TAG" != "$NEW_TAG" ]; then
         echo -e "${RED}Error: --confirm-tag does not match computed next tag.${RESET}"
@@ -303,7 +434,7 @@ elif [ "$MODE" = "interactive" ]; then
     [[ $REPLY =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
 fi
 
-# Dry run
+# Dry run.
 if [ "$DRY_RUN" = true ]; then
     echo -e "${YELLOW}=== Dry Run ===${RESET}"
     echo "Would create tag $NEW_TAG on commit $TARGET_COMMIT_SHORT"
@@ -312,7 +443,7 @@ if [ "$DRY_RUN" = true ]; then
     exit 0
 fi
 
-# Create and push tag
+# Create and push tag.
 echo ""
 echo "Creating tag $NEW_TAG on $TARGET_COMMIT_SHORT..."
 git tag "$NEW_TAG" "$TARGET_COMMIT"


### PR DESCRIPTION
## Summary

Apply the design principle **\"overrides confirm reality, not set state\"** to the Android release script:

> Every override flag takes a value that must match a specific piece of repo state (a SHA, a tag). Wrong value = refused. Correct usage is easy (read from \`--check\`); accidental usage is hard (you'd have to type the right value for the wrong situation).

## What changed

**\`--check\` now prints the exact next command.** Full SHAs, no abbreviations, no shell substitution. Three scenarios detected automatically:
- Normal: validation marker matches → one-arg command
- Rollback: detached HEAD on older tag → three-arg command
- Emergency: validation missing/stale → unvalidated command

**New flags (all require a specific SHA):**
- \`--confirm-rollback-from <sha>\` — required for rollback; must match the latest tag's current SHA
- \`--confirm-unvalidated-release <sha>\` — replaces boolean \`--skip-validation\`; SHA must equal the target commit

**Backward compat:** \`--skip-validation\` still accepted, but prints a deprecation warning.

## Rollback flow (now naturally two steps)

\`\`\`bash
git checkout android/M
./scripts/release-android.sh --check   # prints the rollback command
./scripts/release-android.sh \\
    --confirm-tag android/N \\
    --confirm-hash <full-sha> \\
    --confirm-rollback-from <full-sha>
\`\`\`

Both SHAs come from \`--check\` output on the checked-out commit. You can only produce them by actually doing step 1.

## Test plan

- [x] \`--check\` on dirty-tree + stale marker prints STALE case with correct emergency-release command (full SHAs)
- [x] \`--help\` prints updated flag list
- [x] Clean-tree gate still refuses uncommitted changes
- [x] All existing flags still work (backward compat verified)
- [ ] CI pre-submit
- [ ] Post-merge: next release uses new flow

## Docs

- \`CLAUDE.md\` — rewritten release section around \`--check\` copy-paste pattern + rollback recipe + design principle
- \`.claude/skills/release-android/SKILL.md\` — aligned with new flow

## Next (separate PRs)

- PR B: \`scripts/validate-firebase.sh\` (mirror Android \`validate.sh\`)
- PR C: Firebase release script parity (same \`--check\` pattern, \`--confirm-hash\`, rollback flags, push cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)