### PR TITLE
feat(firebase): AuthService bridge + fake + helper (PR A, prep for H3/H4)

### DIFF
--- a/FirebaseServer/src/controller/AuthService.ts
+++ b/FirebaseServer/src/controller/AuthService.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as firebase from 'firebase-admin';
+
+/**
+ * Swappable wrapper around `firebase.auth().verifyIdToken()`.
+ *
+ * Shape matches src/database/*Database.ts and src/controller/fcm/EventFCM.ts
+ * (interface + default impl + singleton + setImpl/resetImpl). Tests use
+ * FakeAuthService to control token verification without touching Firebase
+ * Auth's network-calling real implementation.
+ *
+ * **Intended consumers (handler testing plan — H3 HTTP + H4 write):**
+ * - `http/RemoteButton.ts` → `httpAddRemoteButtonCommand`
+ * - `http/Snooze.ts`       → `httpSnoozeNotificationsRequest`
+ *
+ * Those handlers currently call `firebase.auth().verifyIdToken(token)`
+ * directly. After the H3/H4 extractions they will call
+ * `AuthService.verifyIdToken(token)` instead. The migration is mechanical
+ * — behavior is byte-identical; only the seam for tests changes.
+ *
+ * **verifyIdToken throw behavior differs between callers.** Preserve it
+ * when wiring:
+ * - `httpSnoozeNotificationsRequest` wraps in try/catch → returns 401 on
+ *   throw.
+ * - `httpAddRemoteButtonCommand` does NOT wrap → exception propagates to
+ *   the outer catch → returns 500.
+ * Tests must exercise both paths (fake throws, caller reacts) to pin the
+ * asymmetry.
+ */
+export interface AuthService {
+  verifyIdToken(idToken: string): Promise<firebase.auth.DecodedIdToken>;
+}
+
+class DefaultAuthService implements AuthService {
+  verifyIdToken(idToken: string): Promise<firebase.auth.DecodedIdToken> {
+    return firebase.auth().verifyIdToken(idToken);
+  }
+}
+
+let _instance: AuthService = new DefaultAuthService();
+
+export const SERVICE: AuthService = {
+  verifyIdToken: (token) => _instance.verifyIdToken(token),
+};
+
+/** TEST-ONLY: swap in a fake implementation. */
+export function setImpl(impl: AuthService): void { _instance = impl; }
+
+/** TEST-ONLY: restore the default (Firebase-Auth-calling) implementation. */
+export function resetImpl(): void { _instance = new DefaultAuthService(); }

--- a/FirebaseServer/test/controller/AuthServiceTest.ts
+++ b/FirebaseServer/test/controller/AuthServiceTest.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contract tests for the AuthService bridge.
+ *
+ * The bridge is introduced ahead of the H3/H4 HTTP handler extractions
+ * (see docs/FIREBASE_HANDLER_TESTING_PLAN.md). There are no callers yet;
+ * these tests pin the swap-in pattern so the follow-up handler tests
+ * can rely on it.
+ */
+
+import { expect } from 'chai';
+
+import {
+  SERVICE as AuthService,
+  setImpl as setAuthServiceImpl,
+  resetImpl as resetAuthServiceImpl,
+} from '../../src/controller/AuthService';
+import { FakeAuthService } from '../fakes/FakeAuthService';
+
+describe('AuthService (swappable bridge)', () => {
+  let fake: FakeAuthService;
+
+  beforeEach(() => {
+    fake = new FakeAuthService();
+    setAuthServiceImpl(fake);
+  });
+
+  afterEach(() => {
+    resetAuthServiceImpl();
+  });
+
+  it('routes verifyIdToken() calls through the injected fake', async () => {
+    fake.seedDecoded({ email: 'user@example.com' });
+
+    const decoded = await AuthService.verifyIdToken('abc.def.ghi');
+
+    expect(decoded.email).to.equal('user@example.com');
+    expect(fake.verifyCalls).to.deep.equal(['abc.def.ghi']);
+  });
+
+  it('propagates the thrown error armed by failNextVerify', async () => {
+    const boom = new Error('auth/invalid-id-token');
+    fake.failNextVerify(boom);
+
+    let caught: unknown;
+    try {
+      await AuthService.verifyIdToken('bad-token');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).to.equal(boom);
+  });
+
+  it('clears the armed failure after a single rejection (single-shot semantics)', async () => {
+    fake.failNextVerify(new Error('once'));
+    fake.seedDecoded({ email: 'next@example.com' });
+
+    let firstThrew = false;
+    try {
+      await AuthService.verifyIdToken('first');
+    } catch {
+      firstThrew = true;
+    }
+    expect(firstThrew).to.be.true;
+
+    // Second call succeeds with the seeded decoded token.
+    const decoded = await AuthService.verifyIdToken('second');
+    expect(decoded.email).to.equal('next@example.com');
+    expect(fake.verifyCalls).to.deep.equal(['first', 'second']);
+  });
+});

--- a/FirebaseServer/test/fakes/FakeAuthService.ts
+++ b/FirebaseServer/test/fakes/FakeAuthService.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import * as firebase from 'firebase-admin';
+import { AuthService } from '../../src/controller/AuthService';
+
+/**
+ * In-memory fake for AuthService. Tests seed a decoded-token payload and
+ * every verifyIdToken() call resolves with it — the `idToken` argument is
+ * captured but not inspected (no real token parsing).
+ *
+ * Use `failNextVerify(error)` to arm the next call to reject, pinning the
+ * auth-throw behavior difference between httpAddRemoteButtonCommand
+ * (propagates → 500) and httpSnoozeNotificationsRequest (catches → 401).
+ */
+export class FakeAuthService implements AuthService {
+  /** Audit log of every verifyIdToken call (succeeded OR threw). */
+  readonly verifyCalls: string[] = [];
+
+  private _decoded: firebase.auth.DecodedIdToken | null = null;
+  private _nextVerifyError: Error | null = null;
+
+  async verifyIdToken(idToken: string): Promise<firebase.auth.DecodedIdToken> {
+    this.verifyCalls.push(idToken);
+    if (this._nextVerifyError) {
+      const e = this._nextVerifyError;
+      this._nextVerifyError = null;
+      throw e;
+    }
+    if (!this._decoded) {
+      // A real DecodedIdToken has many fields; tests that don't seed a
+      // decoded payload usually only care about `.email`. Returning a
+      // minimal shape forces tests to be explicit about what they rely on.
+      return <firebase.auth.DecodedIdToken>{ uid: 'fake-uid' };
+    }
+    return this._decoded;
+  }
+
+  /** Test-only: seed the DecodedIdToken returned by the next verifyIdToken. */
+  seedDecoded(decoded: Partial<firebase.auth.DecodedIdToken>): void {
+    this._decoded = <firebase.auth.DecodedIdToken>{
+      uid: 'fake-uid',
+      ...decoded,
+    };
+  }
+
+  /** Test-only: arm the NEXT verifyIdToken call to reject with `error`. */
+  failNextVerify(error: Error): void { this._nextVerifyError = error; }
+
+  /** Test-only: wipe audit log + seed + any armed failure. */
+  clear(): void {
+    this.verifyCalls.length = 0;
+    this._decoded = null;
+    this._nextVerifyError = null;
+  }
+}

--- a/FirebaseServer/test/helpers/AuthTestHelper.ts
+++ b/FirebaseServer/test/helpers/AuthTestHelper.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { FakeServerConfigDatabase } from '../fakes/FakeServerConfigDatabase';
+import { FakeAuthService } from '../fakes/FakeAuthService';
+
+export const DEFAULT_PUSH_KEY = 'test-push-key';
+export const DEFAULT_EMAIL = 'authorized@example.com';
+
+/**
+ * Seed the given fake-config with a remote-button auth configuration and
+ * prime the given fake-auth-service to decode into the given email. After
+ * this call, the three auth-heavy HTTP handlers
+ * (httpRemoteButton-add-command, httpSnoozeNotificationsRequest) will
+ * accept:
+ *  - X-RemoteButtonPushKey: <pushKey>   (DEFAULT_PUSH_KEY if omitted)
+ *  - X-AuthTokenGoogle:     <any string — FakeAuthService ignores content>
+ * and route through the authorized-user happy path.
+ *
+ * Callers can still override any piece individually — this is a
+ * convenience, not a contract.
+ */
+export function setupAuthHappyPath(
+  fakeConfig: FakeServerConfigDatabase,
+  fakeAuth: FakeAuthService,
+  opts: {
+    email?: string;
+    pushKey?: string;
+    snoozeNotificationsEnabled?: boolean;
+    remoteButtonEnabled?: boolean;
+  } = {},
+): void {
+  const email = opts.email ?? DEFAULT_EMAIL;
+  const pushKey = opts.pushKey ?? DEFAULT_PUSH_KEY;
+  fakeConfig.seed({
+    body: {
+      remoteButtonEnabled: opts.remoteButtonEnabled ?? true,
+      snoozeNotificationsEnabled: opts.snoozeNotificationsEnabled ?? true,
+      remoteButtonPushKey: pushKey,
+      remoteButtonAuthorizedEmails: [email],
+    },
+  });
+  fakeAuth.seedDecoded({ email });
+}


### PR DESCRIPTION
## Summary

**PR A of 3** for the H3 HTTP + H4 write handler extractions — see the revised plan on issue discussion. Zero handler changes and no current callers; this is additive infrastructure the follow-up PRs will wire in.

## Why a prep PR

5 reviewers flagged that the three auth-heavy handlers (`httpAddRemoteButtonCommand`, `httpSnoozeNotificationsRequest`, and the follow-up `httpRemoteButton` poll) share an auth surface that's worth extracting before the handler tests. This decouples Firebase Auth from the handler cores and prevents `sinon.stub(firebase.auth(), ...)` noise across the three forthcoming test files.

## Changes

| File | Role |
|---|---|
| `src/controller/AuthService.ts` | Interface + default impl + `SERVICE` singleton + `setImpl`/`resetImpl` |
| `test/fakes/FakeAuthService.ts` | In-memory fake with `failNextVerify(error)` single-shot failure injection |
| `test/helpers/AuthTestHelper.ts` | `setupAuthHappyPath(fakeConfig, fakeAuth, opts)` — seeds config + auth for the shared happy path |
| `test/controller/AuthServiceTest.ts` | 3 contract tests pinning the bridge's swap-in + single-shot semantics |

Shape mirrors the existing `EventFCMService` (`src/controller/fcm/EventFCM.ts`) — same pattern, same file layout.

## Byte-identical production behavior

`DefaultAuthService.verifyIdToken(idToken)` literally calls `firebase.auth().verifyIdToken(idToken)`. The current handlers don't use `SERVICE` yet, so nothing observable changes. H3/H4 PRs will migrate the handlers to route through `SERVICE` instead of calling `firebase.auth()` directly.

## Why `failNextVerify` matters

Auth reviewer flagged that `httpAddRemoteButtonCommand` does NOT try/catch `verifyIdToken` (throw → 500) while `httpSnoozeNotificationsRequest` does (throw → 401). The follow-up tests use `failNextVerify(error)` to pin both reactions. Keeping the asymmetry explicit prevents a naive "clean-up" that would silently normalize the two paths.

## Test plan

- [x] `./scripts/validate-firebase.sh` passes (208 tests, 3 new)
- [x] No handler file edits; no CHANGELOG entry needed (no release gate)

## Next

- **PR B:** `handleRemoteButtonPoll` extraction + ack-token state-machine tests (no auth).
- **PR C:** `handleAddRemoteButtonCommand` + `handleSnoozeNotificationsRequest` extractions using this bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)