### PR TITLE
docs: Capture inject-externals handler pattern + ignore lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .claude/.validation-passed
 .claude/.firebase-validation-passed
 .claude/.dev-mode
+.claude/scheduled_tasks.lock
 
 # macOS
 .DS_Store

--- a/docs/FIREBASE_HANDLER_TESTING_PLAN.md
+++ b/docs/FIREBASE_HANDLER_TESTING_PLAN.md
@@ -167,6 +167,37 @@ The `HandlerResult<T>` type lives in one shared file
   change only. All collection strings, document shapes, and Firestore
   call patterns stay byte-identical.
 
+### Inject external-state reads via the wrapper
+
+When a handler reads from a framework global — `functions.config()`,
+`Date.now()`, `firebase.firestore.Timestamp.now()`, `process.env`, etc.
+— have the **wrapper** read it and pass the plain value to the pure
+core as an argument. The pure function then takes a regular string /
+number / object and tests drive it without stubbing the global.
+
+Two concrete examples already shipped:
+
+- **`functions.config()` → `expectedKey: string | null`** — the
+  wrapper in `http/ServerConfig.ts` calls
+  `readServerConfigSecret(functions.config(), 'key' | 'updatekey')`
+  (a small exported helper) and passes the resulting string or
+  `null` to `handleServerConfigRead({..., expectedKey})`. Tests pass
+  `expectedKey: null` directly to reach the 500 branch and a real
+  string to reach the 401/403/200 branches.
+
+- **`Date.now()` → `nowMillis: number = Date.now()`** — the pure
+  `handleDataRetentionPolicy(nowMillis?)` takes an optional
+  millisecond override that defaults to `Date.now()`. Tests pin the
+  value; the wrapper relies on the default. Same idea applies to
+  `firebase.firestore.Timestamp.now()` when that's the seam (here the
+  existing approach is a sinon stub because the threshold logic is
+  tested against a frozen "now" — either pattern is acceptable).
+
+Rule of thumb: if the global is a **value read** (config, clock), pass
+it as an argument. If it's a **service call** (Firestore, FCM), use
+the `setImpl`/fake pattern instead — those are already designed for
+that shape.
+
 ## Phased rollout
 
 Each phase = one handler group = one PR. Handlers can land in any


### PR DESCRIPTION
## Summary

Dump session context from the dev-mode batch (#503–#512, H1–H6). Most of the knowledge landed with those PRs themselves; this PR captures the one pattern-level takeaway and a small `.gitignore` fix.

## Changes

### `docs/FIREBASE_HANDLER_TESTING_PLAN.md`
New subsection under Principles: **"Inject external-state reads via the wrapper"**. Documents two concrete applications shipped this session:

- `functions.config()` → `expectedKey: string | null` — the wrapper in `http/ServerConfig.ts` calls `readServerConfigSecret(functions.config(), ...)` and passes the plain string (or null) to the pure core. Tests pass `null` directly to reach the 500 branch.
- `Date.now()` → `nowMillis: number = Date.now()` — `handleDataRetentionPolicy(nowMillis?)` takes an optional override. Tests pin the value; the wrapper uses the default.

Rule of thumb: **value reads** (config, clock) get injected as args; **service calls** (Firestore, FCM) keep using `setImpl`/fake pattern.

### `.gitignore`
Added `.claude/scheduled_tasks.lock` — transient ScheduleWakeup runtime file; not user-visible state.

## Test plan

- [x] Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)