### PR TITLE
test(firebase): H4 (read) — extract handleSnoozeNotificationsLatest + HandlerResult

### DIFF
--- a/FirebaseServer/src/functions/HandlerResult.ts
+++ b/FirebaseServer/src/functions/HandlerResult.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Shared return type for extracted HTTP-handler cores that produce
+ * multiple status codes — see docs/FIREBASE_HANDLER_TESTING_PLAN.md.
+ *
+ * The pure `handle<Action>(input)` function returns a HandlerResult
+ * instead of touching the express Response object directly. The thin
+ * wrapper maps:
+ *
+ *   { kind: 'ok', data }          → response.status(200).send(data)
+ *   { kind: 'error', status, body } → response.status(status).send(body)
+ *
+ * Handlers that only produce 200-or-500 (the "try/catch and rethrow"
+ * shape) don't need this type — they can just `Promise<T>` and let
+ * exceptions bubble to the wrapper's catch. Use HandlerResult when
+ * the handler has validation/auth branches with distinct 4xx codes.
+ */
+export type HandlerResult<T> =
+  | { kind: 'ok'; data: T }
+  | { kind: 'error'; status: number; body: unknown };
+
+export function ok<T>(data: T): HandlerResult<T> {
+  return { kind: 'ok', data };
+}
+
+export function err(status: number, body: unknown): HandlerResult<never> {
+  return { kind: 'error', status, body };
+}

--- a/FirebaseServer/src/functions/http/Snooze.ts
+++ b/FirebaseServer/src/functions/http/Snooze.ts
@@ -21,10 +21,68 @@ import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDat
 import { isSnoozeNotificationsEnabled, getRemoteButtonPushKey, getRemoteButtonAuthorizedEmails } from '../../controller/config/ConfigAccessors';
 import { isAuthorizedToPushRemoteButton } from '../../controller/Auth';
 import { getSnoozeStatus, SnoozeLatestParams, SnoozeLatestResponse, SubmitSnoozeParams, submitSnoozeNotificationsRequest, SubmitSnoozeResponse } from '../../controller/SnoozeNotifications';
+import { HandlerResult, ok, err } from '../HandlerResult';
 
 const BUILD_TIMESTAMP_PARAM_KEY = "buildTimestamp";
 const SNOOZE_DURATION_PARAM_KEY = 'snoozeDuration';
 const SNOOZE_EVENT_TIMESTAMP_KEY = 'snoozeEventTimestamp';
+
+/**
+ * Pure core for the snooze-latest read endpoint. H4 of the handler
+ * testing plan.
+ *
+ * Behavior is byte-identical to the pre-extraction inline code:
+ *  - Config disabled  → 400 { error: 'Disabled' }
+ *  - Method !== GET   → 405 { error: 'Method Not Allowed.' }
+ *  - Missing buildTimestamp → 400 { error: 'Missing required parameter: buildTimestamp' }
+ *  - Controller error → 500 {snoozeResponse}
+ *  - Success          → 200 {snoozeResponse}
+ */
+export async function handleSnoozeNotificationsLatest(input: {
+  method: string;
+  query: any;
+}): Promise<HandlerResult<SnoozeLatestResponse>> {
+  const config = await ServerConfigDatabase.get();
+  if (!isSnoozeNotificationsEnabled(config)) {
+    return err(400, { error: 'Disabled' });
+  }
+  if (input.method !== 'GET') {
+    return err(405, { error: 'Method Not Allowed.' });
+  }
+  const params: SnoozeLatestParams = <SnoozeLatestParams>{
+    buildTimestamp: input.query?.[BUILD_TIMESTAMP_PARAM_KEY] as string,
+  };
+  if (!params.buildTimestamp) {
+    console.error('No build timestamp in request');
+    return err(400, { error: 'Missing required parameter: ' + BUILD_TIMESTAMP_PARAM_KEY });
+  }
+  const snoozeResponse: SnoozeLatestResponse = await getSnoozeStatus(params);
+  if (snoozeResponse.error) {
+    console.error('Returning HTTP 500 error');
+    return err(500, snoozeResponse);
+  }
+  console.info('Returning HTTP 200 success:', snoozeResponse);
+  return ok(snoozeResponse);
+}
+
+/**
+ * Get latest Snooze request.
+ *
+ * curl -X GET \
+ *    -H "Content-Type: application/json" \
+ *    -d '{}' \ "http://localhost:5000/PROJECT-ID/us-central1/snoozeNotificationsLatest?buildTimestamp=Sat%20Mar%2013%2014%3A45%3A00%202021"
+ */
+export const httpSnoozeNotificationsLatest = functions.https.onRequest(async (request, response) => {
+  const result = await handleSnoozeNotificationsLatest({
+    method: request.method,
+    query: request.query,
+  });
+  if (result.kind === 'error') {
+    response.status(result.status).send(result.body);
+  } else {
+    response.status(200).send(result.data);
+  }
+});
 
 /**
  * curl -H "Content-Type: application/json" http://localhost:5000/PROJECT-ID/us-central1/snoozeNotificationsLatest?buildTimestamp=buildTimestamp
@@ -155,68 +213,4 @@ export const httpSnoozeNotificationsRequest = functions.https.onRequest(async (r
     const snooze = snoozeResponse.snooze
     console.info('Returning HTTP 200 success:', snooze);
     response.status(200).send(snooze);
-});
-
-/**
- * Get latest Snooze request.
- *
- * curl -X GET \
- *    -H "Content-Type: application/json" \
- *    -d '{}' \ "http://localhost:5000/PROJECT-ID/us-central1/snoozeNotificationsLatest?buildTimestamp=Sat%20Mar%2013%2014%3A45%3A00%202021"
- */
-export const httpSnoozeNotificationsLatest = functions.https.onRequest(async (request, response) => {
-    // Handle HTTP request.
-    // * Check if snooze notifications are enabled.
-    // * Check that the request is a GET request.
-    // * Get the parameters from the request.
-    //     * buildTimestamp
-    // Then implement the logic to get the latest snooze request.
-    // * Get the current event timestamp from the database.
-    // * Get the latest snooze request from the database.
-    // * Check if the snooze request is active, expired, or none.
-    //     * Result: ACTIVE, EXPIRED, NONE
-    // * Return the JSON response:
-    //     * status: string = ACTIVE, EXPIRED, NONE
-    //     * snooze: SnoozeRequest
-    //     * error: string
-
-    // Handle the HTTP request.
-    const config = await ServerConfigDatabase.get();
-    if (!isSnoozeNotificationsEnabled(config)) {
-        response.status(400).send({ error: 'Disabled' });
-        return;
-    }
-    if (request.method !== 'GET') {
-        response.status(405).send({ error: 'Method Not Allowed.' });
-        return;
-    }
-    let params: SnoozeLatestParams = null;
-    try {
-        params = <SnoozeLatestParams>{
-            buildTimestamp: request.query[BUILD_TIMESTAMP_PARAM_KEY] as string,
-        };
-    } catch {
-        console.error('No build timestamp in request');
-        const result = { error: 'Missing required parameter: ' + BUILD_TIMESTAMP_PARAM_KEY };
-        response.status(400).send(result);
-        return;
-    }
-    if (!params.buildTimestamp) {
-        console.error('No build timestamp in request');
-        const result = { error: 'Missing required parameter: ' + BUILD_TIMESTAMP_PARAM_KEY };
-        response.status(400).send(result);
-        return;
-    }
-
-    // Implement the core logic.
-    const snoozeResponse: SnoozeLatestResponse = await getSnoozeStatus(params);
-
-    // Return the HTTP response.
-    if (snoozeResponse.error) {
-        console.error('Returning HTTP 500 error');
-        response.status(500).send(snoozeResponse);
-        return;
-    }
-    console.info('Returning HTTP 200 success:', snoozeResponse);
-    response.status(200).send(snoozeResponse);
 });

--- a/FirebaseServer/test/functions/http/HttpSnoozeNotificationsLatestTest.ts
+++ b/FirebaseServer/test/functions/http/HttpSnoozeNotificationsLatestTest.ts
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit tests for the extracted httpSnoozeNotificationsLatest handler
+ * core. H4 of the handler testing plan — see
+ * docs/FIREBASE_HANDLER_TESTING_PLAN.md.
+ *
+ * First handler to use HandlerResult<T>. Verifies that the kind +
+ * status + body tuple matches the pre-extraction wrapper's
+ * response.status(...).send(...) arguments byte-for-byte.
+ *
+ * getSnoozeStatus is sinon-stubbed — its internals are covered by
+ * SnoozeNotificationsTest.ts.
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+import { handleSnoozeNotificationsLatest } from '../../../src/functions/http/Snooze';
+import {
+  setImpl as setServerConfigDBImpl,
+  resetImpl as resetServerConfigDBImpl,
+} from '../../../src/database/ServerConfigDatabase';
+import { FakeServerConfigDatabase } from '../../fakes/FakeServerConfigDatabase';
+import * as SnoozeNotifications from '../../../src/controller/SnoozeNotifications';
+import { SnoozeStatus } from '../../../src/model/SnoozeRequest';
+
+const BUILD_TIMESTAMP = 'Sat Mar 13 14:45:00 2021';
+
+describe('handleSnoozeNotificationsLatest (pure handler core)', () => {
+  let fakeConfig: FakeServerConfigDatabase;
+  let getSnoozeStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    fakeConfig = new FakeServerConfigDatabase();
+    setServerConfigDBImpl(fakeConfig);
+    fakeConfig.seed({ body: { snoozeNotificationsEnabled: true } });
+    getSnoozeStub = sinon.stub(SnoozeNotifications, 'getSnoozeStatus');
+  });
+
+  afterEach(() => {
+    resetServerConfigDBImpl();
+    sinon.restore();
+  });
+
+  it('returns 400 Disabled when config has snoozeNotificationsEnabled=false', async () => {
+    fakeConfig.clear();
+    fakeConfig.seed({ body: { snoozeNotificationsEnabled: false } });
+
+    const result = await handleSnoozeNotificationsLatest({
+      method: 'GET',
+      query: { buildTimestamp: BUILD_TIMESTAMP },
+    });
+
+    expect(result).to.deep.equal({
+      kind: 'error',
+      status: 400,
+      body: { error: 'Disabled' },
+    });
+    expect(getSnoozeStub.called).to.be.false;
+  });
+
+  it('returns 405 Method Not Allowed for non-GET methods', async () => {
+    const result = await handleSnoozeNotificationsLatest({
+      method: 'POST',
+      query: { buildTimestamp: BUILD_TIMESTAMP },
+    });
+
+    expect(result).to.deep.equal({
+      kind: 'error',
+      status: 405,
+      body: { error: 'Method Not Allowed.' },
+    });
+    expect(getSnoozeStub.called).to.be.false;
+  });
+
+  it('returns 400 with parameter-name message when buildTimestamp is missing', async () => {
+    const result = await handleSnoozeNotificationsLatest({
+      method: 'GET',
+      query: {},
+    });
+
+    expect(result).to.deep.equal({
+      kind: 'error',
+      status: 400,
+      body: { error: 'Missing required parameter: buildTimestamp' },
+    });
+    expect(getSnoozeStub.called).to.be.false;
+  });
+
+  it('returns 500 with the controller response body when getSnoozeStatus sets error', async () => {
+    const errorResponse = { status: SnoozeStatus.NONE, error: 'boom' };
+    getSnoozeStub.resolves(errorResponse);
+
+    const result = await handleSnoozeNotificationsLatest({
+      method: 'GET',
+      query: { buildTimestamp: BUILD_TIMESTAMP },
+    });
+
+    expect(result).to.deep.equal({
+      kind: 'error',
+      status: 500,
+      body: errorResponse,
+    });
+  });
+
+  it('returns 200 ok with the controller response on success', async () => {
+    const okResponse = { status: SnoozeStatus.ACTIVE, snooze: { snoozeEndTimeSeconds: 9999 } };
+    getSnoozeStub.resolves(okResponse);
+
+    const result = await handleSnoozeNotificationsLatest({
+      method: 'GET',
+      query: { buildTimestamp: BUILD_TIMESTAMP },
+    });
+
+    expect(result).to.deep.equal({ kind: 'ok', data: okResponse });
+    expect(getSnoozeStub.calledOnce).to.be.true;
+    expect(getSnoozeStub.firstCall.args[0]).to.deep.equal({ buildTimestamp: BUILD_TIMESTAMP });
+  });
+});


### PR DESCRIPTION
## Summary

Partial Phase H4 of [`docs/FIREBASE_HANDLER_TESTING_PLAN.md`](../blob/main/docs/FIREBASE_HANDLER_TESTING_PLAN.md) — the read-side snooze handler.

Also introduces `src/functions/HandlerResult.ts`, the shared sealed type for multi-status-code handler cores. H3 (HTTP) and the forthcoming H4 write PR will reuse it.

## Changes

- **New:** `src/functions/HandlerResult.ts` — `HandlerResult<T>` sealed type + `ok()` / `err()` helpers.
- **Refactor:** `src/functions/http/Snooze.ts` — extract `handleSnoozeNotificationsLatest({method, query})` returning `HandlerResult<SnoozeLatestResponse>`. Wrapper is now one `kind === 'error' ? status+body : 200+data` branch.
- **Tests:** `test/functions/http/HttpSnoozeNotificationsLatestTest.ts` — 5 tests (one per branch).

`httpSnoozeNotificationsRequest` is untouched and will ship in a follow-up PR (key auth + token verification + param validation has its own test surface).

## Branches covered

| Status | Cause |
|---|---|
| 400 Disabled | `snoozeNotificationsEnabled=false` |
| 405 Method Not Allowed | Non-`GET` request |
| 400 Missing parameter | `buildTimestamp` absent |
| 500 | `getSnoozeStatus` returned `.error` |
| 200 | Success — controller response passed through |

## Byte-identical behavior

- Same error body shapes (`{ error: 'Disabled' }`, `'Method Not Allowed.'`, `'Missing required parameter: buildTimestamp'`).
- Same 500 body shape (entire controller response, unchanged).
- Same 200 body shape.

## Test plan

- [x] `./scripts/validate-firebase.sh` passes (172 tests, 5 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)