### PR TITLE
hardening(firebase): Corrected A1 — buildTimestamp from production config

### DIFF
--- a/FirebaseServer/src/controller/config/ConfigAccessors.ts
+++ b/FirebaseServer/src/controller/config/ConfigAccessors.ts
@@ -77,9 +77,46 @@ export function getRemoteButtonBuildTimestamp(config: any): string | null {
   if (typeof raw !== 'string' || raw.length === 0) return null;
   try {
     return decodeURIComponent(raw);
-  } catch {
+  } catch (err) {
+    console.warn(
+      'ConfigAccessors: failed to URL-decode remoteButtonBuildTimestamp, returning raw value.',
+      { raw, err: err instanceof Error ? err.message : String(err) },
+    );
     return raw;
   }
+}
+
+/**
+ * Resolve a nullable config-read value to a non-null string, falling
+ * back to a hardcoded literal and emitting a Cloud Logging warning if
+ * the fallback is used. Callers get a guaranteed string; operators
+ * get visibility when config drift happens (missing field, empty
+ * value, etc.).
+ *
+ * Usage:
+ *   const buildTimestamp = resolveBuildTimestamp(
+ *     getBuildTimestamp(config),
+ *     DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK,
+ *     'pubsubCheckForOpenDoorsJob',
+ *   );
+ *
+ * The `context` string identifies the call site in logs so filters
+ * like `logName:"cloudfunctions" severity:"WARNING" textPayload:"buildTimestamp"`
+ * can distinguish fallback hits across functions.
+ */
+export function resolveBuildTimestamp(
+  configValue: string | null,
+  fallback: string,
+  context: string,
+): string {
+  if (configValue === null) {
+    console.warn(
+      `[${context}] buildTimestamp not in config; using hardcoded fallback.`,
+      { fallback },
+    );
+    return fallback;
+  }
+  return configValue;
 }
 
 export function isDeleteOldDataEnabled(config: any): boolean {

--- a/FirebaseServer/src/controller/config/ConfigAccessors.ts
+++ b/FirebaseServer/src/controller/config/ConfigAccessors.ts
@@ -42,11 +42,44 @@ export function isRemoteButtonEnabled(config: any): boolean {
   return false;
 }
 
+/**
+ * buildTimestamp of the door-sensor ESP32. Reads the production key
+ * `body.buildTimestamp` (no prefix — the key has been there since the
+ * first serverConfig.json in April 2021). The value is stored plain/
+ * decoded, so no transform is applied. Empty strings are treated as
+ * missing (returns null) so caller `?? fallback` chains behave
+ * correctly.
+ */
+export function getBuildTimestamp(config: any): string | null {
+  if (!config || !config.body) return null;
+  const value = config.body.buildTimestamp;
+  if (typeof value !== 'string' || value.length === 0) return null;
+  return value;
+}
+
+/**
+ * buildTimestamp of the remote-button device. Reads
+ * `body.remoteButtonBuildTimestamp`, which has been stored URL-encoded
+ * in production config since April 2021. This accessor normalizes by
+ * calling `decodeURIComponent()` so callers always see the decoded
+ * form — matching the pre-refactor hardcoded literal used in
+ * `pubsub/RemoteButton.ts`.
+ *
+ * Defensive behavior:
+ *  - Empty string value → null (callers' `?? fallback` triggers).
+ *  - Already-decoded value → unchanged (decode is idempotent for
+ *    strings without `%`).
+ *  - Malformed percent-encoding → returns raw value, never crashes.
+ */
 export function getRemoteButtonBuildTimestamp(config: any): string | null {
-  if (config && config.hasOwnProperty('body') && config.body.hasOwnProperty('remoteButtonBuildTimestamp')) {
-    return config.body.remoteButtonBuildTimestamp;
+  if (!config || !config.body) return null;
+  const raw = config.body.remoteButtonBuildTimestamp;
+  if (typeof raw !== 'string' || raw.length === 0) return null;
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
   }
-  return null;
 }
 
 export function isDeleteOldDataEnabled(config: any): boolean {

--- a/FirebaseServer/src/functions/http/OpenDoor.ts
+++ b/FirebaseServer/src/functions/http/OpenDoor.ts
@@ -18,9 +18,18 @@ import * as functions from 'firebase-functions/v1';
 
 import { sendFCMForOldData } from '../../controller/fcm/OldDataFCM';
 import { DATABASE as SensorEventDatabase } from '../../database/SensorEventDatabase';
+import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
+import { getBuildTimestamp } from '../../controller/config/ConfigAccessors';
 
-export const httpCheckForOpenDoors = functions.https.onRequest(async (request, response) => {
-  const buildTimestamp = 'Sat Mar 13 14:45:00 2021'; // TODO: Use config.
+// Fallback to the historical hardcoded door-sensor device ID if the
+// config field is missing or empty. Production has the field populated
+// (since April 2021), so the fallback is a safety net, not the
+// expected path.
+const DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK = 'Sat Mar 13 14:45:00 2021';
+
+export const httpCheckForOpenDoors = functions.https.onRequest(async (_request, response) => {
+  const config = await ServerConfigDatabase.get();
+  const buildTimestamp = getBuildTimestamp(config) ?? DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK;
   const eventData = await SensorEventDatabase.getCurrent(buildTimestamp);
   const result = await sendFCMForOldData(buildTimestamp, eventData);
   response.status(200).send(result);

--- a/FirebaseServer/src/functions/http/OpenDoor.ts
+++ b/FirebaseServer/src/functions/http/OpenDoor.ts
@@ -19,17 +19,21 @@ import * as functions from 'firebase-functions/v1';
 import { sendFCMForOldData } from '../../controller/fcm/OldDataFCM';
 import { DATABASE as SensorEventDatabase } from '../../database/SensorEventDatabase';
 import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
-import { getBuildTimestamp } from '../../controller/config/ConfigAccessors';
+import { getBuildTimestamp, resolveBuildTimestamp } from '../../controller/config/ConfigAccessors';
 
 // Fallback to the historical hardcoded door-sensor device ID if the
 // config field is missing or empty. Production has the field populated
 // (since April 2021), so the fallback is a safety net, not the
-// expected path.
+// expected path. Fallback use emits a warn-level Cloud Log entry.
 const DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK = 'Sat Mar 13 14:45:00 2021';
 
 export const httpCheckForOpenDoors = functions.https.onRequest(async (_request, response) => {
   const config = await ServerConfigDatabase.get();
-  const buildTimestamp = getBuildTimestamp(config) ?? DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK;
+  const buildTimestamp = resolveBuildTimestamp(
+    getBuildTimestamp(config),
+    DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK,
+    'httpCheckForOpenDoors',
+  );
   const eventData = await SensorEventDatabase.getCurrent(buildTimestamp);
   const result = await sendFCMForOldData(buildTimestamp, eventData);
   response.status(200).send(result);

--- a/FirebaseServer/src/functions/pubsub/DoorErrors.ts
+++ b/FirebaseServer/src/functions/pubsub/DoorErrors.ts
@@ -18,7 +18,7 @@ import * as functions from 'firebase-functions/v1';
 
 import { updateEvent } from '../../controller/EventUpdates';
 import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
-import { getBuildTimestamp } from '../../controller/config/ConfigAccessors';
+import { getBuildTimestamp, resolveBuildTimestamp } from '../../controller/config/ConfigAccessors';
 
 // See http/OpenDoor.ts for the fallback rationale. Same door-sensor
 // device.
@@ -27,7 +27,11 @@ const DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK = 'Sat Mar 13 14:45:00 2021';
 export const pubsubCheckForDoorErrors = functions.pubsub.schedule('every 1 minutes').onRun(async (_context) => {
   const BUILD_TIMESTAMP_PARAM_KEY = "buildTimestamp";
   const config = await ServerConfigDatabase.get();
-  const buildTimestampString = getBuildTimestamp(config) ?? DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK;
+  const buildTimestampString = resolveBuildTimestamp(
+    getBuildTimestamp(config),
+    DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK,
+    'pubsubCheckForDoorErrors',
+  );
   const scheduledJob = true;
   const data = {};
   data[BUILD_TIMESTAMP_PARAM_KEY] = buildTimestampString;

--- a/FirebaseServer/src/functions/pubsub/DoorErrors.ts
+++ b/FirebaseServer/src/functions/pubsub/DoorErrors.ts
@@ -17,10 +17,17 @@
 import * as functions from 'firebase-functions/v1';
 
 import { updateEvent } from '../../controller/EventUpdates';
+import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
+import { getBuildTimestamp } from '../../controller/config/ConfigAccessors';
+
+// See http/OpenDoor.ts for the fallback rationale. Same door-sensor
+// device.
+const DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK = 'Sat Mar 13 14:45:00 2021';
 
 export const pubsubCheckForDoorErrors = functions.pubsub.schedule('every 1 minutes').onRun(async (_context) => {
   const BUILD_TIMESTAMP_PARAM_KEY = "buildTimestamp";
-  const buildTimestampString = 'Sat Mar 13 14:45:00 2021'; // TODO: Use config.
+  const config = await ServerConfigDatabase.get();
+  const buildTimestampString = getBuildTimestamp(config) ?? DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK;
   const scheduledJob = true;
   const data = {};
   data[BUILD_TIMESTAMP_PARAM_KEY] = buildTimestampString;

--- a/FirebaseServer/src/functions/pubsub/OpenDoor.ts
+++ b/FirebaseServer/src/functions/pubsub/OpenDoor.ts
@@ -18,9 +18,16 @@ import * as functions from 'firebase-functions/v1';
 
 import { sendFCMForOldData } from '../../controller/fcm/OldDataFCM';
 import { DATABASE as SensorEventDatabase } from '../../database/SensorEventDatabase';
+import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
+import { getBuildTimestamp } from '../../controller/config/ConfigAccessors';
+
+// See http/OpenDoor.ts for the fallback rationale. Same door-sensor
+// device.
+const DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK = 'Sat Mar 13 14:45:00 2021';
 
 export const pubsubCheckForOpenDoorsJob = functions.pubsub.schedule('every 5 minutes').onRun(async (_context) => {
-  const buildTimestamp = 'Sat Mar 13 14:45:00 2021'; // TODO: Use config.
+  const config = await ServerConfigDatabase.get();
+  const buildTimestamp = getBuildTimestamp(config) ?? DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK;
   const eventData = await SensorEventDatabase.getCurrent(buildTimestamp);
   await sendFCMForOldData(buildTimestamp, eventData);
   return null;

--- a/FirebaseServer/src/functions/pubsub/OpenDoor.ts
+++ b/FirebaseServer/src/functions/pubsub/OpenDoor.ts
@@ -19,7 +19,7 @@ import * as functions from 'firebase-functions/v1';
 import { sendFCMForOldData } from '../../controller/fcm/OldDataFCM';
 import { DATABASE as SensorEventDatabase } from '../../database/SensorEventDatabase';
 import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
-import { getBuildTimestamp } from '../../controller/config/ConfigAccessors';
+import { getBuildTimestamp, resolveBuildTimestamp } from '../../controller/config/ConfigAccessors';
 
 // See http/OpenDoor.ts for the fallback rationale. Same door-sensor
 // device.
@@ -27,7 +27,11 @@ const DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK = 'Sat Mar 13 14:45:00 2021';
 
 export const pubsubCheckForOpenDoorsJob = functions.pubsub.schedule('every 5 minutes').onRun(async (_context) => {
   const config = await ServerConfigDatabase.get();
-  const buildTimestamp = getBuildTimestamp(config) ?? DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK;
+  const buildTimestamp = resolveBuildTimestamp(
+    getBuildTimestamp(config),
+    DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK,
+    'pubsubCheckForOpenDoorsJob',
+  );
   const eventData = await SensorEventDatabase.getCurrent(buildTimestamp);
   await sendFCMForOldData(buildTimestamp, eventData);
   return null;

--- a/FirebaseServer/src/functions/pubsub/RemoteButton.ts
+++ b/FirebaseServer/src/functions/pubsub/RemoteButton.ts
@@ -20,7 +20,7 @@ import * as functions from 'firebase-functions/v1';
 import { DATABASE as REMOTE_BUTTON_REQUEST_DATABASE } from '../../database/RemoteButtonRequestDatabase';
 import { DATABASE as REMOTE_BUTTON_REQUEST_ERROR_DATABASE } from '../../database/RemoteButtonRequestErrorDatabase';
 import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
-import { getRemoteButtonBuildTimestamp } from '../../controller/config/ConfigAccessors';
+import { getRemoteButtonBuildTimestamp, resolveBuildTimestamp } from '../../controller/config/ConfigAccessors';
 
 const DATABASE_TIMESTAMP_SECONDS_KEY = 'FIRESTORE_databaseTimestampSeconds';
 
@@ -37,7 +37,11 @@ export const pubsubCheckForRemoteButtonErrors = functions.pubsub
   .schedule('every 10 minutes').timeZone('America/Los_Angeles') // California after midnight every day.
   .onRun(async (_context) => {
     const config = await ServerConfigDatabase.get();
-    const buildTimestamp = getRemoteButtonBuildTimestamp(config) ?? REMOTE_BUTTON_BUILD_TIMESTAMP_FALLBACK;
+    const buildTimestamp = resolveBuildTimestamp(
+      getRemoteButtonBuildTimestamp(config),
+      REMOTE_BUTTON_BUILD_TIMESTAMP_FALLBACK,
+      'pubsubCheckForRemoteButtonErrors',
+    );
     if (!buildTimestamp) {
       const result = { error: 'No remote button build timestamp in config: ' + buildTimestamp };
       console.error(result.error);

--- a/FirebaseServer/src/functions/pubsub/RemoteButton.ts
+++ b/FirebaseServer/src/functions/pubsub/RemoteButton.ts
@@ -19,18 +19,25 @@ import * as functions from 'firebase-functions/v1';
 
 import { DATABASE as REMOTE_BUTTON_REQUEST_DATABASE } from '../../database/RemoteButtonRequestDatabase';
 import { DATABASE as REMOTE_BUTTON_REQUEST_ERROR_DATABASE } from '../../database/RemoteButtonRequestErrorDatabase';
+import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
+import { getRemoteButtonBuildTimestamp } from '../../controller/config/ConfigAccessors';
 
 const DATABASE_TIMESTAMP_SECONDS_KEY = 'FIRESTORE_databaseTimestampSeconds';
 
 const REMOTE_BUTTON_REQUEST_ERROR_SECONDS = 60 * 10;
 
+// Fallback to the historical hardcoded remote-button device ID if the
+// config field is missing or empty. Production has the field populated
+// (URL-encoded since April 2021); the accessor decodes it, so this
+// fallback is a safety net, not the expected path. Different device
+// from the door sensor — see http/OpenDoor.ts for that one.
+const REMOTE_BUTTON_BUILD_TIMESTAMP_FALLBACK = 'Sat Apr 10 23:57:32 2021';
+
 export const pubsubCheckForRemoteButtonErrors = functions.pubsub
   .schedule('every 10 minutes').timeZone('America/Los_Angeles') // California after midnight every day.
   .onRun(async (_context) => {
-    // TODO: Use config.
-    // const config = await Config.get();
-    // const buildTimestamp = Config.getRemoteButtonBuildTimestamp(config);
-    const buildTimestamp = 'Sat Apr 10 23:57:32 2021';
+    const config = await ServerConfigDatabase.get();
+    const buildTimestamp = getRemoteButtonBuildTimestamp(config) ?? REMOTE_BUTTON_BUILD_TIMESTAMP_FALLBACK;
     if (!buildTimestamp) {
       const result = { error: 'No remote button build timestamp in config: ' + buildTimestamp };
       console.error(result.error);

--- a/FirebaseServer/test/controller/config/ConfigAccessorsTest.ts
+++ b/FirebaseServer/test/controller/config/ConfigAccessorsTest.ts
@@ -19,9 +19,11 @@
  */
 
 import { expect } from 'chai';
+import * as sinon from 'sinon';
 import {
   getBuildTimestamp,
   getRemoteButtonBuildTimestamp,
+  resolveBuildTimestamp,
 } from '../../../src/controller/config/ConfigAccessors';
 
 describe('getBuildTimestamp (door sensor, production key: "buildTimestamp")', () => {
@@ -102,5 +104,38 @@ describe('getRemoteButtonBuildTimestamp (remote button, production URL-encoded)'
 
   it('returns null for an empty string value (treat as missing)', () => {
     expect(getRemoteButtonBuildTimestamp({ body: { remoteButtonBuildTimestamp: '' } })).to.be.null;
+  });
+
+  it('logs a warning when URL-decoding fails', () => {
+    const warnSpy = sinon.spy(console, 'warn');
+    try {
+      getRemoteButtonBuildTimestamp({ body: { remoteButtonBuildTimestamp: 'Sat%ZZ' } });
+      expect(warnSpy.calledOnce, 'expected console.warn to be called once').to.be.true;
+      expect(warnSpy.firstCall.args[0]).to.match(/failed to URL-decode/i);
+    } finally {
+      warnSpy.restore();
+    }
+  });
+});
+
+describe('resolveBuildTimestamp (fallback-with-log helper)', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('returns the config value unchanged when present', () => {
+    const warnSpy = sinon.spy(console, 'warn');
+    const result = resolveBuildTimestamp('from-config', 'fallback-literal', 'test-context');
+    expect(result).to.equal('from-config');
+    expect(warnSpy.called, 'expected no warning on normal path').to.be.false;
+  });
+
+  it('returns the fallback and emits a warning when config value is null', () => {
+    const warnSpy = sinon.spy(console, 'warn');
+    const result = resolveBuildTimestamp(null, 'fallback-literal', 'test-context');
+    expect(result).to.equal('fallback-literal');
+    expect(warnSpy.calledOnce, 'expected exactly one warning').to.be.true;
+    expect(warnSpy.firstCall.args[0]).to.include('test-context');
+    expect(warnSpy.firstCall.args[0]).to.match(/fallback/i);
   });
 });

--- a/FirebaseServer/test/controller/config/ConfigAccessorsTest.ts
+++ b/FirebaseServer/test/controller/config/ConfigAccessorsTest.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * Contract tests for buildTimestamp accessors. These pin the exact
+ * shape of production config — the keys and encodings that existed
+ * since April 2021. Changing the production config shape requires
+ * updating these tests in lockstep with the config update.
+ *
+ * See docs/FIREBASE_HARDENING_PLAN.md → Part A, and the revert
+ * rationale in PR #494 commit message for the history.
+ */
+
+import { expect } from 'chai';
+import {
+  getBuildTimestamp,
+  getRemoteButtonBuildTimestamp,
+} from '../../../src/controller/config/ConfigAccessors';
+
+describe('getBuildTimestamp (door sensor, production key: "buildTimestamp")', () => {
+  // The door-sensor value is stored plain/decoded in production
+  // config under the key `buildTimestamp` (no prefix). Pinning the
+  // exact shape here guards against accidentally looking at a
+  // different key.
+  it('returns the value for the production key', () => {
+    const config = { body: { buildTimestamp: 'Sat Mar 13 14:45:00 2021' } };
+    expect(getBuildTimestamp(config)).to.equal('Sat Mar 13 14:45:00 2021');
+  });
+
+  it('returns null when the field is missing from body', () => {
+    expect(getBuildTimestamp({ body: {} })).to.be.null;
+  });
+
+  it('returns null when body is missing', () => {
+    expect(getBuildTimestamp({})).to.be.null;
+  });
+
+  it('returns null when config is null', () => {
+    expect(getBuildTimestamp(null)).to.be.null;
+  });
+
+  it('returns null when config is undefined', () => {
+    expect(getBuildTimestamp(undefined)).to.be.null;
+  });
+
+  it('returns null for an empty string value (treat as missing)', () => {
+    // Why null and not the empty string: callers use `?? fallback`,
+    // which only triggers on null/undefined. An empty string here
+    // would bypass the fallback and pass "" into Firestore queries.
+    expect(getBuildTimestamp({ body: { buildTimestamp: '' } })).to.be.null;
+  });
+});
+
+describe('getRemoteButtonBuildTimestamp (remote button, production URL-encoded)', () => {
+  // Production config stores this value URL-encoded — has been that
+  // way since the first serverConfig.json in April 2021. The accessor
+  // normalizes on read so callers always see the decoded form,
+  // matching the pre-refactor hardcoded value in pubsub/RemoteButton.
+  it('decodes the production URL-encoded value', () => {
+    const config = {
+      body: {
+        remoteButtonBuildTimestamp: 'Sat%20Apr%2010%2023:57:32%202021',
+      },
+    };
+    expect(getRemoteButtonBuildTimestamp(config)).to.equal('Sat Apr 10 23:57:32 2021');
+  });
+
+  it('returns an already-decoded value unchanged (decode is idempotent on plain ASCII)', () => {
+    const config = {
+      body: { remoteButtonBuildTimestamp: 'Sat Apr 10 23:57:32 2021' },
+    };
+    expect(getRemoteButtonBuildTimestamp(config)).to.equal('Sat Apr 10 23:57:32 2021');
+  });
+
+  it('returns the raw value if URL-decoding throws (malformed percent-encoding)', () => {
+    // Defensive: never crash the pubsub job because the config was
+    // authored wrong. The caller's fallback will kick in only if the
+    // raw value is also useless (empty, null). This returns
+    // something, leaving the fallback path to a separate null-check.
+    const config = { body: { remoteButtonBuildTimestamp: 'Sat%ZZInvalid' } };
+    expect(getRemoteButtonBuildTimestamp(config)).to.equal('Sat%ZZInvalid');
+  });
+
+  it('returns null when the field is missing from body', () => {
+    expect(getRemoteButtonBuildTimestamp({ body: {} })).to.be.null;
+  });
+
+  it('returns null when body is missing', () => {
+    expect(getRemoteButtonBuildTimestamp({})).to.be.null;
+  });
+
+  it('returns null when config is null', () => {
+    expect(getRemoteButtonBuildTimestamp(null)).to.be.null;
+  });
+
+  it('returns null for an empty string value (treat as missing)', () => {
+    expect(getRemoteButtonBuildTimestamp({ body: { remoteButtonBuildTimestamp: '' } })).to.be.null;
+  });
+});


### PR DESCRIPTION
## Summary

Replacement for the reverted PR #492. Reads \`buildTimestamp\` and \`remoteButtonBuildTimestamp\` from production config, with explicit fallback to the historical hardcoded literals. Zero Firestore impact.

## What changed vs PR #492

| | PR #492 (reverted) | This PR |
|---|---|---|
| Door-sensor config key | \`doorSensorBuildTimestamp\` (didn't exist) | \`buildTimestamp\` (production key, since April 2021) |
| Remote-button decoding | Returned raw URL-encoded | \`decodeURIComponent\` on read |
| Test coverage | Accessor sanity | Pins production config shape + encoding edge cases + malformed-input safety |
| Runtime value after deploy | Door sensor: matched by coincidence; remote button: **wrong** | Both: byte-identical to current hardcoded runtime |

## Accessor behavior

\`\`\`ts
// Door sensor — plain read, empty string → null
getBuildTimestamp({ body: { buildTimestamp: "Sat Mar 13 14:45:00 2021" } })
//  → "Sat Mar 13 14:45:00 2021"

// Remote button — URL-decoded, idempotent, malformed-safe
getRemoteButtonBuildTimestamp({ body: { remoteButtonBuildTimestamp: "Sat%20Apr%2010%2023:57:32%202021" } })
//  → "Sat Apr 10 23:57:32 2021"
getRemoteButtonBuildTimestamp({ body: { remoteButtonBuildTimestamp: "Sat Apr 10 23:57:32 2021" } })
//  → "Sat Apr 10 23:57:32 2021" (idempotent)
getRemoteButtonBuildTimestamp({ body: { remoteButtonBuildTimestamp: "Sat%ZZInvalid" } })
//  → "Sat%ZZInvalid" (decoder threw, returned raw — never crash)
\`\`\`

## Call-site pattern

\`\`\`ts
const DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK = 'Sat Mar 13 14:45:00 2021';
// ...
const config = await ServerConfigDatabase.get();
const buildTimestamp = getBuildTimestamp(config) ?? DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK;
\`\`\`

Fallback is a named file-local constant. A reader sees exactly what ships if config is ever missing — no surprises, no magic elsewhere.

## Zero Firestore impact

- **Production verified:** config has \`buildTimestamp: "Sat Mar 13 14:45:00 2021"\` and \`remoteButtonBuildTimestamp: "Sat%20Apr%2010..."\` — both decode (or plain-read) to the fallback literals. Runtime string passed to Firestore queries: **byte-identical** to current production.
- **Grep-diff:** both literals still present in \`src/\` as named constants.
- \`TimeSeriesDatabase.ts\` not modified.
- Phase 4 lint green.
- CVE guards pass (uuid ≥ 14, fast-xml-parser ≥ 5.7).

## Tests (+13)

- \`getBuildTimestamp\`: 6 tests (present, missing field, missing body, null, undefined, empty-string)
- \`getRemoteButtonBuildTimestamp\`: 7 tests (URL-encoded decode, already-decoded idempotent, malformed graceful, missing/null/empty)

Total: 136 → 149.

## After deploy

For the first time in ~5 years, the remote-button pubsub job reads config for its device ID (the reader has been commented out since June 2021). Because production config already has the URL-encoded value and our accessor decodes to the expected string, behavior is unchanged. Changing a device ID in the future now only requires a config update — no code deploy.

## Test plan

- [x] \`./scripts/validate-firebase.sh\` passes (149 tests)
- [x] All 13 accessor tests pass — including the decode/idempotent/malformed cases
- [x] Production config values verified to match fallback literals after decode
- [x] Fallback literals still present in \`src/\` as named constants
- [x] \`TimeSeriesDatabase.ts\` unchanged
- [x] Phase 4 lint green
- [x] CVE guards green

🤖 Generated with [Claude Code](https://claude.com/claude-code)