### PR TITLE
fix(android): DoorViewModel sticky Loading on tap-to-refresh (2.4.4)

### DIFF
--- a/AndroidGarage/CHANGELOG.md
+++ b/AndroidGarage/CHANGELOG.md
@@ -10,6 +10,9 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
 
+## 2.4.4
+- Fixed Home tab stuck on "Loading" when the door state hadn't changed since the last fetch (e.g. tap-to-refresh, app launch). FCM pushes already worked because a state change produces a distinct value; the refresh path was silently latched by StateFlow value-equality dedup.
+
 ## 2.4.3
 - Snooze card updates to "snoozed until X" immediately after saving (no app restart needed)
 

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorViewModel.kt
@@ -115,7 +115,13 @@ class DefaultDoorViewModel(
             _currentDoorEvent.value = LoadingResult.Loading(_currentDoorEvent.value.data)
             when (val result = fetchCurrentDoorEventUseCase()) {
                 is AppResult.Success -> {
-                    // Data flows through repository → local cache → Flow observation
+                    // Set explicitly. Relying on the Room → repo StateFlow → observer
+                    // pipeline to fire is unsafe: MutableStateFlow dedups by value
+                    // equality, so a refresh that fetches the SAME door event as
+                    // before (common when the door hasn't changed) leaves the UI
+                    // stuck on Loading. FCM works because pushes carry a NEW event
+                    // (state change), so StateFlow sees a different value and emits.
+                    _currentDoorEvent.value = LoadingResult.Complete(result.data)
                 }
                 is AppResult.Error -> {
                     // Restore previous data so UI exits Loading state
@@ -135,7 +141,11 @@ class DefaultDoorViewModel(
             _recentDoorEvents.value = LoadingResult.Loading(_recentDoorEvents.value.data)
             when (val result = fetchRecentDoorEventsUseCase()) {
                 is AppResult.Success -> {
-                    // Data flows through repository → local cache → Flow observation
+                    // Same StateFlow-dedup concern as fetchCurrentDoorEvent — set
+                    // explicitly instead of relying on observation. The list rarely
+                    // equals the previous one so this is less likely to bite, but
+                    // the fix belongs here for consistency + correctness.
+                    _recentDoorEvents.value = LoadingResult.Complete(result.data)
                 }
                 is AppResult.Error -> {
                     // Restore previous data so UI exits Loading state

--- a/AndroidGarage/version.properties
+++ b/AndroidGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.4.3
+versionName=2.4.4


### PR DESCRIPTION
## Summary

Fixes the Home tab "perpetually loading" regression the user reported on android/174. Bumps versionName → 2.4.4.

## Root cause

`DoorViewModel.fetchCurrentDoorEvent()` (lines 112-130 in current main) set `LoadingResult.Loading` at entry but had **no explicit state transition on Success** — relying on the Room → repository StateFlow → ViewModel observer pipeline to emit the new Complete state.

That pipeline uses `MutableStateFlow`, which dedups by value equality. When a refresh fetches the same DoorEvent that's already cached (common — the door spends most of its time in one state), the repository's `_currentDoorEvent.value = event` assignment is a no-op. StateFlow never emits. The observer never fires. **Loading sticks forever.**

FCM pushes bypass this bug because a push carries a NEW event (a state change, by definition), so the value differs and StateFlow emits.

## Fix

Explicitly set `LoadingResult.Complete(result.data)` in the Success branches of `fetchCurrentDoorEvent` and `fetchRecentDoorEvents`. The Error branch already does this for state restoration; Success should too.

```kotlin
is AppResult.Success -> {
    _currentDoorEvent.value = LoadingResult.Complete(result.data)
}
```

## How this was found

After rolling back `server/18` and confirming the bug persisted on the rolled-back server, the server changes were ruled out. Four reviewer agents were dispatched in parallel; two (agent-2 on Loading-state logic + agent-4 on init/emit audit) independently converged on this exact line and exact fix. Agent-3 ruled out R8. Agent-1 flagged the StateFlow-ownership migration PRs as the regression window.

## Test plan

- [x] `./scripts/validate.sh` passes (all checks green)
- [ ] Manual device test: install 2.4.4, open Home tab on app launch (door in stable state), verify card loads
- [ ] Manual device test: tap door card to refresh when state hasn't changed, verify card reloads

## Scope

- `AndroidGarage/usecase/.../DoorViewModel.kt` — 2-line fix + rationale comments
- `AndroidGarage/version.properties` — 2.4.3 → 2.4.4
- `AndroidGarage/CHANGELOG.md` — new 2.4.4 section

🤖 Generated with [Claude Code](https://claude.com/claude-code)