### PR TITLE
ci: Add Android CI Complete gate alongside CI Complete (dual-gate phase)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,37 @@ jobs:
       GARAGE_RELEASE_KEYSTORE_PWD: ${{ secrets.GARAGE_RELEASE_KEYSTORE_PWD }}
       GARAGE_RELEASE_KEY_PWD: ${{ secrets.GARAGE_RELEASE_KEY_PWD }}
 
-  # Gate job — the ONLY required status check in branch protection.
-  # Succeeds when all CI jobs pass OR when they're skipped (no Android changes).
+  # Gate jobs — branch-protection rename in progress.
+  #
+  # BOTH jobs run with identical logic. Branch protection currently requires
+  # `CI Complete` (the historical name). A follow-up step swaps the required
+  # context from `CI Complete` to `Android CI Complete` via `gh api`, then a
+  # final PR deletes the old `ci-complete` job. The dual-gate phase exists so
+  # the branch-protection swap has a safety net: if the new check-name fails
+  # to appear on PRs for any reason, we can revert without stranding PRs.
+  #
+  # Ordering rule: NEVER delete the old gate job before removing it from
+  # branch protection's required contexts. Reverse order blocks every PR.
   ci-complete:
     name: CI Complete
+    if: always()
+    needs: [checks]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        run: |
+          echo "Checks: ${{ needs.checks.result }}"
+
+          if [[ "${{ needs.checks.result }}" == "failure" || \
+                "${{ needs.checks.result }}" == "cancelled" ]]; then
+            echo "::error::CI checks failed"
+            exit 1
+          fi
+
+          echo "All CI checks passed (or skipped — no Android changes / docs-only)"
+
+  android-ci-complete:
+    name: Android CI Complete
     if: always()
     needs: [checks]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Merge order

This is PR 2 of 3 in the Android pre-merge gate rename.

Stack:
1. #473 — non-protected renames (\`Firebase Deploy\`, \`Android Release\`, \`Android Post-Merge Complete\`, etc.)
2. **This PR** — add new \`Android CI Complete\` alongside \`CI Complete\` (both run; neither is required to be first, no ordering conflict with #473)
3. (After this merges + manual branch-protection swap) — follow-up PR removes the old \`CI Complete\`

## Summary

Adds a new gate job \`Android CI Complete\` with identical logic to \`CI Complete\`. Both jobs run on every PR. \`CI Complete\` stays as the branch-protection-required check for now.

## Why the dual-gate phase

\`CI Complete\` is listed in main branch protection's required status checks. If we renamed it in place, every PR would stall forever waiting for a check-run named \`CI Complete\` that no workflow produces anymore. The dual-gate phase makes the rename reversible at every step.

## Coupling rule (also documented in the workflow header)

> **NEVER delete the old gate job before removing it from branch protection's required contexts.** Reverse order blocks every PR.

## After this merges

1. Verify \`Android CI Complete\` appears on a PR (it'll show as a new, non-required check).
2. Swap branch protection:
   \`\`\`bash
   gh api repos/cartland/SmartGarageDoor/branches/main/protection \\
     --method PATCH \\
     --input <(jq -n '{required_status_checks: {strict: true, contexts: ["Android CI Complete", "Firebase CI Complete"]}}')
   \`\`\`
3. Open a follow-up PR that deletes the \`ci-complete\` job and updates \`AndroidGarage/docs/TESTING.md\`. CLAUDE.md gets a note about the ordering rule.

## Rollback at each step

| Step | If broken, recover by |
|---|---|
| This PR merges | revert the PR (removes the new job; branch protection unchanged) |
| Branch protection swap | re-add \`CI Complete\` via the same \`gh api\` (old job still exists and runs) |
| Follow-up PR merges | revert it; re-add \`CI Complete\` via branch-protection API if needed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)