### PR TITLE
test(firebase): H1 — extract httpEcho handler + unit tests

### DIFF
--- a/FirebaseServer/src/functions/http/Echo.ts
+++ b/FirebaseServer/src/functions/http/Echo.ts
@@ -24,35 +24,55 @@ const SESSION_PARAM_KEY = "session";
 const BUILD_TIMESTAMP_PARAM_KEY = "buildTimestamp";
 
 /**
- * HTTP endpoint captures request parameters, stores them in the database, and returns the data.
+ * Pure core — testable with plain object args. Handler-body extraction
+ * per docs/FIREBASE_HANDLER_TESTING_PLAN.md (Phase H1 pilot).
+ *
+ * Behavior is byte-identical to the pre-extraction inline code:
+ * - Builds the echo `data` payload from query + body.
+ * - Uses the provided `session` query param, or generates a v4 UUID.
+ * - Passes `buildTimestamp` through if present in the query.
+ * - Saves to UpdateDatabase keyed by session, then returns the stored
+ *   document read back from `getCurrent(session)`.
  */
-export const httpEcho = functions.https.onRequest(async (request, response) => {
-  // Echo query parameters and body.
-  const data = {
-    queryParams: request.query,
-    body: request.body,
+export async function handleEchoRequest(input: {
+  query: any;
+  body: any;
+}): Promise<any> {
+  const data: any = {
+    queryParams: input.query,
+    body: input.body,
   };
   // The session ID allows a client to tell the server that multiple requests
   // come from the same session.
-  if (SESSION_PARAM_KEY in request.query) {
+  if (input.query && SESSION_PARAM_KEY in input.query) {
     // If the client sends a session ID, respond with the session ID.
-    data[SESSION_PARAM_KEY] = request.query[SESSION_PARAM_KEY];
+    data[SESSION_PARAM_KEY] = input.query[SESSION_PARAM_KEY];
   } else {
     // If the client does not send a session ID, create a session ID.
     data[SESSION_PARAM_KEY] = uuidv4();
   }
   const session = data[SESSION_PARAM_KEY];
   // The build timestamp is unique to each device.
-  if (BUILD_TIMESTAMP_PARAM_KEY in request.query) {
-    data[BUILD_TIMESTAMP_PARAM_KEY] = request.query[BUILD_TIMESTAMP_PARAM_KEY];
+  if (input.query && BUILD_TIMESTAMP_PARAM_KEY in input.query) {
+    data[BUILD_TIMESTAMP_PARAM_KEY] = input.query[BUILD_TIMESTAMP_PARAM_KEY];
   } else {
     // Skip.
   }
 
+  await UpdateDatabase.save(session, data);
+  return UpdateDatabase.getCurrent(session);
+}
+
+/**
+ * HTTP endpoint captures request parameters, stores them in the database, and returns the data.
+ */
+export const httpEcho = functions.https.onRequest(async (request, response) => {
   try {
-    await UpdateDatabase.save(session, data);
-    const retrievedData = await UpdateDatabase.getCurrent(session);
-    response.status(200).send(retrievedData);
+    const result = await handleEchoRequest({
+      query: request.query,
+      body: request.body,
+    });
+    response.status(200).send(result);
   }
   catch (error) {
     console.error(error)

--- a/FirebaseServer/test/functions/http/HttpEchoTest.ts
+++ b/FirebaseServer/test/functions/http/HttpEchoTest.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit tests for the extracted Echo handler core. Pilot for the
+ * handler-body extraction plan — see docs/FIREBASE_HANDLER_TESTING_PLAN.md
+ * (Phase H1). The pure function is tested via FakeUpdateDatabase.
+ *
+ * The HTTP wrapper (`httpEcho`) is trivial map-over-try/catch and is
+ * not directly tested — firebase-functions tests that plumbing on its
+ * side. See the plan for the rationale.
+ */
+
+import { expect } from 'chai';
+
+import { handleEchoRequest } from '../../../src/functions/http/Echo';
+import {
+  setImpl as setUpdateDBImpl,
+  resetImpl as resetUpdateDBImpl,
+} from '../../../src/database/UpdateDatabase';
+import { FakeUpdateDatabase } from '../../fakes/FakeUpdateDatabase';
+
+// Pattern for matching a UUID v4 session identifier.
+const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('handleEchoRequest (pure handler core)', () => {
+  let fakeDB: FakeUpdateDatabase;
+
+  beforeEach(() => {
+    fakeDB = new FakeUpdateDatabase();
+    setUpdateDBImpl(fakeDB);
+  });
+
+  afterEach(() => {
+    resetUpdateDBImpl();
+  });
+
+  it('saves to UpdateDatabase using the session id from the query', async () => {
+    const query = { session: 'client-session-123' };
+    const body = { payload: 'hello' };
+
+    await handleEchoRequest({ query, body });
+
+    expect(fakeDB.saved).to.have.lengthOf(1);
+    const [session, data] = fakeDB.saved[0];
+    expect(session).to.equal('client-session-123');
+    expect(data.session).to.equal('client-session-123');
+    expect(data.queryParams).to.deep.equal(query);
+    expect(data.body).to.deep.equal(body);
+  });
+
+  it('generates a v4 UUID session id when the query omits one', async () => {
+    const query = {};
+    const body = { payload: 'no-session' };
+
+    await handleEchoRequest({ query, body });
+
+    expect(fakeDB.saved).to.have.lengthOf(1);
+    const [session, data] = fakeDB.saved[0];
+    expect(session).to.match(UUID_V4_RE, 'expected a v4 UUID session');
+    expect(data.session).to.equal(session);
+    expect(data.queryParams).to.deep.equal(query);
+    expect(data.body).to.deep.equal(body);
+  });
+
+  it('returns the saved data retrieved via getCurrent(session)', async () => {
+    const query = { session: 'roundtrip', buildTimestamp: 'Sat Mar 13 14:45:00 2021' };
+    const body = { a: 1 };
+
+    const result = await handleEchoRequest({ query, body });
+
+    // The returned value is what getCurrent(session) holds after save —
+    // byte-identical to the stored document in the fake.
+    expect(result.session).to.equal('roundtrip');
+    expect(result.queryParams).to.deep.equal(query);
+    expect(result.body).to.deep.equal(body);
+    expect(result.buildTimestamp).to.equal('Sat Mar 13 14:45:00 2021');
+  });
+
+  it('passes buildTimestamp through unchanged when the query provides it', async () => {
+    const query = { session: 's', buildTimestamp: 'Sat%20Apr%2010%2023:57:32%202021' };
+    const body = {};
+
+    await handleEchoRequest({ query, body });
+
+    // Echo is a pass-through — the value is preserved byte-for-byte,
+    // whatever encoding the caller sent. No decoding, no validation.
+    expect(fakeDB.saved[0][1].buildTimestamp).to.equal(
+      'Sat%20Apr%2010%2023:57:32%202021',
+    );
+  });
+
+  it('omits buildTimestamp from the stored data when the query has none', async () => {
+    const query = { session: 's' };
+    const body = {};
+
+    await handleEchoRequest({ query, body });
+
+    const stored = fakeDB.saved[0][1];
+    expect(stored).to.not.have.property('buildTimestamp');
+  });
+});


### PR DESCRIPTION
## Summary

Pilot phase of the handler-body extraction plan — see [`docs/FIREBASE_HANDLER_TESTING_PLAN.md`](../blob/main/docs/FIREBASE_HANDLER_TESTING_PLAN.md) (Phase H1).

- Split `httpEcho` into a pure `handleEchoRequest({query, body})` core plus a thin HTTP wrapper.
- New `test/functions/http/HttpEchoTest.ts` — 5 tests using `FakeUpdateDatabase` via `setImpl`/`resetImpl`.
- Establishes the `test/functions/http/*Test.ts` directory convention used by later phases (H2–H5).

## Byte-identical behavior

- Same `data = { queryParams, body, session, buildTimestamp? }` shape.
- Session from query or generated v4 UUID (unchanged).
- `buildTimestamp` pass-through — no decoding, no validation.
- Same 200-on-success / 500-on-error response code + body.

## Why extraction (Option B) over `firebase-functions-test` (Option A)

Extends the existing `controller/` (pure) vs `functions/` (thin wrapper) split. Reuses the fakes built during the DB refactor (Phases 1–6) — no new dependencies, no new testing idiom.

## Test plan

- [x] `./scripts/validate-firebase.sh` passes (158 tests, 5 new)
- [x] Pure function covered: session pass-through, UUID generation, round-trip via `getCurrent`, buildTimestamp pass-through, buildTimestamp absence
- [x] No collection strings, document shapes, or Firestore call patterns change — Phase 4 lint stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)