### PR TITLE
ci: Bump actions/setup-node to v5 for Node 24 support

### DIFF
--- a/.github/workflows/firebase-ci-checks.yml
+++ b/.github/workflows/firebase-ci-checks.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
       - name: Install dependencies
@@ -88,7 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
       # firebase-tools requires Java 21+ for the Firestore / Functions

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- Bumps `actions/setup-node@v4` → `@v5` in `firebase-ci-checks.yml` (2 uses) and `firebase-deploy.yml` (1 use)
- v5 is the first release built on Node 24

## Breaking change: automatic caching

v5 adds automatic dependency caching when `package.json` has a `packageManager` field. Checked — `FirebaseServer/package.json` does **not** set `packageManager`, so the new behavior does not activate. npm install flow is unchanged.

## Verification

- Pre-merge `firebase-ci.yml` runs setup-node@v5 on this PR — any regression shows up here before merge
- Post-merge `firebase-ci-post-merge.yml` continues to exercise it
- `firebase-deploy.yml` will be exercised on the next `server/N` release

## Part of a series

1. #457 — `actions/checkout` v4 → v5
2. **This PR** — `actions/setup-node` v4 → v5
3. Next — `google-github-actions/auth` v2 → v3

> **Merge order:** Can merge in any order relative to #457 and the upcoming auth PR — changes are on distinct lines with no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)