### PR TITLE
scripts: Remove deprecated --skip-validation from Android release

### DIFF
--- a/.claude/skills/release-android/SKILL.md
+++ b/.claude/skills/release-android/SKILL.md
@@ -102,5 +102,4 @@ Both SHAs must match what the script computed from the current repo state. You c
 - **Tag version = versionCode** — `android/120` → `versionCode=120`.
 - **Always start with `--check`** — it prints the right command for the current state. Don't type the flags from memory.
 - **Always validate first** — run `./scripts/validate.sh` before every release.
-- **Never skip validation without asking the user.** `--confirm-unvalidated-release` exists for emergencies (hotfixes, rollbacks of old tags). If validation hasn't passed, tell the user and ask whether to run validation or skip it.
-- **`--skip-validation` is deprecated** but still accepted. Prefer `--confirm-unvalidated-release <sha>`. It requires explicitly stating the SHA you're skipping validation on, which prevents accidentally skipping on the wrong commit.
+- **Never skip validation without asking the user.** `--confirm-unvalidated-release <sha>` exists for emergencies (hotfixes, rollbacks of old tags). The SHA must equal the target commit, which prevents skipping validation on the wrong commit. If validation hasn't passed, tell the user and ask whether to run validation or skip it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,7 +222,7 @@ The script computes the next tag as `android/<highest + 1>`. The `--confirm-tag`
 
 **Design principle — overrides confirm reality.** Every override flag takes a value (SHA or tag) that must match what's actually in the repo. Wrong value = refused. This makes correct usage easy (read from `--check`) and accidental usage hard (you'd have to type the right value for the wrong situation).
 
-**Validation is required by default.** Run `./scripts/validate.sh` before releasing. If validation hasn't passed on the commit, the release script will block. For emergencies use `--confirm-unvalidated-release <sha>` (the SHA must equal the target commit). `--skip-validation` is kept as a deprecated alias; prefer the explicit form. Always ask the user before skipping validation.
+**Validation is required by default.** Run `./scripts/validate.sh` before releasing. If validation hasn't passed on the commit, the release script will block. For emergencies use `--confirm-unvalidated-release <sha>` — the SHA must equal the target commit. Always ask the user before skipping validation.
 
 **Rollback requires two steps** (intentionally hard to do accidentally):
 ```bash

--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -52,7 +52,6 @@ CONFIRM_TAG=""
 CONFIRM_HASH=""
 CONFIRM_ROLLBACK_FROM=""
 CONFIRM_UNVALIDATED_RELEASE=""
-SKIP_VALIDATION=false  # legacy; prefer --confirm-unvalidated-release
 DRY_RUN=false
 
 show_help() {
@@ -76,10 +75,6 @@ Override flags (all require a specific value from --check output):
   --confirm-unvalidated-release <sha>
                                     Release without validation marker match.
                                     SHA must equal the target commit.
-
-Deprecated:
-  --skip-validation         Legacy boolean skip; prefer --confirm-unvalidated-release.
-                            Still accepted for backward compat.
 
 Help:
   -h, --help                Show this help
@@ -112,10 +107,6 @@ while [[ $# -gt 0 ]]; do
         --confirm-unvalidated-release)
             CONFIRM_UNVALIDATED_RELEASE="$2"
             shift 2
-            ;;
-        --skip-validation)
-            SKIP_VALIDATION=true
-            shift
             ;;
         --dry-run)
             DRY_RUN=true
@@ -350,10 +341,9 @@ elif [ "$IS_ROLLBACK" = "true" ]; then
 fi
 
 # === Gate: Validation ===
-# Three acceptable paths:
+# Two acceptable paths:
 #   A. Validation marker matches target commit (normal)
 #   B. --confirm-unvalidated-release matches target commit (emergency)
-#   C. --skip-validation (legacy; deprecated)
 if [ "$VALIDATION_STATE" = "matches" ]; then
     echo -e "${GREEN}Validation passed for this commit.${RESET}"
 elif [ -n "$CONFIRM_UNVALIDATED_RELEASE" ]; then
@@ -367,11 +357,6 @@ elif [ -n "$CONFIRM_UNVALIDATED_RELEASE" ]; then
     fi
     echo -e "${YELLOW}WARNING: Releasing without validation (--confirm-unvalidated-release).${RESET}"
     echo "  This is intended for emergencies (hotfixes, rollbacks of old tags)."
-    echo ""
-elif [ "$SKIP_VALIDATION" = true ]; then
-    echo -e "${YELLOW}WARNING: --skip-validation is deprecated.${RESET}"
-    echo "  Prefer --confirm-unvalidated-release <sha>. See --help."
-    echo -e "${YELLOW}WARNING: Validation check skipped.${RESET}"
     echo ""
 else
     if [ "$MODE" = "interactive" ]; then


### PR DESCRIPTION
## Summary

Delete the legacy \`--skip-validation\` boolean flag. \`--confirm-unvalidated-release <sha>\` is the sole emergency override now.

## Rationale

Keeping two flags for the same thing invites drift and confusion. The SHA-based override is strictly better:
- Refuses if the SHA doesn't match the target commit
- Prevents \"skipped validation on the wrong commit\" as a failure mode
- The boolean form has no equivalent check

## Changes

- \`scripts/release-android.sh\`: drop \`SKIP_VALIDATION\` var, case branch, help text entry, and the third validation path
- \`CLAUDE.md\`: remove the \"deprecated alias\" sentence
- \`.claude/skills/release-android/SKILL.md\`: remove the deprecation bullet

Historical references in \`docs/pr-review/*.md\` are left unchanged — they document past state.

## Test plan

- [x] \`--check\` runs cleanly; no mention of removed flag
- [x] \`--help\` lists only current flags
- [x] Grep confirms no remaining \`skip-validation\` / \`SKIP_VALIDATION\` in scripts/, CLAUDE.md, or .claude/skills/
- [ ] CI pre-submit

## Breaking

Technically breaking for anyone still using \`--skip-validation\`. Trivial migration: replace with \`--confirm-unvalidated-release \$(git rev-parse HEAD)\`. Don't use \`\$()\` in practice — run \`--check\` and paste the printed command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)