### PR TITLE
refactor: Phase 2 step 2 — migrate inline eventsCurrent callers to SensorEventDatabase

### DIFF
--- a/FirebaseServer/src/controller/DatabaseCleaner.ts
+++ b/FirebaseServer/src/controller/DatabaseCleaner.ts
@@ -17,11 +17,13 @@
 import { Config } from '../database/ServerConfigDatabase';
 
 import { TimeSeriesDatabase } from '../database/TimeSeriesDatabase';
+import { DATABASE as SensorEventDatabase } from '../database/SensorEventDatabase';
 import { DATABASE as REMOTE_REQUEST_DATABASE } from '../database/RemoteButtonRequestDatabase';
 import { DATABASE as REMOTE_COMMAND_DATABASE } from '../database/RemoteButtonCommandDatabase';
 
+// Phase 3 will centralize the 'updateCurrent'/'updateAll' collection into its
+// own database module. For now this remains an inline TimeSeriesDatabase.
 const UPDATE_DATABASE = new TimeSeriesDatabase('updateCurrent', 'updateAll');
-const EVENT_DATABASE = new TimeSeriesDatabase('eventsCurrent', 'eventsAll');
 
 export async function deleteOldData(cutoffTimestampSeconds: number, dryRunRequested: boolean): Promise<object> {
   const config = await Config.get();
@@ -43,7 +45,7 @@ export async function deleteOldData(cutoffTimestampSeconds: number, dryRunReques
     console.log('deleteOldData: Deleting data!');
   }
   const updateCount = await UPDATE_DATABASE.deleteAllBefore(cutoffTimestampSeconds, dryRun);
-  const eventCount = await EVENT_DATABASE.deleteAllBefore(cutoffTimestampSeconds, dryRun);
+  const eventCount = await SensorEventDatabase.deleteAllBefore(cutoffTimestampSeconds, dryRun);
   const requestCount = await REMOTE_REQUEST_DATABASE.deleteAllBefore(cutoffTimestampSeconds, dryRun);
   const commandCount = await REMOTE_COMMAND_DATABASE.deleteAllBefore(cutoffTimestampSeconds, dryRun);
   const summary = {

--- a/FirebaseServer/src/controller/EventUpdates.ts
+++ b/FirebaseServer/src/controller/EventUpdates.ts
@@ -16,7 +16,7 @@
 
 import * as firebase from 'firebase-admin';
 
-import { TimeSeriesDatabase } from '../database/TimeSeriesDatabase';
+import { DATABASE as SensorEventDatabase } from '../database/SensorEventDatabase';
 
 import { SensorSnapshot } from '../model/SensorSnapshot';
 
@@ -31,8 +31,6 @@ const SENSOR_A_KEY = 'sensorA';
 const SENSOR_B_KEY = 'sensorB';
 const CURRENT_EVENT_KEY = 'currentEvent';
 const PREVIOUS_EVENT_KEY = 'previousEvent';
-
-const EVENT_DATABASE = new TimeSeriesDatabase('eventsCurrent', 'eventsAll');
 
 export async function updateEvent(data, scheduledJob: boolean) {
   if (!data || !(BUILD_TIMESTAMP_PARAM_KEY in data)) {
@@ -68,7 +66,7 @@ export async function updateEvent(data, scheduledJob: boolean) {
 }
 
 async function updateWithParams(buildTimestamp, sensorSnapshot, timestampSeconds, scheduledJob: boolean) {
-  const oldData = await EVENT_DATABASE.getCurrent(buildTimestamp);
+  const oldData = await SensorEventDatabase.getCurrent(buildTimestamp);
   let oldEvent: SensorEvent = null;
   if (CURRENT_EVENT_KEY in oldData) {
     oldEvent = oldData[CURRENT_EVENT_KEY];
@@ -79,7 +77,7 @@ async function updateWithParams(buildTimestamp, sensorSnapshot, timestampSeconds
     data[BUILD_TIMESTAMP_PARAM_KEY] = buildTimestamp;
     data[PREVIOUS_EVENT_KEY] = oldEvent;
     data[CURRENT_EVENT_KEY] = newEvent;
-    await EVENT_DATABASE.save(buildTimestamp, data);
+    await SensorEventDatabase.save(buildTimestamp, data);
     await sendFCMForSensorEvent(buildTimestamp, newEvent);
   } else {
     if (scheduledJob) {
@@ -88,7 +86,7 @@ async function updateWithParams(buildTimestamp, sensorSnapshot, timestampSeconds
       // Update the old data with the current timestamp "check in" time.
       oldEvent.checkInTimestampSeconds = timestampSeconds;
       // Saving the old data again will update FIRESTORE_databaseTimestamp and FIRESTORE_databaseTimestampSeconds.
-      await EVENT_DATABASE.updateCurrentWithMatchingCurrentEventTimestamp(buildTimestamp, oldData);
+      await SensorEventDatabase.updateCurrentWithMatchingCurrentEventTimestamp(buildTimestamp, oldData);
       // Send old event with updated check-in timestamp.
       await sendFCMForSensorEvent(buildTimestamp, oldEvent);
     }

--- a/FirebaseServer/src/functions/http/OpenDoor.ts
+++ b/FirebaseServer/src/functions/http/OpenDoor.ts
@@ -17,13 +17,11 @@
 import * as functions from 'firebase-functions/v1';
 
 import { sendFCMForOldData } from '../../controller/fcm/OldDataFCM';
-import { TimeSeriesDatabase } from '../../database/TimeSeriesDatabase';
-
-const EVENT_DATABASE = new TimeSeriesDatabase('eventsCurrent', 'eventsAll');
+import { DATABASE as SensorEventDatabase } from '../../database/SensorEventDatabase';
 
 export const httpCheckForOpenDoors = functions.https.onRequest(async (request, response) => {
   const buildTimestamp = 'Sat Mar 13 14:45:00 2021'; // TODO: Use config.
-  const eventData = await EVENT_DATABASE.getCurrent(buildTimestamp);
+  const eventData = await SensorEventDatabase.getCurrent(buildTimestamp);
   const result = await sendFCMForOldData(buildTimestamp, eventData);
   response.status(200).send(result);
 });

--- a/FirebaseServer/src/functions/pubsub/OpenDoor.ts
+++ b/FirebaseServer/src/functions/pubsub/OpenDoor.ts
@@ -17,14 +17,12 @@
 import * as functions from 'firebase-functions/v1';
 
 import { sendFCMForOldData } from '../../controller/fcm/OldDataFCM';
-import { TimeSeriesDatabase } from '../../database/TimeSeriesDatabase';
-
-const EVENT_DATABASE = new TimeSeriesDatabase('eventsCurrent', 'eventsAll');
+import { DATABASE as SensorEventDatabase } from '../../database/SensorEventDatabase';
 
 // TODO: Add Snooze option to delay notifications.
 export const pubsubCheckForOpenDoorsJob = functions.pubsub.schedule('every 5 minutes').onRun(async (_context) => {
   const buildTimestamp = 'Sat Mar 13 14:45:00 2021'; // TODO: Use config.
-  const eventData = await EVENT_DATABASE.getCurrent(buildTimestamp);
+  const eventData = await SensorEventDatabase.getCurrent(buildTimestamp);
   await sendFCMForOldData(buildTimestamp, eventData);
   return null;
 });


### PR DESCRIPTION
## Summary

Completes Phase 2 of the database refactor by migrating the 4 remaining inline \`new TimeSeriesDatabase('eventsCurrent', 'eventsAll')\` callers to use the centralized \`SensorEventDatabase\` module from step 1 (#465).

**Zero Firestore behavior change.** All methods delegate to a \`TimeSeriesDatabase\` instance constructed from the pinned collection strings — verified by the existing collection-name contract test.

## Changes

| File | Before | After |
|---|---|---|
| \`src/functions/pubsub/OpenDoor.ts\` | \`EVENT_DATABASE.getCurrent(...)\` | \`SensorEventDatabase.getCurrent(...)\` |
| \`src/functions/http/OpenDoor.ts\` | \`EVENT_DATABASE.getCurrent(...)\` | \`SensorEventDatabase.getCurrent(...)\` |
| \`src/controller/EventUpdates.ts\` | 3 calls (getCurrent, save, updateCurrentWithMatchingCurrentEventTimestamp) | All via \`SensorEventDatabase\` |
| \`src/controller/DatabaseCleaner.ts\` | \`EVENT_DATABASE.deleteAllBefore(...)\` | \`SensorEventDatabase.deleteAllBefore(...)\` |

No method-name changes — step 1 (#465) already renamed the wrapper's methods to match \`TimeSeriesDatabase\` (\`save\`, \`getCurrent\`, etc.) for exactly this reason.

## Remaining inline TimeSeriesDatabase

\`DatabaseCleaner.ts\` still has one inline \`new TimeSeriesDatabase('updateCurrent', 'updateAll')\` — that's Phase 3's target. Added an inline comment pointing at it.

## Safety

| Concern | Check |
|---|---|
| Collection names | Unchanged — \`SensorEventDatabase\` uses \`'eventsCurrent'\` / \`'eventsAll'\`, pinned by contract test |
| Document shapes | Unchanged — wrapper forwards args byte-identically |
| \`firestore.rules\` | Untouched |
| \`firestore.indexes.json\` | Untouched |

## Verification

- \`./scripts/validate-firebase.sh\` passes (82 tests)
- \`grep -rn "new TimeSeriesDatabase('eventsCurrent'"\` returns zero results in \`src/\`
- \`grep -rn "EVENT_DATABASE"\` returns zero results in \`src/\`

## Part of database refactor Phase 2

1. ✅ #465 — SensorEventDatabase interface + fake + contract test
2. **This PR** — migrate the 4 inline callers
3. (Optional) — rewrite \`EventUpdatesTest\` from \`sinon.stub(TimeSeriesDatabase.prototype, ...)\` to use \`FakeSensorEventDatabase\` via \`setImpl\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)