### PR TITLE
scripts: Release Firebase — parity with Android's confirm-reality design

### DIFF
--- a/.claude/skills/release-firebase/SKILL.md
+++ b/.claude/skills/release-firebase/SKILL.md
@@ -6,54 +6,104 @@ description: Release Firebase server functions via tag-based deployment.
 
 Cut a Firebase server release by creating a tag via `scripts/release-firebase.sh`. The tag triggers CI to deploy Cloud Functions.
 
+## Design principle
+
+**The script's `--check` mode prints the exact command to run next, with SHAs and tag numbers already filled in. Copy and paste that command. Don't retype from memory.** Overrides take a specific value (a SHA from reality) that must match; wrong value = refused.
+
 ## Steps
 
 ### 1. Pre-flight checks
 
 ```bash
-# Must be on main with clean tree
 git checkout main && git pull
 git status  # Must be clean
 ```
 
-Verify Firebase CI is green on latest main:
-```bash
-gh run list --branch main --workflow=firebase-ci.yml --limit 1 --json conclusion,headSha --jq '.[0]'
-```
+### 2. Run validation
 
-### 2. Check release state
+**Always run validation before releasing.** Do not skip this step.
 
 ```bash
-scripts/release-firebase.sh --check
+./scripts/validate-firebase.sh
 ```
 
-This prints the latest tag and the computed next tag (`server/<N+1>`).
+Runs `npm run build` + `npm run tests` (80 tests including collection-name contract tests and verifyIdToken library-chain tests). Requires Node 20 — script fails fast with `nvm use 20` instruction if not. Writes marker at `.claude/.firebase-validation-passed` with the commit SHA.
 
-### 3. Cut the release
+### 3. Check release state
 
 ```bash
-scripts/release-firebase.sh --confirm-tag server/N
+./scripts/release-firebase.sh --check
 ```
 
-Where `N` is the next tag number from step 2. The `--confirm-tag` is a safety check — it must match the computed tag exactly.
+This prints:
+- Latest tag and its SHA, next computed tag, HEAD SHA, branch
+- Validation state (PASSED/STALE/MISSING)
+- Remote Firebase CI status (success/unknown/failed)
+- **A copy-paste-ready command for the scenario** (normal, rollback, emergency)
+
+### 4. Cut the release
+
+Paste the command from step 3. For a normal release:
+
+```bash
+./scripts/release-firebase.sh --confirm-tag server/N
+```
+
+For emergency release (validation not passing), `--check` prints:
+
+```bash
+./scripts/release-firebase.sh \
+    --confirm-tag server/N \
+    --confirm-unvalidated-release <40-char-sha>
+```
+
+For rollback (detached HEAD on older tag), `--check` prints:
+
+```bash
+./scripts/release-firebase.sh \
+    --confirm-tag server/N \
+    --confirm-hash <full-sha-of-target> \
+    --confirm-rollback-from <full-sha-of-previous-latest>
+```
 
 The script will:
-- Verify clean git state
-- Verify on main branch
-- Verify Firebase CI passed on HEAD
-- Create and push the tag
+- Verify clean git state (unless `--confirm-hash` is used)
+- Verify on main branch (unless `--confirm-hash` is used)
+- Verify validation marker matches target commit (unless `--confirm-unvalidated-release` is used)
+- Verify remote Firebase CI passed (warn-only)
+- Create and push the tag; on push failure, remove the local tag
 - The tag triggers `.github/workflows/firebase-deploy.yml`
 
-### 4. Verify deployment
+### 5. Verify deployment
 
-Watch the deploy workflow:
 ```bash
 gh run list --workflow=firebase-deploy.yml --limit 1
 gh run watch <run-id>
 ```
 
-### Rules
+Verify the affirmative success marker `✔ Deploy complete!` appears in the deploy log (see `docs/FIREBASE_DEPLOY_SETUP.md` for the silent-failure pattern to watch out for).
 
-- **Never push tags directly** — hooks block `git tag`. Only release scripts can create tags.
+## Rollback recipe (two steps — intentionally hard to do accidentally)
+
+```bash
+# 1. Move HEAD to the commit you want to re-release.
+git checkout server/M
+
+# 2. Print the rollback command and paste it.
+./scripts/release-firebase.sh --check
+./scripts/release-firebase.sh \
+    --confirm-tag server/N \
+    --confirm-hash <full-sha-from-check> \
+    --confirm-rollback-from <full-sha-from-check>
+```
+
+Both SHAs must match what the script computed on the checked-out commit. You can only produce them by running `--check` on the rollback target, which forces you to move HEAD deliberately.
+
+## Rules
+
+- **Never push tags directly** — hooks block `git tag`. Only the release script can create tags.
 - **Tag pattern:** `server/N` (e.g., server/1, server/2)
-- **Don't skip CI** — the script verifies Firebase CI passed before tagging.
+- **Always start with `--check`** — it prints the right command for the current state.
+- **Always validate first** — run `./scripts/validate-firebase.sh`.
+- **Don't skip validation without asking.** `--confirm-unvalidated-release <sha>` is for emergencies.
+- **Node 20 is required** — FirebaseServer/.nvmrc pins it. Node 24 breaks mocha.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,16 +224,25 @@ The script computes the next tag as `android/<highest + 1>`. The `--confirm-tag`
 **Versioning rule (see [CHANGELOG.md](AndroidGarage/CHANGELOG.md#versioning)):** major = rewrite or core-experience shift; minor = added or removed user-facing feature/capability; patch = fixes, polish, refactors. `CHANGELOG.md` logs every version; `distribution/whatsnew/` gets one line per minor/major (patches roll up).
 
 ### Releasing Firebase Server
-Use `./scripts/release-firebase.sh` — same pattern as Android releases.
+Use `./scripts/release-firebase.sh` — same pattern as Android releases (same flags, same `--check` copy-paste workflow, same rollback recipe).
 
 ```bash
-./scripts/release-firebase.sh              # Interactive (terminal only)
-./scripts/release-firebase.sh --check      # Print latest + next tag
-./scripts/release-firebase.sh --confirm-tag server/N  # Non-interactive
-./scripts/release-firebase.sh --dry-run    # Preview without releasing
+./scripts/release-firebase.sh --check              # State + copy-paste-ready next command
+./scripts/release-firebase.sh --confirm-tag server/N  # Normal release
+./scripts/release-firebase.sh --dry-run            # Preview without releasing
 ```
 
+**Always start with `--check`.** It prints the exact command to run next (normal, rollback, or emergency), with SHAs and tag numbers already filled in. Copy and paste — don't retype from memory.
+
 The script computes the next tag as `server/<highest + 1>`. Deploys Cloud Functions only.
+
+**Validation is required by default.** Run `./scripts/validate-firebase.sh` before releasing (runs `npm run build` + `npm run tests`, writes marker with commit SHA). For emergencies use `--confirm-unvalidated-release <sha>` — the SHA must equal the target commit. Remote Firebase CI status is also checked but is warn-only (not all commits run full CI).
+
+**Rollback = two steps** (same as Android):
+```bash
+git checkout server/M
+./scripts/release-firebase.sh --check   # prints --confirm-hash + --confirm-rollback-from command
+```
 
 **Firebase server operations:** See [`docs/FIREBASE_DEPLOY_SETUP.md`](docs/FIREBASE_DEPLOY_SETUP.md) — long-term maintenance guide. Covers: release process, rollback, monitoring & logs, cost hygiene, Node/runtime deprecation calendar, deployer-SA re-provisioning + rotation, required GitHub secrets, required GCP APIs, and a troubleshooting table. CI deploy was fixed 2026-04-21 after a long period of silent-failure (`firebase deploy` exiting 0 despite `⚠ failed to update function` — the doc describes how to recognize it and what role was missing).
 

--- a/scripts/release-firebase.sh
+++ b/scripts/release-firebase.sh
@@ -1,176 +1,465 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Firebase Server release script — mirrors scripts/release-android.sh.
-# Creates a server/N tag that triggers .github/workflows/firebase-deploy.yml.
+# Release Firebase Cloud Functions by creating and pushing a server/N tag.
+# The tag triggers .github/workflows/firebase-deploy.yml.
 #
-# Usage:
-#   ./scripts/release-firebase.sh              # Interactive (terminal only)
-#   ./scripts/release-firebase.sh --check      # Print latest + next tag
-#   ./scripts/release-firebase.sh --confirm-tag server/N  # Non-interactive
-#   ./scripts/release-firebase.sh --dry-run    # Preview without releasing
+# USAGE
+#
+# Start with --check. It prints the exact command to run next, with
+# real values filled in (SHAs, tag names). Copy-paste it; don't re-type
+# from memory.
+#
+#   ./scripts/release-firebase.sh --check
+#
+# Normal release (validation marker matches HEAD):
+#   ./scripts/release-firebase.sh --confirm-tag server/N
+#
+# Emergency release (validation has not passed for HEAD):
+#   ./scripts/release-firebase.sh \
+#       --confirm-tag server/N \
+#       --confirm-unvalidated-release <40-char-sha>
+#
+# Rollback release (detached HEAD on an older tag):
+#   git checkout server/M
+#   ./scripts/release-firebase.sh --check   # prints the rollback command
+#   ./scripts/release-firebase.sh \
+#       --confirm-tag server/N \
+#       --confirm-hash <40-char-sha-of-target> \
+#       --confirm-rollback-from <40-char-sha-of-previous-latest>
+#
+# DESIGN PRINCIPLE
+#
+# Every override flag takes a value from reality (a SHA, a tag). The
+# script fails if the value does not match. Correct usage is easy
+# (read from --check output); accidental usage is hard.
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
 BOLD='\033[1m'
 RESET='\033[0m'
 
-# Find the latest server tag number.
-latest_tag_number() {
-    git tag -l 'server/*' \
-        | sed 's|server/||' \
-        | sort -n \
-        | tail -1
+# Parse flags.
+MODE="interactive"
+CONFIRM_TAG=""
+CONFIRM_HASH=""
+CONFIRM_ROLLBACK_FROM=""
+CONFIRM_UNVALIDATED_RELEASE=""
+DRY_RUN=false
+
+show_help() {
+    cat <<'EOF'
+Usage: ./scripts/release-firebase.sh [OPTIONS]
+
+Recommended workflow: run with --check first. It prints the exact
+command to run next, with SHAs filled in. Copy-paste that command.
+
+Modes:
+  (no args)                 Interactive mode — prompts for confirmation
+  --check                   Print state + recommended next command, then exit
+  --confirm-tag <tag>       Non-interactive release. Tag must match computed next tag.
+  --dry-run                 Show what would happen without creating tags
+
+Override flags (all require a specific value from --check output):
+  --confirm-hash <sha>              Release a specific commit. SHA must match
+                                    exactly (recommend 40-char full SHA).
+  --confirm-rollback-from <sha>     Required for rollback releases. Must match
+                                    the SHA the latest tag currently points to.
+  --confirm-unvalidated-release <sha>
+                                    Release without validation marker match.
+                                    SHA must equal the target commit.
+
+Help:
+  -h, --help                Show this help
+
+Examples:
+  ./scripts/release-firebase.sh --check
+  ./scripts/release-firebase.sh --confirm-tag server/8
+EOF
 }
 
-LATEST_NUM=$(latest_tag_number)
-if [[ -z "$LATEST_NUM" ]]; then
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --check)
+            MODE="check"
+            shift
+            ;;
+        --confirm-tag)
+            MODE="confirm"
+            CONFIRM_TAG="$2"
+            shift 2
+            ;;
+        --confirm-hash)
+            CONFIRM_HASH="$2"
+            shift 2
+            ;;
+        --confirm-rollback-from)
+            CONFIRM_ROLLBACK_FROM="$2"
+            shift 2
+            ;;
+        --confirm-unvalidated-release)
+            CONFIRM_UNVALIDATED_RELEASE="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Error: Unknown option: $1${RESET}"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+# Fetch tags.
+git fetch origin --tags --quiet
+
+# Compute latest tag number and its SHA.
+HIGHEST_VERSION=$(git tag -l 'server/[0-9]*' | \
+    sed 's|server/||' | \
+    grep -E '^[0-9]+$' || true)
+HIGHEST_VERSION=$(echo "$HIGHEST_VERSION" | sort -n | tail -1)
+
+if [ -z "$HIGHEST_VERSION" ]; then
+    NEXT_VERSION=1
     LATEST_TAG="(none)"
-    NEXT_NUM=1
+    LATEST_TAG_SHA="(none)"
 else
-    LATEST_TAG="server/$LATEST_NUM"
-    NEXT_NUM=$((LATEST_NUM + 1))
+    NEXT_VERSION=$((HIGHEST_VERSION + 1))
+    LATEST_TAG="server/$HIGHEST_VERSION"
+    LATEST_TAG_SHA=$(git rev-parse "$LATEST_TAG" 2>/dev/null || echo "(missing)")
 fi
-NEXT_TAG="server/$NEXT_NUM"
-BRANCH=$(git branch --show-current)
-SHORT_SHA=$(git rev-parse --short HEAD)
-FULL_SHA=$(git rev-parse HEAD)
 
-# Check for existing tags on this commit.
-TAGS_ON_COMMIT=$(git tag -l 'server/[0-9]*' --points-at HEAD 2>/dev/null | sort -t/ -k2 -n)
-check_existing_tags() {
-    if [[ -n "$TAGS_ON_COMMIT" ]]; then
-        NEWEST_TAG_ON_COMMIT=$(echo "$TAGS_ON_COMMIT" | tail -1)
-        if [[ "$NEWEST_TAG_ON_COMMIT" == "$LATEST_TAG" ]]; then
-            echo "WARNING: This commit already has $LATEST_TAG."
-            echo "  Creating $NEXT_TAG on the same commit (version bump, no code change)."
-        else
-            echo "WARNING: This commit was previously released as: $TAGS_ON_COMMIT"
-            echo "  Latest tag $LATEST_TAG is on a different commit."
-            echo "  Creating $NEXT_TAG here (rollback/rollforward)."
-        fi
+NEW_TAG="server/$NEXT_VERSION"
+
+# Resolve target commit.
+if [ -n "$CONFIRM_HASH" ]; then
+    TARGET_COMMIT=$(git rev-parse --verify "$CONFIRM_HASH" 2>/dev/null) || {
+        echo -e "${RED}Error: --confirm-hash '$CONFIRM_HASH' is not a valid git ref.${RESET}"
+        exit 1
+    }
+    TARGET_COMMIT_SHORT=$(git rev-parse --short "$TARGET_COMMIT")
+    TARGET_SOURCE="--confirm-hash $CONFIRM_HASH -> $TARGET_COMMIT_SHORT"
+else
+    TARGET_COMMIT=$(git rev-parse HEAD)
+    TARGET_COMMIT_SHORT=$(git rev-parse --short HEAD)
+    TARGET_SOURCE="HEAD ($TARGET_COMMIT_SHORT)"
+fi
+
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+if [ -z "$CURRENT_BRANCH" ]; then
+    IS_DETACHED="true"
+    CURRENT_BRANCH="(detached)"
+else
+    IS_DETACHED="false"
+fi
+
+# Local validation marker state.
+#   matches : marker exists and matches TARGET_COMMIT
+#   stale   : marker exists but matches some other commit
+#   missing : marker file does not exist
+VALIDATION_FILE="$REPO_ROOT/.claude/.firebase-validation-passed"
+VALIDATION_STATE="missing"
+VALIDATED_COMMIT=""
+if [ -f "$VALIDATION_FILE" ]; then
+    VALIDATED_COMMIT=$(cat "$VALIDATION_FILE" 2>/dev/null | tr -d '[:space:]')
+    if [ "$VALIDATED_COMMIT" = "$TARGET_COMMIT" ]; then
+        VALIDATION_STATE="matches"
+    else
+        VALIDATION_STATE="stale"
     fi
+fi
+
+# Remote CI status (warn-only; does not gate release).
+# Firebase CI runs unit tests + emulator smoke; a failure here is still
+# worth knowing about even if the local marker is green.
+check_remote_ci() {
+    gh api "repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/commits/$TARGET_COMMIT/check-runs" \
+        --jq '[.check_runs[] | select(.name == "Run Unit Tests" and .check_suite.conclusion != null)] | last | .conclusion' 2>/dev/null || echo ""
 }
 
-# --- --check mode ---
-if [[ "${1:-}" == "--check" ]]; then
-    echo "Latest tag: $LATEST_TAG"
-    echo "Next tag:   $NEXT_TAG"
-    echo "Branch:     $BRANCH"
-    echo "Commit:     $SHORT_SHA"
-    if ! git diff --quiet HEAD 2>/dev/null; then
-        echo "WARNING: Uncommitted changes"
+# Rollback detection.
+EXISTING_TAGS_ON_TARGET=$(git tag -l 'server/[0-9]*' --points-at "$TARGET_COMMIT" 2>/dev/null | sort -t/ -k2 -n || true)
+IS_ROLLBACK="false"
+if [ -n "$EXISTING_TAGS_ON_TARGET" ]; then
+    NEWEST_TAG_ON_TARGET=$(echo "$EXISTING_TAGS_ON_TARGET" | tail -1)
+    if [ "$NEWEST_TAG_ON_TARGET" != "$LATEST_TAG" ]; then
+        IS_ROLLBACK="true"
     fi
-    UNTRACKED_CHECK=$(git ls-files --others --exclude-standard 2>/dev/null)
-    if [[ -n "$UNTRACKED_CHECK" ]]; then
-        UNTRACKED_COUNT=$(echo "$UNTRACKED_CHECK" | wc -l | tr -d ' ')
-        echo "WARNING: $UNTRACKED_COUNT untracked file(s)"
+fi
+
+# === --check mode ===
+if [ "$MODE" = "check" ]; then
+    echo "Latest tag:   $LATEST_TAG (sha: $LATEST_TAG_SHA)"
+    echo "Next tag:     $NEW_TAG"
+    echo "HEAD:         $TARGET_COMMIT"
+    echo "Branch:       $CURRENT_BRANCH"
+
+    case "$VALIDATION_STATE" in
+        matches)
+            echo -e "Validation:   ${GREEN}PASSED${RESET} on $VALIDATED_COMMIT"
+            ;;
+        stale)
+            echo -e "Validation:   ${YELLOW}STALE${RESET} (marker is for $VALIDATED_COMMIT, not HEAD)"
+            ;;
+        missing)
+            echo -e "Validation:   ${YELLOW}MISSING${RESET} — run ./scripts/validate-firebase.sh first"
+            ;;
+    esac
+
+    echo -n "Remote CI:    "
+    REMOTE_CI=$(check_remote_ci)
+    case "$REMOTE_CI" in
+        success) echo -e "${GREEN}success${RESET}" ;;
+        "")      echo -e "${YELLOW}unknown${RESET} (Firebase CI may not have run on this commit)" ;;
+        *)       echo -e "${RED}$REMOTE_CI${RESET}" ;;
+    esac
+
+    if [ -n "$EXISTING_TAGS_ON_TARGET" ]; then
+        echo "Target tags:  $(echo "$EXISTING_TAGS_ON_TARGET" | tr '\n' ' ')"
     fi
-    check_existing_tags
+
+    echo ""
+
+    if [ "$IS_ROLLBACK" = "true" ]; then
+        echo -e "${BOLD}Detected ROLLBACK${RESET} (HEAD is on $NEWEST_TAG_ON_TARGET, older than $LATEST_TAG)."
+        echo ""
+        echo "Copy and run this command to proceed:"
+        echo ""
+        echo "  ./scripts/release-firebase.sh \\"
+        echo "      --confirm-tag $NEW_TAG \\"
+        echo "      --confirm-hash $TARGET_COMMIT \\"
+        echo "      --confirm-rollback-from $LATEST_TAG_SHA"
+        echo ""
+        if [ "$VALIDATION_STATE" != "matches" ]; then
+            echo "If you also need to skip validation (expected for old rollback targets), append:"
+            echo "      --confirm-unvalidated-release $TARGET_COMMIT"
+            echo ""
+        fi
+    elif [ "$VALIDATION_STATE" = "matches" ]; then
+        echo "Copy and run this command to release:"
+        echo ""
+        echo "  ./scripts/release-firebase.sh --confirm-tag $NEW_TAG"
+        echo ""
+    else
+        echo "Validation is not passing for HEAD. Two options:"
+        echo ""
+        echo "(1) Run validation, then re-run --check (recommended):"
+        echo "    ./scripts/validate-firebase.sh && ./scripts/release-firebase.sh --check"
+        echo ""
+        echo "(2) Release WITHOUT validation (emergency only):"
+        echo ""
+        echo "    ./scripts/release-firebase.sh \\"
+        echo "        --confirm-tag $NEW_TAG \\"
+        echo "        --confirm-unvalidated-release $TARGET_COMMIT"
+        echo ""
+    fi
+
     exit 0
 fi
 
-# --- Validations ---
+# === Interactive mode guard ===
+if [ "$MODE" = "interactive" ]; then
+    if [ ! -t 0 ] || [ ! -t 1 ]; then
+        echo -e "${RED}Error: Interactive mode requires a TTY.${RESET}"
+        echo ""
+        echo "Run --check to see the exact command for this state:"
+        echo "  ./scripts/release-firebase.sh --check"
+        exit 1
+    fi
+fi
+
 echo -e "${BOLD}=== Firebase Server Release ===${RESET}"
+echo ""
 
-# Must be on main.
-if [[ "$BRANCH" != "main" ]]; then
-    echo -e "${RED}ERROR: Must be on 'main' branch (currently on '$BRANCH').${RESET}"
-    exit 1
-fi
-
-# Must have clean working tree (tracked files).
-if ! git diff --quiet HEAD 2>/dev/null; then
-    echo -e "${RED}ERROR: Working tree has uncommitted changes.${RESET}"
-    exit 1
-fi
-
-# Warn on untracked files (could affect build).
-UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null)
-if [[ -n "$UNTRACKED" ]]; then
-    echo -e "WARNING: Untracked files detected:"
-    echo "$UNTRACKED" | head -10
-    UNTRACKED_COUNT=$(echo "$UNTRACKED" | wc -l | tr -d ' ')
-    if [[ "$UNTRACKED_COUNT" -gt 10 ]]; then
-        echo "  ... and $((UNTRACKED_COUNT - 10)) more"
+# === Gate: Clean working tree (only when tagging HEAD) ===
+if [ -z "$CONFIRM_HASH" ]; then
+    if ! git diff --quiet HEAD 2>/dev/null; then
+        echo -e "${RED}Error: Working tree has uncommitted changes.${RESET}"
+        echo "Commit or stash changes before releasing."
+        exit 1
     fi
-    echo ""
-    if [[ -t 0 ]]; then
-        read -p "Continue with untracked files? (y/N) " -n 1 -r
-        echo
-        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-            echo "Aborted."
-            exit 1
+
+    UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null)
+    if [ -n "$UNTRACKED" ]; then
+        echo -e "${YELLOW}Warning: Untracked files detected:${RESET}"
+        echo "$UNTRACKED" | head -10
+        UNTRACKED_COUNT=$(echo "$UNTRACKED" | wc -l | tr -d ' ')
+        if [ "$UNTRACKED_COUNT" -gt 10 ]; then
+            echo "  ... and $((UNTRACKED_COUNT - 10)) more"
         fi
-    else
-        echo "Non-interactive: proceeding with untracked files."
+        echo ""
+        if [ "$MODE" = "interactive" ]; then
+            read -p "Continue with untracked files? (y/N) " -n 1 -r
+            echo
+            if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+                echo "Aborted."
+                exit 1
+            fi
+        else
+            echo -e "${YELLOW}Non-interactive: proceeding with untracked files.${RESET}"
+        fi
     fi
 fi
 
-# Check for existing tags on this commit
-check_existing_tags
-
-# Check Firebase CI passed on HEAD.
-echo "Checking CI status on HEAD..."
-FIREBASE_CI_CONCLUSION=$(gh api "repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/commits/$FULL_SHA/check-runs" \
-    --jq '[.check_runs[] | select(.name == "Run Unit Tests" and .check_suite.conclusion != null)] | last | .conclusion' 2>/dev/null || echo "")
-
-if [[ "$FIREBASE_CI_CONCLUSION" == "success" ]]; then
-    echo -e "${GREEN}CI passed on HEAD.${RESET}"
-elif [[ -z "$FIREBASE_CI_CONCLUSION" ]]; then
-    echo -e "WARNING: Could not verify Firebase CI status. Proceeding anyway (Firebase CI may not run on all commits)."
-else
-    echo -e "${RED}ERROR: Firebase CI concluded '$FIREBASE_CI_CONCLUSION'. Fix CI before releasing.${RESET}"
+# === Gate: Must be on main (when tagging HEAD) — override via --confirm-hash ===
+if [ -z "$CONFIRM_HASH" ] && [ "$CURRENT_BRANCH" != "main" ]; then
+    echo -e "${RED}Error: Not on main branch (on '$CURRENT_BRANCH').${RESET}"
+    echo ""
+    echo "Run --check to see the exact command for this state:"
+    echo "  ./scripts/release-firebase.sh --check"
     exit 1
 fi
 
+if [ -n "$CONFIRM_HASH" ]; then
+    echo -e "${YELLOW}Releasing specific commit: $TARGET_COMMIT_SHORT${RESET}"
+    echo "  Resolved from: $CONFIRM_HASH"
+    echo "  Full SHA:      $TARGET_COMMIT"
+    echo ""
+fi
+
+# === Gate: Rollback confirmation ===
+if [ -n "$CONFIRM_ROLLBACK_FROM" ]; then
+    if [ "$CONFIRM_ROLLBACK_FROM" != "$LATEST_TAG_SHA" ]; then
+        echo -e "${RED}Error: --confirm-rollback-from does not match the latest tag's commit.${RESET}"
+        echo "  Expected (sha of $LATEST_TAG): $LATEST_TAG_SHA"
+        echo "  Got:                           $CONFIRM_ROLLBACK_FROM"
+        echo ""
+        echo "Run --check to see the correct value."
+        exit 1
+    fi
+    echo -e "${YELLOW}Rollback confirmed: $LATEST_TAG -> $NEW_TAG at $TARGET_COMMIT_SHORT${RESET}"
+    echo ""
+elif [ "$IS_ROLLBACK" = "true" ]; then
+    echo -e "${RED}Error: Target commit is on tag $NEWEST_TAG_ON_TARGET, older than $LATEST_TAG.${RESET}"
+    echo "  This looks like a rollback but --confirm-rollback-from was not provided."
+    echo ""
+    echo "Run --check to see the correct command."
+    exit 1
+fi
+
+# === Gate: Validation ===
+if [ "$VALIDATION_STATE" = "matches" ]; then
+    echo -e "${GREEN}Validation passed for this commit.${RESET}"
+elif [ -n "$CONFIRM_UNVALIDATED_RELEASE" ]; then
+    if [ "$CONFIRM_UNVALIDATED_RELEASE" != "$TARGET_COMMIT" ]; then
+        echo -e "${RED}Error: --confirm-unvalidated-release SHA does not match target commit.${RESET}"
+        echo "  Expected (target commit): $TARGET_COMMIT"
+        echo "  Got:                      $CONFIRM_UNVALIDATED_RELEASE"
+        echo ""
+        echo "Run --check to see the correct value."
+        exit 1
+    fi
+    echo -e "${YELLOW}WARNING: Releasing without local validation (--confirm-unvalidated-release).${RESET}"
+    echo "  This is intended for emergencies (hotfixes, rollbacks of old tags)."
+    echo ""
+else
+    if [ "$MODE" = "interactive" ]; then
+        if [ "$VALIDATION_STATE" = "stale" ]; then
+            echo -e "${YELLOW}Warning: Firebase validation marker is stale.${RESET}"
+            echo "  Marker SHA: $VALIDATED_COMMIT"
+            echo "  Target SHA: $TARGET_COMMIT"
+        else
+            echo -e "${YELLOW}Warning: no validation marker — run ./scripts/validate-firebase.sh first.${RESET}"
+        fi
+        read -p "Continue without validation? (y/N) " -n 1 -r
+        echo ""
+        [[ $REPLY =~ ^[Yy]$ ]] || { echo "Aborted. Run ./scripts/validate-firebase.sh first, or run --check for options."; exit 1; }
+    else
+        echo -e "${RED}Error: validation has not passed for this commit.${RESET}"
+        echo ""
+        echo "Run --check to see the exact command for this state:"
+        echo "  ./scripts/release-firebase.sh --check"
+        exit 1
+    fi
+fi
+
+# === Remote CI status (warn-only) ===
+echo "Checking remote CI status on target commit..."
+REMOTE_CI=$(check_remote_ci)
+if [ "$REMOTE_CI" = "success" ]; then
+    echo -e "${GREEN}Remote CI passed on target commit.${RESET}"
+elif [ -z "$REMOTE_CI" ]; then
+    echo -e "${YELLOW}Warning: could not verify remote Firebase CI status (may not have run on this commit).${RESET}"
+else
+    echo -e "${RED}Error: Remote Firebase CI concluded '$REMOTE_CI'. Fix CI before releasing.${RESET}"
+    exit 1
+fi
+echo ""
+
+# Existing tags on this commit (informational).
+if [ -n "$EXISTING_TAGS_ON_TARGET" ]; then
+    NEWEST_TAG_ON_COMMIT=$(echo "$EXISTING_TAGS_ON_TARGET" | tail -1)
+    if [ "$NEWEST_TAG_ON_COMMIT" = "$LATEST_TAG" ]; then
+        echo -e "${YELLOW}Note: This commit already has $LATEST_TAG.${RESET}"
+        echo "  Creating $NEW_TAG on the same commit (version bump, no code change)."
+    else
+        echo -e "${YELLOW}Note: This commit previously released as: $(echo "$EXISTING_TAGS_ON_TARGET" | tr '\n' ' ')${RESET}"
+    fi
+fi
+
+# Release details.
 echo ""
 echo "=== Release Details ==="
-echo "  Branch:     $BRANCH"
-echo "  Latest tag: $LATEST_TAG"
-echo "  New tag:    $NEXT_TAG"
-echo "  Commit:     $SHORT_SHA ($FULL_SHA)"
+echo "  Target:     $TARGET_SOURCE"
+echo "  Branch:     $CURRENT_BRANCH"
+echo "  Latest tag: $LATEST_TAG ($LATEST_TAG_SHA)"
+echo "  New tag:    $NEW_TAG"
+echo "  Commit:     $TARGET_COMMIT_SHORT ($TARGET_COMMIT)"
 echo ""
 
-# --- --dry-run mode ---
-if [[ "${1:-}" == "--dry-run" ]]; then
-    echo "(Dry run — no tag created)"
+# Confirmation.
+if [ "$MODE" = "confirm" ]; then
+    if [ "$CONFIRM_TAG" != "$NEW_TAG" ]; then
+        echo -e "${RED}Error: --confirm-tag does not match computed next tag.${RESET}"
+        echo "  Provided: $CONFIRM_TAG"
+        echo "  Expected: $NEW_TAG"
+        echo ""
+        echo "--confirm-tag is a safety check, not an override."
+        echo "The next tag is always computed as highest existing + 1."
+        exit 1
+    fi
+    echo "--confirm-tag matches, proceeding..."
+elif [ "$MODE" = "interactive" ]; then
+    echo -e "${YELLOW}This will create tag '$NEW_TAG' and push it to origin.${RESET}"
+    read -p "Proceed with release? (y/N) " -n 1 -r
+    echo ""
+    [[ $REPLY =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
+fi
+
+# Dry run.
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${YELLOW}=== Dry Run ===${RESET}"
+    echo "Would create tag $NEW_TAG on commit $TARGET_COMMIT_SHORT"
+    echo "Would push tag to origin"
+    echo "No tags were created or pushed."
     exit 0
 fi
 
-# --- --confirm-tag mode ---
-if [[ "${1:-}" == "--confirm-tag" ]]; then
-    CONFIRM="${2:-}"
-    if [[ "$CONFIRM" != "$NEXT_TAG" ]]; then
-        echo -e "${RED}ERROR: --confirm-tag '$CONFIRM' does not match computed tag '$NEXT_TAG'.${RESET}"
-        echo "The tag number is computed as latest + 1. You cannot override it."
-        exit 1
-    fi
-    # Proceed to create tag below.
-elif [[ -t 0 ]]; then
-    # Interactive mode.
-    read -p "Create and push tag $NEXT_TAG? [y/N] " -n 1 -r
-    echo
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        echo "Aborted."
-        exit 1
-    fi
-else
-    echo -e "${RED}ERROR: Non-interactive mode requires --confirm-tag $NEXT_TAG${RESET}"
-    exit 1
-fi
-
-# --- Create and push tag ---
-echo "Creating tag $NEXT_TAG..."
-git tag "$NEXT_TAG"
+# Create and push tag.
+echo ""
+echo "Creating tag $NEW_TAG on $TARGET_COMMIT_SHORT..."
+git tag "$NEW_TAG" "$TARGET_COMMIT"
 
 echo "Pushing tag to origin..."
-git push origin "$NEXT_TAG"
-
-echo ""
-echo -e "${GREEN}=== Release Initiated ===${RESET}"
-echo ""
-echo "Tag $NEXT_TAG pushed to origin."
-echo "Monitor: https://github.com/$(gh repo view --json nameWithOwner -q .nameWithOwner)/actions"
+if git push origin "$NEW_TAG"; then
+    echo ""
+    echo -e "${GREEN}=== Release Initiated ===${RESET}"
+    echo ""
+    echo "Tag $NEW_TAG pushed to origin."
+    echo "Monitor: https://github.com/$(gh repo view --json nameWithOwner -q .nameWithOwner)/actions"
+else
+    echo -e "${RED}Error: Failed to push tag.${RESET}"
+    echo "Removing local tag..."
+    git tag -d "$NEW_TAG"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Bring \`release-firebase.sh\` up to parity with the Android improvements from PR #453 and consume the validation marker from PR #454.

**Final piece of the three-PR series:**
- #453 (merged) — Android release script rewritten around \`--check\` copy-paste + confirm-reality overrides
- #454 (merging) — new \`validate-firebase.sh\` writes \`.claude/.firebase-validation-passed\`
- **#455 (this PR)** — Firebase release script consumes that marker; mirrors Android flag set

## What changed

**\`--check\` prints the exact next command** with full SHAs, based on detected state (normal / rollback / emergency). Same three-scenario structure as Android.

**New flags (all require a specific SHA):**
- \`--confirm-hash <sha>\` — release a specific commit (was missing entirely)
- \`--confirm-rollback-from <sha>\` — required for rollback; must match latest tag's SHA
- \`--confirm-unvalidated-release <sha>\` — emergency skip; SHA must equal target commit

**Validation marker check** — release now gated on \`.claude/.firebase-validation-passed\` matching target commit, OR an explicit \`--confirm-unvalidated-release\` with the correct SHA.

**Remote CI check preserved** — still warn-only, catches emulator smoke failures that local validate doesn't run.

**Push-failure cleanup** — on failed \`git push\`, delete the local tag. Mirrors Android.

## Rollback flow (now first-class)

\`\`\`bash
git checkout server/M
./scripts/release-firebase.sh --check   # prints the three-arg rollback command
./scripts/release-firebase.sh \\
    --confirm-tag server/N \\
    --confirm-hash <full-sha> \\
    --confirm-rollback-from <full-sha>
\`\`\`

## Test plan

- [x] \`--check\` on branch with fresh marker → PASSED + copy-paste command
- [x] \`--help\` prints full flag list
- [x] Marker from \`validate-firebase.sh\` (PR #454) is read correctly
- [ ] CI pre-submit
- [ ] After merge: first validated Firebase release

## Docs

- \`CLAUDE.md\` Releasing Firebase Server section rewritten for new flow
- \`.claude/skills/release-firebase/SKILL.md\` aligned with new steps + rollback recipe

## Non-breaking

- All new flags are additive
- \`--check\`, \`--confirm-tag\`, \`--dry-run\` behave the same as before (plus richer \`--check\` output)
- New validation-marker gate: if marker is missing and interactive, script prompts — matches Android behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)