### PR TITLE
ci: Rename Firebase unit-test job to match Android naming

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   changes:
-    name: Detect Changes
+    name: Android Detect Changes
     runs-on: ubuntu-latest
     outputs:
       android: ${{ steps.filter.outputs.android }}
@@ -63,7 +63,7 @@ jobs:
 
   # Shared checks (same as PR CI)
   checks:
-    name: Checks
+    name: Android Checks
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
     uses: ./.github/workflows/ci-checks.yml
@@ -78,7 +78,7 @@ jobs:
 
   # Instrumented tests — post-merge only
   instrumented-tests:
-    name: Instrumented Tests
+    name: Android Instrumented Tests
     needs: changes
     if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   changes:
-    name: Detect Changes
+    name: Android Detect Changes
     runs-on: ubuntu-latest
     outputs:
       android: ${{ steps.filter.outputs.android }}
@@ -65,7 +65,7 @@ jobs:
           fi
 
   checks:
-    name: Checks
+    name: Android Checks
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
     uses: ./.github/workflows/ci-checks.yml

--- a/.github/workflows/firebase-ci-checks.yml
+++ b/.github/workflows/firebase-ci-checks.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   test:
-    name: Run Unit Tests
+    name: Unit Tests
     if: inputs.firebase == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/firebase-ci-post-merge.yml
+++ b/.github/workflows/firebase-ci-post-merge.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   changes:
-    name: Detect Changes
+    name: Firebase Detect Changes
     runs-on: ubuntu-latest
     outputs:
       firebase: ${{ steps.filter.outputs.firebase }}
@@ -62,7 +62,7 @@ jobs:
 
   # Shared checks (same as PR CI)
   checks:
-    name: Checks
+    name: Firebase Checks
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
     uses: ./.github/workflows/firebase-ci-checks.yml

--- a/.github/workflows/firebase-ci.yml
+++ b/.github/workflows/firebase-ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   changes:
-    name: Detect Changes
+    name: Firebase Detect Changes
     runs-on: ubuntu-latest
     outputs:
       firebase: ${{ steps.filter.outputs.firebase }}
@@ -62,7 +62,7 @@ jobs:
           fi
 
   checks:
-    name: Checks
+    name: Firebase Checks
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
     uses: ./.github/workflows/firebase-ci-checks.yml

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -18,10 +18,11 @@ jobs:
           TAG_SHA="${GITHUB_SHA}"
           echo "Checking Firebase CI status for commit $TAG_SHA..."
 
-          # Match "Run Unit Tests" whether it comes from the inline job (legacy) or
-          # the reusable workflow (prefixed as "<caller-job> / Run Unit Tests").
+          # The Firebase unit test job appears as "Firebase Checks / Unit Tests"
+          # when run via the reusable workflow from firebase-ci.yml. We match
+          # exactly to disambiguate from the Android "Unit Tests" job.
           TESTS_CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/$TAG_SHA/check-runs" \
-            --jq '[.check_runs[] | select((.name | endswith("Run Unit Tests")) and .app.slug == "github-actions")] | last | .conclusion')
+            --jq '[.check_runs[] | select(.name == "Firebase Checks / Unit Tests" and .app.slug == "github-actions")] | last | .conclusion')
 
           echo "Firebase Tests: $TESTS_CONCLUSION"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ Run `./scripts/run-instrumented-tests.sh` when changing Room entities/DAOs, DI w
 **Firebase** (mirrors Android):
 - **Pre-submit** (`firebase-ci.yml` → `firebase-ci-checks.yml`): Runs on PRs. Gate job `Firebase CI Complete` is the required status check.
 - **Post-merge** (`firebase-ci-post-merge.yml` → `firebase-ci-checks.yml`): Runs on push to main. Auto-creates GitHub issue on failure (`ci-failure/firebase-post-merge`), auto-closes on fix.
-- The `firebase-deploy.yml` `verify-ci` step matches the `Run Unit Tests` check-run via `endswith(...)`, so it works whether the check comes from the inline name or the reusable-workflow-prefixed name.
+- The `firebase-deploy.yml` `verify-ci` step matches the check-run named `Firebase Checks / Unit Tests` exactly. That's the name produced by the reusable workflow when called via the `Firebase Checks` caller job (see `firebase-ci.yml`).
 
 **Docs-only fast path (Android + Firebase):**
 - When every changed file matches `**/*.md`, `docs/**`, `.claude/**`, `LICENSE`, `.gitignore`, or `AndroidGarage/distribution/whatsnew/**`, the `checks` reusable workflow is skipped and the gate jobs post success in ~20–30s.

--- a/scripts/release-firebase.sh
+++ b/scripts/release-firebase.sh
@@ -215,7 +215,7 @@ fi
 # worth knowing about even if the local marker is green.
 check_remote_ci() {
     gh api "repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/commits/$TARGET_COMMIT/check-runs" \
-        --jq '[.check_runs[] | select(.name == "Run Unit Tests" and .check_suite.conclusion != null)] | last | .conclusion' 2>/dev/null || echo ""
+        --jq '[.check_runs[] | select(.name == "Firebase Checks / Unit Tests" and .check_suite.conclusion != null)] | last | .conclusion' 2>/dev/null || echo ""
 }
 
 # Rollback detection.


### PR DESCRIPTION
## Merge order

This is PR 2 of 2 in the CI naming cleanup stack.

⚠️ **Merge AFTER #466.** This PR depends on the \`Firebase Checks\` caller prefix that #466 establishes.

## Summary

Drops the "Run" verb from the Firebase unit-test job name so both pipelines match: \`Unit Tests\` everywhere, platform distinction coming from the caller prefix that #466 adds.

Before (on main today):
- \`Firebase Checks / Run Unit Tests\`
- \`Android Checks / Unit Tests\`

After:
- \`Firebase Checks / Unit Tests\`
- \`Android Checks / Unit Tests\`

## Why the grep changes

The \`firebase-deploy.yml\` \`verify-ci\` step currently uses \`endswith("Run Unit Tests")\`. Once the "Run" is dropped, \`endswith("Unit Tests")\` would match BOTH pipelines' unit-test jobs — including the Android one, which would give false-positive matches.

Fix: replace with an **exact** match on \`"Firebase Checks / Unit Tests"\`. Exact match is unambiguous and more robust than the old endswith, which was only working because of the accidental "Run" prefix.

Same update in \`scripts/release-firebase.sh\` → \`check_remote_ci()\`.

## Changes

- \`firebase-ci-checks.yml\`: job \`Run Unit Tests\` → \`Unit Tests\`
- \`firebase-deploy.yml\`: \`endswith("Run Unit Tests")\` → exact \`== "Firebase Checks / Unit Tests"\`
- \`scripts/release-firebase.sh\`: same in \`check_remote_ci()\`
- \`CLAUDE.md\`: doc note updated

## Verification

- Local validation passes (82 tests)
- Pre-merge CI on this PR exercises the renamed job
- The real test is the next Firebase release cutting after merge — \`firebase-deploy.yml\`'s \`verify-ci\` will try the new exact match

## Part of CI naming cleanup

1. #466 — prefix caller jobs (\`Checks\` → \`Android Checks\` / \`Firebase Checks\`, etc.)
2. **This PR** — rename \`Run Unit Tests\` → \`Unit Tests\`
3. (Future) — rename gate jobs (\`CI Complete\` → \`Android CI Complete\` etc.), needs branch-protection dance

🤖 Generated with [Claude Code](https://claude.com/claude-code)