### PR TITLE
refactor: Phase 2 step 1 — SensorEventDatabase interface + fake + contract test

### DIFF
--- a/FirebaseServer/src/controller/SnoozeNotifications.ts
+++ b/FirebaseServer/src/controller/SnoozeNotifications.ts
@@ -56,7 +56,7 @@ export async function getSnoozeStatus(params: SnoozeLatestParams): Promise<Snooz
     // Get the current event timestamp from the database.
     let eventsCurrent = null;
     try {
-        eventsCurrent = await SensorEventDatabase.get(buildTimestamp);
+        eventsCurrent = await SensorEventDatabase.getCurrent(buildTimestamp);
     } catch (error) {
         console.error(error);
         return <SnoozeLatestResponse> {
@@ -134,7 +134,7 @@ export async function submitSnoozeNotificationsRequest(params: SubmitSnoozeParam
     // Get the current event timestamp from the database.
     let eventsCurrent = null;
     try {
-        eventsCurrent = await SensorEventDatabase.get(buildTimestamp);
+        eventsCurrent = await SensorEventDatabase.getCurrent(buildTimestamp);
     } catch (error) {
         console.error(error);
         return <SubmitSnoozeResponse>{ error: 'Error getting current event', code: 500 };

--- a/FirebaseServer/src/database/SensorEventDatabase.ts
+++ b/FirebaseServer/src/database/SensorEventDatabase.ts
@@ -14,29 +14,49 @@
  * limitations under the License.
  */
 
-const COLLECTION_CURRENT = 'eventsCurrent';
-const COLLECTION_ALL = 'eventsAll';
-
 import { TimeSeriesDatabase } from './TimeSeriesDatabase';
 
-class SensorEventDatabase {
-  DB = new TimeSeriesDatabase(COLLECTION_CURRENT, COLLECTION_ALL);
+// Canonical collection strings for this database. Pinned by
+// test/database/SensorEventDatabaseTest.ts. Changing them requires a
+// Firestore data migration in production — see
+// docs/FIREBASE_DATABASE_REFACTOR.md.
+export const COLLECTION_CURRENT = 'eventsCurrent';
+export const COLLECTION_ALL = 'eventsAll';
 
-  async set(buildTimestamp: string, data: any) {
-    await this.DB.save(buildTimestamp, data);
-  }
+export interface SensorEventDatabase {
+  save(buildTimestamp: string, data: any): Promise<void>;
+  getCurrent(buildTimestamp: string): Promise<any>;
+  updateCurrentWithMatchingCurrentEventTimestamp(buildTimestamp: string, matchingCurrent: any): Promise<any>;
+  deleteAllBefore(cutoffTimestampSeconds: number, dryRun: boolean): Promise<number>;
+  getLatestN(n: number): Promise<any>;
+  getRecentForBuildTimestamp(buildTimestamp: string, n: number): Promise<any>;
+}
 
-  async get(buildTimestamp: string): Promise<any> {
-    return this.DB.getCurrent(buildTimestamp);
+class FirestoreSensorEventDatabase implements SensorEventDatabase {
+  private readonly db = new TimeSeriesDatabase(COLLECTION_CURRENT, COLLECTION_ALL);
+  save(t: string, d: any) { return this.db.save(t, d); }
+  getCurrent(t: string) { return this.db.getCurrent(t); }
+  updateCurrentWithMatchingCurrentEventTimestamp(t: string, m: any) {
+    return this.db.updateCurrentWithMatchingCurrentEventTimestamp(t, m);
   }
+  deleteAllBefore(c: number, dry: boolean) { return this.db.deleteAllBefore(c, dry); }
+  getLatestN(n: number) { return this.db.getLatestN(n); }
+  getRecentForBuildTimestamp(t: string, n: number) { return this.db.getRecentForBuildTimestamp(t, n); }
+}
 
-  async getRecentN(n: number): Promise<any> {
-    return this.DB.getLatestN(n);
-  }
+let _instance: SensorEventDatabase = new FirestoreSensorEventDatabase();
 
-  async getRecentForBuildTimestamp(buildTimestamp: string, n: number): Promise<any> {
-    return this.DB.getRecentForBuildTimestamp(buildTimestamp, n);
-  }
+export const DATABASE: SensorEventDatabase = {
+  save: (t, d) => _instance.save(t, d),
+  getCurrent: (t) => _instance.getCurrent(t),
+  updateCurrentWithMatchingCurrentEventTimestamp: (t, m) => _instance.updateCurrentWithMatchingCurrentEventTimestamp(t, m),
+  deleteAllBefore: (c, dry) => _instance.deleteAllBefore(c, dry),
+  getLatestN: (n) => _instance.getLatestN(n),
+  getRecentForBuildTimestamp: (t, n) => _instance.getRecentForBuildTimestamp(t, n),
 };
 
-export const DATABASE = new SensorEventDatabase();
+/** TEST-ONLY: swap in a fake implementation. */
+export function setImpl(impl: SensorEventDatabase): void { _instance = impl; }
+
+/** TEST-ONLY: restore the Firestore implementation. */
+export function resetImpl(): void { _instance = new FirestoreSensorEventDatabase(); }

--- a/FirebaseServer/src/functions/http/Events.ts
+++ b/FirebaseServer/src/functions/http/Events.ts
@@ -72,7 +72,7 @@ export const httpCurrentEventData = functions.https.onRequest(async (request, re
   }
 
   try {
-    const currentData = await SensorEventDatabase.get(buildTimestamp);
+    const currentData = await SensorEventDatabase.getCurrent(buildTimestamp);
     data[CURRENT_EVENT_DATA_KEY] = currentData;
     response.status(200).send(data);
   }
@@ -178,10 +178,10 @@ export const httpNextEvent = functions.https.onRequest(async (request, response)
     timestampSeconds = parseInt(String(request.query[TIMESTAMP_SECONDS_PARAM_KEY]));
   }
   try {
-    const oldEvent = await SensorEventDatabase.get(buildTimestamp);
+    const oldEvent = await SensorEventDatabase.getCurrent(buildTimestamp);
     const newEvent = getNewEventOrNull(oldEvent, sensorSnapshot, timestampSeconds);
     if (newEvent !== null) {
-      await SensorEventDatabase.set(buildTimestamp, newEvent);
+      await SensorEventDatabase.save(buildTimestamp, newEvent);
     }
     data[OLD_EVENT_KEY] = oldEvent;
     data[NEW_EVENT_KEY] = newEvent;

--- a/FirebaseServer/test/controller/SnoozeNotificationsTest.ts
+++ b/FirebaseServer/test/controller/SnoozeNotificationsTest.ts
@@ -29,7 +29,7 @@ describe('SnoozeNotifications', () => {
 
   describe('getSnoozeStatus', () => {
     it('should return NONE when there is no current event', async () => {
-      sinon.stub(SensorEventDatabase, 'get').resolves(null);
+      sinon.stub(SensorEventDatabase, 'getCurrent').resolves(null);
       const params = { buildTimestamp: 'test' };
       const result = await getSnoozeStatus(params);
       expect(result.status).to.equal(SnoozeStatus.NONE);
@@ -37,7 +37,7 @@ describe('SnoozeNotifications', () => {
 
     it('should return NONE when there is no snooze request', async () => {
       const currentEvent = { currentEvent: { timestampSeconds: '12345' } };
-      sinon.stub(SensorEventDatabase, 'get').resolves(currentEvent);
+      sinon.stub(SensorEventDatabase, 'getCurrent').resolves(currentEvent);
       sinon.stub(SnoozeNotificationsDatabase, 'get').resolves(null);
       const params = { buildTimestamp: 'test' };
       const result = await getSnoozeStatus(params);
@@ -50,7 +50,7 @@ describe('SnoozeNotifications', () => {
         snoozeEndTimeSeconds: Math.floor(Date.now() / 1000) - 3600, // 1 hour ago
         currentEventTimestampSeconds: 12345,
       };
-      sinon.stub(SensorEventDatabase, 'get').resolves(currentEvent);
+      sinon.stub(SensorEventDatabase, 'getCurrent').resolves(currentEvent);
       sinon.stub(SnoozeNotificationsDatabase, 'get').resolves(snoozeRequest);
       const params = { buildTimestamp: 'test' };
       const result = await getSnoozeStatus(params);
@@ -63,7 +63,7 @@ describe('SnoozeNotifications', () => {
         snoozeEndTimeSeconds: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now
         currentEventTimestampSeconds: 12345,
       };
-      sinon.stub(SensorEventDatabase, 'get').resolves(currentEvent);
+      sinon.stub(SensorEventDatabase, 'getCurrent').resolves(currentEvent);
       sinon.stub(SnoozeNotificationsDatabase, 'get').resolves(snoozeRequest);
       const params = { buildTimestamp: 'test' };
       const result = await getSnoozeStatus(params);
@@ -74,7 +74,7 @@ describe('SnoozeNotifications', () => {
   describe('submitSnoozeNotificationsRequest', () => {
     it('should return an error when the snooze event timestamp does not match the current event timestamp', async () => {
       const currentEvent = { currentEvent: { timestampSeconds: '12345' } };
-      sinon.stub(SensorEventDatabase, 'get').resolves(currentEvent);
+      sinon.stub(SensorEventDatabase, 'getCurrent').resolves(currentEvent);
       const params = {
         buildTimestamp: 'test',
         snoozeDuration: '1h',
@@ -87,7 +87,7 @@ describe('SnoozeNotifications', () => {
 
     it('should return an error for an invalid snooze duration', async () => {
       const currentEvent = { currentEvent: { timestampSeconds: '12345' } };
-      sinon.stub(SensorEventDatabase, 'get').resolves(currentEvent);
+      sinon.stub(SensorEventDatabase, 'getCurrent').resolves(currentEvent);
       const params = {
         buildTimestamp: 'test',
         snoozeDuration: 'invalid',
@@ -104,7 +104,7 @@ describe('SnoozeNotifications', () => {
         snoozeEndTimeSeconds: Math.floor(Date.now() / 1000) + 3600,
         currentEventTimestampSeconds: 12345,
       };
-      sinon.stub(SensorEventDatabase, 'get').resolves(currentEvent);
+      sinon.stub(SensorEventDatabase, 'getCurrent').resolves(currentEvent);
       sinon.stub(SnoozeNotificationsDatabase, 'set').resolves();
       sinon.stub(SnoozeNotificationsDatabase, 'get').resolves(snoozeRequest);
       const params = {

--- a/FirebaseServer/test/database/SensorEventDatabaseTest.ts
+++ b/FirebaseServer/test/database/SensorEventDatabaseTest.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { expect } from 'chai';
+import {
+  COLLECTION_CURRENT,
+  COLLECTION_ALL,
+} from '../../src/database/SensorEventDatabase';
+
+describe('SensorEventDatabase: collection-name contract', () => {
+  // These strings MUST match what pubsub/OpenDoor.ts, http/OpenDoor.ts,
+  // controller/EventUpdates.ts, and controller/DatabaseCleaner.ts wrote
+  // before centralization. A mismatch means new code writes to a different
+  // Firestore collection than existing production data — the app appears
+  // to work while historical door-event data becomes unreachable.
+  //
+  // firestore.rules and firestore.indexes.json also reference these strings;
+  // both must stay in sync with this contract test.
+  //
+  // Intentional change requires a full data migration:
+  //   1. Copy documents from old collection to new in production.
+  //   2. Update this test.
+  //   3. Update the data-retention cron.
+  //   4. Update firestore.rules and firestore.indexes.json.
+  //   5. Deploy atomically.
+
+  it('current collection is pinned', () => {
+    expect(COLLECTION_CURRENT).to.equal('eventsCurrent');
+  });
+
+  it('all collection is pinned', () => {
+    expect(COLLECTION_ALL).to.equal('eventsAll');
+  });
+});

--- a/FirebaseServer/test/fakes/FakeSensorEventDatabase.ts
+++ b/FirebaseServer/test/fakes/FakeSensorEventDatabase.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { SensorEventDatabase } from '../../src/database/SensorEventDatabase';
+
+export class FakeSensorEventDatabase implements SensorEventDatabase {
+  private readonly store = new Map<string, any>();
+
+  /** Audit log of all save() calls. */
+  readonly saved: Array<[string, any]> = [];
+
+  /** Audit log of all updateCurrentWithMatchingCurrentEventTimestamp() calls. */
+  readonly updates: Array<[string, any]> = [];
+
+  /** Audit log of all deleteAllBefore() calls. */
+  readonly deleteCalls: Array<{ cutoff: number, dryRun: boolean }> = [];
+
+  async save(buildTimestamp: string, data: any): Promise<void> {
+    this.store.set(buildTimestamp, data);
+    this.saved.push([buildTimestamp, data]);
+  }
+
+  async getCurrent(buildTimestamp: string): Promise<any> {
+    return this.store.get(buildTimestamp) ?? null;
+  }
+
+  async updateCurrentWithMatchingCurrentEventTimestamp(buildTimestamp: string, matchingCurrent: any): Promise<any> {
+    this.updates.push([buildTimestamp, matchingCurrent]);
+    this.store.set(buildTimestamp, matchingCurrent);
+    return null;
+  }
+
+  async deleteAllBefore(cutoffTimestampSeconds: number, dryRun: boolean): Promise<number> {
+    this.deleteCalls.push({ cutoff: cutoffTimestampSeconds, dryRun });
+    return 0;
+  }
+
+  async getLatestN(_n: number): Promise<any> {
+    // Tests that need richer history semantics should override this.
+    return [];
+  }
+
+  async getRecentForBuildTimestamp(_buildTimestamp: string, _n: number): Promise<any> {
+    return [];
+  }
+
+  /** Test-only helper: pre-populate storage without recording in saved[]. */
+  seed(buildTimestamp: string, data: any): void {
+    this.store.set(buildTimestamp, data);
+  }
+
+  /** Test-only helper: wipe storage and audit logs. */
+  clear(): void {
+    this.store.clear();
+    this.saved.length = 0;
+    this.updates.length = 0;
+    this.deleteCalls.length = 0;
+  }
+}


### PR DESCRIPTION
## Summary

Step 1 of the \`eventsCurrent\`/\`eventsAll\` consolidation (database refactor Phase 2). **Zero Firestore behavior change.** Same collection strings, same document shapes — pinned by a new contract test.

## Changes

- \`FirebaseServer/src/database/SensorEventDatabase.ts\` rewritten to the Phase 1a shape:
  - Interface \`SensorEventDatabase\` with every method used by any caller
  - \`FirestoreSensorEventDatabase\` implementation wrapping \`TimeSeriesDatabase\`
  - Module-level \`DATABASE\` singleton delegating to a swappable \`_instance\`
  - \`setImpl(fake)\` / \`resetImpl()\` for tests
- Method names now match \`TimeSeriesDatabase\` (\`save\`, \`getCurrent\`) so step 2 can migrate the 4 inline callers with no method-name churn
- Existing wrapper consumers updated to the renamed methods:
  - \`functions/http/Events.ts\` (3 calls)
  - \`controller/SnoozeNotifications.ts\` (2 calls)
  - \`test/controller/SnoozeNotificationsTest.ts\` (7 sinon stubs renamed to match)

## New

- \`test/fakes/FakeSensorEventDatabase.ts\` — in-memory fake
- \`test/database/SensorEventDatabaseTest.ts\` — pins \`COLLECTION_CURRENT='eventsCurrent'\` and \`COLLECTION_ALL='eventsAll'\` against accidental rename

## Safety — "we cannot change what Firebase sees"

| Concern | Check |
|---|---|
| Collection names | Identical strings; contract test pins them |
| Document shapes | All methods delegate to \`TimeSeriesDatabase\` with identical args |
| Firestore rules | \`firestore.rules\` untouched |
| Firestore indexes | \`firestore.indexes.json\` untouched |
| Production data | Not touched |

## Verification

- \`./scripts/validate-firebase.sh\` passes — **82 tests** (was 80; +2 new contract tests)
- Build + lint clean

## Follow-ups

- **Step 2** (next PR): migrate the 4 inline callers (\`pubsub/OpenDoor\`, \`http/OpenDoor\`, \`EventUpdates\`, \`DatabaseCleaner\`) to use \`DATABASE\`. Pure import/variable rename; method names already match.
- **Step 3** (optional): rewrite \`EventUpdatesTest\` to use \`FakeSensorEventDatabase\` + \`setImpl\` instead of \`sinon.stub(TimeSeriesDatabase.prototype, ...)\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)