### PR TITLE
ci: Bump actions/checkout to v5 for Node 24 support

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -28,7 +28,7 @@ jobs:
     if: inputs.android == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-android
         with:
           encrypt-key: ${{ secrets.ENCRYPT_KEY }}
@@ -54,7 +54,7 @@ jobs:
     if: inputs.android == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-android
         with:
           encrypt-key: ${{ secrets.ENCRYPT_KEY }}
@@ -89,7 +89,7 @@ jobs:
     if: inputs.android == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-android
         with:
           encrypt-key: ${{ secrets.ENCRYPT_KEY }}
@@ -115,7 +115,7 @@ jobs:
     if: inputs.android == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-android
         with:
           encrypt-key: ${{ secrets.ENCRYPT_KEY }}
@@ -141,7 +141,7 @@ jobs:
     if: inputs.android == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-android
         with:
           encrypt-key: ${{ secrets.ENCRYPT_KEY }}

--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -25,7 +25,7 @@ jobs:
       android: ${{ steps.filter.outputs.android }}
       docs_only: ${{ steps.filter.outputs.docs_only }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check for Android changes
         id: filter
         run: |
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-android
         with:
           encrypt-key: ${{ secrets.ENCRYPT_KEY }}
@@ -133,7 +133,7 @@ jobs:
     needs: [changes, checks, instrumented-tests]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Determine overall result
         id: result
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       android: ${{ steps.filter.outputs.android }}
       docs_only: ${{ steps.filter.outputs.docs_only }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check for Android changes
         id: filter
         run: |

--- a/.github/workflows/firebase-ci-checks.yml
+++ b/.github/workflows/firebase-ci-checks.yml
@@ -17,7 +17,7 @@ jobs:
     if: inputs.firebase == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/firebase-ci-post-merge.yml
+++ b/.github/workflows/firebase-ci-post-merge.yml
@@ -24,7 +24,7 @@ jobs:
       firebase: ${{ steps.filter.outputs.firebase }}
       docs_only: ${{ steps.filter.outputs.docs_only }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check for Firebase changes
         id: filter
         run: |
@@ -93,7 +93,7 @@ jobs:
     needs: [changes, checks]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Determine overall result
         id: result
         run: |

--- a/.github/workflows/firebase-ci.yml
+++ b/.github/workflows/firebase-ci.yml
@@ -16,7 +16,7 @@ jobs:
       firebase: ${{ steps.filter.outputs.firebase }}
       docs_only: ${{ steps.filter.outputs.docs_only }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check for Firebase changes
         id: filter
         run: |

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -37,7 +37,7 @@ jobs:
           echo "Validated: tag=$TAG, versionCode=$VERSION"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: ./.github/actions/setup-android
         with:


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout@v4` → `@v5` in all 8 workflow files
- v4 runs on Node 20; GitHub is forcing Node 24 as the default June 2, 2026 and removing Node 20 September 16, 2026
- v5 is the first checkout release built on Node 24 — only the runtime changed, no input schema changes

## Verification

- **This PR's own CI** runs both `ci.yml` and `firebase-ci.yml`, each of which starts with `actions/checkout@v5` — if the new version breaks, the PR CI fails here before merge
- Post-merge CI continues to exercise it

## Part of a series

1. **This PR** — `actions/checkout` v4 → v5
2. Next — `actions/setup-node` v4 → v5
3. Next — `google-github-actions/auth` v2 → v3

🤖 Generated with [Claude Code](https://claude.com/claude-code)