### PR TITLE
hardening(firebase): A3 — remove buildTimestamp fallbacks; config is authoritative

### DIFF
--- a/FirebaseServer/src/controller/config/ConfigAccessors.ts
+++ b/FirebaseServer/src/controller/config/ConfigAccessors.ts
@@ -87,34 +87,40 @@ export function getRemoteButtonBuildTimestamp(config: any): string | null {
 }
 
 /**
- * Resolve a nullable config-read value to a non-null string, falling
- * back to a hardcoded literal and emitting a Cloud Logging warning if
- * the fallback is used. Callers get a guaranteed string; operators
- * get visibility when config drift happens (missing field, empty
- * value, etc.).
+ * Require a non-null buildTimestamp from config. Throws if the value
+ * is missing/empty. This replaces the fallback pattern used in
+ * server/16 — production config is now the authoritative source of
+ * the device ID. See docs/FIREBASE_HARDENING_PLAN.md → Part A / A3
+ * for the history and revert path.
+ *
+ * Why a throw rather than a silent fallback: after A2 verified
+ * production config has both `body.buildTimestamp` and
+ * `body.remoteButtonBuildTimestamp` populated and the warn-level
+ * fallback logs from server/16 confirmed the fallback never fired
+ * in 24+ hours, the fallback's only effect was to mask a future
+ * config-deletion bug. Throwing surfaces that bug in Cloud Logging
+ * as an ERROR, which pages or alerts — fast feedback beats silent
+ * continuation with a stale hardcoded value.
+ *
+ * Callers: use try/catch (HTTP handlers that return 500) or let the
+ * throw propagate (pubsub jobs — Firebase marks the run failed, the
+ * next scheduled tick retries).
  *
  * Usage:
- *   const buildTimestamp = resolveBuildTimestamp(
+ *   const config = await ServerConfigDatabase.get();
+ *   const buildTimestamp = requireBuildTimestamp(
  *     getBuildTimestamp(config),
- *     DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK,
  *     'pubsubCheckForOpenDoorsJob',
  *   );
- *
- * The `context` string identifies the call site in logs so filters
- * like `logName:"cloudfunctions" severity:"WARNING" textPayload:"buildTimestamp"`
- * can distinguish fallback hits across functions.
  */
-export function resolveBuildTimestamp(
+export function requireBuildTimestamp(
   configValue: string | null,
-  fallback: string,
   context: string,
 ): string {
   if (configValue === null) {
-    console.warn(
-      `[${context}] buildTimestamp not in config; using hardcoded fallback.`,
-      { fallback },
-    );
-    return fallback;
+    const msg = `[${context}] buildTimestamp missing from config — cannot proceed. See docs/FIREBASE_HARDENING_PLAN.md Part A / A3.`;
+    console.error(msg);
+    throw new Error(msg);
   }
   return configValue;
 }

--- a/FirebaseServer/src/functions/http/OpenDoor.ts
+++ b/FirebaseServer/src/functions/http/OpenDoor.ts
@@ -19,22 +19,27 @@ import * as functions from 'firebase-functions/v1';
 import { sendFCMForOldData } from '../../controller/fcm/OldDataFCM';
 import { DATABASE as SensorEventDatabase } from '../../database/SensorEventDatabase';
 import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
-import { getBuildTimestamp, resolveBuildTimestamp } from '../../controller/config/ConfigAccessors';
+import { getBuildTimestamp, requireBuildTimestamp } from '../../controller/config/ConfigAccessors';
 
-// Fallback to the historical hardcoded door-sensor device ID if the
-// config field is missing or empty. Production has the field populated
-// (since April 2021), so the fallback is a safety net, not the
-// expected path. Fallback use emits a warn-level Cloud Log entry.
-const DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK = 'Sat Mar 13 14:45:00 2021';
+// History: a DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK = 'Sat Mar 13 14:45:00 2021'
+// constant lived here through server/16. Removed in A3 after
+// production was verified to have body.buildTimestamp populated with
+// that exact value, and server/16's warn-level fallback logs stayed
+// empty for 24+ hours. See docs/FIREBASE_HARDENING_PLAN.md → Part A / A3
+// for the full rationale + revert path.
 
 export const httpCheckForOpenDoors = functions.https.onRequest(async (_request, response) => {
-  const config = await ServerConfigDatabase.get();
-  const buildTimestamp = resolveBuildTimestamp(
-    getBuildTimestamp(config),
-    DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK,
-    'httpCheckForOpenDoors',
-  );
-  const eventData = await SensorEventDatabase.getCurrent(buildTimestamp);
-  const result = await sendFCMForOldData(buildTimestamp, eventData);
-  response.status(200).send(result);
+  try {
+    const config = await ServerConfigDatabase.get();
+    const buildTimestamp = requireBuildTimestamp(
+      getBuildTimestamp(config),
+      'httpCheckForOpenDoors',
+    );
+    const eventData = await SensorEventDatabase.getCurrent(buildTimestamp);
+    const result = await sendFCMForOldData(buildTimestamp, eventData);
+    response.status(200).send(result);
+  } catch (error) {
+    console.error('httpCheckForOpenDoors failed', error);
+    response.status(500).send({ error: error instanceof Error ? error.message : String(error) });
+  }
 });

--- a/FirebaseServer/src/functions/pubsub/DoorErrors.ts
+++ b/FirebaseServer/src/functions/pubsub/DoorErrors.ts
@@ -18,18 +18,16 @@ import * as functions from 'firebase-functions/v1';
 
 import { updateEvent } from '../../controller/EventUpdates';
 import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
-import { getBuildTimestamp, resolveBuildTimestamp } from '../../controller/config/ConfigAccessors';
+import { getBuildTimestamp, requireBuildTimestamp } from '../../controller/config/ConfigAccessors';
 
-// See http/OpenDoor.ts for the fallback rationale. Same door-sensor
-// device.
-const DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK = 'Sat Mar 13 14:45:00 2021';
+// History: see http/OpenDoor.ts for the fallback removal rationale.
+// Same door-sensor device; same A3 story.
 
 export const pubsubCheckForDoorErrors = functions.pubsub.schedule('every 1 minutes').onRun(async (_context) => {
   const BUILD_TIMESTAMP_PARAM_KEY = "buildTimestamp";
   const config = await ServerConfigDatabase.get();
-  const buildTimestampString = resolveBuildTimestamp(
+  const buildTimestampString = requireBuildTimestamp(
     getBuildTimestamp(config),
-    DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK,
     'pubsubCheckForDoorErrors',
   );
   const scheduledJob = true;

--- a/FirebaseServer/src/functions/pubsub/OpenDoor.ts
+++ b/FirebaseServer/src/functions/pubsub/OpenDoor.ts
@@ -19,17 +19,15 @@ import * as functions from 'firebase-functions/v1';
 import { sendFCMForOldData } from '../../controller/fcm/OldDataFCM';
 import { DATABASE as SensorEventDatabase } from '../../database/SensorEventDatabase';
 import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
-import { getBuildTimestamp, resolveBuildTimestamp } from '../../controller/config/ConfigAccessors';
+import { getBuildTimestamp, requireBuildTimestamp } from '../../controller/config/ConfigAccessors';
 
-// See http/OpenDoor.ts for the fallback rationale. Same door-sensor
-// device.
-const DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK = 'Sat Mar 13 14:45:00 2021';
+// History: see http/OpenDoor.ts for the fallback removal rationale.
+// Same door-sensor device; same A3 story.
 
 export const pubsubCheckForOpenDoorsJob = functions.pubsub.schedule('every 5 minutes').onRun(async (_context) => {
   const config = await ServerConfigDatabase.get();
-  const buildTimestamp = resolveBuildTimestamp(
+  const buildTimestamp = requireBuildTimestamp(
     getBuildTimestamp(config),
-    DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK,
     'pubsubCheckForOpenDoorsJob',
   );
   const eventData = await SensorEventDatabase.getCurrent(buildTimestamp);

--- a/FirebaseServer/src/functions/pubsub/RemoteButton.ts
+++ b/FirebaseServer/src/functions/pubsub/RemoteButton.ts
@@ -20,34 +20,33 @@ import * as functions from 'firebase-functions/v1';
 import { DATABASE as REMOTE_BUTTON_REQUEST_DATABASE } from '../../database/RemoteButtonRequestDatabase';
 import { DATABASE as REMOTE_BUTTON_REQUEST_ERROR_DATABASE } from '../../database/RemoteButtonRequestErrorDatabase';
 import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
-import { getRemoteButtonBuildTimestamp, resolveBuildTimestamp } from '../../controller/config/ConfigAccessors';
+import { getRemoteButtonBuildTimestamp, requireBuildTimestamp } from '../../controller/config/ConfigAccessors';
 
 const DATABASE_TIMESTAMP_SECONDS_KEY = 'FIRESTORE_databaseTimestampSeconds';
 
 const REMOTE_BUTTON_REQUEST_ERROR_SECONDS = 60 * 10;
 
-// Fallback to the historical hardcoded remote-button device ID if the
-// config field is missing or empty. Production has the field populated
-// (URL-encoded since April 2021); the accessor decodes it, so this
-// fallback is a safety net, not the expected path. Different device
-// from the door sensor — see http/OpenDoor.ts for that one.
-const REMOTE_BUTTON_BUILD_TIMESTAMP_FALLBACK = 'Sat Apr 10 23:57:32 2021';
+// History: a REMOTE_BUTTON_BUILD_TIMESTAMP_FALLBACK = 'Sat Apr 10 23:57:32 2021'
+// constant lived here through server/16. Different device from the
+// door sensor, so a different fallback value. Removed in A3 after
+// production was verified to have body.remoteButtonBuildTimestamp
+// populated (URL-encoded; the accessor decodes it to the same string).
+// See docs/FIREBASE_HARDENING_PLAN.md → Part A / A3 for full history
+// + revert path.
 
 export const pubsubCheckForRemoteButtonErrors = functions.pubsub
   .schedule('every 10 minutes').timeZone('America/Los_Angeles') // California after midnight every day.
   .onRun(async (_context) => {
     const config = await ServerConfigDatabase.get();
-    const buildTimestamp = resolveBuildTimestamp(
+    const buildTimestamp = requireBuildTimestamp(
       getRemoteButtonBuildTimestamp(config),
-      REMOTE_BUTTON_BUILD_TIMESTAMP_FALLBACK,
       'pubsubCheckForRemoteButtonErrors',
     );
-    if (!buildTimestamp) {
-      const result = { error: 'No remote button build timestamp in config: ' + buildTimestamp };
-      console.error(result.error);
-      await REMOTE_BUTTON_REQUEST_ERROR_DATABASE.save(buildTimestamp, result);
-      return null;
-    }
+    // NOTE: the previous `if (!buildTimestamp)` branch that wrote an
+    // error entry to `remoteButtonRequestErrorAll` was removed with
+    // the A3 fallback cleanup — `requireBuildTimestamp` throws on
+    // missing config, which surfaces the same condition as an ERROR
+    // in Cloud Logging without writing a noise entry to Firestore.
     const remoteButtonRequest = await REMOTE_BUTTON_REQUEST_DATABASE.getCurrent(buildTimestamp);
     if (!remoteButtonRequest) {
       const result = { error: 'No remote button requests found for build timestamp: ' + buildTimestamp };

--- a/FirebaseServer/test/controller/config/ConfigAccessorsTest.ts
+++ b/FirebaseServer/test/controller/config/ConfigAccessorsTest.ts
@@ -23,7 +23,7 @@ import * as sinon from 'sinon';
 import {
   getBuildTimestamp,
   getRemoteButtonBuildTimestamp,
-  resolveBuildTimestamp,
+  requireBuildTimestamp,
 } from '../../../src/controller/config/ConfigAccessors';
 
 describe('getBuildTimestamp (door sensor, production key: "buildTimestamp")', () => {
@@ -53,9 +53,10 @@ describe('getBuildTimestamp (door sensor, production key: "buildTimestamp")', ()
   });
 
   it('returns null for an empty string value (treat as missing)', () => {
-    // Why null and not the empty string: callers use `?? fallback`,
-    // which only triggers on null/undefined. An empty string here
-    // would bypass the fallback and pass "" into Firestore queries.
+    // Why null and not the empty string: callers pair this with
+    // requireBuildTimestamp, which throws on null. An empty string
+    // slipping through would be passed into Firestore queries — the
+    // null return forces the caller path to fail loudly.
     expect(getBuildTimestamp({ body: { buildTimestamp: '' } })).to.be.null;
   });
 });
@@ -82,10 +83,11 @@ describe('getRemoteButtonBuildTimestamp (remote button, production URL-encoded)'
   });
 
   it('returns the raw value if URL-decoding throws (malformed percent-encoding)', () => {
-    // Defensive: never crash the pubsub job because the config was
-    // authored wrong. The caller's fallback will kick in only if the
-    // raw value is also useless (empty, null). This returns
-    // something, leaving the fallback path to a separate null-check.
+    // Defensive: never crash the accessor itself. The raw value flows
+    // to requireBuildTimestamp, which would accept a truthy string and
+    // downstream Firestore queries would target "Sat%ZZInvalid" — a
+    // surfaced problem but no crash. This keeps decode failures from
+    // masquerading as config-missing errors.
     const config = { body: { remoteButtonBuildTimestamp: 'Sat%ZZInvalid' } };
     expect(getRemoteButtonBuildTimestamp(config)).to.equal('Sat%ZZInvalid');
   });
@@ -118,24 +120,33 @@ describe('getRemoteButtonBuildTimestamp (remote button, production URL-encoded)'
   });
 });
 
-describe('resolveBuildTimestamp (fallback-with-log helper)', () => {
+describe('requireBuildTimestamp (strict — throws on null)', () => {
   afterEach(() => {
     sinon.restore();
   });
 
   it('returns the config value unchanged when present', () => {
-    const warnSpy = sinon.spy(console, 'warn');
-    const result = resolveBuildTimestamp('from-config', 'fallback-literal', 'test-context');
+    const errorSpy = sinon.spy(console, 'error');
+    const result = requireBuildTimestamp('from-config', 'test-context');
     expect(result).to.equal('from-config');
-    expect(warnSpy.called, 'expected no warning on normal path').to.be.false;
+    expect(errorSpy.called, 'expected no error on normal path').to.be.false;
   });
 
-  it('returns the fallback and emits a warning when config value is null', () => {
-    const warnSpy = sinon.spy(console, 'warn');
-    const result = resolveBuildTimestamp(null, 'fallback-literal', 'test-context');
-    expect(result).to.equal('fallback-literal');
-    expect(warnSpy.calledOnce, 'expected exactly one warning').to.be.true;
-    expect(warnSpy.firstCall.args[0]).to.include('test-context');
-    expect(warnSpy.firstCall.args[0]).to.match(/fallback/i);
+  it('throws and logs an error when config value is null', () => {
+    const errorSpy = sinon.spy(console, 'error');
+    expect(() => requireBuildTimestamp(null, 'test-context')).to.throw(
+      /test-context.*buildTimestamp missing from config/,
+    );
+    expect(errorSpy.calledOnce, 'expected exactly one error log').to.be.true;
+    expect(errorSpy.firstCall.args[0]).to.include('test-context');
+  });
+
+  it('error message includes the doc pointer for revert context', () => {
+    // If a future operator sees this error in Cloud Logs, the message
+    // should point them directly to the docs that explain the history
+    // and how to restore the fallback if needed.
+    expect(() => requireBuildTimestamp(null, 'ctx')).to.throw(
+      /FIREBASE_HARDENING_PLAN\.md.*A3/,
+    );
   });
 });

--- a/docs/FIREBASE_HARDENING_PLAN.md
+++ b/docs/FIREBASE_HARDENING_PLAN.md
@@ -27,7 +27,7 @@ guards.
 ### Deferred / next
 
 - **uuid alert #67 (transitive versions 9.0.1, 11.1.0 under `firebase-admin`).** Remaining Dependabot alert. Not in our exploit path (we call `v4()` with no `buf`; transitives are used by `@google-cloud/*` for request IDs). Decision: **wait for `firebase-admin` itself to bump** rather than force a transitive override. The direct dep is at 14.0.0; the CVE-guard test in `CveGuardTest.ts` pins that.
-- **Remove `_FALLBACK` constants (A3 in the original plan).** `server/16` logs confirm the fallback never fires — production config has the fields populated. A follow-up PR removes the constants and replaces them with an early-return-on-missing-config pattern. Documented separately.
+- **~~Remove `_FALLBACK` constants (A3 in the original plan).~~** **Shipped** — see *A3 — Fallback removal* section below.
 
 **Invariants (both parts, as written pre-execution):**
 - Zero Firestore data impact. Collection strings, document shapes,
@@ -36,6 +36,142 @@ guards.
 - Phase 4 lint guard stays green — no new inline `new
   TimeSeriesDatabase(...)`.
 - `./scripts/validate-firebase.sh` passes on every PR.
+
+---
+
+## A3 — Fallback removal (history + revert)
+
+Shipped after `server/16` verified that production config has both
+`body.buildTimestamp` and `body.remoteButtonBuildTimestamp` populated
+and the warn-level fallback logs added during A1 stayed empty for
+24+ hours across every pubsub cycle.
+
+### What changed
+
+Before (server/16):
+
+```typescript
+// src/functions/http/OpenDoor.ts  (and three sibling files)
+const DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK = 'Sat Mar 13 14:45:00 2021';
+
+export const httpCheckForOpenDoors = functions.https.onRequest(async (_request, response) => {
+  const config = await ServerConfigDatabase.get();
+  const buildTimestamp = resolveBuildTimestamp(
+    getBuildTimestamp(config),
+    DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK,     // ← silent fallback + warn-log
+    'httpCheckForOpenDoors',
+  );
+  // ...
+});
+```
+
+After (A3):
+
+```typescript
+// src/functions/http/OpenDoor.ts  (and three sibling files)
+
+// History: DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK = 'Sat Mar 13 14:45:00 2021'
+// lived here through server/16; removed in A3.
+
+export const httpCheckForOpenDoors = functions.https.onRequest(async (_request, response) => {
+  try {
+    const config = await ServerConfigDatabase.get();
+    const buildTimestamp = requireBuildTimestamp(      // ← throws on null
+      getBuildTimestamp(config),
+      'httpCheckForOpenDoors',
+    );
+    // ...
+  } catch (error) {
+    response.status(500).send({ error: ... });
+  }
+});
+```
+
+The `resolveBuildTimestamp` helper was replaced with
+`requireBuildTimestamp`, which throws on null instead of returning a
+fallback. The error message includes the context string and a
+pointer back to this doc section.
+
+### Why the trade-off
+
+| Aspect | Fallback (server/16) | Strict (A3) |
+|---|---|---|
+| Config missing → runtime effect | Silent success with stale hardcode | Throw + ERROR log |
+| Detectability | Warn-level log (easy to miss) | Error-level log (pages/alerts) |
+| Blast radius of config deletion | None | The affected function fails its next run |
+| Blast radius of fallback drift (hardcode and prod config diverging) | Silent divergence, possibly for months | Impossible — no hardcode |
+| Time-to-detect a real config problem | Hours/days | Minutes |
+
+The A3 trade-off is explicit: we're trading a safety net that masked
+bugs for a louder error surface. The safety net was verified dormant
+before removal, so we're not losing any working state — just the
+illusion that the hardcode was a viable plan B.
+
+### Verification before shipping
+
+Before merging A3:
+
+1. `server/16` deployed and stable for 24+ hours. ✅
+2. `gcloud logging read '... "buildTimestamp not in config" ...'` in
+   the 24-hour window: **0 hits**. ✅
+3. `gcloud logging read '... "failed to URL-decode" ...'`: **0 hits**.
+   ✅
+4. All 4 functions executed successfully (pubsub + HTTP): **confirmed
+   via Cloud Logs**. ✅
+5. Production config `body.buildTimestamp` + `body.remoteButtonBuildTimestamp`
+   verified manually via `httpServerConfig`. ✅
+
+### Revert path (if A3 causes problems in prod)
+
+If an `ERROR [<context>] buildTimestamp missing from config` log
+fires post-deploy, the cause is almost certainly one of:
+
+1. Production config field got deleted (via `httpServerConfigUpdate`
+   or manual Firestore edit).
+2. Production config field's value went empty.
+3. `ServerConfigDatabase.get()` returned unexpectedly (Firestore
+   outage — unrelated to A3).
+
+**Fastest recovery:** restore the config field via
+`httpServerConfigUpdate` with the correct value. No code change
+needed.
+
+**Full revert (emergency only — reintroduces the fallback):**
+
+```bash
+# 1. Revert the A3 commit on main.
+git revert <A3-PR-squash-SHA>
+
+# 2. Validate + release.
+./scripts/validate-firebase.sh
+./scripts/release-firebase.sh --check          # prints `server/N` command
+./scripts/release-firebase.sh --confirm-tag server/N
+
+# 3. Monitor: the warn-level fallback log returns as the signal that
+#    config is still broken, while the function keeps working on the
+#    hardcoded fallback.
+```
+
+The revert restores:
+- `DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK = 'Sat Mar 13 14:45:00 2021'`
+  in 3 door-sensor call sites.
+- `REMOTE_BUTTON_BUILD_TIMESTAMP_FALLBACK = 'Sat Apr 10 23:57:32 2021'`
+  in the remote-button call site.
+- `resolveBuildTimestamp` in `ConfigAccessors.ts` (with its
+  warn-level log on fallback use).
+
+### Long-term rule
+
+**Config is authoritative.** If you change a device ID, update
+production config via `httpServerConfigUpdate` — never edit the
+hardcoded literals (there are none to edit any more). A future
+contributor hitting the throw path in Cloud Logs should investigate
+the config, not re-add a hardcode.
+
+If the rule ever changes (e.g. we need to support per-environment
+hardcode-as-default because staging's config differs from prod), the
+right move is a new accessor parameter or a second config field —
+not restoring the silent fallback.
 
 ---
 


### PR DESCRIPTION
## Summary

Part **A3** of \`docs/FIREBASE_HARDENING_PLAN.md\`. Removes the \`_FALLBACK\` constants from the 4 call sites, replaces \`resolveBuildTimestamp\` with \`requireBuildTimestamp\` (throws on null). server/16 verified fallbacks never fired — the safety net was masking no bugs, so it's now removed.

## Why now

Verification checklist before removal (all ✅):

1. server/16 deployed stable 24+ hours
2. \`"buildTimestamp not in config"\` log query: **0 hits** in the window
3. \`"failed to URL-decode"\` log query: **0 hits**
4. All 4 functions executed successfully (confirmed in Cloud Logs)
5. Production config fields verified populated

## Trade-off

| | Fallback (server/16) | Strict (A3) |
|---|---|---|
| Config missing → runtime | Silent success with stale hardcode | Throw + ERROR log |
| Blast radius of config deletion | None (masked) | Function fails next run |
| Fallback/prod divergence | Possible, silent | Impossible (no hardcode) |

We're explicitly trading a silent safety net for a loud error surface, because the safety net was verified to be masking no active bugs.

## History docs

**Inline at each call site:** short comment block explaining what was removed and pointing at the doc section.

**New section in \`docs/FIREBASE_HARDENING_PLAN.md\`:** \"A3 — Fallback removal (history + revert)\" covers before/after code, trade-off table, verification checklist, revert path with exact commands, and a long-term rule for future contributors.

## Revert path (documented)

If ERROR logs fire in production post-deploy:
1. **Fast recovery:** restore the config field via \`httpServerConfigUpdate\` — no code change needed.
2. **Full revert (emergency):** \`git revert <this PR's SHA>\` → validate → release server/N+1. Reintroduces the fallback + warn-log behavior.

## Zero Firestore impact

- No collection strings, document shapes, or Firestore call patterns changed.
- Production config already has the required values — \`requireBuildTimestamp\` never throws in the current state.
- \`TimeSeriesDatabase.ts\` untouched, Phase 4 lint green, CVE guards green.

## Test count

152 → 153 (net +1: removed 2 \`resolveBuildTimestamp\` tests, added 3 \`requireBuildTimestamp\` tests — the extra test verifies the error message includes the doc-section pointer).

## Test plan

- [x] \`./scripts/validate-firebase.sh\` passes (153 tests)
- [x] Grep-diff: no more \`'Sat Mar 13 14:45:00 2021'\` or \`'Sat Apr 10 23:57:32 2021'\` in \`src/\` code (only in history comments)
- [x] Dead \`if (!buildTimestamp)\` check in \`pubsub/RemoteButton.ts\` removed (was unreachable after requireBuildTimestamp)
- [x] \`TimeSeriesDatabase.ts\` unchanged, Phase 4 lint green, CVE guards green

🤖 Generated with [Claude Code](https://claude.com/claude-code)