### PR TITLE
test: Close failure-mode coverage gap + extend fakes with failNextX helpers

### DIFF
--- a/FirebaseServer/test/controller/EventUpdatesFakeTest.ts
+++ b/FirebaseServer/test/controller/EventUpdatesFakeTest.ts
@@ -135,4 +135,95 @@ describe('EventUpdates (via fakes)', () => {
     expect(fakeFCM.sends).to.have.length(1);
     expect(fakeFCM.sends[0]).to.deep.equal({ buildTimestamp: 'test', event: newEvent });
   });
+
+  // --- Failure-mode tests: updateEvent has no try/catch, so any step that
+  //     throws propagates immediately. These tests document and pin that
+  //     contract: errors are NOT silently swallowed, and later steps are
+  //     skipped when an earlier one fails.
+
+  describe('failure modes', () => {
+    // Local helper — assert that `fn()` rejects and return the error.
+    async function assertRejects(fn: () => Promise<any>): Promise<Error> {
+      try {
+        await fn();
+      } catch (e) {
+        return e as Error;
+      }
+      throw new Error('expected promise to reject, but it resolved');
+    }
+
+    it('propagates getCurrent failure; save and FCM are skipped', async () => {
+      fakeDB.failNextGetCurrent(new Error('Firestore down: getCurrent'));
+
+      const err = await assertRejects(() => updateEvent({ buildTimestamp: 'test' }, false));
+      expect(err.message).to.equal('Firestore down: getCurrent');
+
+      expect(fakeDB.saved).to.be.empty;
+      expect(fakeDB.updates).to.be.empty;
+      expect(fakeFCM.sends).to.be.empty;
+    });
+
+    it('propagates save failure (new-event path); FCM is NOT called', async () => {
+      const newEvent: SensorEvent = {
+        type: SensorEventType.Closed, timestampSeconds: 12345, message: '', checkInTimestampSeconds: 0,
+      };
+      sinon.stub(EventInterpreter, 'getNewEventOrNull').returns(newEvent);
+      fakeDB.failNextSave(new Error('Firestore down: save'));
+
+      const err = await assertRejects(() => updateEvent({ buildTimestamp: 'test' }, false));
+      expect(err.message).to.equal('Firestore down: save');
+
+      // save() was attempted (audit log captures even failed attempts).
+      expect(fakeDB.saved).to.have.length(1);
+      // FCM must NOT have been called — proves the error short-circuits.
+      expect(fakeFCM.sends).to.be.empty;
+    });
+
+    it('propagates updateCurrent... failure (unchanged-event path); FCM is NOT called', async () => {
+      const oldEvent: SensorEvent = {
+        type: SensorEventType.Closed, timestampSeconds: 12345, message: '', checkInTimestampSeconds: 0,
+      };
+      fakeDB.seed('test', { currentEvent: oldEvent });
+      sinon.stub(EventInterpreter, 'getNewEventOrNull').returns(null);
+      fakeDB.failNextUpdate(new Error('Firestore down: update'));
+
+      const err = await assertRejects(() => updateEvent({ buildTimestamp: 'test' }, false));
+      expect(err.message).to.equal('Firestore down: update');
+
+      expect(fakeDB.updates).to.have.length(1);
+      expect(fakeFCM.sends).to.be.empty;
+    });
+
+    it('propagates FCM failure after save succeeded (new-event path)', async () => {
+      const newEvent: SensorEvent = {
+        type: SensorEventType.Closed, timestampSeconds: 12345, message: '', checkInTimestampSeconds: 0,
+      };
+      sinon.stub(EventInterpreter, 'getNewEventOrNull').returns(newEvent);
+      fakeFCM.failNextSend(new Error('FCM unavailable'));
+
+      const err = await assertRejects(() => updateEvent({ buildTimestamp: 'test' }, false));
+      expect(err.message).to.equal('FCM unavailable');
+
+      // save() succeeded before FCM failed — the DB write is committed.
+      expect(fakeDB.saved).to.have.length(1);
+      expect(fakeDB.saved[0][1].currentEvent).to.equal(newEvent);
+      // FCM was attempted (audit log captures even failed attempts).
+      expect(fakeFCM.sends).to.have.length(1);
+    });
+
+    it('propagates FCM failure after updateCurrent... succeeded (unchanged-event path)', async () => {
+      const oldEvent: SensorEvent = {
+        type: SensorEventType.Closed, timestampSeconds: 12345, message: '', checkInTimestampSeconds: 0,
+      };
+      fakeDB.seed('test', { currentEvent: oldEvent });
+      sinon.stub(EventInterpreter, 'getNewEventOrNull').returns(null);
+      fakeFCM.failNextSend(new Error('FCM unavailable'));
+
+      const err = await assertRejects(() => updateEvent({ buildTimestamp: 'test' }, false));
+      expect(err.message).to.equal('FCM unavailable');
+
+      expect(fakeDB.updates).to.have.length(1);
+      expect(fakeFCM.sends).to.have.length(1);
+    });
+  });
 });

--- a/FirebaseServer/test/fakes/FakeEventFCMService.ts
+++ b/FirebaseServer/test/fakes/FakeEventFCMService.ts
@@ -13,16 +13,28 @@ import { SensorEvent } from '../../src/model/SensorEvent';
 import { TopicMessage } from '../../src/model/FCM';
 
 export class FakeEventFCMService implements EventFCMService {
-  /** Audit log of every sendFCMForSensorEvent call. */
+  /** Audit log of every sendFCMForSensorEvent call (succeeded OR threw). */
   readonly sends: Array<{ buildTimestamp: string, event: SensorEvent }> = [];
+
+  // Failure-injection slot. Single-shot; cleared on use.
+  private _nextSendError: Error | null = null;
 
   async sendFCMForSensorEvent(buildTimestamp: string, sensorEvent: SensorEvent): Promise<TopicMessage> {
     this.sends.push({ buildTimestamp, event: sensorEvent });
+    if (this._nextSendError) {
+      const e = this._nextSendError;
+      this._nextSendError = null;
+      throw e;
+    }
     return null;
   }
 
-  /** Test-only helper: wipe audit log. */
+  /** Test-only helper: wipe audit log and any armed failure. */
   clear(): void {
     this.sends.length = 0;
+    this._nextSendError = null;
   }
+
+  /** Test-only helper: arm the NEXT sendFCMForSensorEvent() call to reject with `error`. */
+  failNextSend(error: Error): void { this._nextSendError = error; }
 }

--- a/FirebaseServer/test/fakes/FakeSensorEventDatabase.ts
+++ b/FirebaseServer/test/fakes/FakeSensorEventDatabase.ts
@@ -13,21 +13,39 @@ import { SensorEventDatabase } from '../../src/database/SensorEventDatabase';
 export class FakeSensorEventDatabase implements SensorEventDatabase {
   private readonly store = new Map<string, any>();
 
-  /** Audit log of all save() calls. */
+  /** Audit log of all save() calls, even ones that throw. */
   readonly saved: Array<[string, any]> = [];
 
-  /** Audit log of all updateCurrentWithMatchingCurrentEventTimestamp() calls. */
+  /** Audit log of all updateCurrentWithMatchingCurrentEventTimestamp() calls, even ones that throw. */
   readonly updates: Array<[string, any]> = [];
 
   /** Audit log of all deleteAllBefore() calls. */
   readonly deleteCalls: Array<{ cutoff: number, dryRun: boolean }> = [];
 
+  // Failure-injection slots. Each `failNextX(error)` arms the NEXT call to X
+  // to reject with `error`. Single-shot; cleared on use. Tests that need
+  // multi-call failure patterns should call failNextX again in the handler.
+  private _nextSaveError: Error | null = null;
+  private _nextGetCurrentError: Error | null = null;
+  private _nextUpdateError: Error | null = null;
+  private _nextDeleteError: Error | null = null;
+
   async save(buildTimestamp: string, data: any): Promise<void> {
-    this.store.set(buildTimestamp, data);
     this.saved.push([buildTimestamp, data]);
+    if (this._nextSaveError) {
+      const e = this._nextSaveError;
+      this._nextSaveError = null;
+      throw e;
+    }
+    this.store.set(buildTimestamp, data);
   }
 
   async getCurrent(buildTimestamp: string): Promise<any> {
+    if (this._nextGetCurrentError) {
+      const e = this._nextGetCurrentError;
+      this._nextGetCurrentError = null;
+      throw e;
+    }
     // Match TimeSeriesDatabase.getCurrent, which routes through
     // convertFromFirestore() and always returns {} for missing documents.
     // Returning null here would diverge from production and break callers
@@ -37,12 +55,22 @@ export class FakeSensorEventDatabase implements SensorEventDatabase {
 
   async updateCurrentWithMatchingCurrentEventTimestamp(buildTimestamp: string, matchingCurrent: any): Promise<any> {
     this.updates.push([buildTimestamp, matchingCurrent]);
+    if (this._nextUpdateError) {
+      const e = this._nextUpdateError;
+      this._nextUpdateError = null;
+      throw e;
+    }
     this.store.set(buildTimestamp, matchingCurrent);
     return null;
   }
 
   async deleteAllBefore(cutoffTimestampSeconds: number, dryRun: boolean): Promise<number> {
     this.deleteCalls.push({ cutoff: cutoffTimestampSeconds, dryRun });
+    if (this._nextDeleteError) {
+      const e = this._nextDeleteError;
+      this._nextDeleteError = null;
+      throw e;
+    }
     return 0;
   }
 
@@ -66,5 +94,21 @@ export class FakeSensorEventDatabase implements SensorEventDatabase {
     this.saved.length = 0;
     this.updates.length = 0;
     this.deleteCalls.length = 0;
+    this._nextSaveError = null;
+    this._nextGetCurrentError = null;
+    this._nextUpdateError = null;
+    this._nextDeleteError = null;
   }
+
+  /** Test-only helper: arm the NEXT save() call to reject with `error`. */
+  failNextSave(error: Error): void { this._nextSaveError = error; }
+
+  /** Test-only helper: arm the NEXT getCurrent() call to reject with `error`. */
+  failNextGetCurrent(error: Error): void { this._nextGetCurrentError = error; }
+
+  /** Test-only helper: arm the NEXT updateCurrent...() call to reject with `error`. */
+  failNextUpdate(error: Error): void { this._nextUpdateError = error; }
+
+  /** Test-only helper: arm the NEXT deleteAllBefore() call to reject with `error`. */
+  failNextDelete(error: Error): void { this._nextDeleteError = error; }
 }


### PR DESCRIPTION
## Summary

Closes the main gap identified when comparing the new fake-based tests to the retired sinon-based ones: neither the old sinon tests nor the new fake tests exercised failure paths. This PR fills that gap.

## Two parts

### 1. Fakes get \`failNext*()\` helpers

Both fakes now support single-shot failure injection — one per method, cleared on use:

\`\`\`
FakeSensorEventDatabase.failNextSave(error)
                       .failNextGetCurrent(error)
                       .failNextUpdate(error)
                       .failNextDelete(error)
FakeEventFCMService.failNextSend(error)
\`\`\`

Each method pushes to its audit log **before** throwing, so tests can still inspect the arguments of a failed attempt.

This parallels \`sinon.stub().rejects(error)\` but in a way that doesn't mutate prototypes and requires explicit injection via \`setImpl\`.

### 2. Five new failure-mode tests in EventUpdatesFakeTest.ts

\`\`\`
✔ propagates getCurrent failure; save and FCM are skipped
✔ propagates save failure (new-event path); FCM is NOT called
✔ propagates updateCurrent... failure (unchanged-event path); FCM is NOT called
✔ propagates FCM failure after save succeeded (new-event path)
✔ propagates FCM failure after updateCurrent... succeeded (unchanged-event path)
\`\`\`

Each test documents the current contract of \`updateEvent()\`: since it has no \`try/catch\`, errors propagate immediately and later steps are skipped. These pins flag the behavior change if a future PR ever wraps the write/FCM pair in a transaction or retry.

## Superseded tests

**None.** Searched \`test/\` for existing happy-path tests whose coverage is now duplicated by the new tests — found nothing. All original \`EventUpdatesFakeTest\` scenarios still prove unique happy paths. The failure-mode tests are strictly additive.

## Why this matters

Previous session discussion called out three potential gaps vs sinon: failure injection, per-call return differentiation, cross-stub ordering. Of those, **failure injection was the one that would plausibly be exercised by a real future test** — if someone adds error-handling logic to \`updateEvent\`, they'd want to prove it works. The fake now supports that preemptively.

Per-call differentiation and cross-stub ordering remain out of scope — they haven't been used by any test in this codebase and can be added if/when a specific test needs them.

## Verification

- \`./scripts/validate-firebase.sh\` passes — **87 tests** (was 82; +5 new)
- No production code changes (only \`test/fakes/*\` and \`test/controller/EventUpdatesFakeTest.ts\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)