### PR TITLE
chore(firebase): Phase 4 — ban new TimeSeriesDatabase() outside src/database/

### DIFF
--- a/FirebaseServer/eslint.config.js
+++ b/FirebaseServer/eslint.config.js
@@ -85,6 +85,32 @@ module.exports = [
         "argsIgnorePattern": "^_",
         "varsIgnorePattern": "^_",
       }],
+
+      // Phase 4 of the database refactor (see
+      // docs/FIREBASE_DATABASE_REFACTOR.md). Every Firestore collection
+      // is wrapped by a typed singleton in src/database/; instantiating
+      // TimeSeriesDatabase anywhere else reintroduces the duplication
+      // pattern the refactor removed. Allowlisted paths below.
+      "no-restricted-syntax": ["error", {
+        "selector": "NewExpression[callee.name='TimeSeriesDatabase']",
+        "message": "Do not instantiate TimeSeriesDatabase outside src/database/. Import the singleton for your collection (e.g., `import { DATABASE as FooDatabase } from '../database/FooDatabase'`). See docs/FIREBASE_DATABASE_REFACTOR.md.",
+      }],
+    },
+  },
+  {
+    // The canonical home for TimeSeriesDatabase wrappers — one module
+    // per collection. Direct instantiation here is the whole point.
+    files: ["src/database/**/*.ts"],
+    rules: {
+      "no-restricted-syntax": "off",
+    },
+  },
+  {
+    // Contract test for TimeSeriesDatabase itself needs to instantiate
+    // it directly. Other database tests use fakes, not the wrapper.
+    files: ["test/database/TimeSeriesDatabaseTest.ts"],
+    rules: {
+      "no-restricted-syntax": "off",
     },
   },
   {

--- a/FirebaseServer/src/controller/fcm/OldDataFCM.ts
+++ b/FirebaseServer/src/controller/fcm/OldDataFCM.ts
@@ -16,15 +16,13 @@
 
 import * as firebase from 'firebase-admin';
 
-import { TimeSeriesDatabase } from '../../database/TimeSeriesDatabase';
+import { DATABASE as NotificationsDatabase } from '../../database/NotificationsDatabase';
 
 import { SensorEvent, SensorEventType } from '../../model/SensorEvent';
 import { AndroidMessagePriority, TopicMessage, Notification, NotificationPriority, AndroidConfig, AndroidNotification } from '../../model/FCM';
 import { buildTimestampToFcmTopic } from '../../model/FcmTopic';
 import { getSnoozeStatus, SnoozeLatestParams } from '../SnoozeNotifications';
 import { SnoozeStatus } from '../../model/SnoozeRequest';
-
-const NOTIFICATIONS_DATABASE = new TimeSeriesDatabase('notificationsCurrent', 'notificationsAll');
 
 const CURRENT_EVENT_KEY = 'currentEvent';
 const NOTIFICATION_CURRENT_EVENT_KEY = 'notificationCurrentEvent';
@@ -62,7 +60,7 @@ export async function sendFCMForOldData(buildTimestamp: string, eventData): Prom
     console.error('Could not generate message to send');
     return null;
   }
-  const oldNotificationData = await NOTIFICATIONS_DATABASE.getCurrent(buildTimestamp);
+  const oldNotificationData = await NotificationsDatabase.getCurrent(buildTimestamp);
   if (NOTIFICATION_CURRENT_EVENT_KEY in oldNotificationData
     && TIMESTAMP_SECONDS_KEY in oldNotificationData[NOTIFICATION_CURRENT_EVENT_KEY]) {
     const oldTimestampSeconds = oldNotificationData[NOTIFICATION_CURRENT_EVENT_KEY][TIMESTAMP_SECONDS_KEY];
@@ -76,7 +74,7 @@ export async function sendFCMForOldData(buildTimestamp: string, eventData): Prom
   const data = {};
   data[NOTIFICATION_CURRENT_EVENT_KEY] = currentEvent;
   data[NOTIFICATION_MESSAGE_KEY] = message;
-  await NOTIFICATIONS_DATABASE.save(buildTimestamp, data);
+  await NotificationsDatabase.save(buildTimestamp, data);
   console.log('Sending notification', JSON.stringify(message));
   await firebase.messaging().send(message)
     .then((response) => {

--- a/FirebaseServer/src/database/NotificationsDatabase.ts
+++ b/FirebaseServer/src/database/NotificationsDatabase.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2021 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TimeSeriesDatabase } from './TimeSeriesDatabase';
+
+// Canonical collection strings for this database. Pinned by
+// test/database/NotificationsDatabaseTest.ts. Changing them requires a
+// Firestore data migration in production — see
+// docs/FIREBASE_DATABASE_REFACTOR.md.
+export const COLLECTION_CURRENT = 'notificationsCurrent';
+export const COLLECTION_ALL = 'notificationsAll';
+
+export interface NotificationsDatabase {
+  save(buildTimestamp: string, data: any): Promise<void>;
+  getCurrent(buildTimestamp: string): Promise<any>;
+}
+
+class FirestoreNotificationsDatabase implements NotificationsDatabase {
+  private readonly db = new TimeSeriesDatabase(COLLECTION_CURRENT, COLLECTION_ALL);
+  save(b: string, d: any) { return this.db.save(b, d); }
+  getCurrent(b: string) { return this.db.getCurrent(b); }
+}
+
+let _instance: NotificationsDatabase = new FirestoreNotificationsDatabase();
+
+export const DATABASE: NotificationsDatabase = {
+  save: (b, d) => _instance.save(b, d),
+  getCurrent: (b) => _instance.getCurrent(b),
+};
+
+/** TEST-ONLY: swap in a fake implementation. */
+export function setImpl(impl: NotificationsDatabase): void { _instance = impl; }
+
+/** TEST-ONLY: restore the Firestore implementation. */
+export function resetImpl(): void { _instance = new FirestoreNotificationsDatabase(); }

--- a/FirebaseServer/test/database/NotificationsDatabaseTest.ts
+++ b/FirebaseServer/test/database/NotificationsDatabaseTest.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { expect } from 'chai';
+import {
+  COLLECTION_CURRENT,
+  COLLECTION_ALL,
+} from '../../src/database/NotificationsDatabase';
+
+describe('NotificationsDatabase: collection-name contract', () => {
+  // These strings MUST match what controller/fcm/OldDataFCM.ts wrote
+  // before centralization. A mismatch means new code writes to a
+  // different Firestore collection than existing production data —
+  // duplicate-notification suppression would silently stop working
+  // because getCurrent() would miss the historical entry.
+  //
+  // Intentional change requires a full data migration:
+  //   1. Copy documents from old collection to new in production.
+  //   2. Update this test.
+  //   3. Deploy atomically.
+
+  it('current collection is pinned', () => {
+    expect(COLLECTION_CURRENT).to.equal('notificationsCurrent');
+  });
+
+  it('all collection is pinned', () => {
+    expect(COLLECTION_ALL).to.equal('notificationsAll');
+  });
+});

--- a/FirebaseServer/test/fakes/FakeNotificationsDatabase.ts
+++ b/FirebaseServer/test/fakes/FakeNotificationsDatabase.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { NotificationsDatabase } from '../../src/database/NotificationsDatabase';
+
+export class FakeNotificationsDatabase implements NotificationsDatabase {
+  private readonly store = new Map<string, any>();
+
+  /** Audit log of all save() calls. */
+  readonly saved: Array<[string, any]> = [];
+
+  private _nextSaveError: Error | null = null;
+  private _nextGetCurrentError: Error | null = null;
+
+  async save(buildTimestamp: string, data: any): Promise<void> {
+    this.saved.push([buildTimestamp, data]);
+    if (this._nextSaveError) {
+      const err = this._nextSaveError;
+      this._nextSaveError = null;
+      throw err;
+    }
+    this.store.set(buildTimestamp, data);
+  }
+
+  async getCurrent(buildTimestamp: string): Promise<any> {
+    if (this._nextGetCurrentError) {
+      const err = this._nextGetCurrentError;
+      this._nextGetCurrentError = null;
+      throw err;
+    }
+    // Match TimeSeriesDatabase.getCurrent, which routes missing documents
+    // through convertFromFirestore() → {}. Returning null would diverge.
+    return this.store.get(buildTimestamp) ?? {};
+  }
+
+  /** Test-only helper: pre-populate storage without recording in saved[]. */
+  seed(buildTimestamp: string, data: any): void {
+    this.store.set(buildTimestamp, data);
+  }
+
+  /** Test-only helper: wipe storage and audit logs. */
+  clear(): void {
+    this.store.clear();
+    this.saved.length = 0;
+    this._nextSaveError = null;
+    this._nextGetCurrentError = null;
+  }
+
+  /** Make the next save() reject with the given error. */
+  failNextSave(error: Error): void { this._nextSaveError = error; }
+
+  /** Make the next getCurrent() reject with the given error. */
+  failNextGetCurrent(error: Error): void { this._nextGetCurrentError = error; }
+}

--- a/docs/FIREBASE_DATABASE_REFACTOR.md
+++ b/docs/FIREBASE_DATABASE_REFACTOR.md
@@ -54,7 +54,8 @@ Four collections are already centralized in `src/database/`:
 - `SensorEventDatabase.ts` — `'eventsCurrent'`/`'eventsAll'`
 - `SnoozeNotificationsDatabase.ts` — snooze collections
 - `ServerConfigDatabase.ts` — config collections
-- `Database.ts` — `'updateCurrent'`/`'updateAll'` *(misnamed file)*
+- `UpdateDatabase.ts` — `'updateCurrent'`/`'updateAll'`
+- `NotificationsDatabase.ts` — `'notificationsCurrent'`/`'notificationsAll'`
 
 ### Pattern B — duplicated inline (bad)
 
@@ -68,7 +69,7 @@ controllers. The same collection is instantiated multiple times:
 | `'remoteButtonRequestCurrent'` | no | 3 inline instances |
 | `'remoteButtonCommandCurrent'` | no | 2 inline instances |
 | `'remoteButtonRequestErrorCurrent'` | no | 2 inline instances |
-| `'notificationsCurrent'` | no | 1 inline instance |
+| `'notificationsCurrent'` | yes (`NotificationsDatabase`) | 0 inline instances (migrated) |
 
 Duplicates currently pass tests because `TimeSeriesDatabase` is
 stateless. The issue is maintenance: renaming a collection requires
@@ -254,15 +255,18 @@ CI passes. No phase depends on a subsequent phase.
 - `HttpEchoTest.ts` — reporting endpoint.
 - Extend `OldDataFCMTest.ts` with fake-based coverage.
 
-### Phase 4 — Regression guard (optional)
+### Phase 4 — Regression guard (complete)
 
-**Scope:**
-- Add a CI grep check (or ESLint rule) banning `new TimeSeriesDatabase(`
-  outside `src/database/`.
-- Prevents accidental reintroduction of Pattern B.
-
-Skip this phase if low-priority — the convention is self-documenting
-once Phases 1–3 land.
+**Shipped:**
+- ESLint `no-restricted-syntax` rule in `FirebaseServer/eslint.config.js`
+  bans `new TimeSeriesDatabase(...)` project-wide, with narrow allowlist
+  overrides for `src/database/**/*.ts` (the canonical home) and
+  `test/database/TimeSeriesDatabaseTest.ts` (the wrapper's own contract
+  test).
+- Error message points the reader at the singleton pattern and this
+  doc, so a future contributor gets the right fix on first read.
+- Verified by adding a temporary `new TimeSeriesDatabase(...)` in a
+  non-allowed file — lint fails with the rule's message.
 
 ## Safety Guards
 


### PR DESCRIPTION
## Summary

**Phase 4** of the Firebase database refactor — a regression guard preventing future contributors from reintroducing the pre-refactor duplication pattern.

- `FirebaseServer/eslint.config.js`: adds `no-restricted-syntax` with a \`NewExpression[callee.name='TimeSeriesDatabase']\` selector
- Narrow allowlist overrides for \`src/database/**/*.ts\` (canonical home) and \`test/database/TimeSeriesDatabaseTest.ts\` (wrapper's own contract test)
- Error message directs contributors at the singleton-import fix + \`docs/FIREBASE_DATABASE_REFACTOR.md\`
- Refactor doc updated: Phase 4 marked complete, notifications row reflects migration, current-state section lists all centralized modules

## Verification

- \`./scripts/validate-firebase.sh\` passes (lint + build + 89 tests)
- Regression test: temporarily added \`new TimeSeriesDatabase('x', 'y')\` in \`src/regression_test.ts\` — lint failed with the expected error message. File removed before commit.

## Merge order

⚠️ **Stacked on #481.** Depends on \`OldDataFCM.ts\` being migrated to \`NotificationsDatabase\`. Must merge AFTER #481. Auto-merge will serialize naturally — when #481 lands, this PR auto-updates, CI re-runs, then merges.

## Test plan

- [x] Lint passes on current code
- [x] Lint FAILS on a deliberate regression (verified locally)
- [x] All 89 unit tests pass
- [x] Contract tests still pin every collection name

🤖 Generated with [Claude Code](https://claude.com/claude-code)