### PR TITLE
refactor(firebase): Centralize notifications collection onto NotificationsDatabase

### DIFF
--- a/FirebaseServer/src/controller/fcm/OldDataFCM.ts
+++ b/FirebaseServer/src/controller/fcm/OldDataFCM.ts
@@ -16,15 +16,13 @@
 
 import * as firebase from 'firebase-admin';
 
-import { TimeSeriesDatabase } from '../../database/TimeSeriesDatabase';
+import { DATABASE as NotificationsDatabase } from '../../database/NotificationsDatabase';
 
 import { SensorEvent, SensorEventType } from '../../model/SensorEvent';
 import { AndroidMessagePriority, TopicMessage, Notification, NotificationPriority, AndroidConfig, AndroidNotification } from '../../model/FCM';
 import { buildTimestampToFcmTopic } from '../../model/FcmTopic';
 import { getSnoozeStatus, SnoozeLatestParams } from '../SnoozeNotifications';
 import { SnoozeStatus } from '../../model/SnoozeRequest';
-
-const NOTIFICATIONS_DATABASE = new TimeSeriesDatabase('notificationsCurrent', 'notificationsAll');
 
 const CURRENT_EVENT_KEY = 'currentEvent';
 const NOTIFICATION_CURRENT_EVENT_KEY = 'notificationCurrentEvent';
@@ -62,7 +60,7 @@ export async function sendFCMForOldData(buildTimestamp: string, eventData): Prom
     console.error('Could not generate message to send');
     return null;
   }
-  const oldNotificationData = await NOTIFICATIONS_DATABASE.getCurrent(buildTimestamp);
+  const oldNotificationData = await NotificationsDatabase.getCurrent(buildTimestamp);
   if (NOTIFICATION_CURRENT_EVENT_KEY in oldNotificationData
     && TIMESTAMP_SECONDS_KEY in oldNotificationData[NOTIFICATION_CURRENT_EVENT_KEY]) {
     const oldTimestampSeconds = oldNotificationData[NOTIFICATION_CURRENT_EVENT_KEY][TIMESTAMP_SECONDS_KEY];
@@ -76,7 +74,7 @@ export async function sendFCMForOldData(buildTimestamp: string, eventData): Prom
   const data = {};
   data[NOTIFICATION_CURRENT_EVENT_KEY] = currentEvent;
   data[NOTIFICATION_MESSAGE_KEY] = message;
-  await NOTIFICATIONS_DATABASE.save(buildTimestamp, data);
+  await NotificationsDatabase.save(buildTimestamp, data);
   console.log('Sending notification', JSON.stringify(message));
   await firebase.messaging().send(message)
     .then((response) => {

--- a/FirebaseServer/src/database/NotificationsDatabase.ts
+++ b/FirebaseServer/src/database/NotificationsDatabase.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2021 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TimeSeriesDatabase } from './TimeSeriesDatabase';
+
+// Canonical collection strings for this database. Pinned by
+// test/database/NotificationsDatabaseTest.ts. Changing them requires a
+// Firestore data migration in production — see
+// docs/FIREBASE_DATABASE_REFACTOR.md.
+export const COLLECTION_CURRENT = 'notificationsCurrent';
+export const COLLECTION_ALL = 'notificationsAll';
+
+export interface NotificationsDatabase {
+  save(buildTimestamp: string, data: any): Promise<void>;
+  getCurrent(buildTimestamp: string): Promise<any>;
+}
+
+class FirestoreNotificationsDatabase implements NotificationsDatabase {
+  private readonly db = new TimeSeriesDatabase(COLLECTION_CURRENT, COLLECTION_ALL);
+  save(b: string, d: any) { return this.db.save(b, d); }
+  getCurrent(b: string) { return this.db.getCurrent(b); }
+}
+
+let _instance: NotificationsDatabase = new FirestoreNotificationsDatabase();
+
+export const DATABASE: NotificationsDatabase = {
+  save: (b, d) => _instance.save(b, d),
+  getCurrent: (b) => _instance.getCurrent(b),
+};
+
+/** TEST-ONLY: swap in a fake implementation. */
+export function setImpl(impl: NotificationsDatabase): void { _instance = impl; }
+
+/** TEST-ONLY: restore the Firestore implementation. */
+export function resetImpl(): void { _instance = new FirestoreNotificationsDatabase(); }

--- a/FirebaseServer/test/database/NotificationsDatabaseTest.ts
+++ b/FirebaseServer/test/database/NotificationsDatabaseTest.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { expect } from 'chai';
+import {
+  COLLECTION_CURRENT,
+  COLLECTION_ALL,
+} from '../../src/database/NotificationsDatabase';
+
+describe('NotificationsDatabase: collection-name contract', () => {
+  // These strings MUST match what controller/fcm/OldDataFCM.ts wrote
+  // before centralization. A mismatch means new code writes to a
+  // different Firestore collection than existing production data —
+  // duplicate-notification suppression would silently stop working
+  // because getCurrent() would miss the historical entry.
+  //
+  // Intentional change requires a full data migration:
+  //   1. Copy documents from old collection to new in production.
+  //   2. Update this test.
+  //   3. Deploy atomically.
+
+  it('current collection is pinned', () => {
+    expect(COLLECTION_CURRENT).to.equal('notificationsCurrent');
+  });
+
+  it('all collection is pinned', () => {
+    expect(COLLECTION_ALL).to.equal('notificationsAll');
+  });
+});

--- a/FirebaseServer/test/fakes/FakeNotificationsDatabase.ts
+++ b/FirebaseServer/test/fakes/FakeNotificationsDatabase.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { NotificationsDatabase } from '../../src/database/NotificationsDatabase';
+
+export class FakeNotificationsDatabase implements NotificationsDatabase {
+  private readonly store = new Map<string, any>();
+
+  /** Audit log of all save() calls. */
+  readonly saved: Array<[string, any]> = [];
+
+  private _nextSaveError: Error | null = null;
+  private _nextGetCurrentError: Error | null = null;
+
+  async save(buildTimestamp: string, data: any): Promise<void> {
+    this.saved.push([buildTimestamp, data]);
+    if (this._nextSaveError) {
+      const err = this._nextSaveError;
+      this._nextSaveError = null;
+      throw err;
+    }
+    this.store.set(buildTimestamp, data);
+  }
+
+  async getCurrent(buildTimestamp: string): Promise<any> {
+    if (this._nextGetCurrentError) {
+      const err = this._nextGetCurrentError;
+      this._nextGetCurrentError = null;
+      throw err;
+    }
+    // Match TimeSeriesDatabase.getCurrent, which routes missing documents
+    // through convertFromFirestore() → {}. Returning null would diverge.
+    return this.store.get(buildTimestamp) ?? {};
+  }
+
+  /** Test-only helper: pre-populate storage without recording in saved[]. */
+  seed(buildTimestamp: string, data: any): void {
+    this.store.set(buildTimestamp, data);
+  }
+
+  /** Test-only helper: wipe storage and audit logs. */
+  clear(): void {
+    this.store.clear();
+    this.saved.length = 0;
+    this._nextSaveError = null;
+    this._nextGetCurrentError = null;
+  }
+
+  /** Make the next save() reject with the given error. */
+  failNextSave(error: Error): void { this._nextSaveError = error; }
+
+  /** Make the next getCurrent() reject with the given error. */
+  failNextGetCurrent(error: Error): void { this._nextGetCurrentError = error; }
+}


### PR DESCRIPTION
## Summary

Completes **Phase 3** of the Firebase database refactor ([docs/FIREBASE_DATABASE_REFACTOR.md](docs/FIREBASE_DATABASE_REFACTOR.md)). `OldDataFCM.ts` was the last inline `new TimeSeriesDatabase(...)` call site outside `src/database/` — now every Firestore collection goes through a typed singleton.

- `src/database/NotificationsDatabase.ts` — interface + FirestoreImpl + singleton + `setImpl` / `resetImpl` (same shape as `UpdateDatabase`)
- `test/fakes/FakeNotificationsDatabase.ts` — Map-backed fake with audit array + `failNextSave` / `failNextGetCurrent` helpers
- `test/database/NotificationsDatabaseTest.ts` — contract test pinning `notificationsCurrent` / `notificationsAll`
- `src/controller/fcm/OldDataFCM.ts` — switches `NOTIFICATIONS_DATABASE` → `NotificationsDatabase` singleton

## Zero Firestore impact

- Collection strings: byte-identical (`notificationsCurrent`, `notificationsAll`)
- Document shape: unchanged
- Call order in `sendFCMForOldData`: unchanged (`getCurrent` → dedup check → `save` → send)
- `TimeSeriesDatabase.ts`: not modified

## Follow-up

Unblocks **Phase 4** — lint rule banning `new TimeSeriesDatabase(` outside `src/database/`. Will land in a separate PR.

## Test plan

- [x] `./scripts/validate-firebase.sh` — 89 passing (was 87; +2 from contract tests)
- [x] New contract tests pin the collection strings
- [x] Reviewed `OldDataFCM.ts` — behavior preserved (same method signatures via singleton delegation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)