### PR TITLE
docs: dump-context skill prioritizes repo over memory

### DIFF
--- a/.claude/skills/dump-context/SKILL.md
+++ b/.claude/skills/dump-context/SKILL.md
@@ -6,6 +6,19 @@ description: Capture session knowledge into project documentation before session
 
 Capture conversation knowledge into durable artifacts before a session ends or context is compacted.
 
+## Priority: repo first, memory second
+
+**The repo is where long-lived knowledge lives.** `CLAUDE.md`, `AndroidGarage/docs/`, `FirebaseServer/docs/`, `docs/`, and code-adjacent `*/README.md` files all survive machine rebuilds, benefit from PR review, and are discoverable by anyone on the project (including future-you, reading the repo cold).
+
+Memory is only for information that is **machine-local or session-pointer in nature**:
+
+- User's tool preferences on this dev box (e.g. "they use `nvm` not `asdf`")
+- Paths, shell aliases, IDE state specific to this machine
+- Short-lived pointers that will rot (e.g. "currently tracking bug in PR #N") — but only when a repo doc would be wrong
+- Inbox-style reminders that don't belong in a reviewed doc
+
+**When in doubt, put it in the repo.** A paragraph in CLAUDE.md that everyone can see is more valuable than a memory entry only the current session recalls. Memory can never be reviewed by a human in a PR.
+
 ## When to Use
 
 - Before ending a session where significant work was done
@@ -23,41 +36,46 @@ Review the conversation and categorize knowledge:
 3. **Operational knowledge** — workarounds, commands, mistakes corrected
 4. **Status** — what's completed, in progress, blocked
 
+For each item, decide: **repo doc, code comment, or memory?** Default to repo. Memory only for truly local/transient content.
+
 Write a brief summary before proceeding.
 
-### Phase 2: Update Documentation
+### Phase 2: Update Repo Docs (PRIMARY)
 
-Update these files with knowledge from the conversation:
+This is the main phase. Most dump-context work should land here.
 
 #### `CLAUDE.md` — Agent Instructions
 - New workflow rules or conventions
-- Changes to CI/hooks/validation process
+- Changes to CI / hooks / validation process
 - Mistakes to avoid (especially incorrect state reported to user)
+- New scripts, commands, or safety rules
 
-#### `AndroidGarage/docs/TESTING.md` — Testing Plan
-- Mark completed phases
-- Add new test gaps discovered
-- Update test counts
+#### Component docs
+- `AndroidGarage/docs/TESTING.md` — testing plan, completed phases, test gaps
+- `AndroidGarage/docs/DECISIONS.md` — new ADRs from decisions made during the session
+- `AndroidGarage/docs/MIGRATION.md` — migration progress
+- `FirebaseServer/CHANGELOG.md` — every release entry (gate-enforced)
+- `FirebaseServer/docs/*.md` — Firebase-server-specific patterns and plans
+- `docs/FIREBASE_DEPLOY_SETUP.md`, `docs/FIREBASE_DATABASE_REFACTOR.md` — cross-component runbooks
 
-#### `AndroidGarage/docs/DECISIONS.md` — Architecture Decisions
-- New ADRs from decisions made during session
-- Updates to existing ADRs
+#### Code-adjacent
+- Header comments in scripts and workflow files — ordering rules, coupling notes
+- Module doc comments — shape/pattern conventions (e.g. the service pattern in `*Database.ts` / `*FCM.ts`)
+- `test/fakes/README.md` — fake-pattern conventions
 
-#### `AndroidGarage/docs/MIGRATION.md` — Migration Progress
-- Mark completed migration steps
-- Add new steps discovered
+### Phase 3: Update Memory (SECONDARY, narrow use)
 
-### Phase 3: Update Memory
-
-Save session-specific learnings to memory files:
+Only use memory for content that doesn't belong in the repo. Before writing a memory entry, ask: "Could this go in CLAUDE.md or a docs file instead?" If yes, put it there.
 
 ```
 ~/.claude/projects/-Users-cartland-github-cartland-SmartGarageDoor/memory/
 ```
 
-- **feedback_*.md** — Corrections, validated approaches, workflow preferences
-- **project_*.md** — Project state, ongoing work, decisions
+- **feedback_*.md** — user's machine-specific preferences (e.g. "uses nvm, pins Node 22")
+- **project_*.md** — session-pointer state that would be wrong in a reviewed doc (e.g. "currently mid-investigation of PR #N")
 - Update `MEMORY.md` index
+
+Avoid creating memory entries that duplicate content already in CLAUDE.md or repo docs — those are redundant at best and drift-prone at worst.
 
 ### Phase 4: Check Open PRs
 
@@ -73,6 +91,8 @@ gh pr list --state open --json number,title,mergeStateStatus,autoMergeRequest
 
 ### Phase 5: Commit via PR
 
+If Phase 2 produced repo changes (expected for most dumps):
+
 1. Create branch from latest main:
    ```bash
    git checkout -b docs/dump-context-YYYY-MM-DD origin/main
@@ -80,7 +100,7 @@ gh pr list --state open --json number,title,mergeStateStatus,autoMergeRequest
 
 2. Stage and commit:
    ```bash
-   git add CLAUDE.md AndroidGarage/docs/
+   git add CLAUDE.md AndroidGarage/docs/ FirebaseServer/ docs/
    git commit -m "docs: Dump session context — [brief summary]"
    ```
 
@@ -91,9 +111,12 @@ gh pr list --state open --json number,title,mergeStateStatus,autoMergeRequest
    gh pr merge --auto --squash --delete-branch
    ```
 
+If the dump is memory-only (rare), the repo PR step is skipped — but think twice first. Most session knowledge earns its place in the repo.
+
 ## Tips
 
 - Don't put session-specific state in docs — only document confirmed knowledge
 - Be specific about what changed and why
 - If the session was trivial, skip phases that don't apply
 - Check for merge conflicts on all open PRs before finishing
+- If you catch yourself writing "this is worth remembering for next session" — consider whether a repo doc is the better home. It usually is.


### PR DESCRIPTION
## Summary

Corrects a long-standing default in the \`/dump-context\` skill: recent dump runs were writing project state, patterns, and conventions to memory when they belonged in the repo.

**The rule, plainly stated in the updated skill:**

> The repo is where long-lived knowledge lives. \`CLAUDE.md\`, \`AndroidGarage/docs/\`, \`FirebaseServer/docs/\`, \`docs/\`, and code-adjacent \`*/README.md\` files all survive machine rebuilds, benefit from PR review, and are discoverable by anyone on the project. Memory is only for machine-local or session-pointer state.

## What changed

- **New top-level "Priority" section** that states the rule up front
- **Phase 2 renamed "Update Repo Docs (PRIMARY)"** with expanded targets (FirebaseServer docs, CHANGELOG.md, script headers, module comments, \`test/fakes/README.md\`)
- **Phase 3 renamed "Update Memory (SECONDARY, narrow use)"** with an explicit pre-check before writing any memory entry
- **Phase 5 commit list** broadened to include \`FirebaseServer/\` and \`docs/\` (matches what recent dumps actually committed, but wasn't reflected in the skill)
- **Tips** nudge to re-evaluate "worth remembering" instincts toward a repo doc

A small backstop memory entry mirrors this preference so sessions that haven't reloaded the skill file still get the hint.

## Why this matters

A memory entry can never be PR-reviewed. It's also invisible to anyone opening the repo cold. Paragraphs in \`CLAUDE.md\` and component docs are strictly more useful — they survive compactions, they document themselves in git history, and they scale to readers beyond the current session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)