### PR TITLE
docs: Update CLAUDE.md Android Clean Architecture bullets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,9 +78,9 @@ idf.py menuconfig      # Enable fake implementations for testing
 ### Android Clean Architecture
 - **Domain module** (`domain/`): Pure Kotlin types and repository interfaces — no Android deps
 - **Data module** (`data/`): Pure Kotlin data source interfaces (`LocalDoorDataSource`, `NetworkDoorDataSource`, etc.) — abstracts Room/Ktor
-- **UseCase module** (`usecase/`): Shared business logic in `commonMain` — `RemoteButtonStateMachine`, fetch/push/snooze use cases
-- **ViewModels**: `DoorViewModel`, `AuthViewModel`, `RemoteButtonViewModel` — delegate to UseCases
-- **Repositories**: `DoorRepository`, `AuthRepository`, `PushRepository` — implement domain interfaces, depend on data interfaces
+- **UseCase module** (`usecase/`): Shared business logic in `commonMain` — `ButtonStateMachine`, fetch/push/snooze use cases. Also hosts all 5 ViewModels post-Phase 27–30.
+- **ViewModels** (in `usecase/`): `DoorViewModel`, `AuthViewModel`, `RemoteButtonViewModel`, `AppLoggerViewModel`, `AppSettingsViewModel` — delegate to UseCases
+- **Repositories** (impls in `data/`, interfaces in `domain/`): `DoorRepository`, `AuthRepository`, `RemoteButtonRepository`, `SnoozeRepository`, `DoorFcmRepository`, `ServerConfigRepository`, `AppLoggerRepository`, `AppSettingsRepository` — `PushRepository` was split into `RemoteButtonRepository` + `SnoozeRepository` in #203
 - **Typed errors**: `AppResult<D, E>` and `NetworkResult<T>` with sealed error types — exhaustive `when`, no `else`. See ADR-010, ADR-011
 - **Platform bridges**: `AuthBridge`, `MessagingBridge` decouple Firebase SDK — enables unit testing and future iOS
 - **DI**: kotlin-inject (`AppComponent`) — Hilt fully removed. See `docs/DI-MIGRATION.md`


### PR DESCRIPTION
## Summary
Fixed three stale current-state claims in the Android Clean Architecture section of `CLAUDE.md`, caught during the doc audit that also refreshed `ARCHITECTURE.md` (#528).

- `RemoteButtonStateMachine` → `ButtonStateMachine` (only the latter exists in the tree; renamed some phases ago).
- ViewModels list enumerates all five (`DoorViewModel`, `AuthViewModel`, `RemoteButtonViewModel`, `AppLoggerViewModel`, `AppSettingsViewModel`). The previous list named only three.
- `PushRepository` entry expanded to the real 8 repo interfaces (`DoorRepository`, `AuthRepository`, `RemoteButtonRepository`, `SnoozeRepository`, `DoorFcmRepository`, `ServerConfigRepository`, `AppLoggerRepository`, `AppSettingsRepository`), with a pointer to #203 for the `PushRepository` split.

Also noted the post-Phase-27–30 placement of ViewModels in `usecase/` and the impl/interface split (`data/` vs `domain/`) so the bullets match what `ARCHITECTURE.md` now says.

## Test plan
- [x] `grep -rn 'class RemoteButtonStateMachine' AndroidGarage --include='*.kt'` — zero matches
- [x] `ls AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/*ViewModel.kt` — shows all 5 ViewModels
- [x] `ls AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/` — confirms the 8 interfaces
- [x] Docs-only change — CI fast-path

🤖 Generated with [Claude Code](https://claude.com/claude-code)