### PR TITLE
test: Add fake-based EventUpdatesFakeTest alongside existing sinon tests

### DIFF
--- a/FirebaseServer/test/controller/EventUpdatesFakeTest.ts
+++ b/FirebaseServer/test/controller/EventUpdatesFakeTest.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Parallel test file for src/controller/EventUpdates.ts that uses
+ * FakeSensorEventDatabase (via SensorEventDatabase.setImpl) instead of
+ * sinon.stub(TimeSeriesDatabase.prototype, ...). Runs alongside
+ * EventUpdatesTest.ts — if both pass, we have independent verification
+ * that the production code works regardless of test-double strategy.
+ *
+ * The old file will be deleted in a follow-up once these tests are trusted.
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+import { updateEvent } from '../../src/controller/EventUpdates';
+import { setImpl, resetImpl } from '../../src/database/SensorEventDatabase';
+import { FakeSensorEventDatabase } from '../fakes/FakeSensorEventDatabase';
+import * as EventInterpreter from '../../src/controller/EventInterpreter';
+import * as EventFCM from '../../src/controller/fcm/EventFCM';
+import { SensorEvent, SensorEventType } from '../../src/model/SensorEvent';
+
+describe('EventUpdates (via FakeSensorEventDatabase)', () => {
+  let fakeDB: FakeSensorEventDatabase;
+
+  beforeEach(() => {
+    fakeDB = new FakeSensorEventDatabase();
+    setImpl(fakeDB);
+  });
+
+  afterEach(() => {
+    resetImpl();
+    sinon.restore();
+  });
+
+  it('should do nothing if buildTimestamp is missing', async () => {
+    const consoleLogSpy = sinon.spy(console, 'log');
+    await updateEvent({}, false);
+    expect(consoleLogSpy.calledWith(
+      'scheduledJob:', false,
+      'Skipping updateEvent() because data does not have buildTimestamp', {})).to.be.true;
+    expect(fakeDB.saved).to.be.empty;
+    expect(fakeDB.updates).to.be.empty;
+  });
+
+  it('should create a new event if there is no previous event', async () => {
+    const newEvent: SensorEvent = {
+      type: SensorEventType.Closed, timestampSeconds: 12345, message: '', checkInTimestampSeconds: 0,
+    };
+    sinon.stub(EventFCM, 'sendFCMForSensorEvent').resolves();
+    sinon.stub(EventInterpreter, 'getNewEventOrNull').returns(newEvent);
+
+    await updateEvent({ buildTimestamp: 'test' }, false);
+
+    expect(fakeDB.saved).to.have.length(1);
+    expect(fakeDB.saved[0][0]).to.equal('test');
+    expect(fakeDB.saved[0][1].currentEvent).to.equal(newEvent);
+    expect(fakeDB.updates).to.be.empty;
+  });
+
+  it('should update the check-in time if the event has not changed', async () => {
+    const oldEvent: SensorEvent = {
+      type: SensorEventType.Closed, timestampSeconds: 12345, message: '', checkInTimestampSeconds: 0,
+    };
+    fakeDB.seed('test', { currentEvent: oldEvent });
+    sinon.stub(EventFCM, 'sendFCMForSensorEvent').resolves();
+    sinon.stub(EventInterpreter, 'getNewEventOrNull').returns(null);
+
+    await updateEvent({ buildTimestamp: 'test' }, false);
+
+    expect(fakeDB.updates).to.have.length(1);
+    expect(fakeDB.updates[0][0]).to.equal('test');
+    // The seeded currentEvent object gets its checkInTimestampSeconds
+    // mutated in place and written back via updateCurrent...().
+    expect(fakeDB.updates[0][1].currentEvent).to.equal(oldEvent);
+    expect(fakeDB.saved).to.be.empty;
+  });
+
+  it('should create a new event if the event has changed', async () => {
+    const oldEvent: SensorEvent = {
+      type: SensorEventType.Closed, timestampSeconds: 12345, message: '', checkInTimestampSeconds: 0,
+    };
+    const newEvent: SensorEvent = {
+      type: SensorEventType.Open, timestampSeconds: 54321, message: '', checkInTimestampSeconds: 0,
+    };
+    fakeDB.seed('test', { currentEvent: oldEvent });
+    sinon.stub(EventFCM, 'sendFCMForSensorEvent').resolves();
+    sinon.stub(EventInterpreter, 'getNewEventOrNull').returns(newEvent);
+
+    await updateEvent({ buildTimestamp: 'test' }, false);
+
+    expect(fakeDB.saved).to.have.length(1);
+    expect(fakeDB.saved[0][0]).to.equal('test');
+    expect(fakeDB.saved[0][1].currentEvent).to.equal(newEvent);
+    expect(fakeDB.saved[0][1].previousEvent).to.equal(oldEvent);
+    expect(fakeDB.updates).to.be.empty;
+  });
+});

--- a/FirebaseServer/test/fakes/FakeSensorEventDatabase.ts
+++ b/FirebaseServer/test/fakes/FakeSensorEventDatabase.ts
@@ -28,7 +28,11 @@ export class FakeSensorEventDatabase implements SensorEventDatabase {
   }
 
   async getCurrent(buildTimestamp: string): Promise<any> {
-    return this.store.get(buildTimestamp) ?? null;
+    // Match TimeSeriesDatabase.getCurrent, which routes through
+    // convertFromFirestore() and always returns {} for missing documents.
+    // Returning null here would diverge from production and break callers
+    // that use `KEY in oldData` guards without null-checks.
+    return this.store.get(buildTimestamp) ?? {};
   }
 
   async updateCurrentWithMatchingCurrentEventTimestamp(buildTimestamp: string, matchingCurrent: any): Promise<any> {


### PR DESCRIPTION
## Summary

Adds parallel test coverage for \`updateEvent\` using \`FakeSensorEventDatabase\` via \`SensorEventDatabase.setImpl\`. The existing \`EventUpdatesTest.ts\` (sinon-based) is **untouched**. Both files run. If both pass, we have independent verification of the same production behavior.

## Why both

Deleting the old sinon-based tests while swapping in the fake approach is two moves in one: changing the test strategy AND reducing coverage count during the transition. Running both in parallel means the fake tests have to match the sinon tests' behavior before the old ones can be retired in a follow-up PR.

## Companion fix: FakeSensorEventDatabase returning \`{}\` for missing docs

Before this PR, the fake returned \`null\` for missing keys. Production \`TimeSeriesDatabase.getCurrent\` never returns null — it routes through \`convertFromFirestore()\` which produces \`{}\` for empty \`snap.data()\`. The divergence would have broken the "no previous event" scenario because \`EventUpdates\` does \`if (CURRENT_EVENT_KEY in oldData)\` without a null-check.

Fixed: fake now returns \`{}\` for missing entries, with a comment explaining the invariant.

## Tests added

Four scenarios mirroring the existing file:
- \`should do nothing if buildTimestamp is missing\`
- \`should create a new event if there is no previous event\`
- \`should update the check-in time if the event has not changed\`
- \`should create a new event if the event has changed\`

Assertions use \`fakeDB.saved\` and \`fakeDB.updates\` audit arrays instead of sinon \`.calledWith\`.

## Verification

- \`./scripts/validate-firebase.sh\` passes — **86 tests** (was 82; +4 new).

## Follow-up

Once trusted, delete \`EventUpdatesTest.ts\` (the sinon-based file) in a follow-up PR. Memory: the test style moves from \`sinon.stub(TimeSeriesDatabase.prototype, ...)\` toward fakes-at-the-interface-boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)