### PR TITLE
refactor(firebase): Phase 6 — SnoozeNotificationsDatabase to canonical pattern

### DIFF
--- a/FirebaseServer/src/database/SnoozeNotificationsDatabase.ts
+++ b/FirebaseServer/src/database/SnoozeNotificationsDatabase.ts
@@ -14,25 +14,38 @@
  * limitations under the License.
  */
 
-const COLLECTION_CURRENT = 'snoozeNotificationsCurrent';
-const COLLECTION_ALL = 'snoozeNotificationsAll';
-
 import { TimeSeriesDatabase } from './TimeSeriesDatabase';
 
-class SnoozeNotificationsDatabase {
-  DB = new TimeSeriesDatabase(COLLECTION_CURRENT, COLLECTION_ALL);
+// Canonical collection strings for this database. Pinned by
+// test/database/SnoozeNotificationsDatabaseTest.ts. Changing them
+// requires a Firestore data migration in production — see
+// docs/FIREBASE_DATABASE_REFACTOR.md.
+export const COLLECTION_CURRENT = 'snoozeNotificationsCurrent';
+export const COLLECTION_ALL = 'snoozeNotificationsAll';
 
-  async set(buildTimestamp: string, data: any) {
-    await this.DB.save(buildTimestamp, data);
-  }
+export interface SnoozeNotificationsDatabase {
+  set(buildTimestamp: string, data: any): Promise<void>;
+  get(buildTimestamp: string): Promise<any>;
+  getRecentN(n: number): Promise<any>;
+}
 
-  async get(buildTimestamp: string): Promise<any> {
-    return this.DB.getCurrent(buildTimestamp);
-  }
+class FirestoreSnoozeNotificationsDatabase implements SnoozeNotificationsDatabase {
+  private readonly db = new TimeSeriesDatabase(COLLECTION_CURRENT, COLLECTION_ALL);
+  set(b: string, d: any) { return this.db.save(b, d); }
+  get(b: string) { return this.db.getCurrent(b); }
+  getRecentN(n: number) { return this.db.getLatestN(n); }
+}
 
-  async getRecentN(n: number): Promise<any> {
-    return this.DB.getLatestN(n);
-  }
+let _instance: SnoozeNotificationsDatabase = new FirestoreSnoozeNotificationsDatabase();
+
+export const DATABASE: SnoozeNotificationsDatabase = {
+  set: (b, d) => _instance.set(b, d),
+  get: (b) => _instance.get(b),
+  getRecentN: (n) => _instance.getRecentN(n),
 };
 
-export const DATABASE = new SnoozeNotificationsDatabase();
+/** TEST-ONLY: swap in a fake implementation. */
+export function setImpl(impl: SnoozeNotificationsDatabase): void { _instance = impl; }
+
+/** TEST-ONLY: restore the Firestore implementation. */
+export function resetImpl(): void { _instance = new FirestoreSnoozeNotificationsDatabase(); }

--- a/FirebaseServer/test/database/SnoozeNotificationsDatabaseTest.ts
+++ b/FirebaseServer/test/database/SnoozeNotificationsDatabaseTest.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { expect } from 'chai';
+import {
+  COLLECTION_CURRENT,
+  COLLECTION_ALL,
+} from '../../src/database/SnoozeNotificationsDatabase';
+
+describe('SnoozeNotificationsDatabase: collection-name contract', () => {
+  // These strings MUST match what controller/SnoozeNotifications.ts
+  // wrote before centralization. A mismatch means new code writes to a
+  // different Firestore collection than existing production data —
+  // active snooze requests would silently fail to suppress
+  // notifications, because getSnoozeStatus() would miss the
+  // historical entry.
+  //
+  // Intentional change requires a full data migration:
+  //   1. Copy documents from old collection to new in production.
+  //   2. Update this test.
+  //   3. Deploy atomically.
+
+  it('current collection is pinned', () => {
+    expect(COLLECTION_CURRENT).to.equal('snoozeNotificationsCurrent');
+  });
+
+  it('all collection is pinned', () => {
+    expect(COLLECTION_ALL).to.equal('snoozeNotificationsAll');
+  });
+});

--- a/FirebaseServer/test/fakes/FakeSnoozeNotificationsDatabase.ts
+++ b/FirebaseServer/test/fakes/FakeSnoozeNotificationsDatabase.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { SnoozeNotificationsDatabase } from '../../src/database/SnoozeNotificationsDatabase';
+
+export class FakeSnoozeNotificationsDatabase implements SnoozeNotificationsDatabase {
+  private readonly store = new Map<string, any>();
+
+  /**
+   * Newest-first history of every set() (and seed()). getRecentN(n)
+   * returns the first n entries. Mirrors TimeSeriesDatabase.getLatestN
+   * which orders by FIRESTORE_databaseTimestampSeconds desc.
+   */
+  private readonly history: any[] = [];
+
+  /** Audit log of all set() calls. */
+  readonly saved: Array<[string, any]> = [];
+
+  private _nextSetError: Error | null = null;
+  private _nextGetError: Error | null = null;
+  private _nextGetRecentNError: Error | null = null;
+
+  async set(buildTimestamp: string, data: any): Promise<void> {
+    this.saved.push([buildTimestamp, data]);
+    if (this._nextSetError) {
+      const err = this._nextSetError;
+      this._nextSetError = null;
+      throw err;
+    }
+    this.store.set(buildTimestamp, data);
+    this.history.unshift(data);
+  }
+
+  async get(buildTimestamp: string): Promise<any> {
+    if (this._nextGetError) {
+      const err = this._nextGetError;
+      this._nextGetError = null;
+      throw err;
+    }
+    // Match TimeSeriesDatabase.getCurrent, which routes missing documents
+    // through convertFromFirestore() → {}. Returning null would diverge.
+    return this.store.get(buildTimestamp) ?? {};
+  }
+
+  async getRecentN(n: number): Promise<any> {
+    if (this._nextGetRecentNError) {
+      const err = this._nextGetRecentNError;
+      this._nextGetRecentNError = null;
+      throw err;
+    }
+    return this.history.slice(0, n);
+  }
+
+  /** Test-only helper: pre-populate storage without recording in saved[]. */
+  seed(buildTimestamp: string, data: any): void {
+    this.store.set(buildTimestamp, data);
+    this.history.unshift(data);
+  }
+
+  /** Test-only helper: wipe storage and audit logs. */
+  clear(): void {
+    this.store.clear();
+    this.history.length = 0;
+    this.saved.length = 0;
+    this._nextSetError = null;
+    this._nextGetError = null;
+    this._nextGetRecentNError = null;
+  }
+
+  /** Make the next set() reject with the given error. */
+  failNextSet(error: Error): void { this._nextSetError = error; }
+
+  /** Make the next get() reject with the given error. */
+  failNextGet(error: Error): void { this._nextGetError = error; }
+
+  /** Make the next getRecentN() reject with the given error. */
+  failNextGetRecentN(error: Error): void { this._nextGetRecentNError = error; }
+}


### PR DESCRIPTION
## Summary

Phase 6 of the Firebase DB refactor (see \`docs/FIREBASE_DATABASE_REFACTOR.md\` → *Follow-up Phases*). Converts \`SnoozeNotificationsDatabase\` from the concrete-class pattern to the interface + FirestoreImpl + swappable singleton pattern used by the other modules.

- **\`src/database/SnoozeNotificationsDatabase.ts\`** — exports \`COLLECTION_CURRENT\` / \`COLLECTION_ALL\` (previously module-local), adds \`interface SnoozeNotificationsDatabase\`, \`FirestoreSnoozeNotificationsDatabase\` impl class, \`DATABASE\` singleton delegating to \`_instance\`, \`setImpl\` / \`resetImpl\`. **Public API preserved** — callers still use \`DATABASE.set/get/getRecentN\`.
- **\`test/fakes/FakeSnoozeNotificationsDatabase.ts\`** — Map-backed fake with \`history\` for \`getRecentN\`, audit array, and \`failNextX\` helpers.
- **\`test/database/SnoozeNotificationsDatabaseTest.ts\`** — contract test pins \`'snoozeNotificationsCurrent'\` / \`'snoozeNotificationsAll'\`.

## Zero Firestore impact

- Collection strings byte-identical (grep-diff below)
- Document shape unchanged
- \`TimeSeriesDatabase.ts\` not modified
- Phase 4 lint still green (only \`src/database/**\` instantiates \`TimeSeriesDatabase\`)
- Existing \`sinon.stub(DATABASE, 'get')\` in \`SnoozeNotificationsTest.ts\` still passes — replacing the delegator short-circuits \`_instance.get()\`.

## Grep diff (collection strings — set unchanged)

Before and after, this query returns the same set for \`snoozeNotifications*\`:
\`\`\`
grep -rE \"'[a-z][a-zA-Z]+(Current|All)'\" FirebaseServer/src | sort -u
\`\`\`

## Test count

89 → 91 (+2 contract tests). All tests pass.

## Unblocks

Phase 9 (\`OldDataFCMFakeTest\`) needs \`FakeSnoozeNotificationsDatabase\`.

## Test plan

- [x] \`./scripts/validate-firebase.sh\` passes (lint + build + 91 tests)
- [x] Contract strings pinned
- [x] Grep-diff: collection string set unchanged
- [x] \`TimeSeriesDatabase.ts\` unchanged
- [x] Phase 4 lint green
- [x] Existing \`SnoozeNotificationsTest\` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)