### PR TITLE
ci: Rename non-protected workflows and jobs for naming consistency

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -1,4 +1,4 @@
-name: Post-Merge CI
+name: Android Post-Merge CI
 
 # Post-submit checks — runs on push to main only.
 # Re-runs all shared checks (catches merge-induced breakage)
@@ -106,7 +106,7 @@ jobs:
 
   # Gate job — single check-run name for release script to verify.
   post-merge-complete:
-    name: Post-Merge Complete
+    name: Android Post-Merge Complete
     if: always()
     needs: [checks, instrumented-tests]
     runs-on: ubuntu-latest
@@ -128,7 +128,7 @@ jobs:
 
   # Track post-merge failures via a single GitHub issue
   track-failure:
-    name: Track Post-Merge Failure
+    name: Track Android Post-Merge Failure
     if: always() && needs.changes.outputs.android == 'true'
     needs: [changes, checks, instrumented-tests]
     runs-on: ubuntu-latest
@@ -150,4 +150,4 @@ jobs:
         with:
           label: ci-failure/post-merge
           result: ${{ steps.result.outputs.overall }}
-          workflow-name: "Post-Merge CI (checks: ${{ steps.result.outputs.checks }}, instrumented: ${{ steps.result.outputs.instrumented }})"
+          workflow-name: "Android Post-Merge CI (checks: ${{ steps.result.outputs.checks }}, instrumented: ${{ steps.result.outputs.instrumented }})"

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy Firebase Server
+name: Firebase Deploy
 
 # Triggered by server/N tags only — never on push to main.
 # To deploy: push a tag like server/1, server/2, etc.
@@ -9,7 +9,7 @@ on:
 
 jobs:
   verify-ci:
-    name: Verify Firebase CI Passed
+    name: Firebase Deploy Verify CI
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -36,7 +36,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
   deploy:
-    name: Deploy to Firebase
+    name: Firebase Deploy Run
     needs: verify-ci
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -1,4 +1,4 @@
-name: Release Android to Play Store (Internal)
+name: Android Release
 
 # Triggered by android/N tags pushed by scripts/release-android.sh
 # Deploys to internal track only — never production.
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   release:
-    name: Build and Deploy to Internal
+    name: Android Release Build and Deploy to Internal
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/AndroidGarage/docs/TESTING.md
+++ b/AndroidGarage/docs/TESTING.md
@@ -18,7 +18,7 @@
 - **14 shared fakes** in `test-common` module — one copy each, no duplicates across modules
 - **Zero Mockito** — all tests use fake implementations
 - **CI architecture:** pre-submit (`ci.yml` → `ci-checks.yml`) + post-merge (`ci-post-merge.yml` → `ci-checks.yml` + instrumented tests)
-- **CI gate jobs:** `CI Complete` (PRs), `Post-Merge Complete` (main) — single check-run names for branch protection and release script
+- **CI gate jobs:** `CI Complete` (PRs — branch-protection-required name, rename pending), `Android Post-Merge Complete` (main) — single check-run names for branch protection and release script
 - **CI checks:** unit tests (3 build variants), Spotless formatting (all modules), Detekt, Android Lint, screenshot test compilation, debug APK build, release AAB build
 - **CI path filtering:** Android CI skips for Firebase-only/docs-only changes, and vice versa
 - **CI failure tracking:** post-merge failures auto-create GitHub issues (`ci-failure/post-merge`), auto-close on fix, flakiness detection


### PR DESCRIPTION
## Summary

First of three PRs cleaning up remaining CI naming inconsistencies. **This PR touches only names that have NO branch-protection coupling,** so it's a normal merge.

## Renames

| File | Kind | Before | After |
|---|---|---|---|
| \`firebase-deploy.yml\` | workflow | \`Deploy Firebase Server\` | \`Firebase Deploy\` |
| \`firebase-deploy.yml\` | job | \`Verify Firebase CI Passed\` | \`Firebase Deploy Verify CI\` |
| \`firebase-deploy.yml\` | job | \`Deploy to Firebase\` | \`Firebase Deploy Run\` |
| \`release-android.yml\` | workflow | \`Release Android to Play Store (Internal)\` | \`Android Release\` |
| \`release-android.yml\` | job | \`Build and Deploy to Internal\` | \`Android Release Build and Deploy to Internal\` |
| \`ci-post-merge.yml\` | workflow | \`Post-Merge CI\` | \`Android Post-Merge CI\` |
| \`ci-post-merge.yml\` | job | \`Post-Merge Complete\` | \`Android Post-Merge Complete\` |
| \`ci-post-merge.yml\` | job | \`Track Post-Merge Failure\` | \`Track Android Post-Merge Failure\` |

Also updated the \`workflow-name\` input passed to \`ci-failure-tracker\` inside \`ci-post-merge.yml\` to match the new workflow name, and \`AndroidGarage/docs/TESTING.md\` to reference \`Android Post-Merge Complete\`.

## Why none of these need a branch-protection dance

I grepped for every renamed name across the repo. Only \`AndroidGarage/docs/TESTING.md\` referenced any of them (just the gate-job line), and branch protection only requires \`CI Complete\` and \`Firebase CI Complete\`. None of the names changed in this PR are in the required-status-checks list.

## What's NOT in this PR

\`CI Complete\` → \`Android CI Complete\` (Android pre-merge gate job) requires a three-step dance because it IS a required status check:
1. Add new gate job \`Android CI Complete\` alongside \`CI Complete\` (both run)
2. Swap branch protection via \`gh api\` (\`CI Complete\` → \`Android CI Complete\`)
3. Remove the old \`CI Complete\` job

That's coming in two follow-up PRs. Doing this rename in the same PR as #1 here would couple "low-risk renames" with "branch-protection change" and make rollback muddy.

## Verification

- Pre-merge CI runs on this PR and exercises the renamed Android post-merge jobs via its own push-to-main trigger after merge.
- Next Firebase release (\`server/N+1\`) exercises \`Firebase Deploy\` / \`Firebase Deploy Verify CI\` / \`Firebase Deploy Run\`.
- Next Android release exercises \`Android Release\` / \`Android Release Build and Deploy to Internal\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)