### PR TITLE
test(firebase): H3 HTTP — extract handleRemoteButtonPoll + ack-token tests (PR B)

### DIFF
--- a/FirebaseServer/src/functions/http/RemoteButton.ts
+++ b/FirebaseServer/src/functions/http/RemoteButton.ts
@@ -26,6 +26,7 @@ import { DATABASE as REMOTE_BUTTON_REQUEST_DATABASE } from '../../database/Remot
 import { isAuthorizedToPushRemoteButton } from '../../controller/Auth';
 
 import { RemoteButtonCommand } from '../../model/RemoteButtonCommand';
+import { HandlerResult, ok, err } from '../HandlerResult';
 
 const DATABASE_TIMESTAMP_SECONDS_KEY = 'FIRESTORE_databaseTimestampSeconds';
 const SESSION_PARAM_KEY = "session";
@@ -37,98 +38,122 @@ const REMOTE_BUTTON_MIN_PERIOD_SECONDS = 10;
 const REMOTE_BUTTON_COMMAND_TIMEOUT_SECONDS = 60;
 
 /**
- * curl -H "Content-Type: application/json" http://localhost:5000/PROJECT-ID/us-central1/remoteButton?buildTimestamp=buildTimestamp&buttonAckToken=buttonAckToken
+ * Pure core for the device-polling endpoint. H3 (pubsub→HTTP
+ * continuation) of the handler testing plan.
+ *
+ * Behavior is byte-identical to the pre-extraction inline code:
+ *  - Config not enabled                            → 400 Disabled.
+ *  - `buildTimestamp` missing from query           → passed through
+ *    as `undefined` (the empty `// Skip.` else branch is preserved so
+ *    downstream `getCurrent(undefined)` calls produce the same logs
+ *    as before).
+ *  - Request is ALWAYS saved for logging, regardless of what branch
+ *    the command state machine takes.
+ *  - Ack-token state machine: saves a noop-command + returns the
+ *    freshly re-read version (Firestore timestamps populated) when
+ *    `shouldStopSendingRemoteButtonCommand && oldAckToken !== ''`;
+ *    otherwise returns `oldCommand` directly (no save, no re-read).
+ *    This asymmetry — return fresh on save-path, return pre-save
+ *    on else-path — is intentional. Tests pin it.
+ *  - Any throw during the save/read sequence                → 500.
+ *
+ * No auth: the ESP32 polls this endpoint and has no credentials.
  */
-export const httpRemoteButton = functions.https.onRequest(async (request, response) => {
+export async function handleRemoteButtonPoll(input: {
+  query: any;
+  body: any;
+}): Promise<HandlerResult<any>> {
   const config = await ServerConfigDatabase.get();
   if (!isRemoteButtonEnabled(config)) {
-    response.status(400).send({ error: 'Disabled' });
-    return;
+    return err(400, { error: 'Disabled' });
   }
-  const data = {
-    queryParams: request.query,
-    body: request.body,
+  const data: any = {
+    queryParams: input.query,
+    body: input.body,
   };
-  // The session ID allows a client to tell the server that multiple requests
-  // come from the same session.
-  if (SESSION_PARAM_KEY in request.query) {
-    // If the client sends a session ID, respond with the session ID.
-    data[SESSION_PARAM_KEY] = request.query[SESSION_PARAM_KEY];
+  if (input.query && SESSION_PARAM_KEY in input.query) {
+    data[SESSION_PARAM_KEY] = input.query[SESSION_PARAM_KEY];
   } else {
-    // If the client does not send a session ID, create a session ID.
     data[SESSION_PARAM_KEY] = uuidv4();
   }
   const session = data[SESSION_PARAM_KEY];
-  if (BUTTON_ACK_TOKEN_PARAM_KEY in request.query) {
-    // Client is echoing back a previously-issued ack token. The downstream
-    // `buttonAcknowledged` check uses this to decide whether to clear the
-    // pending command.
-    data[BUTTON_ACK_TOKEN_PARAM_KEY] = request.query[BUTTON_ACK_TOKEN_PARAM_KEY];
+  if (input.query && BUTTON_ACK_TOKEN_PARAM_KEY in input.query) {
+    data[BUTTON_ACK_TOKEN_PARAM_KEY] = input.query[BUTTON_ACK_TOKEN_PARAM_KEY];
   } else {
-    // Client sent no ack token. Leave data[BUTTON_ACK_TOKEN_PARAM_KEY]
-    // undefined — `buttonAckToken` below is then undefined and
-    // `buttonAcknowledged` stays false. This matches how a fresh device
-    // behaves on first poll (no previous command to acknowledge). The
-    // counterpart in httpAddRemoteButtonCommand has a similar un-enforced
-    // path and documents the historical reason to keep it that way; the
-    // same reasoning applies here.
+    // Client sent no ack token. Leave data[...] undefined — preserves the
+    // "undefined ack token means buttonAcknowledged stays false" semantics.
   }
   const buttonAckToken = data[BUTTON_ACK_TOKEN_PARAM_KEY];
-  // The build timestamp is unique to each device.
-  if (BUILD_TIMESTAMP_PARAM_KEY in request.query) {
-    data[BUILD_TIMESTAMP_PARAM_KEY] = request.query[BUILD_TIMESTAMP_PARAM_KEY];
+  if (input.query && BUILD_TIMESTAMP_PARAM_KEY in input.query) {
+    data[BUILD_TIMESTAMP_PARAM_KEY] = input.query[BUILD_TIMESTAMP_PARAM_KEY];
   } else {
-    // Skip.
+    // Skip. Preserved from pre-extraction: buildTimestamp flows through as
+    // `undefined` and downstream DB reads see that — byte-identical to the
+    // prior behavior.
   }
   const buildTimestamp = data[BUILD_TIMESTAMP_PARAM_KEY];
+  // Save the request. This is mostly for logging purposes.
+  await REMOTE_BUTTON_REQUEST_DATABASE.save(buildTimestamp, data);
+  const oldCommand = await REMOTE_BUTTON_COMMAND_DATABASE.getCurrent(buildTimestamp);
+  const oldAckToken = oldCommand?.[BUTTON_ACK_TOKEN_PARAM_KEY] ?? '';
+  const timeSinceLastRemoteButtonCommandSeconds = oldCommand?.[DATABASE_TIMESTAMP_SECONDS_KEY]
+    ? firebase.firestore.Timestamp.now().seconds - oldCommand[DATABASE_TIMESTAMP_SECONDS_KEY]
+    : Number.MAX_SAFE_INTEGER;
+  // Clear the pending command when any of:
+  //   1) the stored command has no ack token (invalid state),
+  //   2) the client echoed back the matching ack token (acknowledged), or
+  //   3) the stored command is older than the timeout AND still has an
+  //      ack token (replace stale).
+  const commandDoesNotContainAckToken = !oldCommand || !(BUTTON_ACK_TOKEN_PARAM_KEY in oldCommand);
+  const buttonAcknowledged = buttonAckToken === oldAckToken;
+  const replaceOldCommand = (timeSinceLastRemoteButtonCommandSeconds > REMOTE_BUTTON_COMMAND_TIMEOUT_SECONDS)
+    && (oldAckToken !== '');
+  const shouldStopSendingRemoteButtonCommand =
+    commandDoesNotContainAckToken
+    || buttonAcknowledged
+    || replaceOldCommand;
+  if (shouldStopSendingRemoteButtonCommand &&
+    typeof oldAckToken === 'string' &&
+    oldAckToken !== ''
+  ) {
+    const noopCommand = <RemoteButtonCommand>{
+      session: session,
+      buildTimestamp: buildTimestamp,
+      buttonAckToken: '',
+      commandDidNotContainAckToken: commandDoesNotContainAckToken,
+      commandAcknowledged: buttonAcknowledged,
+      commandTimeout: replaceOldCommand,
+      oldAckToken: oldAckToken,
+    };
+    console.log('Saving noop command:', noopCommand);
+    await REMOTE_BUTTON_COMMAND_DATABASE.save(buildTimestamp, noopCommand);
+    // Intentional re-read: the fresh document carries Firestore-injected
+    // fields (FIRESTORE_databaseTimestampSeconds). The else branch below
+    // returns `oldCommand` without a second read — preserve that split.
+    const updatedCommand = await REMOTE_BUTTON_COMMAND_DATABASE.getCurrent(buildTimestamp);
+    return ok(updatedCommand);
+  }
+  return ok(oldCommand);
+}
+
+/**
+ * curl -H "Content-Type: application/json" http://localhost:5000/PROJECT-ID/us-central1/remoteButton?buildTimestamp=buildTimestamp&buttonAckToken=buttonAckToken
+ */
+export const httpRemoteButton = functions.https.onRequest(async (request, response) => {
   try {
-    // Save the request. This is mostly for logging purposes.
-    await REMOTE_BUTTON_REQUEST_DATABASE.save(buildTimestamp, data);
-    // Get the remote button command from the database. We need to return this value.
-    const oldCommand = await REMOTE_BUTTON_COMMAND_DATABASE.getCurrent(buildTimestamp);
-    const oldAckToken = oldCommand?.[BUTTON_ACK_TOKEN_PARAM_KEY] ?? '';
-    const timeSinceLastRemoteButtonCommandSeconds = oldCommand?.[DATABASE_TIMESTAMP_SECONDS_KEY]
-      ? firebase.firestore.Timestamp.now().seconds - oldCommand[DATABASE_TIMESTAMP_SECONDS_KEY]
-      : Number.MAX_SAFE_INTEGER;
-    // We reset the button command if any of the following are true:
-    // Condition 1) The command does not contain an ACK token (invaild state).
-    const commandDoesNotContainAckToken = !oldCommand || !(BUTTON_ACK_TOKEN_PARAM_KEY in oldCommand);
-    // Condition 2) The client sends a request with the ACK token (successfully acknowledge).
-    const buttonAcknowledged = buttonAckToken === oldAckToken;
-    // Condition 3) The command is too old.
-    const replaceOldCommand = (timeSinceLastRemoteButtonCommandSeconds > REMOTE_BUTTON_COMMAND_TIMEOUT_SECONDS)
-      && (oldAckToken !== '');
-    const shouldStopSendingRemoteButtonCommand =
-      commandDoesNotContainAckToken // Condition 1.
-      || buttonAcknowledged // Condition 2.
-      || replaceOldCommand; // Condition 3.
-    if (shouldStopSendingRemoteButtonCommand &&
-      typeof oldAckToken === 'string' &&
-      oldAckToken !== ''
-    ) {
-      const noopCommand = <RemoteButtonCommand>{
-        session: session,
-        buildTimestamp: buildTimestamp,
-        buttonAckToken: '',
-        commandDidNotContainAckToken: commandDoesNotContainAckToken,
-        commandAcknowledged: buttonAcknowledged,
-        commandTimeout: replaceOldCommand,
-        oldAckToken: oldAckToken,
-      };
-      console.log('Saving noop command:', noopCommand);
-      await REMOTE_BUTTON_COMMAND_DATABASE.save(buildTimestamp, noopCommand);
-      const updatedCommand = await REMOTE_BUTTON_COMMAND_DATABASE.getCurrent(buildTimestamp);
-      response.status(200).send(updatedCommand);
-      return;
+    const result = await handleRemoteButtonPoll({
+      query: request.query,
+      body: request.body,
+    });
+    if (result.kind === 'error') {
+      response.status(result.status).send(result.body);
     } else {
-      response.status(200).send(oldCommand);
-      return;
+      response.status(200).send(result.data);
     }
   }
   catch (error) {
-    console.error(error)
-    response.status(500).send(error)
-    return;
+    console.error(error);
+    response.status(500).send(error);
   }
 });
 

--- a/FirebaseServer/test/functions/http/HttpRemoteButtonPollTest.ts
+++ b/FirebaseServer/test/functions/http/HttpRemoteButtonPollTest.ts
@@ -1,0 +1,230 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit tests for the extracted httpRemoteButton device-poll handler
+ * core. H3 (HTTP poll) of docs/FIREBASE_HANDLER_TESTING_PLAN.md.
+ *
+ * The poll endpoint has no auth (ESP32 polls it without credentials).
+ * Tests cover the ack-token state machine's three "clear the pending
+ * command" branches plus the asymmetric post-save re-read vs
+ * pre-save return (flagged by the behavior reviewer) and the
+ * always-save-the-request-for-logging invariant.
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import * as firebase from 'firebase-admin';
+
+import { handleRemoteButtonPoll } from '../../../src/functions/http/RemoteButton';
+import {
+  setImpl as setServerConfigDBImpl,
+  resetImpl as resetServerConfigDBImpl,
+} from '../../../src/database/ServerConfigDatabase';
+import {
+  setImpl as setRemoteButtonRequestDBImpl,
+  resetImpl as resetRemoteButtonRequestDBImpl,
+} from '../../../src/database/RemoteButtonRequestDatabase';
+import {
+  setImpl as setRemoteButtonCommandDBImpl,
+  resetImpl as resetRemoteButtonCommandDBImpl,
+} from '../../../src/database/RemoteButtonCommandDatabase';
+import { FakeServerConfigDatabase } from '../../fakes/FakeServerConfigDatabase';
+import { FakeRemoteButtonRequestDatabase } from '../../fakes/FakeRemoteButtonRequestDatabase';
+import { FakeRemoteButtonCommandDatabase } from '../../fakes/FakeRemoteButtonCommandDatabase';
+
+const BUILD_TIMESTAMP = 'Sat Apr 10 23:57:32 2021';
+const NOW_SECONDS = 1_800_000_000;
+const TIMEOUT_SECONDS = 60;
+const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('handleRemoteButtonPoll (pure handler core)', () => {
+  let fakeConfig: FakeServerConfigDatabase;
+  let fakeRequestDB: FakeRemoteButtonRequestDatabase;
+  let fakeCommandDB: FakeRemoteButtonCommandDatabase;
+
+  beforeEach(() => {
+    fakeConfig = new FakeServerConfigDatabase();
+    fakeRequestDB = new FakeRemoteButtonRequestDatabase();
+    fakeCommandDB = new FakeRemoteButtonCommandDatabase();
+    setServerConfigDBImpl(fakeConfig);
+    setRemoteButtonRequestDBImpl(fakeRequestDB);
+    setRemoteButtonCommandDBImpl(fakeCommandDB);
+    sinon.stub(firebase.firestore.Timestamp, 'now').returns(
+      new firebase.firestore.Timestamp(NOW_SECONDS, 0),
+    );
+    fakeConfig.seed({ body: { remoteButtonEnabled: true } });
+  });
+
+  afterEach(() => {
+    resetServerConfigDBImpl();
+    resetRemoteButtonRequestDBImpl();
+    resetRemoteButtonCommandDBImpl();
+    sinon.restore();
+  });
+
+  it('returns 400 Disabled when remoteButtonEnabled is false', async () => {
+    fakeConfig.clear();
+    fakeConfig.seed({ body: { remoteButtonEnabled: false } });
+
+    const result = await handleRemoteButtonPoll({ query: {}, body: {} });
+
+    expect(result).to.deep.equal({
+      kind: 'error',
+      status: 400,
+      body: { error: 'Disabled' },
+    });
+    // No save-for-logging when disabled — verify we bail before the save.
+    expect(fakeRequestDB.saved).to.be.empty;
+    expect(fakeCommandDB.saved).to.be.empty;
+  });
+
+  it('always saves the request for logging (even when no command is pending)', async () => {
+    const result = await handleRemoteButtonPoll({
+      query: { buildTimestamp: BUILD_TIMESTAMP, session: 'client-sess' },
+      body: { payload: 'x' },
+    });
+
+    expect(fakeRequestDB.saved).to.have.lengthOf(1);
+    const [savedBt, savedData] = fakeRequestDB.saved[0];
+    expect(savedBt).to.equal(BUILD_TIMESTAMP);
+    expect(savedData.queryParams).to.deep.equal({
+      buildTimestamp: BUILD_TIMESTAMP,
+      session: 'client-sess',
+    });
+    expect(savedData.body).to.deep.equal({ payload: 'x' });
+    expect(savedData.session).to.equal('client-sess');
+    expect(savedData.buildTimestamp).to.equal(BUILD_TIMESTAMP);
+    // With no prior command, the response body is the null/undefined
+    // return of getCurrent — the poll was just for logging.
+    expect(result).to.deep.equal({ kind: 'ok', data: null });
+  });
+
+  it('generates a v4 UUID session when the query omits one', async () => {
+    await handleRemoteButtonPoll({
+      query: { buildTimestamp: BUILD_TIMESTAMP },
+      body: {},
+    });
+
+    expect(fakeRequestDB.saved[0][1].session).to.match(UUID_V4_RE);
+  });
+
+  it('preserves the "missing buildTimestamp passes through as undefined" quirk', async () => {
+    // The pre-extraction code had an empty `else { // Skip. }` so a
+    // missing buildTimestamp flowed downstream and the request was
+    // saved under key `undefined`. Preserved byte-for-byte.
+    await handleRemoteButtonPoll({ query: {}, body: {} });
+
+    expect(fakeRequestDB.saved).to.have.lengthOf(1);
+    expect(fakeRequestDB.saved[0][0]).to.equal(undefined as any);
+    expect(fakeRequestDB.saved[0][1]).to.not.have.property('buildTimestamp');
+  });
+
+  it('returns oldCommand pre-save when no clear-condition fires (fresh pending command, no matching ack)', async () => {
+    // Seed a pending command: fresh (now), has an ack token the client
+    // is NOT echoing back. None of the three clear conditions fire, so
+    // the handler returns the stored command UNCHANGED and does NOT
+    // re-read. The returned object is `oldCommand` by reference.
+    const pendingCommand = {
+      buttonAckToken: 'server-issued-token',
+      FIRESTORE_databaseTimestampSeconds: NOW_SECONDS - 5,
+    };
+    fakeCommandDB.seed(BUILD_TIMESTAMP, pendingCommand);
+
+    const result = await handleRemoteButtonPoll({
+      query: { buildTimestamp: BUILD_TIMESTAMP, buttonAckToken: 'different-token' },
+      body: {},
+    });
+
+    expect(result.kind).to.equal('ok');
+    if (result.kind === 'ok') {
+      expect(result.data).to.equal(pendingCommand);
+    }
+    expect(fakeCommandDB.saved, 'no save should occur on this branch').to.be.empty;
+  });
+
+  it('clears the pending command (condition 2: ack match) and returns the re-read fresh copy', async () => {
+    // Seed a pending command with a known ack token. Client echoes it
+    // back in the query — condition 2 fires, handler saves a noop and
+    // re-reads. The returned value is the noop, not the pre-save
+    // pendingCommand.
+    const pendingCommand = {
+      buttonAckToken: 'server-issued-token',
+      FIRESTORE_databaseTimestampSeconds: NOW_SECONDS - 5,
+    };
+    fakeCommandDB.seed(BUILD_TIMESTAMP, pendingCommand);
+
+    const result = await handleRemoteButtonPoll({
+      query: {
+        buildTimestamp: BUILD_TIMESTAMP,
+        buttonAckToken: 'server-issued-token',
+        session: 'my-session',
+      },
+      body: {},
+    });
+
+    expect(fakeCommandDB.saved).to.have.lengthOf(1);
+    const [savedBt, savedCommand] = fakeCommandDB.saved[0];
+    expect(savedBt).to.equal(BUILD_TIMESTAMP);
+    expect(savedCommand.buttonAckToken).to.equal('');
+    expect(savedCommand.commandAcknowledged).to.equal(true);
+    expect(savedCommand.commandDidNotContainAckToken).to.equal(false);
+    expect(savedCommand.commandTimeout).to.equal(false);
+    expect(savedCommand.oldAckToken).to.equal('server-issued-token');
+    expect(savedCommand.session).to.equal('my-session');
+    // Returned = fresh getCurrent() after save. Our FakeRemoteButtonCommandDatabase
+    // returns the last saved value, so result.data === savedCommand.
+    if (result.kind === 'ok') {
+      expect(result.data).to.equal(savedCommand);
+    }
+  });
+
+  it('clears the pending command (condition 3: timeout) even without a matching ack', async () => {
+    // Pending command is older than REMOTE_BUTTON_COMMAND_TIMEOUT_SECONDS (60s).
+    // Client doesn't send an ack token. Condition 3 fires: replace the
+    // stale command.
+    const pendingCommand = {
+      buttonAckToken: 'stale-token',
+      FIRESTORE_databaseTimestampSeconds: NOW_SECONDS - TIMEOUT_SECONDS - 1,
+    };
+    fakeCommandDB.seed(BUILD_TIMESTAMP, pendingCommand);
+
+    await handleRemoteButtonPoll({
+      query: { buildTimestamp: BUILD_TIMESTAMP },
+      body: {},
+    });
+
+    expect(fakeCommandDB.saved).to.have.lengthOf(1);
+    expect(fakeCommandDB.saved[0][1].commandTimeout).to.equal(true);
+    expect(fakeCommandDB.saved[0][1].commandAcknowledged).to.equal(false);
+  });
+
+  it('does NOT save a noop when there is no pending command (oldAckToken is empty — guard trips)', async () => {
+    // No seed in the command DB — getCurrent returns null.
+    // commandDoesNotContainAckToken is true (condition 1), but the
+    // outer guard `oldAckToken !== ''` is false (oldAckToken defaults
+    // to '' via `?? ''`), so the else branch runs: no save, return
+    // oldCommand (null). This is the exact "first poll on a fresh
+    // device" path.
+    const result = await handleRemoteButtonPoll({
+      query: { buildTimestamp: BUILD_TIMESTAMP, buttonAckToken: 'some-token' },
+      body: {},
+    });
+
+    expect(fakeCommandDB.saved).to.be.empty;
+    expect(result).to.deep.equal({ kind: 'ok', data: null });
+  });
+});


### PR DESCRIPTION
## Summary

**PR B of 3** from the revised H3/H4 plan (PR A #514 shipped). Extracts `handleRemoteButtonPoll` from `httpRemoteButton` — the device-polling endpoint the ESP32 hits to receive button commands.

No auth on this endpoint (device has no credentials), so this PR doesn't consume the `AuthService` bridge from PR A yet — PR C will.

## Changes

- `src/functions/http/RemoteButton.ts` — extract `handleRemoteButtonPoll({query, body})` returning `HandlerResult<any>`. Wrapper becomes a thin map-over-try/catch.
- `test/functions/http/HttpRemoteButtonPollTest.ts` — 8 tests covering all observable branches.

## Preserved quirks (from 5-reviewer audit)

| Quirk | Preservation |
|---|---|
| L81-82 empty `// Skip.` else | Missing `buildTimestamp` flows through as `undefined`; the logging save uses `undefined` as the doc key. Pinned by the dedicated test. |
| L120 vs L124 asymmetric post-save re-read | Save-branch calls `getCurrent` a second time for Firestore timestamps; else-branch returns `oldCommand` directly. Intent called out in code comments + pinned by tests. |
| First-poll guard (`oldAckToken !== ''`) | No save happens when there's no stored command even though `commandDoesNotContainAckToken` is true. Dedicated test. |

## Test coverage

All 3 ack-token state-machine branches exercised:
- **Condition 1** (no ack token in stored command) — guarded out on first poll
- **Condition 2** (client echoes matching ack token) — save + re-read path
- **Condition 3** (stored command timed out) — save path without matching ack

Plus: config gate, always-save-for-logging invariant, UUID session generation, missing-buildTimestamp fallthrough, and pre-save return path.

## Byte-identical behavior

- `data = { queryParams, body, session, buttonAckToken?, buildTimestamp? }` shape preserved.
- `save(buildTimestamp, data)` to `REMOTE_BUTTON_REQUEST_DATABASE` happens exactly once, always, unless 400.
- `REMOTE_BUTTON_COMMAND_DATABASE.save` only fires on the clear-condition branch.
- `console.log('Saving noop command:', ...)` output preserved.
- 400 body `{ error: 'Disabled' }` preserved.

## Test plan

- [x] `./scripts/validate-firebase.sh` passes (216 tests, 8 new)
- [x] Zero Firestore data contract changes — Phase 4 lint stays green

## Next

**PR C:** `handleAddRemoteButtonCommand` + `handleSnoozeNotificationsRequest` using the `AuthService` bridge from PR A. Will preserve the verifyIdToken throw asymmetry (AddCommand → 500, Snooze → 401) + the four remaining quirks flagged by reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)