### PR TITLE
ci: Bump Firebase Functions runtime to Node 22

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
       - name: Install dependencies
         working-directory: FirebaseServer
         run: npm install

--- a/FirebaseServer/package.json
+++ b/FirebaseServer/package.json
@@ -43,7 +43,7 @@
     "path-to-regexp": "0.1.13"
   },
   "engines": {
-    "node": "20"
+    "node": "22"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary

Stage 2 of 2 for the Node 20 → 22 migration. This PR flips the production Cloud Functions runtime.

- `FirebaseServer/package.json` \`engines.node\`: \`"20"\` → \`"22"\`
  (Firebase reads this to pick the Cloud Functions runtime at deploy.)
- `.github/workflows/firebase-deploy.yml` \`setup-node\` \`node-version\`: \`'20'\` → \`'22'\`
  (Matches the runtime so the build artifact is produced on the Node major that will execute it.)

## What #460 already verified

#460 (merged) verified that Node 22 works for:
- Local dev (`.nvmrc`, `validate-firebase.sh` auto-switch, `firebase-npm.sh` wrapper)
- CI pre-merge: build + lint + 80 unit tests + emulator smoke test on Node 22.22.2

The bug it caught: Node 22.18+ native TypeScript type-stripping changes CJS/ESM interop and breaks \`import * as admin from 'firebase-admin'\`. Fixed by setting \`NODE_OPTIONS='--no-experimental-strip-types'\` in the \`tests\` npm script.

## What this PR changes that #460 did NOT

- **Production runtime**: Cloud Functions running on Google's infrastructure will execute under Node 22 instead of Node 20.
- **Deploy build**: the build step in \`firebase-deploy.yml\` runs on Node 22, so any Node-version-sensitive compilation happens on the same major as the runtime.

## Verification

- Pre-merge CI doesn't exercise \`firebase-deploy.yml\` (only runs on tag push). Not possible to verify this PR via CI.
- **Actual verification: cut \`server/10\` after merge.** That's when Firebase actually deploys under Node 22.

## Rollback plan

If \`server/10\` deploy fails or production misbehaves on Node 22:
1. Revert this commit on main
2. Cut \`server/11\` — deploys under Node 20 runtime again
3. Node 20 remains valid until Cloud Functions deprecation deadline **2026-10-30**, so rollback has months of headroom

## Context

- \`firebase-functions\` engines: \`>=18.0.0\` — Node 22 supported.
- \`firebase-tools\` engines: \`>=20.0.0 || >=22.0.0 || >=24.0.0\` — Node 22 explicit.
- All 80 tests pass on Node 22.22.2 locally (after #460's strip-types fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)