### PR TITLE
refactor: Move AppVersion data class to domain

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/AndroidAppInfoCard.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/AndroidAppInfoCard.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.chriscartland.garage.di.rememberAppComponent
+import com.chriscartland.garage.domain.model.AppVersion
 import com.chriscartland.garage.usecase.AppSettingsViewModel
 import com.chriscartland.garage.version.AppVersion
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/version/VersionModel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/version/VersionModel.kt
@@ -20,15 +20,7 @@ package com.chriscartland.garage.version
 import android.content.Context
 import android.os.Build
 import com.chriscartland.garage.BuildConfig
-
-data class AppVersion(
-    val packageName: String,
-    val versionCode: Long,
-    val versionName: String,
-    val buildTimestamp: String,
-) {
-    override fun toString(): String = "$packageName-$versionName-$versionCode ($buildTimestamp)"
-}
+import com.chriscartland.garage.domain.model.AppVersion
 
 fun Context.AppVersion(): AppVersion =
     AppVersion(

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/AppVersion.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/AppVersion.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.domain.model
+
+data class AppVersion(
+    val packageName: String,
+    val versionCode: Long,
+    val versionName: String,
+    val buildTimestamp: String,
+) {
+    override fun toString(): String = "$packageName-$versionName-$versionCode ($buildTimestamp)"
+}


### PR DESCRIPTION
## Summary

- Move the pure Kotlin `AppVersion` data class from `androidApp/` to `domain/src/commonMain/kotlin/.../domain/model/`.
- Keep `Context.AppVersion()` extension in `androidApp/` (reads `PackageManager` + `BuildConfig` — platform-specific).
- `AndroidAppInfoCard.kt` now imports the data class from `domain.model` and the extension from `version`.
- `AppComponent.kt` unchanged (only uses the extension).

## Rationale

Closes part of Phase 37 (KMP expect/actual). Version info data class is now in commonMain; platform-specific lookup stays in androidApp, matching the `AppConfig` precedent.

## Test plan

- [x] `./scripts/validate.sh` passes
- [x] `AndroidAppInfoCard` preview + constructor call compiles
- [x] `AppComponent.provideAppVersionName` + `RoomAppLoggerRepository(…AppVersion().toString())` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)