### PR TITLE
docs: Refresh Android + Firebase READMEs to current tech stack

### DIFF
--- a/AndroidGarage/README.md
+++ b/AndroidGarage/README.md
@@ -16,20 +16,25 @@ Android app for monitoring and controlling the garage door remotely. Built with 
 
 ## Technical Stack
 - UI: Jetpack Compose with Material 3
-- Navigation: Scaffold, NavHost, TopAppBar, BottomNavigationBar
-- Network: Retrofit, Moshi
-- Database: Room
-- Authentication: Firebase Auth, Google Sign-In
+- Navigation: Navigation 3 (`NavDisplay` + `entryProvider`, `@Serializable` route objects)
+- Network: Ktor HTTP client + kotlinx.serialization (engine selected via KMP `expect/actual`)
+- Database: Room (KMP) + DataStore for settings
+- Authentication: Firebase Auth, Google Sign-In (Credential Manager)
 - Push Notifications: Firebase Cloud Messaging (FCM)
-- Dependency Injection: Hilt
+- Dependency Injection: kotlin-inject
+- Logging: Kermit (KMP)
 - Permissions: Accompanist PermissionState
 
 ## Architecture
-- **ViewModels**: Handle UI state and business logic
-- **Repositories**: Manage data operations and network calls
-- **Room Database**: Store door events and state
-- **FCM Service**: Handle push notifications and data updates
-- **Authentication**: Two-step process with Google and Firebase tokens
+
+Shared business logic lives in KMP modules; `androidApp/` is Compose UI + Firebase bridges + DI wiring only. See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full module graph and data flows.
+
+- **`domain/`** — pure Kotlin model types + repository interfaces
+- **`data/`** — data source interfaces, Ktor implementations, platform bridges (`AuthBridge`, `MessagingBridge`), repository implementations
+- **`data-local/`** — Room database + DataStore
+- **`usecase/`** — UseCases + all 5 ViewModels + app-scoped managers
+- **`presentation-model/`** — screen-state data classes
+- **`androidApp/`** — Compose UI + Firebase bridge impls + DI wiring + Activity/Application/Service entry points
 
 ## Build Configuration
 The Android build uses Kotlin build files with version catalogs (TOML).

--- a/FirebaseServer/README.md
+++ b/FirebaseServer/README.md
@@ -37,9 +37,11 @@ The server is built using:
 
 ### Prerequisites
 
-- Node.js 20
+- Node.js 22 (pinned via `.nvmrc`; `engines.node` in `package.json` enforces at install)
 - Firebase CLI
 - TypeScript
+
+Use `scripts/firebase-npm.sh` (or `scripts/validate-firebase.sh`) from the repo root — both auto-switch Node via nvm so you don't need to `nvm use` by hand. See CLAUDE.md for why `NODE_OPTIONS='--no-experimental-strip-types'` is pinned in the `tests` npm script (Node 22.18+ default strip-types breaks `import * as admin from 'firebase-admin'` under mocha).
 
 ### Setup
 
@@ -87,13 +89,18 @@ curl -H "Content-Type: application/json" -H "X-ServerConfigKey: $SERVER_CONFIG_U
 
 ### Database Structure
 
-Collections:
-- `eventsCurrent`: Current door state
-- `eventsAll`: Historical door states
-- `updateCurrent`: Latest sensor updates
-- `updateAll`: Historical sensor data
-- `configCurrent`: Server configuration
-- `notificationsCurrent`: Active notifications
+Every Firestore collection is wrapped by a typed module in `src/database/` with a contract test pinning the collection string (see `docs/FIREBASE_DATABASE_REFACTOR.md`).
+
+| Collection pair | Module | Purpose |
+|-----------------|--------|---------|
+| `eventsCurrent` / `eventsAll` | `SensorEventDatabase` | Interpreted door events (derived from sensor updates) |
+| `updateCurrent` / `updateAll` | `UpdateDatabase` | Raw sensor updates from the ESP32 |
+| `configCurrent` / `configAll` | `ServerConfigDatabase` | Server configuration (buildTimestamps, keys, feature flags) |
+| `notificationsCurrent` / `notificationsAll` | `NotificationsDatabase` | FCM notification history (open-door warnings) |
+| `snoozeNotificationsCurrent` / `snoozeNotificationsAll` | `SnoozeNotificationsDatabase` | User-initiated snooze windows |
+| `remoteButtonCommandCurrent` / `remoteButtonCommandAll` | `RemoteButtonCommandDatabase` | Server-issued button-push commands (polled by ESP32) |
+| `remoteButtonRequestCurrent` / `remoteButtonRequestAll` | `RemoteButtonRequestDatabase` | Client-initiated button-push requests |
+| `remoteButtonRequestErrorCurrent` / `remoteButtonRequestErrorAll` | `RemoteButtonRequestErrorDatabase` | Error entries for stale/missing button requests |
 
 ```
 


### PR DESCRIPTION
## Summary
Audit extension — two READMEs had stale Technical Stack / Prerequisites sections.

### `AndroidGarage/README.md`
Technical Stack claimed a pre-migration stack:
- **Retrofit + Moshi** → Ktor + kotlinx.serialization (Phase 4, #74/#75)
- **Hilt** → kotlin-inject (`DI-MIGRATION.md`)
- **Scaffold + NavHost** → Navigation 3 (#192)
- Missing Kermit (KMP logging) and DataStore (replaced SharedPreferences, #199)

Architecture section collapsed the whole KMP split into four bullets that didn't mention `domain/`, `data/`, `data-local/`, `usecase/`, or `presentation-model/`. Replaced with a per-module rundown matching `docs/ARCHITECTURE.md`.

### `FirebaseServer/README.md`
- **Prerequisites**: said Node 20; `.nvmrc` and `package.json` `engines.node` both pin Node 22. Fixed and added a note about `scripts/firebase-npm.sh` auto-switching + the `NODE_OPTIONS=--no-experimental-strip-types` pitfall.
- **Database Structure**: listed 6 collections; the real count is 16 (eight `src/database/` modules × current/all pairs). Replaced with a table keyed to each module with a one-line purpose.

## Test plan
- [x] Verified `.nvmrc` = 22, `"node": "22"` in `engines`
- [x] `grep -rEn 'COLLECTION_CURRENT|COLLECTION_ALL' FirebaseServer/src/database/` — confirmed 8 modules
- [x] `grep -rEn 'class RemoteButtonStateMachine' AndroidGarage --include='*.kt'` — no match (hence `ButtonStateMachine`)
- [x] Docs-only change — CI fast-path

🤖 Generated with [Claude Code](https://claude.com/claude-code)