### PR TITLE
ci: Prefix caller jobs with Android / Firebase for clarity

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   changes:
-    name: Detect Changes
+    name: Android Detect Changes
     runs-on: ubuntu-latest
     outputs:
       android: ${{ steps.filter.outputs.android }}
@@ -63,7 +63,7 @@ jobs:
 
   # Shared checks (same as PR CI)
   checks:
-    name: Checks
+    name: Android Checks
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
     uses: ./.github/workflows/ci-checks.yml
@@ -78,7 +78,7 @@ jobs:
 
   # Instrumented tests — post-merge only
   instrumented-tests:
-    name: Instrumented Tests
+    name: Android Instrumented Tests
     needs: changes
     if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   changes:
-    name: Detect Changes
+    name: Android Detect Changes
     runs-on: ubuntu-latest
     outputs:
       android: ${{ steps.filter.outputs.android }}
@@ -65,7 +65,7 @@ jobs:
           fi
 
   checks:
-    name: Checks
+    name: Android Checks
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
     uses: ./.github/workflows/ci-checks.yml

--- a/.github/workflows/firebase-ci-post-merge.yml
+++ b/.github/workflows/firebase-ci-post-merge.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   changes:
-    name: Detect Changes
+    name: Firebase Detect Changes
     runs-on: ubuntu-latest
     outputs:
       firebase: ${{ steps.filter.outputs.firebase }}
@@ -62,7 +62,7 @@ jobs:
 
   # Shared checks (same as PR CI)
   checks:
-    name: Checks
+    name: Firebase Checks
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
     uses: ./.github/workflows/firebase-ci-checks.yml

--- a/.github/workflows/firebase-ci.yml
+++ b/.github/workflows/firebase-ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   changes:
-    name: Detect Changes
+    name: Firebase Detect Changes
     runs-on: ubuntu-latest
     outputs:
       firebase: ${{ steps.filter.outputs.firebase }}
@@ -62,7 +62,7 @@ jobs:
           fi
 
   checks:
-    name: Checks
+    name: Firebase Checks
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
     uses: ./.github/workflows/firebase-ci-checks.yml


### PR DESCRIPTION
## Summary

Disambiguates CI check names in the PR UI. Job names from a reusable workflow appear as \`<caller job name> / <called job name>\`. Currently both pipelines have a caller named \`Checks\`, so the same-named inner jobs collide — e.g. \`Checks / Unit Tests\` could be Android or Firebase. Prefixing the caller solves it at the top of the hierarchy.

## Before

\`\`\`
Checks / Build Debug APK
Checks / Emulator Smoke Test
Checks / FCM Contract Tests
Checks / Formatting & Static Analysis
Checks / Run Unit Tests         ← Firebase (only distinguished by the "Run" prefix)
Checks / Unit Tests             ← Android
Detect Changes                  ← appears twice, indistinguishable
Detect Changes
\`\`\`

## After

\`\`\`
Android Checks / Build Debug APK
Android Checks / FCM Contract Tests
Android Checks / Formatting & Static Analysis
Android Checks / Unit Tests
Android Detect Changes
Firebase Checks / Emulator Smoke Test
Firebase Checks / Run Unit Tests
Firebase Detect Changes
\`\`\`

Post-merge CI picks up the same pattern — \`Instrumented Tests\` becomes \`Android Instrumented Tests\`.

## Not in this PR

- **Gate-job renames** (\`CI Complete\` → \`Android CI Complete\`, etc.) — those touch branch protection and need a careful rollout (add-new-then-drop-old).
- **Reusable-workflow internal job renames** (Firebase \`Run Unit Tests\` → \`Unit Tests\`) — would require updating the \`endswith\` grep in \`firebase-deploy.yml\` and \`release-firebase.sh\`. Easier as a separate PR once this caller prefix is live (the grep can then match \`Firebase Checks / Unit Tests\`).

## Verification

- Pre-merge CI runs on this PR, exercises all renamed jobs
- No functional change — only display names in the UI
- No branch protection impact (gate jobs unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)