### PR TITLE
test(firebase): H2 — extract door-sensor handlers + unit tests

### DIFF
--- a/FirebaseServer/src/functions/http/OpenDoor.ts
+++ b/FirebaseServer/src/functions/http/OpenDoor.ts
@@ -28,15 +28,28 @@ import { getBuildTimestamp, requireBuildTimestamp } from '../../controller/confi
 // empty for 24+ hours. See docs/FIREBASE_HARDENING_PLAN.md → Part A / A3
 // for the full rationale + revert path.
 
+/**
+ * Pure core — testable via fakes on ServerConfigDatabase and
+ * SensorEventDatabase. Extracted in H2 of the handler testing plan.
+ *
+ * Reads buildTimestamp from config (throws if missing), fetches the
+ * current sensor event for that device, and delegates to
+ * sendFCMForOldData. Returns whatever sendFCMForOldData returns —
+ * which the HTTP wrapper passes straight through as the 200 body.
+ */
+export async function handleCheckForOpenDoorsRequest(): Promise<unknown> {
+  const config = await ServerConfigDatabase.get();
+  const buildTimestamp = requireBuildTimestamp(
+    getBuildTimestamp(config),
+    'httpCheckForOpenDoors',
+  );
+  const eventData = await SensorEventDatabase.getCurrent(buildTimestamp);
+  return sendFCMForOldData(buildTimestamp, eventData);
+}
+
 export const httpCheckForOpenDoors = functions.https.onRequest(async (_request, response) => {
   try {
-    const config = await ServerConfigDatabase.get();
-    const buildTimestamp = requireBuildTimestamp(
-      getBuildTimestamp(config),
-      'httpCheckForOpenDoors',
-    );
-    const eventData = await SensorEventDatabase.getCurrent(buildTimestamp);
-    const result = await sendFCMForOldData(buildTimestamp, eventData);
+    const result = await handleCheckForOpenDoorsRequest();
     response.status(200).send(result);
   } catch (error) {
     console.error('httpCheckForOpenDoors failed', error);

--- a/FirebaseServer/src/functions/pubsub/DoorErrors.ts
+++ b/FirebaseServer/src/functions/pubsub/DoorErrors.ts
@@ -20,19 +20,29 @@ import { updateEvent } from '../../controller/EventUpdates';
 import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
 import { getBuildTimestamp, requireBuildTimestamp } from '../../controller/config/ConfigAccessors';
 
+const BUILD_TIMESTAMP_PARAM_KEY = 'buildTimestamp';
+
 // History: see http/OpenDoor.ts for the fallback removal rationale.
 // Same door-sensor device; same A3 story.
 
-export const pubsubCheckForDoorErrors = functions.pubsub.schedule('every 1 minutes').onRun(async (_context) => {
-  const BUILD_TIMESTAMP_PARAM_KEY = "buildTimestamp";
+/**
+ * Pure core — testable via fakes. Extracted in H2. Reads buildTimestamp
+ * from config (throws on missing), then invokes updateEvent with
+ * scheduledJob=true. The data payload shape passed to updateEvent is
+ * byte-identical to the pre-extraction inline code.
+ */
+export async function handleCheckForDoorErrors(): Promise<void> {
   const config = await ServerConfigDatabase.get();
-  const buildTimestampString = requireBuildTimestamp(
+  const buildTimestamp = requireBuildTimestamp(
     getBuildTimestamp(config),
     'pubsubCheckForDoorErrors',
   );
-  const scheduledJob = true;
   const data = {};
-  data[BUILD_TIMESTAMP_PARAM_KEY] = buildTimestampString;
-  await updateEvent(data, scheduledJob);
+  data[BUILD_TIMESTAMP_PARAM_KEY] = buildTimestamp;
+  await updateEvent(data, true);
+}
+
+export const pubsubCheckForDoorErrors = functions.pubsub.schedule('every 1 minutes').onRun(async (_context) => {
+  await handleCheckForDoorErrors();
   return null;
 });

--- a/FirebaseServer/src/functions/pubsub/OpenDoor.ts
+++ b/FirebaseServer/src/functions/pubsub/OpenDoor.ts
@@ -24,7 +24,14 @@ import { getBuildTimestamp, requireBuildTimestamp } from '../../controller/confi
 // History: see http/OpenDoor.ts for the fallback removal rationale.
 // Same door-sensor device; same A3 story.
 
-export const pubsubCheckForOpenDoorsJob = functions.pubsub.schedule('every 5 minutes').onRun(async (_context) => {
+/**
+ * Pure core — testable via fakes. Extracted in H2. Same body as
+ * handleCheckForOpenDoorsRequest but resolves to void (the pubsub
+ * tick does not propagate the FCM result back to a caller) and uses
+ * its own context string for ERROR-log attribution when config is
+ * missing.
+ */
+export async function handleCheckForOpenDoorsJob(): Promise<void> {
   const config = await ServerConfigDatabase.get();
   const buildTimestamp = requireBuildTimestamp(
     getBuildTimestamp(config),
@@ -32,5 +39,9 @@ export const pubsubCheckForOpenDoorsJob = functions.pubsub.schedule('every 5 min
   );
   const eventData = await SensorEventDatabase.getCurrent(buildTimestamp);
   await sendFCMForOldData(buildTimestamp, eventData);
+}
+
+export const pubsubCheckForOpenDoorsJob = functions.pubsub.schedule('every 5 minutes').onRun(async (_context) => {
+  await handleCheckForOpenDoorsJob();
   return null;
 });

--- a/FirebaseServer/test/functions/http/HttpCheckForOpenDoorsTest.ts
+++ b/FirebaseServer/test/functions/http/HttpCheckForOpenDoorsTest.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit tests for the extracted httpCheckForOpenDoors handler core.
+ * H2 of docs/FIREBASE_HANDLER_TESTING_PLAN.md.
+ *
+ * The fakes cover config + sensor-event reads. sendFCMForOldData is
+ * sinon-stubbed because its orchestration (snooze lookup, dedupe,
+ * firebase.messaging().send) is covered by OldDataFCMFakeTest.ts —
+ * re-verifying it here would duplicate that coverage.
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+import { handleCheckForOpenDoorsRequest } from '../../../src/functions/http/OpenDoor';
+import {
+  setImpl as setServerConfigDBImpl,
+  resetImpl as resetServerConfigDBImpl,
+} from '../../../src/database/ServerConfigDatabase';
+import {
+  setImpl as setSensorEventDBImpl,
+  resetImpl as resetSensorEventDBImpl,
+} from '../../../src/database/SensorEventDatabase';
+import { FakeServerConfigDatabase } from '../../fakes/FakeServerConfigDatabase';
+import { FakeSensorEventDatabase } from '../../fakes/FakeSensorEventDatabase';
+import * as OldDataFCM from '../../../src/controller/fcm/OldDataFCM';
+
+const BUILD_TIMESTAMP = 'Sat Mar 13 14:45:00 2021';
+
+describe('handleCheckForOpenDoorsRequest (pure handler core)', () => {
+  let fakeConfig: FakeServerConfigDatabase;
+  let fakeSensorDB: FakeSensorEventDatabase;
+  let sendFcmStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    fakeConfig = new FakeServerConfigDatabase();
+    fakeSensorDB = new FakeSensorEventDatabase();
+    setServerConfigDBImpl(fakeConfig);
+    setSensorEventDBImpl(fakeSensorDB);
+    sendFcmStub = sinon.stub(OldDataFCM, 'sendFCMForOldData');
+  });
+
+  afterEach(() => {
+    resetServerConfigDBImpl();
+    resetSensorEventDBImpl();
+    sinon.restore();
+  });
+
+  it('throws when production config has no buildTimestamp', async () => {
+    // The A3 contract — missing buildTimestamp surfaces as an ERROR
+    // log + thrown Error, not a silent fallback. The HTTP wrapper
+    // catches this and returns 500.
+    fakeConfig.seed({ body: {} });
+
+    let caught: unknown;
+    try {
+      await handleCheckForOpenDoorsRequest();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).to.be.instanceOf(Error);
+    expect((caught as Error).message).to.match(/httpCheckForOpenDoors.*buildTimestamp missing/);
+    expect(sendFcmStub.called).to.be.false;
+  });
+
+  it('passes buildTimestamp + current event data to sendFCMForOldData', async () => {
+    fakeConfig.seed({ body: { buildTimestamp: BUILD_TIMESTAMP } });
+    const eventData = { currentEvent: { timestampSeconds: 12345 } };
+    fakeSensorDB.seed(BUILD_TIMESTAMP, eventData);
+    sendFcmStub.resolves(null);
+
+    await handleCheckForOpenDoorsRequest();
+
+    expect(sendFcmStub.calledOnce).to.be.true;
+    const [passedBuildTimestamp, passedEventData] = sendFcmStub.firstCall.args;
+    expect(passedBuildTimestamp).to.equal(BUILD_TIMESTAMP);
+    expect(passedEventData).to.deep.equal(eventData);
+  });
+
+  it('returns the value produced by sendFCMForOldData', async () => {
+    fakeConfig.seed({ body: { buildTimestamp: BUILD_TIMESTAMP } });
+    const sentinel = { topic: 'door-test', data: { ok: true } };
+    sendFcmStub.resolves(sentinel);
+
+    const result = await handleCheckForOpenDoorsRequest();
+
+    expect(result).to.equal(sentinel);
+  });
+});

--- a/FirebaseServer/test/functions/pubsub/PubsubCheckForDoorErrorsTest.ts
+++ b/FirebaseServer/test/functions/pubsub/PubsubCheckForDoorErrorsTest.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit tests for the extracted pubsubCheckForDoorErrors handler core.
+ * H2 of docs/FIREBASE_HANDLER_TESTING_PLAN.md.
+ *
+ * updateEvent is sinon-stubbed — its branching (old-event comparison,
+ * FCM sending, Firestore persistence) is exercised by
+ * EventUpdatesFakeTest.ts.
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+import { handleCheckForDoorErrors } from '../../../src/functions/pubsub/DoorErrors';
+import {
+  setImpl as setServerConfigDBImpl,
+  resetImpl as resetServerConfigDBImpl,
+} from '../../../src/database/ServerConfigDatabase';
+import { FakeServerConfigDatabase } from '../../fakes/FakeServerConfigDatabase';
+import * as EventUpdates from '../../../src/controller/EventUpdates';
+
+const BUILD_TIMESTAMP = 'Sat Mar 13 14:45:00 2021';
+
+describe('handleCheckForDoorErrors (pure handler core)', () => {
+  let fakeConfig: FakeServerConfigDatabase;
+  let updateEventStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    fakeConfig = new FakeServerConfigDatabase();
+    setServerConfigDBImpl(fakeConfig);
+    updateEventStub = sinon.stub(EventUpdates, 'updateEvent').resolves();
+  });
+
+  afterEach(() => {
+    resetServerConfigDBImpl();
+    sinon.restore();
+  });
+
+  it('throws when production config has no buildTimestamp (context label: pubsubCheckForDoorErrors)', async () => {
+    fakeConfig.seed({ body: {} });
+
+    let caught: unknown;
+    try {
+      await handleCheckForDoorErrors();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).to.be.instanceOf(Error);
+    expect((caught as Error).message).to.match(/pubsubCheckForDoorErrors.*buildTimestamp missing/);
+    expect(updateEventStub.called).to.be.false;
+  });
+
+  it('calls updateEvent with { buildTimestamp } and scheduledJob=true', async () => {
+    fakeConfig.seed({ body: { buildTimestamp: BUILD_TIMESTAMP } });
+
+    await handleCheckForDoorErrors();
+
+    expect(updateEventStub.calledOnce).to.be.true;
+    const [data, scheduledJob] = updateEventStub.firstCall.args;
+    expect(data).to.deep.equal({ buildTimestamp: BUILD_TIMESTAMP });
+    expect(scheduledJob).to.equal(true);
+  });
+
+  it('resolves with no return value on the happy path', async () => {
+    fakeConfig.seed({ body: { buildTimestamp: BUILD_TIMESTAMP } });
+
+    const result = await handleCheckForDoorErrors();
+
+    expect(result).to.be.undefined;
+  });
+});

--- a/FirebaseServer/test/functions/pubsub/PubsubOpenDoorsJobTest.ts
+++ b/FirebaseServer/test/functions/pubsub/PubsubOpenDoorsJobTest.ts
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit tests for the extracted pubsubCheckForOpenDoorsJob handler core.
+ * H2 of docs/FIREBASE_HANDLER_TESTING_PLAN.md.
+ *
+ * Same inputs as the HTTP variant; different context label (used in
+ * the thrown-error message + ERROR log when config is missing).
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+import { handleCheckForOpenDoorsJob } from '../../../src/functions/pubsub/OpenDoor';
+import {
+  setImpl as setServerConfigDBImpl,
+  resetImpl as resetServerConfigDBImpl,
+} from '../../../src/database/ServerConfigDatabase';
+import {
+  setImpl as setSensorEventDBImpl,
+  resetImpl as resetSensorEventDBImpl,
+} from '../../../src/database/SensorEventDatabase';
+import { FakeServerConfigDatabase } from '../../fakes/FakeServerConfigDatabase';
+import { FakeSensorEventDatabase } from '../../fakes/FakeSensorEventDatabase';
+import * as OldDataFCM from '../../../src/controller/fcm/OldDataFCM';
+
+const BUILD_TIMESTAMP = 'Sat Mar 13 14:45:00 2021';
+
+describe('handleCheckForOpenDoorsJob (pure handler core)', () => {
+  let fakeConfig: FakeServerConfigDatabase;
+  let fakeSensorDB: FakeSensorEventDatabase;
+  let sendFcmStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    fakeConfig = new FakeServerConfigDatabase();
+    fakeSensorDB = new FakeSensorEventDatabase();
+    setServerConfigDBImpl(fakeConfig);
+    setSensorEventDBImpl(fakeSensorDB);
+    sendFcmStub = sinon.stub(OldDataFCM, 'sendFCMForOldData').resolves(null);
+  });
+
+  afterEach(() => {
+    resetServerConfigDBImpl();
+    resetSensorEventDBImpl();
+    sinon.restore();
+  });
+
+  it('throws when production config has no buildTimestamp (context label: pubsubCheckForOpenDoorsJob)', async () => {
+    // A failed pubsub tick throws — Firebase marks the run failed and
+    // retries on the next scheduled invocation. See ConfigAccessors
+    // docstring for the rationale.
+    fakeConfig.seed({ body: {} });
+
+    let caught: unknown;
+    try {
+      await handleCheckForOpenDoorsJob();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).to.be.instanceOf(Error);
+    expect((caught as Error).message).to.match(/pubsubCheckForOpenDoorsJob.*buildTimestamp missing/);
+    expect(sendFcmStub.called).to.be.false;
+  });
+
+  it('invokes sendFCMForOldData with the config-derived buildTimestamp and current event', async () => {
+    fakeConfig.seed({ body: { buildTimestamp: BUILD_TIMESTAMP } });
+    const eventData = { currentEvent: { timestampSeconds: 99999 } };
+    fakeSensorDB.seed(BUILD_TIMESTAMP, eventData);
+
+    await handleCheckForOpenDoorsJob();
+
+    expect(sendFcmStub.calledOnce).to.be.true;
+    const [passedBuildTimestamp, passedEventData] = sendFcmStub.firstCall.args;
+    expect(passedBuildTimestamp).to.equal(BUILD_TIMESTAMP);
+    expect(passedEventData).to.deep.equal(eventData);
+  });
+
+  it('resolves with no return value on the happy path', async () => {
+    fakeConfig.seed({ body: { buildTimestamp: BUILD_TIMESTAMP } });
+
+    const result = await handleCheckForOpenDoorsJob();
+
+    // Pubsub handlers return null from onRun(); the pure function
+    // resolves to undefined (its body has no return statement). The
+    // wrapper explicitly returns null.
+    expect(result).to.be.undefined;
+  });
+});


### PR DESCRIPTION
## Summary

Phase H2 of [`docs/FIREBASE_HANDLER_TESTING_PLAN.md`](../blob/main/docs/FIREBASE_HANDLER_TESTING_PLAN.md). Splits three door-sensor handlers into pure cores + thin wrappers:

| Wrapper | Pure core |
|---|---|
| `httpCheckForOpenDoors` | `handleCheckForOpenDoorsRequest()` |
| `pubsubCheckForOpenDoorsJob` | `handleCheckForOpenDoorsJob()` |
| `pubsubCheckForDoorErrors` | `handleCheckForDoorErrors()` |

## New tests (9 total)

- `test/functions/http/HttpCheckForOpenDoorsTest.ts` — 3 tests
- `test/functions/pubsub/PubsubOpenDoorsJobTest.ts` — 3 tests
- `test/functions/pubsub/PubsubCheckForDoorErrorsTest.ts` — 3 tests

Each handler is tested for:
1. **A3 contract:** throws with its context label when config has no `buildTimestamp`.
2. **Happy path:** controller function receives `buildTimestamp` + event data (or `{buildTimestamp}` payload) with byte-identical shape.
3. **Resolution:** returns the controller's result (http) or resolves to undefined (pubsub).

Fakes cover `ServerConfigDatabase` + `SensorEventDatabase`. `sendFCMForOldData` and `updateEvent` are sinon-stubbed because their internals are covered by `OldDataFCMFakeTest.ts` and `EventUpdatesFakeTest.ts`.

## Zero production-data impact

- Request/response shapes unchanged.
- Controller-call argument shapes unchanged (`(buildTimestamp, eventData)`, `({buildTimestamp}, true)`).
- A3 context-label strings unchanged (`httpCheckForOpenDoors`, `pubsubCheckForOpenDoorsJob`, `pubsubCheckForDoorErrors`).
- No Firestore access pattern changes. Phase 4 lint stays green.

## Test plan

- [x] `./scripts/validate-firebase.sh` passes (162 tests, 9 new)
- [x] All three handlers compile + invoke their pure cores unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)