### PR TITLE
refactor(firebase): Phase 5 — ServerConfigDatabase to canonical pattern

### DIFF
--- a/FirebaseServer/src/controller/DatabaseCleaner.ts
+++ b/FirebaseServer/src/controller/DatabaseCleaner.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Config } from '../database/ServerConfigDatabase';
+import { DATABASE as ServerConfigDatabase } from '../database/ServerConfigDatabase';
+import { isDeleteOldDataEnabled, isDeleteOldDataEnabledDryRun } from './config/ConfigAccessors';
 
 import { DATABASE as UpdateDatabase } from '../database/UpdateDatabase';
 import { DATABASE as SensorEventDatabase } from '../database/SensorEventDatabase';
@@ -22,15 +23,15 @@ import { DATABASE as REMOTE_REQUEST_DATABASE } from '../database/RemoteButtonReq
 import { DATABASE as REMOTE_COMMAND_DATABASE } from '../database/RemoteButtonCommandDatabase';
 
 export async function deleteOldData(cutoffTimestampSeconds: number, dryRunRequested: boolean): Promise<object> {
-  const config = await Config.get();
-  if (!Config.isDeleteOldDataEnabled(config)) {
+  const config = await ServerConfigDatabase.get();
+  if (!isDeleteOldDataEnabled(config)) {
     console.log('deleteOldData: Deleting data is disabled');
     return {};
   }
   if (dryRunRequested) {
     console.log('deleteOldData: Dry run requested');
   }
-  const dryRunConfig = Config.isDeleteOldDataEnabledDryRun(config);
+  const dryRunConfig = isDeleteOldDataEnabledDryRun(config);
   if (dryRunConfig) {
     console.log('deleteOldData: Dry run is configured');
   }

--- a/FirebaseServer/src/controller/config/ConfigAccessors.ts
+++ b/FirebaseServer/src/controller/config/ConfigAccessors.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2021 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Pure accessors over a server-config payload fetched from
+ * `ServerConfigDatabase.get()`. These don't touch Firestore — they're
+ * stateless reads over the config object's `body` shape. Kept out of
+ * the DB interface so the DB module stays narrowly focused on get/set.
+ */
+
+export function getRemoteButtonPushKey(config: any): string | null {
+  if (config && config.hasOwnProperty('body') && config.body.hasOwnProperty('remoteButtonPushKey')) {
+    return config.body.remoteButtonPushKey;
+  }
+  return null;
+}
+
+export function getRemoteButtonAuthorizedEmails(config: any): string[] | null {
+  if (config && config.hasOwnProperty('body') && config.body.hasOwnProperty('remoteButtonAuthorizedEmails')) {
+    return config.body.remoteButtonAuthorizedEmails;
+  }
+  return null;
+}
+
+export function isRemoteButtonEnabled(config: any): boolean {
+  if (config && config.hasOwnProperty('body') && config.body.hasOwnProperty('remoteButtonEnabled')) {
+    return config.body.remoteButtonEnabled;
+  }
+  return false;
+}
+
+export function getRemoteButtonBuildTimestamp(config: any): string | null {
+  if (config && config.hasOwnProperty('body') && config.body.hasOwnProperty('remoteButtonBuildTimestamp')) {
+    return config.body.remoteButtonBuildTimestamp;
+  }
+  return null;
+}
+
+export function isDeleteOldDataEnabled(config: any): boolean {
+  if (config && config.hasOwnProperty('body') && config.body.hasOwnProperty('deleteOldDataEnabled')) {
+    return config.body.deleteOldDataEnabled;
+  }
+  return false;
+}
+
+export function isDeleteOldDataEnabledDryRun(config: any): boolean {
+  if (config && config.hasOwnProperty('body') && config.body.hasOwnProperty('deleteOldDataEnabledDryRun')) {
+    return config.body.deleteOldDataEnabledDryRun;
+  }
+  return false;
+}
+
+export function isSnoozeNotificationsEnabled(config: any): boolean {
+  if (config && config.hasOwnProperty('body') && config.body.hasOwnProperty('snoozeNotificationsEnabled')) {
+    return config.body.snoozeNotificationsEnabled;
+  }
+  return false;
+}

--- a/FirebaseServer/src/database/ServerConfigDatabase.ts
+++ b/FirebaseServer/src/database/ServerConfigDatabase.ts
@@ -16,66 +16,34 @@
 
 import { TimeSeriesDatabase } from './TimeSeriesDatabase';
 
-class ServerConfig {
-  DATABASE = new TimeSeriesDatabase('configCurrent', 'configAll');
-  CURRENT_KEY = 'current';
+// Canonical collection strings + document key for this database.
+// Pinned by test/database/ServerConfigDatabaseTest.ts. Changing them
+// requires a Firestore data migration in production — see
+// docs/FIREBASE_DATABASE_REFACTOR.md.
+export const COLLECTION_CURRENT = 'configCurrent';
+export const COLLECTION_ALL = 'configAll';
+export const CURRENT_KEY = 'current';
 
-  async set(data) {
-    await this.DATABASE.save(this.CURRENT_KEY, data);
-  }
+export interface ServerConfigDatabase {
+  get(): Promise<any>;
+  set(data: any): Promise<void>;
+}
 
-  async get(): Promise<any> {
-    return this.DATABASE.getCurrent(this.CURRENT_KEY);
-  }
+class FirestoreServerConfigDatabase implements ServerConfigDatabase {
+  private readonly db = new TimeSeriesDatabase(COLLECTION_CURRENT, COLLECTION_ALL);
+  get() { return this.db.getCurrent(CURRENT_KEY); }
+  set(d: any) { return this.db.save(CURRENT_KEY, d); }
+}
 
-  getRemoteButtonPushKey(config): string {
-    if (config && config.hasOwnProperty('body') && config.body.hasOwnProperty('remoteButtonPushKey')) {
-      return config.body.remoteButtonPushKey;
-    }
-    return null;
-  }
+let _instance: ServerConfigDatabase = new FirestoreServerConfigDatabase();
 
-  getRemoteButtonAuthorizedEmails(config): string[] {
-    if (config && config.hasOwnProperty('body') && config.body.hasOwnProperty('remoteButtonAuthorizedEmails')) {
-      return config.body.remoteButtonAuthorizedEmails;
-    }
-    return null;
-  }
-
-  isRemoteButtonEnabled(config): boolean {
-    if (config && config.hasOwnProperty('body') && config.body.hasOwnProperty('remoteButtonEnabled')) {
-      return config.body.remoteButtonEnabled;
-    }
-    return false;
-  }
-
-  getRemoteButtonBuildTimestamp(config): string {
-    if (config && config.hasOwnProperty('body') && config.body.hasOwnProperty('remoteButtonBuildTimestamp')) {
-      return config.body.remoteButtonBuildTimestamp;
-    }
-    return null;
-  }
-
-  isDeleteOldDataEnabled(config): boolean {
-    if (config && config.hasOwnProperty('body') && config.body.hasOwnProperty('deleteOldDataEnabled')) {
-      return config.body.deleteOldDataEnabled;
-    }
-    return false;
-  }
-
-  isDeleteOldDataEnabledDryRun(config): boolean {
-    if (config && config.hasOwnProperty('body') && config.body.hasOwnProperty('deleteOldDataEnabledDryRun')) {
-      return config.body.deleteOldDataEnabledDryRun;
-    }
-    return false;
-  }
-  
-  isSnoozeNotificationsEnabled(config): boolean {
-    if (config && config.hasOwnProperty('body') && config.body.hasOwnProperty('snoozeNotificationsEnabled')) {
-      return config.body.snoozeNotificationsEnabled;
-    }
-    return false;
-  }
+export const DATABASE: ServerConfigDatabase = {
+  get: () => _instance.get(),
+  set: (d) => _instance.set(d),
 };
 
-export const Config = new ServerConfig();
+/** TEST-ONLY: swap in a fake implementation. */
+export function setImpl(impl: ServerConfigDatabase): void { _instance = impl; }
+
+/** TEST-ONLY: restore the Firestore implementation. */
+export function resetImpl(): void { _instance = new FirestoreServerConfigDatabase(); }

--- a/FirebaseServer/src/functions/http/DeleteData.ts
+++ b/FirebaseServer/src/functions/http/DeleteData.ts
@@ -16,12 +16,13 @@
 
 import * as functions from 'firebase-functions/v1';
 
-import { Config } from '../../database/ServerConfigDatabase';
+import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
+import { isDeleteOldDataEnabled } from '../../controller/config/ConfigAccessors';
 import { deleteOldData } from '../../controller/DatabaseCleaner';
 
 export const httpDeleteOldData = functions.https.onRequest(async (request, response) => {
-  const config = await Config.get();
-  if (!Config.isDeleteOldDataEnabled(config)) {
+  const config = await ServerConfigDatabase.get();
+  if (!isDeleteOldDataEnabled(config)) {
     console.log('Deleting data is disabled');
     response.status(400).send({ error: 'Disabled' });
     return;

--- a/FirebaseServer/src/functions/http/RemoteButton.ts
+++ b/FirebaseServer/src/functions/http/RemoteButton.ts
@@ -19,7 +19,8 @@ import { v4 as uuidv4 } from 'uuid';
 import * as firebase from 'firebase-admin';
 import * as functions from 'firebase-functions/v1';
 
-import { Config } from '../../database/ServerConfigDatabase';
+import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
+import { isRemoteButtonEnabled, getRemoteButtonPushKey, getRemoteButtonAuthorizedEmails } from '../../controller/config/ConfigAccessors';
 import { DATABASE as REMOTE_BUTTON_COMMAND_DATABASE } from '../../database/RemoteButtonCommandDatabase';
 import { DATABASE as REMOTE_BUTTON_REQUEST_DATABASE } from '../../database/RemoteButtonRequestDatabase';
 import { isAuthorizedToPushRemoteButton } from '../../controller/Auth';
@@ -39,8 +40,8 @@ const REMOTE_BUTTON_COMMAND_TIMEOUT_SECONDS = 60;
  * curl -H "Content-Type: application/json" http://localhost:5000/PROJECT-ID/us-central1/remoteButton?buildTimestamp=buildTimestamp&buttonAckToken=buttonAckToken
  */
 export const httpRemoteButton = functions.https.onRequest(async (request, response) => {
-  const config = await Config.get();
-  if (!Config.isRemoteButtonEnabled(config)) {
+  const config = await ServerConfigDatabase.get();
+  if (!isRemoteButtonEnabled(config)) {
     response.status(400).send({ error: 'Disabled' });
     return;
   }
@@ -127,8 +128,8 @@ export const httpRemoteButton = functions.https.onRequest(async (request, respon
  * curl -H "Content-Type: application/json" http://localhost:5000/PROJECT-ID/us-central1/addRemoteButtonCommand?buildTimestamp=buildTimestamp&buttonAckToken=buttonAckToken
  */
 export const httpAddRemoteButtonCommand = functions.https.onRequest(async (request, response) => {
-  const config = await Config.get();
-  if (!Config.isRemoteButtonEnabled(config)) {
+  const config = await ServerConfigDatabase.get();
+  if (!isRemoteButtonEnabled(config)) {
     response.status(400).send({ error: 'Disabled' });
     return;
   }
@@ -139,7 +140,7 @@ export const httpAddRemoteButtonCommand = functions.https.onRequest(async (reque
     response.status(401).send(result);
     return;
   }
-  if (Config.getRemoteButtonPushKey(config) !== buttonPushKeyHeader) {
+  if (getRemoteButtonPushKey(config) !== buttonPushKeyHeader) {
     const result = { error: 'Forbidden (key).' };
     console.error(result);
     response.status(403).send(result);
@@ -156,7 +157,7 @@ export const httpAddRemoteButtonCommand = functions.https.onRequest(async (reque
   const decodedToken = await firebase.auth().verifyIdToken(googleIdToken);
   const email = decodedToken.email;
   console.log('email:', email);
-  const authorizedEmails = Config.getRemoteButtonAuthorizedEmails(config);
+  const authorizedEmails = getRemoteButtonAuthorizedEmails(config);
   if (!isAuthorizedToPushRemoteButton(email, authorizedEmails)) {
     const result = { error: 'Forbidden (user).' };
     console.error(result);

--- a/FirebaseServer/src/functions/http/ServerConfig.ts
+++ b/FirebaseServer/src/functions/http/ServerConfig.ts
@@ -16,7 +16,7 @@
 
 import * as functions from 'firebase-functions/v1';
 
-import { Config } from '../../database/ServerConfigDatabase';
+import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
 
 export const httpServerConfig = functions.https.onRequest(async (request, response) => {
   const functionConfig = functions.config();
@@ -48,7 +48,7 @@ export const httpServerConfig = functions.https.onRequest(async (request, respon
     return;
   }
   // Fully authorized.
-  const config = await Config.get();
+  const config = await ServerConfigDatabase.get();
   response.status(200).send(config);
   return;
 });
@@ -88,8 +88,8 @@ export const httpServerConfigUpdate = functions.https.onRequest(async (request, 
     return;
   }
   try {
-    await Config.set(data);
-    const config = await Config.get();
+    await ServerConfigDatabase.set(data);
+    const config = await ServerConfigDatabase.get();
     response.status(200).send(config);
     return;
   }

--- a/FirebaseServer/src/functions/http/Snooze.ts
+++ b/FirebaseServer/src/functions/http/Snooze.ts
@@ -17,7 +17,8 @@
 import * as firebase from 'firebase-admin';
 import * as functions from 'firebase-functions/v1';
 
-import { Config } from '../../database/ServerConfigDatabase';
+import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
+import { isSnoozeNotificationsEnabled, getRemoteButtonPushKey, getRemoteButtonAuthorizedEmails } from '../../controller/config/ConfigAccessors';
 import { isAuthorizedToPushRemoteButton } from '../../controller/Auth';
 import { getSnoozeStatus, SnoozeLatestParams, SnoozeLatestResponse, SubmitSnoozeParams, submitSnoozeNotificationsRequest, SubmitSnoozeResponse } from '../../controller/SnoozeNotifications';
 
@@ -48,8 +49,8 @@ export const httpSnoozeNotificationsRequest = functions.https.onRequest(async (r
     //     * SnoozeRequest | error: string
 
     // Handle the HTTP request.
-    const config = await Config.get();
-    if (!Config.isSnoozeNotificationsEnabled(config)) {
+    const config = await ServerConfigDatabase.get();
+    if (!isSnoozeNotificationsEnabled(config)) {
         response.status(400).send({ error: 'Disabled' });
         return;
     }
@@ -70,7 +71,7 @@ export const httpSnoozeNotificationsRequest = functions.https.onRequest(async (r
         response.status(401).send(result);
         return;
     }
-    if (Config.getRemoteButtonPushKey(config) !== buttonPushKeyHeader) {
+    if (getRemoteButtonPushKey(config) !== buttonPushKeyHeader) {
         const result = { error: 'Forbidden (key).' };
         console.error(result);
         response.status(403).send(result);
@@ -99,7 +100,7 @@ export const httpSnoozeNotificationsRequest = functions.https.onRequest(async (r
     }
     console.log('email:', email);
     // User is authenticated. Check if they are authorized.
-    const authorizedEmails = Config.getRemoteButtonAuthorizedEmails(config);
+    const authorizedEmails = getRemoteButtonAuthorizedEmails(config);
     if (!isAuthorizedToPushRemoteButton(email, authorizedEmails)) {
         const result = { error: 'Forbidden (user).' };
         console.error(result);
@@ -180,8 +181,8 @@ export const httpSnoozeNotificationsLatest = functions.https.onRequest(async (re
     //     * error: string
 
     // Handle the HTTP request.
-    const config = await Config.get();
-    if (!Config.isSnoozeNotificationsEnabled(config)) {
+    const config = await ServerConfigDatabase.get();
+    if (!isSnoozeNotificationsEnabled(config)) {
         response.status(400).send({ error: 'Disabled' });
         return;
     }

--- a/FirebaseServer/src/functions/pubsub/DataRetentionPolicy.ts
+++ b/FirebaseServer/src/functions/pubsub/DataRetentionPolicy.ts
@@ -16,14 +16,15 @@
 
 import * as functions from 'firebase-functions/v1';
 
-import { Config } from '../../database/ServerConfigDatabase';
+import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
+import { isDeleteOldDataEnabled } from '../../controller/config/ConfigAccessors';
 import { deleteOldData } from '../../controller/DatabaseCleaner';
 
 export const pubsubDataRetentionPolicy = functions.pubsub
   .schedule('0 0 * * *').timeZone('America/Los_Angeles') // California midnight every day.
   .onRun(async (_context) => {
-    const config = await Config.get();
-    if (!Config.isDeleteOldDataEnabled(config)) {
+    const config = await ServerConfigDatabase.get();
+    if (!isDeleteOldDataEnabled(config)) {
       console.log('Deleting data is disabled');
       return null;
     }

--- a/FirebaseServer/test/database/ServerConfigDatabaseTest.ts
+++ b/FirebaseServer/test/database/ServerConfigDatabaseTest.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { expect } from 'chai';
+import {
+  COLLECTION_CURRENT,
+  COLLECTION_ALL,
+  CURRENT_KEY,
+} from '../../src/database/ServerConfigDatabase';
+
+describe('ServerConfigDatabase: collection-name contract', () => {
+  // These strings MUST match what the pre-refactor ServerConfigDatabase
+  // wrote. `CURRENT_KEY` ('current') is the single document ID within
+  // the `configCurrent` collection — changing it would orphan every
+  // existing config read. A mismatch would cause the server to read a
+  // blank config, falling back to every feature flag's default
+  // (disabled), silently breaking the app.
+  //
+  // Intentional change requires a full data migration:
+  //   1. Copy the single config document from old → new location.
+  //   2. Update this test.
+  //   3. Redeploy every caller atomically.
+
+  it('current collection is pinned', () => {
+    expect(COLLECTION_CURRENT).to.equal('configCurrent');
+  });
+
+  it('all collection is pinned', () => {
+    expect(COLLECTION_ALL).to.equal('configAll');
+  });
+
+  it('current document key is pinned', () => {
+    expect(CURRENT_KEY).to.equal('current');
+  });
+});

--- a/FirebaseServer/test/fakes/FakeServerConfigDatabase.ts
+++ b/FirebaseServer/test/fakes/FakeServerConfigDatabase.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { ServerConfigDatabase } from '../../src/database/ServerConfigDatabase';
+
+export class FakeServerConfigDatabase implements ServerConfigDatabase {
+  private current: any = null;
+
+  /** Audit log of all set() calls. */
+  readonly saved: any[] = [];
+
+  private _nextSetError: Error | null = null;
+  private _nextGetError: Error | null = null;
+
+  async set(data: any): Promise<void> {
+    this.saved.push(data);
+    if (this._nextSetError) {
+      const err = this._nextSetError;
+      this._nextSetError = null;
+      throw err;
+    }
+    this.current = data;
+  }
+
+  async get(): Promise<any> {
+    if (this._nextGetError) {
+      const err = this._nextGetError;
+      this._nextGetError = null;
+      throw err;
+    }
+    // Match TimeSeriesDatabase.getCurrent, which routes missing documents
+    // through convertFromFirestore() → {}. Returning null would diverge.
+    return this.current ?? {};
+  }
+
+  /** Test-only helper: pre-populate without recording in saved[]. */
+  seed(data: any): void {
+    this.current = data;
+  }
+
+  /** Test-only helper: wipe state and audit logs. */
+  clear(): void {
+    this.current = null;
+    this.saved.length = 0;
+    this._nextSetError = null;
+    this._nextGetError = null;
+  }
+
+  /** Make the next set() reject with the given error. */
+  failNextSet(error: Error): void { this._nextSetError = error; }
+
+  /** Make the next get() reject with the given error. */
+  failNextGet(error: Error): void { this._nextGetError = error; }
+}


### PR DESCRIPTION
## Summary

Phase 5 of the Firebase DB refactor follow-up (see \`docs/FIREBASE_DATABASE_REFACTOR.md\` → *Follow-up Phases*). Converts \`ServerConfigDatabase\` from the concrete-class pattern to interface + FirestoreImpl + swappable singleton, and splits pure config-payload getters into free functions.

### Production code

- **\`src/database/ServerConfigDatabase.ts\`** — exports \`COLLECTION_CURRENT\`, \`COLLECTION_ALL\`, \`CURRENT_KEY\`. \`interface ServerConfigDatabase\`, \`FirestoreServerConfigDatabase\` impl, \`DATABASE\` singleton, \`setImpl\` / \`resetImpl\`.
- **\`src/controller/config/ConfigAccessors.ts\`** (new) — 7 pure functions over config payload: \`getRemoteButtonPushKey\`, \`getRemoteButtonAuthorizedEmails\`, \`isRemoteButtonEnabled\`, \`getRemoteButtonBuildTimestamp\`, \`isDeleteOldDataEnabled\`, \`isDeleteOldDataEnabledDryRun\`, \`isSnoozeNotificationsEnabled\`.

### Callers migrated (6)

\`controller/DatabaseCleaner.ts\`, \`functions/http/{RemoteButton,Snooze,ServerConfig,DeleteData}.ts\`, \`functions/pubsub/DataRetentionPolicy.ts\`.

Migration pattern:
- \`Config.get()\` → \`ServerConfigDatabase.get()\`
- \`Config.set(d)\` → \`ServerConfigDatabase.set(d)\`
- \`Config.getXxx(cfg)\` → \`getXxx(cfg)\`

### Tests

- **\`test/fakes/FakeServerConfigDatabase.ts\`** — Map-backed fake with \`failNextSet\` / \`failNextGet\`.
- **\`test/database/ServerConfigDatabaseTest.ts\`** — contract test pins \`'configCurrent'\`, \`'configAll'\`, and \`CURRENT_KEY = 'current'\`. The document key is critical: the config lives in a single doc within the collection — changing it would orphan every config read.

## Zero Firestore impact

- Collection strings byte-identical (grep-diff below)
- \`CURRENT_KEY = 'current'\` unchanged
- Document shape unchanged
- \`TimeSeriesDatabase.ts\` not modified
- Phase 4 lint green
- No caller runtime behavior change — \`DATABASE.get()\` returns the same payload, all accessor semantics preserved (same \`hasOwnProperty\` chain, same defaults, same return types)

## Grep diff

\`\`\`
grep -rE \"'[a-z][a-zA-Z]+(Current|All)'\" FirebaseServer/src | sort -u
\`\`\`

String set unchanged before/after. \`'configCurrent'\` / \`'configAll'\` now live as exported consts instead of inline.

## Unblocks

Phase 7 (RemoteButton handler tests) — needs \`FakeServerConfigDatabase\`.

## Test count

89 → 92 (+3 contract tests: current, all, CURRENT_KEY).

## Test plan

- [x] \`./scripts/validate-firebase.sh\` passes (lint + build + 92 tests)
- [x] Contract strings + CURRENT_KEY pinned
- [x] Grep-diff: collection string set unchanged
- [x] \`TimeSeriesDatabase.ts\` unchanged
- [x] Phase 4 lint green
- [x] All 6 caller files compile with the new imports
- [x] Accessor logic preserved byte-for-byte (same \`hasOwnProperty\` chain + defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)