### PR TITLE
docs: Changelog for server/11

### DIFF
--- a/FirebaseServer/CHANGELOG.md
+++ b/FirebaseServer/CHANGELOG.md
@@ -24,6 +24,12 @@ Example:
 
 ---
 
+## server/11
+- Release with no behavior changes. Internal refactor only — no Firestore collection or document-shape change.
+- Database refactor Phase 2: centralized the `eventsCurrent` / `eventsAll` callers onto `SensorEventDatabase` (interface + in-memory fake + contract-pinned collection names). Four inline `new TimeSeriesDatabase('eventsCurrent', ...)` call sites removed.
+- First release to exercise the new CHANGELOG gate in `release-firebase.sh` and the exact-match `Firebase Checks / Unit Tests` verifier in `firebase-deploy.yml`.
+- CI job naming standardized: `Android Checks` / `Firebase Checks` caller prefixes, plus `Run Unit Tests` renamed to `Unit Tests` on the Firebase side.
+
 ## server/10
 - Bump Firebase Functions runtime to Node 22 (production). Local dev + CI also moved to Node 22.
 


### PR DESCRIPTION
## Summary

Adds the \`## server/11\` entry to \`FirebaseServer/CHANGELOG.md\` required by the new release-script gate.

Release with no behavior changes — covers the internal DB refactor (Phase 2), CI plumbing standardization, and the CHANGELOG gate / \`Firebase Checks / Unit Tests\` verifier introductions.

After this merges, cut \`server/11\` to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)