### PR TITLE
chore: Extend .editorconfig to prevent IDE/ktlint friction

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,19 @@
+root = true
+
+[*]
+# Ensure every file ends with a trailing newline on save. ktlint already
+# enforces this for .kt files via its final-newline rule; this line extends
+# the behavior to every other file type (.md, .yml, .sh, .ts, ...) so the
+# IDE writes files that won't need a second save to pass CI.
+insert_final_newline = true
+
 [*.{kt,kts}]
+# Tell IntelliJ / Android Studio to never auto-collapse imports into wildcards.
+# ktlint's no-wildcard-imports rule already rejects them in CI — this setting
+# stops the IDE from producing the code CI would reject, closing the
+# "IDE writes `import foo.*` → CI rejects → manually fix" cycle at the source.
+ij_kotlin_name_count_to_use_star_import = 2147483647
+
 # Kotlin style typically requires functions to start with a lowercase letter.
 # Composable functions should start with a capital letter.
 ktlint_function_naming_ignore_when_annotated_with = Composable


### PR DESCRIPTION
## Summary
- Add `insert_final_newline = true` under `[*]` so every file (md, yml, sh, ts, ...) gets a trailing newline on IDE save. ktlint already enforces this for `.kt` files; this extends the behavior upstream so CI isn't the first place a missing newline is caught.
- Add `ij_kotlin_name_count_to_use_star_import = 2147483647` under `[*.{kt,kts}]` so IntelliJ/Android Studio never collapses imports into wildcards. ktlint's `no-wildcard-imports` rule already rejects them; this closes the "IDE auto-adds `import foo.*` → CI rejects → manually fix" cycle.
- Add `root = true` so editorconfig-aware tools stop searching upward.

No code changes and no CI rule changes — purely IDE-side prevention aligning the editor with what CI already enforces.

## Test plan
- [x] CI passes (docs-only / config-only fast path)
- [x] No `.kt` files changed — existing code already conforms to both rules since ktlint enforces them in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)