### PR TITLE
ci: Remove old CI Complete gate + document the rename ordering rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,35 +78,8 @@ jobs:
       GARAGE_RELEASE_KEYSTORE_PWD: ${{ secrets.GARAGE_RELEASE_KEYSTORE_PWD }}
       GARAGE_RELEASE_KEY_PWD: ${{ secrets.GARAGE_RELEASE_KEY_PWD }}
 
-  # Gate jobs — branch-protection rename in progress.
-  #
-  # BOTH jobs run with identical logic. Branch protection currently requires
-  # `CI Complete` (the historical name). A follow-up step swaps the required
-  # context from `CI Complete` to `Android CI Complete` via `gh api`, then a
-  # final PR deletes the old `ci-complete` job. The dual-gate phase exists so
-  # the branch-protection swap has a safety net: if the new check-name fails
-  # to appear on PRs for any reason, we can revert without stranding PRs.
-  #
-  # Ordering rule: NEVER delete the old gate job before removing it from
-  # branch protection's required contexts. Reverse order blocks every PR.
-  ci-complete:
-    name: CI Complete
-    if: always()
-    needs: [checks]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check results
-        run: |
-          echo "Checks: ${{ needs.checks.result }}"
-
-          if [[ "${{ needs.checks.result }}" == "failure" || \
-                "${{ needs.checks.result }}" == "cancelled" ]]; then
-            echo "::error::CI checks failed"
-            exit 1
-          fi
-
-          echo "All CI checks passed (or skipped — no Android changes / docs-only)"
-
+  # Gate job — the required status check in branch protection.
+  # Succeeds when all CI jobs pass OR when they're skipped (no Android changes).
   android-ci-complete:
     name: Android CI Complete
     if: always()

--- a/AndroidGarage/docs/TESTING.md
+++ b/AndroidGarage/docs/TESTING.md
@@ -18,7 +18,7 @@
 - **14 shared fakes** in `test-common` module — one copy each, no duplicates across modules
 - **Zero Mockito** — all tests use fake implementations
 - **CI architecture:** pre-submit (`ci.yml` → `ci-checks.yml`) + post-merge (`ci-post-merge.yml` → `ci-checks.yml` + instrumented tests)
-- **CI gate jobs:** `CI Complete` (PRs — branch-protection-required name, rename pending), `Android Post-Merge Complete` (main) — single check-run names for branch protection and release script
+- **CI gate jobs:** `Android CI Complete` (PRs, branch-protection-required), `Android Post-Merge Complete` (main) — single check-run names for branch protection and release script
 - **CI checks:** unit tests (3 build variants), Spotless formatting (all modules), Detekt, Android Lint, screenshot test compilation, debug APK build, release AAB build
 - **CI path filtering:** Android CI skips for Firebase-only/docs-only changes, and vice versa
 - **CI failure tracking:** post-merge failures auto-create GitHub issues (`ci-failure/post-merge`), auto-close on fix, flakiness detection

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ Run `./scripts/run-instrumented-tests.sh` when changing Room entities/DAOs, DI w
 ### CI Architecture
 
 **Android:**
-- **Pre-submit** (`ci.yml` → `ci-checks.yml`): Runs on PRs. Gate job `CI Complete` is the required status check.
+- **Pre-submit** (`ci.yml` → `ci-checks.yml`): Runs on PRs. Gate job `Android CI Complete` is the required status check.
 - **Post-merge** (`ci-post-merge.yml` → `ci-checks.yml` + instrumented tests): Runs on push to main. Auto-creates GitHub issue on failure (`ci-failure/post-merge`), auto-closes on fix with flakiness detection.
 
 **Firebase** (mirrors Android):
@@ -154,6 +154,12 @@ Run `./scripts/run-instrumented-tests.sh` when changing Room entities/DAOs, DI w
 - When every changed file matches `**/*.md`, `docs/**`, `.claude/**`, `LICENSE`, `.gitignore`, or `AndroidGarage/distribution/whatsnew/**`, the `checks` reusable workflow is skipped and the gate jobs post success in ~20–30s.
 - Mixed PRs (docs + code) take the full pipeline. Anything under `.github/**` or `scripts/**` is NOT docs — workflow and script edits still trigger full CI.
 - Rule: skip CI only when the change cannot affect what CI verifies.
+
+**Renaming a branch-protection-required gate job (ordering rule):**
+- `Android CI Complete` (Android pre-submit) and `Firebase CI Complete` (Firebase pre-submit) are listed in branch protection's required status checks. Their names cannot be changed in a single PR without stalling every subsequent PR.
+- Correct order: (1) PR adds a new gate job alongside the old one (both run); (2) wait for the new check-run to appear on a completed PR; (3) `gh api repos/:owner/:repo/branches/main/protection/required_status_checks/contexts --method PUT --input <(echo '["<new name>","<other required>"]')` — swaps the required contexts; (4) follow-up PR deletes the old gate job.
+- **NEVER delete the old gate job before removing it from required contexts.** Reverse order leaves branch protection expecting a check-run no workflow produces, which blocks every PR. Recovery is re-adding the old context via the same `gh api` call.
+- This was used to rename `CI Complete` → `Android CI Complete` in PRs #474 + #475.
 
 **Screenshot generation**: Use `./scripts/generate-android-screenshots.sh` (never run screenshot Gradle tasks directly — hooks block this).
 


### PR DESCRIPTION
## Merge order

This is PR 3 of 3. Final step of the Android pre-submit gate rename.

Stack:
1. ✅ #473 — non-protected renames
2. ✅ #474 — added \`Android CI Complete\` alongside \`CI Complete\` (both ran)
3. ✅ branch-protection swap (manual, via \`gh api\`) — required contexts now \`["Android CI Complete", "Firebase CI Complete"]\`
4. **This PR** — removes the old \`ci-complete\` / \`CI Complete\` job

## Why this is safe now

Branch protection was already updated in step 3 above. Verified:

\`\`\`
$ gh api repos/cartland/SmartGarageDoor/branches/main/protection/required_status_checks --jq '.contexts'
["Firebase CI Complete","Android CI Complete"]
\`\`\`

\`CI Complete\` is no longer required, so removing its workflow job doesn't strand PRs. This PR's own CI runs \`Android CI Complete\` as the required check — it'll be the first real-world verification of the new required name in isolation.

## Doc updates

- \`AndroidGarage/docs/TESTING.md\` — gate-job line updated to \`Android CI Complete\`
- \`CLAUDE.md\` — Pre-submit gate line updated; **new subsection** "Renaming a branch-protection-required gate job" under CI Architecture that spells out the ordering rule so future maintainers don't accidentally strand PRs

The documented rule:

> **NEVER delete the old gate job before removing it from required contexts.** Reverse order leaves branch protection expecting a check-run no workflow produces, which blocks every PR. Recovery is re-adding the old context via the same \`gh api\` call.

## Rollback

If this PR breaks something (unlikely — pure job deletion):
1. Re-add \`CI Complete\` to the required-status-checks list via \`gh api\`
2. Revert the PR (restores the \`ci-complete\` job)
3. PRs stop failing immediately since both check-runs will reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)