### PR TITLE
fix: Make the CHANGELOG gate ignore fenced example headings

### DIFF
--- a/FirebaseServer/CHANGELOG.md
+++ b/FirebaseServer/CHANGELOG.md
@@ -10,15 +10,15 @@ Server releases use a monotonic integer (`server/N`). No semver — each release
 
 Every release that reaches `main` gets an entry here. `scripts/release-firebase.sh` blocks the tag push if `## server/N` has no body. Emergency override: `--confirm-no-changelog <target-sha>`.
 
-**Supersede pattern.** Releases that supersede an untested predecessor (bug-chase chain — server/11 shipped, broken, server/12 attempted fix, still broken, server/13 finally worked) may **replace** the predecessor's entry with a single entry on the final release. Git log of this file preserves the original content, so archaeology is possible without cluttering the human-readable history.
+**Supersede pattern.** Releases that supersede an untested predecessor (bug-chase chain — a release ships broken, an attempted fix is still broken, the next attempt finally works) may **replace** the predecessor's entry with a single entry on the final release. Git log of this file preserves the original content, so archaeology is possible without cluttering the human-readable history.
 
-Example:
+Example (placeholder tag numbers — the gate looks for exact `server/<real number>` headings and the release script additionally ignores matches inside fenced code blocks):
 
 ```markdown
-## server/13
-- Fixed snooze TTL bug. (First attempts in server/11 and server/12 had off-by-one errors that only surfaced in production.)
+## server/<final>
+- Fixed snooze TTL bug. (First attempts in server/<final-2> and server/<final-1> had off-by-one errors that only surfaced in production.)
 
-## server/10
+## server/<prior>
 - Bump Firebase Functions runtime to Node 22.
 ```
 

--- a/scripts/release-firebase.sh
+++ b/scripts/release-firebase.sh
@@ -191,19 +191,37 @@ fi
 #   empty   : heading exists but body is whitespace-only
 #   missing : no heading for this tag
 #   no_file : FirebaseServer/CHANGELOG.md does not exist
+#
+# Matching rules:
+# - Lines inside fenced code blocks (```...```) are ignored — they're example
+#   content in the docs intro, not real release entries. Without this, an
+#   example heading like "## server/13" in the docs block would match before
+#   the real entry below it.
+# - Fence toggling: lines starting with ``` flip the in_fence state.
 CHANGELOG_FILE="$REPO_ROOT/FirebaseServer/CHANGELOG.md"
 CHANGELOG_STATE="no_file"
 CHANGELOG_BODY=""
 if [ -f "$CHANGELOG_FILE" ]; then
-    # Extract body: lines between "## $NEW_TAG" and the next "## " heading.
+    # Extract body: lines between "## $NEW_TAG" and the next "## " heading,
+    # ignoring anything inside ``` fences.
     CHANGELOG_BODY=$(awk -v tag="$NEW_TAG" '
-        $0 ~ ("^## "tag"([ ]|$)") { found=1; next }
+        BEGIN { in_fence = 0; found = 0 }
+        /^```/ { in_fence = !in_fence; next }
+        in_fence { next }
+        $0 ~ ("^## "tag"([ ]|$)") { found = 1; next }
         found && /^## / { exit }
         found { print }
     ' "$CHANGELOG_FILE")
+    # Heading existence also respects fences.
+    HEADING_FOUND=$(awk -v tag="$NEW_TAG" '
+        BEGIN { in_fence = 0 }
+        /^```/ { in_fence = !in_fence; next }
+        in_fence { next }
+        $0 ~ ("^## "tag"([ ]|$)") { print "yes"; exit }
+    ' "$CHANGELOG_FILE")
     if [ -n "$(echo "$CHANGELOG_BODY" | tr -d '[:space:]')" ]; then
         CHANGELOG_STATE="present"
-    elif grep -qE "^## $NEW_TAG([ ]|$)" "$CHANGELOG_FILE"; then
+    elif [ "$HEADING_FOUND" = "yes" ]; then
         CHANGELOG_STATE="empty"
     else
         CHANGELOG_STATE="missing"


### PR DESCRIPTION
## Summary

Fixes the gate bug noticed during the server/13 release. The gate's \`awk\` extractor matched headings inside markdown code fences (the example block in \`CHANGELOG.md\`'s intro) before finding the real release entry below.

## The bug, concretely

\`FirebaseServer/CHANGELOG.md\` has this example in its header:

\`\`\`markdown
## server/13
- Fixed snooze TTL bug. (First attempts in server/11 and server/12 ...)
\`\`\`

It's illustrative — not a real entry. But \`awk\` doesn't know about fences. During server/13's release, the gate printed:

\`\`\`
Changelog:    PRESENT (entry for server/13 in FirebaseServer/CHANGELOG.md)
  First line: - Fixed snooze TTL bug. (First attempts in server/11 ...
\`\`\`

That first line is the **example**, not the actual entry. Release proceeded correctly (the tag points at HEAD's real CHANGELOG), but the gate's preview was wrong and — more importantly — an **empty** real entry would have passed the gate as long as the example covered the same tag number.

## Two-layer fix

### Layer 1 — CHANGELOG.md: placeholder example tag numbers

Rewrote the example block to use \`server/<final>\`, \`server/<final-1>\`, \`server/<prior>\` placeholders. Even a fence-unaware matcher can't collide with a real release tag.

### Layer 2 — release-firebase.sh: fence-aware awk

Extractor now tracks markdown fence state (``\`\`\``` toggles \`in_fence\`) and skips heading matches inside fences. The heading-existence check (for distinguishing \`missing\` vs \`empty\`) uses the same fence-aware awk instead of a plain \`grep\`.

Belt and suspenders — either layer alone catches today's case. Both ensures future examples with real-looking tags can't re-break the gate.

## Verification

Synthetic tests in the commit message, reproduced here:

- **Heading only in fence, no real entry** → \`HEADING_FOUND\` empty → gate reports \`missing\` ✓
- **Real entry after fenced example** → awk extracts the real body, not the fenced one ✓
- **Applied to live \`FirebaseServer/CHANGELOG.md\` with \`server/13\`** → returns the actual release entry, not the example ✓

## No production impact

\`CHANGELOG.md\` is docs-only. \`release-firebase.sh\` runs locally before tagging; the deploy workflow itself is unaffected. Next Firebase release (\`server/14\`) exercises the fixed gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)