### PR TITLE
feat: Firebase server changelog + release-script gate

### DIFF
--- a/.claude/skills/release-firebase/SKILL.md
+++ b/.claude/skills/release-firebase/SKILL.md
@@ -27,9 +27,24 @@ git status  # Must be clean
 ./scripts/validate-firebase.sh
 ```
 
-Runs `npm run build` + `npm run tests` (80 tests including collection-name contract tests and verifyIdToken library-chain tests). Requires Node 20 — script fails fast with `nvm use 20` instruction if not. Writes marker at `.claude/.firebase-validation-passed` with the commit SHA.
+Runs `npm run build` + `npm run tests` (80 tests including collection-name contract tests and verifyIdToken library-chain tests). Auto-switches Node via nvm to the version in `FirebaseServer/.nvmrc`. Writes marker at `.claude/.firebase-validation-passed` with the commit SHA.
 
-### 3. Check release state
+### 3. Add a CHANGELOG entry
+
+Edit `FirebaseServer/CHANGELOG.md`. Add a new section keyed by the tag you're about to create:
+
+```markdown
+## server/N
+- One or more bullets on what shipped
+```
+
+Commit and push. The release script refuses to tag when the entry is missing or empty.
+
+**Supersede rule.** If this release supersedes an untested predecessor (bug-chase chain — server/11 shipped broken, server/12 still broken, server/13 finally worked), you may **delete** the predecessor's entry and write a single entry on the final tag. Git log preserves the original content; the visible changelog stays clean.
+
+Skip this step only for true emergencies — then add `--confirm-no-changelog <target-sha>` in step 5 and write the entry after the fact.
+
+### 4. Check release state
 
 ```bash
 ./scripts/release-firebase.sh --check
@@ -39,11 +54,12 @@ This prints:
 - Latest tag and its SHA, next computed tag, HEAD SHA, branch
 - Validation state (PASSED/STALE/MISSING)
 - Remote Firebase CI status (success/unknown/failed)
+- Changelog state (PRESENT/EMPTY/MISSING/NO FILE)
 - **A copy-paste-ready command for the scenario** (normal, rollback, emergency)
 
-### 4. Cut the release
+### 5. Cut the release
 
-Paste the command from step 3. For a normal release:
+Paste the command from step 4. For a normal release:
 
 ```bash
 ./scripts/release-firebase.sh --confirm-tag server/N
@@ -55,6 +71,14 @@ For emergency release (validation not passing), `--check` prints:
 ./scripts/release-firebase.sh \
     --confirm-tag server/N \
     --confirm-unvalidated-release <40-char-sha>
+```
+
+For no-changelog release (emergency only), `--check` prints:
+
+```bash
+./scripts/release-firebase.sh \
+    --confirm-tag server/N \
+    --confirm-no-changelog <40-char-sha>
 ```
 
 For rollback (detached HEAD on older tag), `--check` prints:
@@ -70,11 +94,12 @@ The script will:
 - Verify clean git state (unless `--confirm-hash` is used)
 - Verify on main branch (unless `--confirm-hash` is used)
 - Verify validation marker matches target commit (unless `--confirm-unvalidated-release` is used)
+- Verify `FirebaseServer/CHANGELOG.md` has a non-empty `## server/N` entry (unless `--confirm-no-changelog` is used)
 - Verify remote Firebase CI passed (warn-only)
 - Create and push the tag; on push failure, remove the local tag
 - The tag triggers `.github/workflows/firebase-deploy.yml`
 
-### 5. Verify deployment
+### 6. Verify deployment
 
 ```bash
 gh run list --workflow=firebase-deploy.yml --limit 1
@@ -105,5 +130,7 @@ Both SHAs must match what the script computed on the checked-out commit. You can
 - **Tag pattern:** `server/N` (e.g., server/1, server/2)
 - **Always start with `--check`** — it prints the right command for the current state.
 - **Always validate first** — run `./scripts/validate-firebase.sh`.
+- **Always write a CHANGELOG entry** — `FirebaseServer/CHANGELOG.md` must have `## server/N` with a non-empty body. Supersede-previous pattern is allowed for bug-chase chains.
 - **Don't skip validation without asking.** `--confirm-unvalidated-release <sha>` is for emergencies.
-- **Node 20 is required** — FirebaseServer/.nvmrc pins it. Node 24 breaks mocha.
+- **Don't skip changelog without asking.** `--confirm-no-changelog <sha>` is for emergencies — add the entry retroactively.
+- **Node version is pinned** — `FirebaseServer/.nvmrc` sets it. The `validate-firebase.sh` auto-switches via nvm.

--- a/.claude/skills/update-firebase-changelog/SKILL.md
+++ b/.claude/skills/update-firebase-changelog/SKILL.md
@@ -1,0 +1,65 @@
+---
+description: Add a Firebase server changelog entry for the next server/N tag based on commits since the last tag.
+allowed-tools: Bash(*), Read, Edit, Write, Grep, Glob
+user-invocable: true
+---
+
+# Update Firebase Changelog
+
+Draft and add an entry to `FirebaseServer/CHANGELOG.md` for the next `server/N` tag, based on commits since the latest tag. The release script (`scripts/release-firebase.sh`) requires this entry before it will cut a tag.
+
+## Steps
+
+### 1. Compute next tag
+
+```bash
+git tag -l 'server/*' --sort=-version:refname | head -1
+```
+
+The next tag is `server/<N+1>`.
+
+### 2. Read existing changelog
+
+Read `FirebaseServer/CHANGELOG.md` to see style and the most recent entries.
+
+### 3. Find changes since last tag
+
+```bash
+# Latest released tag
+LATEST=$(git tag -l 'server/*' --sort=-version:refname | head -1)
+
+# Commits since that tag
+git log "$LATEST..HEAD" --oneline
+```
+
+### 4. Draft the entry
+
+- 1-4 bullets, matching the existing style
+- Focus on what matters 6 months later, not the full commit list
+- Skip pure internal noise (CI tweaks, dep bumps without behavior change, refactors)
+- If the release is ALL noise, write `Release with no behavior changes.` followed by a one-line summary of what the infra/dep change was
+- No commit hashes, no PR numbers
+
+Present the draft to the user before writing.
+
+### 5. Apply the supersede rule if needed
+
+If the previous tag's entry was an untested predecessor (the current release exists because it broke), offer to **delete** the predecessor's entry and replace it with a single entry on the new tag. Ask the user first — this is opt-in.
+
+Example prompt: "server/11 was a broken fix attempt. Replace its entry with a single server/12 entry that covers both? (Recommended for bug-chase chains.)"
+
+### 6. Write the entry
+
+Insert the new `## server/N` section at the top of the release-history block — above the previous `## server/<N-1>` entry, below the `---` separator.
+
+### 7. Create PR
+
+Create a branch, commit, push, and create a PR with auto-merge. Title: `docs: Changelog for server/N`.
+
+## Rules
+
+- The tag number comes from `git tag -l`, not the user
+- Match existing style (short bullets, no jargon, no commit hashes)
+- If args are provided, use them as the entry content instead of inferring from commits
+- Never write an empty entry — the release script will block the tag push
+- For a release with no behavior changes, be explicit: `Release with no behavior changes. <one-line reason>.`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,8 @@ The script computes the next tag as `server/<highest + 1>`. Deploys Cloud Functi
 
 **Validation is required by default.** Run `./scripts/validate-firebase.sh` before releasing (runs `npm run build` + `npm run tests`, writes marker with commit SHA). For emergencies use `--confirm-unvalidated-release <sha>` — the SHA must equal the target commit. Remote Firebase CI status is also checked but is warn-only (not all commits run full CI).
 
+**Changelog entry is required by default.** `FirebaseServer/CHANGELOG.md` must have a `## server/N` heading with a non-empty body before the tag can be pushed. See the file's header for the supersede rule (bug-chase chains may replace the predecessor's entry instead of appending). Draft with `/update-firebase-changelog`. For emergencies use `--confirm-no-changelog <sha>` — the SHA must equal the target commit. Add the entry retroactively after a no-changelog release.
+
 **Rollback = two steps** (same as Android):
 ```bash
 git checkout server/M

--- a/FirebaseServer/CHANGELOG.md
+++ b/FirebaseServer/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Firebase Server Changelog
+
+Internal release history for Cloud Functions deployments. The Android app and ESP32 firmware do not read a version from the server; this log is for the maintainer and for rollback decisions.
+
+## Versioning
+
+Server releases use a monotonic integer (`server/N`). No semver — each release is a deployment snapshot, not a library version. The tag itself is the identity.
+
+## Release-line convention
+
+Every release that reaches `main` gets an entry here. `scripts/release-firebase.sh` blocks the tag push if `## server/N` has no body. Emergency override: `--confirm-no-changelog <target-sha>`.
+
+**Supersede pattern.** Releases that supersede an untested predecessor (bug-chase chain — server/11 shipped, broken, server/12 attempted fix, still broken, server/13 finally worked) may **replace** the predecessor's entry with a single entry on the final release. Git log of this file preserves the original content, so archaeology is possible without cluttering the human-readable history.
+
+Example:
+
+```markdown
+## server/13
+- Fixed snooze TTL bug. (First attempts in server/11 and server/12 had off-by-one errors that only surfaced in production.)
+
+## server/10
+- Bump Firebase Functions runtime to Node 22.
+```
+
+---
+
+## server/10
+- Bump Firebase Functions runtime to Node 22 (production). Local dev + CI also moved to Node 22.
+
+## server/9
+- Release with no behavior changes. GitHub Actions bumped (checkout v5, setup-node v5, google-github-actions/auth v3) to support Node 24 on CI runners.
+
+## server/8
+- First Firebase release cut with the new `scripts/release-firebase.sh` script (parity with Android's `release-android.sh`).
+- Added `scripts/validate-firebase.sh` local pre-push check and validation marker.
+- Internal: began database-centralization refactor (Phase 0 + Phase 1a — RemoteButton databases). No external API change.
+
+## server/7
+- Release with no behavior changes. Cleaned up 16 ESLint unused-var warnings.
+
+## server/6
+- Dropped unused `googleapis` direct dependency.
+- Added `qs` and `path-to-regexp` npm overrides to patch Express transitive CVEs.
+- Dependabot hygiene: `fast-xml-parser` and `protobufjs` updates.
+- Pinned local Node version via `FirebaseServer/.nvmrc` (Node 20).
+
+## server/5
+- Release with no behavior changes. The long-running silent-deploy-failure was diagnosed and fixed around this release by re-provisioning the deployer service account with the correct `roles/iam.serviceAccountUser` on the runtime SA. Fix lives outside the repo; this tag is the first clean deploy after it. Runbook: `docs/FIREBASE_DEPLOY_SETUP.md`.
+
+## server/4
+- Overrode transitive `jws` to 4.0.1 + 3.2.3, closing Dependabot alerts #25 and #26.
+- Added `verifyIdToken` library-chain regression guard test so future `jws` / `jsonwebtoken` / `google-auth-library` bumps can't silently break auth.
+- Added Firebase emulator smoke test to CI.
+- Added `npm audit` warn step to Firebase CI.
+
+## server/3
+- Pinned all Firebase server dependencies to exact versions (no `^`/`~` ranges) to eliminate surprise transitive drift.
+- Fixed TypeScript build errors that had accumulated on `main`.
+
+## server/2
+- Release with no behavior changes. Path-based CI skipping + gate jobs (repo-level plumbing).
+
+## server/1
+- Initial tagged release. Migrated Firebase server from tslint to ESLint.
+- Added `TimeSeriesDatabase` unit test coverage and general test scaffolding.
+- Repository restructure: Firebase server moved into its own directory.

--- a/scripts/release-firebase.sh
+++ b/scripts/release-firebase.sh
@@ -48,6 +48,7 @@ CONFIRM_TAG=""
 CONFIRM_HASH=""
 CONFIRM_ROLLBACK_FROM=""
 CONFIRM_UNVALIDATED_RELEASE=""
+CONFIRM_NO_CHANGELOG=""
 DRY_RUN=false
 
 show_help() {
@@ -71,6 +72,8 @@ Override flags (all require a specific value from --check output):
   --confirm-unvalidated-release <sha>
                                     Release without validation marker match.
                                     SHA must equal the target commit.
+  --confirm-no-changelog <sha>      Release without a CHANGELOG entry for the
+                                    new tag. SHA must equal the target commit.
 
 Help:
   -h, --help                Show this help
@@ -102,6 +105,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --confirm-unvalidated-release)
             CONFIRM_UNVALIDATED_RELEASE="$2"
+            shift 2
+            ;;
+        --confirm-no-changelog)
+            CONFIRM_NO_CHANGELOG="$2"
             shift 2
             ;;
         --dry-run)
@@ -179,6 +186,30 @@ if [ -f "$VALIDATION_FILE" ]; then
     fi
 fi
 
+# CHANGELOG state for the tag we're about to create.
+#   present : `## server/N` heading exists and has non-empty body
+#   empty   : heading exists but body is whitespace-only
+#   missing : no heading for this tag
+#   no_file : FirebaseServer/CHANGELOG.md does not exist
+CHANGELOG_FILE="$REPO_ROOT/FirebaseServer/CHANGELOG.md"
+CHANGELOG_STATE="no_file"
+CHANGELOG_BODY=""
+if [ -f "$CHANGELOG_FILE" ]; then
+    # Extract body: lines between "## $NEW_TAG" and the next "## " heading.
+    CHANGELOG_BODY=$(awk -v tag="$NEW_TAG" '
+        $0 ~ ("^## "tag"([ ]|$)") { found=1; next }
+        found && /^## / { exit }
+        found { print }
+    ' "$CHANGELOG_FILE")
+    if [ -n "$(echo "$CHANGELOG_BODY" | tr -d '[:space:]')" ]; then
+        CHANGELOG_STATE="present"
+    elif grep -qE "^## $NEW_TAG([ ]|$)" "$CHANGELOG_FILE"; then
+        CHANGELOG_STATE="empty"
+    else
+        CHANGELOG_STATE="missing"
+    fi
+fi
+
 # Remote CI status (warn-only; does not gate release).
 # Firebase CI runs unit tests + emulator smoke; a failure here is still
 # worth knowing about even if the local marker is green.
@@ -224,6 +255,13 @@ if [ "$MODE" = "check" ]; then
         *)       echo -e "${RED}$REMOTE_CI${RESET}" ;;
     esac
 
+    case "$CHANGELOG_STATE" in
+        present) echo -e "Changelog:    ${GREEN}PRESENT${RESET} (entry for $NEW_TAG in FirebaseServer/CHANGELOG.md)" ;;
+        empty)   echo -e "Changelog:    ${YELLOW}EMPTY${RESET} (heading for $NEW_TAG has no body)" ;;
+        missing) echo -e "Changelog:    ${YELLOW}MISSING${RESET} (no heading for $NEW_TAG in FirebaseServer/CHANGELOG.md)" ;;
+        no_file) echo -e "Changelog:    ${YELLOW}NO FILE${RESET} (FirebaseServer/CHANGELOG.md does not exist)" ;;
+    esac
+
     if [ -n "$EXISTING_TAGS_ON_TARGET" ]; then
         echo "Target tags:  $(echo "$EXISTING_TAGS_ON_TARGET" | tr '\n' ' ')"
     fi
@@ -240,17 +278,23 @@ if [ "$MODE" = "check" ]; then
         echo "      --confirm-hash $TARGET_COMMIT \\"
         echo "      --confirm-rollback-from $LATEST_TAG_SHA"
         echo ""
+        EXTRAS=()
         if [ "$VALIDATION_STATE" != "matches" ]; then
-            echo "If you also need to skip validation (expected for old rollback targets), append:"
-            echo "      --confirm-unvalidated-release $TARGET_COMMIT"
+            EXTRAS+=("--confirm-unvalidated-release $TARGET_COMMIT")
+        fi
+        if [ "$CHANGELOG_STATE" != "present" ]; then
+            EXTRAS+=("--confirm-no-changelog $TARGET_COMMIT")
+        fi
+        if [ ${#EXTRAS[@]} -gt 0 ]; then
+            echo "Append the following for the conditions flagged above (validation stale, no changelog entry):"
+            for extra in "${EXTRAS[@]}"; do
+                echo "      $extra"
+            done
+            echo ""
+            echo "Recommended instead: add a CHANGELOG entry describing the rollback (e.g. \"rollback to $NEWEST_TAG_ON_TARGET because X\")."
             echo ""
         fi
-    elif [ "$VALIDATION_STATE" = "matches" ]; then
-        echo "Copy and run this command to release:"
-        echo ""
-        echo "  ./scripts/release-firebase.sh --confirm-tag $NEW_TAG"
-        echo ""
-    else
+    elif [ "$VALIDATION_STATE" != "matches" ]; then
         echo "Validation is not passing for HEAD. Two options:"
         echo ""
         echo "(1) Run validation, then re-run --check (recommended):"
@@ -261,6 +305,33 @@ if [ "$MODE" = "check" ]; then
         echo "    ./scripts/release-firebase.sh \\"
         echo "        --confirm-tag $NEW_TAG \\"
         echo "        --confirm-unvalidated-release $TARGET_COMMIT"
+        echo ""
+    elif [ "$CHANGELOG_STATE" != "present" ]; then
+        echo "No CHANGELOG entry for $NEW_TAG. Two options:"
+        echo ""
+        echo "(1) Add an entry, commit, push, re-run --check (recommended):"
+        echo ""
+        echo "    Edit FirebaseServer/CHANGELOG.md and add:"
+        echo ""
+        echo "      ## $NEW_TAG"
+        echo "      - <one or more bullets on what shipped>"
+        echo ""
+        echo "    If this release supersedes a previous untested release (bug-chase"
+        echo "    chain), you may REPLACE the predecessor's entry with this one."
+        echo "    Git log of the file preserves the original."
+        echo ""
+        echo "    Then: git commit + push, ./scripts/validate-firebase.sh, ./scripts/release-firebase.sh --check"
+        echo ""
+        echo "(2) Release WITHOUT a changelog entry (emergency only):"
+        echo ""
+        echo "    ./scripts/release-firebase.sh \\"
+        echo "        --confirm-tag $NEW_TAG \\"
+        echo "        --confirm-no-changelog $TARGET_COMMIT"
+        echo ""
+    else
+        echo "Copy and run this command to release:"
+        echo ""
+        echo "  ./scripts/release-firebase.sh --confirm-tag $NEW_TAG"
         echo ""
     fi
 
@@ -381,6 +452,38 @@ else
         echo "  ./scripts/release-firebase.sh --check"
         exit 1
     fi
+fi
+
+# === Gate: CHANGELOG entry ===
+if [ "$CHANGELOG_STATE" = "present" ]; then
+    FIRST_LINE=$(echo "$CHANGELOG_BODY" | grep -m1 -E '[^[:space:]]' || echo "")
+    echo -e "${GREEN}Changelog entry found for $NEW_TAG.${RESET}"
+    if [ -n "$FIRST_LINE" ]; then
+        echo "  First line: $(echo "$FIRST_LINE" | head -c 120)"
+    fi
+elif [ -n "$CONFIRM_NO_CHANGELOG" ]; then
+    if [ "$CONFIRM_NO_CHANGELOG" != "$TARGET_COMMIT" ]; then
+        echo -e "${RED}Error: --confirm-no-changelog SHA does not match target commit.${RESET}"
+        echo "  Expected (target commit): $TARGET_COMMIT"
+        echo "  Got:                      $CONFIRM_NO_CHANGELOG"
+        echo ""
+        echo "Run --check to see the correct value."
+        exit 1
+    fi
+    echo -e "${YELLOW}WARNING: Releasing without CHANGELOG entry (--confirm-no-changelog).${RESET}"
+    echo "  Add an entry after the fact if this release has user-visible effect."
+    echo ""
+else
+    case "$CHANGELOG_STATE" in
+        missing) REASON="no heading for $NEW_TAG in FirebaseServer/CHANGELOG.md" ;;
+        empty)   REASON="heading for $NEW_TAG exists but body is empty" ;;
+        no_file) REASON="FirebaseServer/CHANGELOG.md does not exist" ;;
+        *)       REASON="unknown" ;;
+    esac
+    echo -e "${RED}Error: CHANGELOG gate failed ($REASON).${RESET}"
+    echo ""
+    echo "Run --check to see how to fix (write the entry, or emergency override)."
+    exit 1
 fi
 
 # === Remote CI status (warn-only) ===


### PR DESCRIPTION
## Summary

Brings parity with Android's release documentation for the Firebase server — one opinionated design, not a menu of options.

- **New file**: \`FirebaseServer/CHANGELOG.md\` — backfilled entries for server/1-10 plus a header explaining versioning and the supersede rule
- **Gate**: \`scripts/release-firebase.sh\` refuses to push a tag if \`## server/N\` doesn't have a non-empty body
- **Override**: \`--confirm-no-changelog <target-sha>\` for emergencies (SHA must match target commit, consistent with existing override pattern)
- **New skill**: \`/update-firebase-changelog\` — drafts entries from \`git log server/N-1..HEAD\`, supports the supersede rule opt-in
- **SKILL.md + CLAUDE.md** updated to document the new step

## Design decisions (opinionated; agent team discussion on #PR-thread)

- **No semver in \`package.json\`** — Android app and ESP32 don't read a server version. Tag \`server/N\` is already monotonic identity. Two sources of truth invite drift.
- **No GitHub Releases** — duplicates the changelog into a second location that requires network to read. Keeping the log in-repo makes \`git log FirebaseServer/CHANGELOG.md\` the audit trail.
- **No Keep-a-Changelog categories** — forces friction per release without reader benefit at this scale. Mirror Android's terse-bullet style.
- **Gate blocks by default, override is cheap** — matches the validation gate's shape. If the gate didn't block, the file would rot half-maintained.

## Supersede pattern (the bug-chase escape hatch)

When a release chain exists because the earlier tags were broken fix attempts, the final release may **delete** predecessor entries and write a single entry covering the whole saga. Git log of \`FirebaseServer/CHANGELOG.md\` preserves the original content; the visible file stays one-entry-per-shipped-event.

Documented in the file header with an example block.

## Verification

- Gate logic (awk body-extraction): tested on present / empty / missing cases
- \`--check\` output: tested the three CHANGELOG states plus the rollback recipe (now appends \`--confirm-no-changelog\` when needed)
- Full enforcement path will be exercised by the next real release (server/11)

## After merge

The next release cut will require a CHANGELOG entry. The \`/update-firebase-changelog\` skill can draft one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)