### PR TITLE
screenshots: Refresh gallery timestamp (2.4.4 build, no UI changes)

### DIFF
--- a/AndroidGarage/android-screenshot-tests/SCREENSHOT_GALLERY.md
+++ b/AndroidGarage/android-screenshot-tests/SCREENSHOT_GALLERY.md
@@ -2,7 +2,7 @@
 
 # Screenshot Gallery
 
-Generated on Fri Apr 17 16:10:02 PDT 2026
+Generated on Fri Apr 24 12:11:50 PDT 2026
 
 ## Table of Contents
 - [ComponentsScreenshotTestKt](#componentsscreenshottestkt)


### PR DESCRIPTION
## Summary

Ran `./scripts/generate-android-screenshots.sh`. All 98 reference PNGs are byte-identical to what's already in git — confirms the 2.4.4 fix (DoorViewModel Loading-state transition, PR #518) is UI-invariant.

Only change: gallery Markdown's timestamp (Apr 17 → Apr 24).

## Known blank previews (not introduced here)

The health check flagged 5 pre-existing blanks that depend on `rememberAppComponent()`:
- `HomeScreenPreviewTest` (Light + Dark)
- `SettingsTabPreviewTest` (Light)
- `DoorStatusCardPreviewTest` (Light + Dark)

These need stateless preview overloads per the skill docs, but that's out of scope for a screenshot refresh.

## Test plan

- [x] Gallery regenerated successfully
- [x] No PNG changes → no UI regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)