### PR TITLE
test(firebase): H5 (retention) — extract pubsubDataRetentionPolicy + tests

### DIFF
--- a/FirebaseServer/src/functions/pubsub/DataRetentionPolicy.ts
+++ b/FirebaseServer/src/functions/pubsub/DataRetentionPolicy.ts
@@ -20,17 +20,38 @@ import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDat
 import { isDeleteOldDataEnabled } from '../../controller/config/ConfigAccessors';
 import { deleteOldData } from '../../controller/DatabaseCleaner';
 
+const TWO_WEEKS_SECONDS = 60 * 60 * 24 * 14;
+
+/**
+ * Pure core — testable via a fake ServerConfigDatabase + sinon stub
+ * on deleteOldData. H5 of the handler testing plan.
+ *
+ * The 2-week window is computed from `nowMillis` (defaulting to
+ * `Date.now()`) so tests can pin it without stubbing the global.
+ *
+ * Behavior is byte-identical to the pre-extraction inline code:
+ *  - disabled → logs the existing message, does not call deleteOldData.
+ *  - enabled  → calls deleteOldData(cutoffSeconds, dryRun=false) where
+ *    cutoffSeconds = (nowMillis - 2w) / 1000 — same arithmetic as
+ *    before, just with `nowMillis` injected for testability.
+ */
+export async function handleDataRetentionPolicy(
+  nowMillis: number = Date.now(),
+): Promise<void> {
+  const config = await ServerConfigDatabase.get();
+  if (!isDeleteOldDataEnabled(config)) {
+    console.log('Deleting data is disabled');
+    return;
+  }
+  const cutoffMillis = nowMillis - 1000 * TWO_WEEKS_SECONDS;
+  const cutoffSeconds = cutoffMillis / 1000;
+  const dryRunRequested = false;
+  await deleteOldData(cutoffSeconds, dryRunRequested);
+}
+
 export const pubsubDataRetentionPolicy = functions.pubsub
   .schedule('0 0 * * *').timeZone('America/Los_Angeles') // California midnight every day.
   .onRun(async (_context) => {
-    const config = await ServerConfigDatabase.get();
-    if (!isDeleteOldDataEnabled(config)) {
-      console.log('Deleting data is disabled');
-      return null;
-    }
-    const cutoffMillis = new Date().getTime() - 1000 * 60 * 60 * 24 * 14; // 2 weeks.
-    const cutoffSeconds = cutoffMillis / 1000;
-    const dryRunRequested = false;
-    await deleteOldData(cutoffSeconds, dryRunRequested);
+    await handleDataRetentionPolicy();
     return null;
   });

--- a/FirebaseServer/test/functions/pubsub/PubsubDataRetentionPolicyTest.ts
+++ b/FirebaseServer/test/functions/pubsub/PubsubDataRetentionPolicyTest.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit tests for the extracted pubsubDataRetentionPolicy handler core.
+ * H5 of the handler testing plan —
+ * docs/FIREBASE_HANDLER_TESTING_PLAN.md.
+ *
+ * deleteOldData is sinon-stubbed — the handler's job is the config
+ * gate and the 2-week cutoff arithmetic; the cleanup logic has its
+ * own tests in the controller layer.
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+import { handleDataRetentionPolicy } from '../../../src/functions/pubsub/DataRetentionPolicy';
+import {
+  setImpl as setServerConfigDBImpl,
+  resetImpl as resetServerConfigDBImpl,
+} from '../../../src/database/ServerConfigDatabase';
+import { FakeServerConfigDatabase } from '../../fakes/FakeServerConfigDatabase';
+import * as DatabaseCleaner from '../../../src/controller/DatabaseCleaner';
+
+describe('handleDataRetentionPolicy (pure handler core)', () => {
+  let fakeConfig: FakeServerConfigDatabase;
+  let deleteStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    fakeConfig = new FakeServerConfigDatabase();
+    setServerConfigDBImpl(fakeConfig);
+    deleteStub = sinon.stub(DatabaseCleaner, 'deleteOldData').resolves({});
+  });
+
+  afterEach(() => {
+    resetServerConfigDBImpl();
+    sinon.restore();
+  });
+
+  it('skips deletion (with the existing info log) when deleteOldDataEnabled is false', async () => {
+    fakeConfig.seed({ body: { deleteOldDataEnabled: false } });
+    const logSpy = sinon.spy(console, 'log');
+
+    await handleDataRetentionPolicy();
+
+    expect(deleteStub.called).to.be.false;
+    expect(
+      logSpy.calledWith('Deleting data is disabled'),
+      'expected disabled-path log message',
+    ).to.be.true;
+  });
+
+  it('calls deleteOldData with the 2-week cutoff in seconds and dryRun=false', async () => {
+    fakeConfig.seed({ body: { deleteOldDataEnabled: true } });
+    // Pin "now" so the cutoff is deterministic.
+    const nowMillis = 2_000_000_000_000;
+    const expectedCutoffSeconds = (nowMillis - 1000 * 60 * 60 * 24 * 14) / 1000;
+
+    await handleDataRetentionPolicy(nowMillis);
+
+    expect(deleteStub.calledOnce).to.be.true;
+    const [cutoffSeconds, dryRun] = deleteStub.firstCall.args;
+    expect(cutoffSeconds).to.equal(expectedCutoffSeconds);
+    expect(dryRun).to.equal(false);
+  });
+
+  it('is a no-op when config is missing the deleteOldDataEnabled flag (defaults to false)', async () => {
+    // isDeleteOldDataEnabled returns false when the body key is absent
+    // — same effect as explicitly setting the flag to false.
+    fakeConfig.seed({ body: {} });
+
+    await handleDataRetentionPolicy();
+
+    expect(deleteStub.called).to.be.false;
+  });
+});


### PR DESCRIPTION
## Summary

Partial Phase H5 of [`docs/FIREBASE_HANDLER_TESTING_PLAN.md`](../blob/main/docs/FIREBASE_HANDLER_TESTING_PLAN.md) — the data-retention pubsub handler.

## Changes

- `src/functions/pubsub/DataRetentionPolicy.ts` — extract `handleDataRetentionPolicy(nowMillis?)` pure core. The 2-week cutoff is computed from the injected `nowMillis` (defaulting to `Date.now()`) so tests can pin it without stubbing the global.
- `test/functions/pubsub/PubsubDataRetentionPolicyTest.ts` — 3 tests.

## Test coverage

| Branch | Test |
|---|---|
| `deleteOldDataEnabled=false` | no-op, existing `'Deleting data is disabled'` log |
| `deleteOldDataEnabled=true`  | `deleteOldData(cutoffSeconds, dryRun=false)` called; cutoffSeconds matches pre-extraction arithmetic `(nowMillis - 2w) / 1000` |
| Missing flag | defaults to disabled; no-op |

## Zero production-data impact

- Same arithmetic (2 weeks = `60 * 60 * 24 * 14` seconds).
- Same `dryRunRequested = false` hardcode.
- Same disabled-path info log.
- Firestore call patterns unchanged.

## Test plan

- [x] `./scripts/validate-firebase.sh` passes (175 tests, 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)