### PR TITLE
ci: Bump google-github-actions/auth to v3 for Node 24 support

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
       - name: Authenticate with Google Cloud
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
       - name: Deploy to Firebase


### PR DESCRIPTION
## Summary

- Bumps `google-github-actions/auth@v2` → `@v3` in `firebase-deploy.yml`
- v3 is the first release built on Node 24

## Breaking changes in v3 (verified not impacting)

v3 removed these inputs: \`retries\`, \`backoff\`, \`backoff_limit\`. We only pass \`credentials_json\`, so this is a no-op for us.

## Verification — the tricky one

\`firebase-deploy.yml\` only runs on \`server/N\` tag push. That means **this change is NOT exercised by pre-merge or post-merge CI** — it can only be verified by a real Firebase release.

**Verification plan:** After merge, cut \`server/9\` as a confidence check. The payload vs \`server/8\` will be:
- This PR (auth v3)
- Any other PRs that land in between (probably #457 checkout, #458 setup-node, both of which are exercised by other workflows pre-merge)

If the deploy succeeds, we're good. If it fails, revert this PR and the fallback is \`auth@v2\` until we understand what changed.

## Part of a series

1. #457 — \`actions/checkout\` v4 → v5
2. #458 — \`actions/setup-node\` v4 → v5
3. **This PR** — \`google-github-actions/auth\` v2 → v3

🤖 Generated with [Claude Code](https://claude.com/claude-code)