### PR TITLE
docs: PR 4/6 — Front-matter rollout + validator

### DIFF
--- a/AndroidGarage/CHANGELOG.md
+++ b/AndroidGarage/CHANGELOG.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # Android Changelog
 
 Internal release history. For Play Store "What's New" text, see `distribution/whatsnew/`.

--- a/AndroidGarage/README.md
+++ b/AndroidGarage/README.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # Smart Garage Door - Android App
 
 ## Overview

--- a/AndroidGarage/docs/ARCHITECTURE.md
+++ b/AndroidGarage/docs/ARCHITECTURE.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # Architecture
 
 ## System Overview

--- a/AndroidGarage/docs/DECISIONS.md
+++ b/AndroidGarage/docs/DECISIONS.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # Architectural Decision Records
 
 ## ADR-001: Server-Centric Design

--- a/AndroidGarage/docs/DI_SINGLETON_REQUIREMENTS.md
+++ b/AndroidGarage/docs/DI_SINGLETON_REQUIREMENTS.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # DI Singleton Requirements and Verification
 
 Reference for the kotlin-inject `@Singleton` scoping bug discovered during

--- a/AndroidGarage/docs/MIGRATION.md
+++ b/AndroidGarage/docs/MIGRATION.md
@@ -1,3 +1,7 @@
+---
+category: plan
+status: active
+---
 # Migration Roadmap
 
 Target: Align with [battery-butler](https://github.com/cartland/battery-butler) technology stack over several independent refactoring projects. Each phase is a separate PR or series of PRs. No phase depends on a later phase.

--- a/AndroidGarage/docs/MIGRATION_PLAN.md
+++ b/AndroidGarage/docs/MIGRATION_PLAN.md
@@ -1,3 +1,7 @@
+---
+category: plan
+status: active
+---
 # Migration Plan — ADR-021 + ADR-022
 
 Rollout plan for the state-ownership principles (ADR-021) and the

--- a/AndroidGarage/docs/R8_INSTRUMENTED_TESTS.md
+++ b/AndroidGarage/docs/R8_INSTRUMENTED_TESTS.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # Running Instrumented Tests Under R8
 
 Normal `connectedDebugAndroidTest` runs against an unminified debug build.

--- a/AndroidGarage/docs/TESTING.md
+++ b/AndroidGarage/docs/TESTING.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # Android Testing & CI Stability Plan
 
 ## Goal

--- a/AndroidGarage/docs/archive/DI-MIGRATION.md
+++ b/AndroidGarage/docs/archive/DI-MIGRATION.md
@@ -1,3 +1,7 @@
+---
+category: archive
+status: shipped
+---
 # Hilt → kotlin-inject Migration Guide
 
 This document records the step-by-step migration from Hilt to kotlin-inject. It serves as a permanent reference for this project and a template for migrating other repositories.

--- a/AndroidGarage/docs/archive/POSTMORTEM_ANDROID_170.md
+++ b/AndroidGarage/docs/archive/POSTMORTEM_ANDROID_170.md
@@ -1,3 +1,7 @@
+---
+category: archive
+status: shipped
+---
 # Postmortem — android/170 snooze propagation regression
 
 **Final status:** Resolved on android/174 (2026-04-19).

--- a/AndroidGarage/docs/archive/VIEWMODEL_SCOPING_ISSUE.md
+++ b/AndroidGarage/docs/archive/VIEWMODEL_SCOPING_ISSUE.md
@@ -1,3 +1,8 @@
+---
+category: archive
+status: superseded
+superseded_by: AndroidGarage/docs/archive/POSTMORTEM_ANDROID_170.md
+---
 # ViewModel Scoping Issue — Multi-Instance Propagation Hazard
 
 **Status:** Resolved. The root cause was the kotlin-inject `@Singleton` caching gap; fixed permanently via the `abstract val` provider pattern in android/173–android/174 (2026-04-19). The PR #354 workaround was removed once the structural fix landed. See `POSTMORTEM_ANDROID_170.md` for the full timeline and ADR-022 for the resulting architectural rule.

--- a/AndroidGarage/docs/archive/design/PLAN-BUTTON-UX-REDESIGN.md
+++ b/AndroidGarage/docs/archive/design/PLAN-BUTTON-UX-REDESIGN.md
@@ -1,3 +1,7 @@
+---
+category: archive
+status: shipped
+---
 # Button UX Redesign — Implementation Plan
 
 Reference: ADR-012 in `docs/DECISIONS.md`

--- a/AndroidGarage/docs/archive/design/PLAN-HOME-SPLIT-BUTTON-COLORS-EMPTY-STATES.md
+++ b/AndroidGarage/docs/archive/design/PLAN-HOME-SPLIT-BUTTON-COLORS-EMPTY-STATES.md
@@ -1,3 +1,7 @@
+---
+category: archive
+status: shipped
+---
 # Design Implementation Plan — High Value, Low Effort
 
 These three changes improve the most-used screens with minimal code.

--- a/AndroidGarage/docs/archive/design/PLAN-REMOVE-PUSH-STATUS.md
+++ b/AndroidGarage/docs/archive/design/PLAN-REMOVE-PUSH-STATUS.md
@@ -1,3 +1,7 @@
+---
+category: archive
+status: shipped
+---
 # Plan: Remove PushStatus StateFlow (ADR-013 Violation Fix)
 
 ## Problem

--- a/AndroidGarage/docs/design/HISTORY.md
+++ b/AndroidGarage/docs/design/HISTORY.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # Design History
 
 Decision log for each iteration. Read top-to-bottom to understand how the spec evolved.

--- a/AndroidGarage/docs/design/INSTRUCTIONS.md
+++ b/AndroidGarage/docs/design/INSTRUCTIONS.md
@@ -1,3 +1,7 @@
+---
+category: plan
+status: active
+---
 # Design Iteration Instructions
 
 This directory contains an iterative UX and design specification for the SmartGarageDoor Android app. Each iteration reviews what exists, brainstorms improvements, picks one area, and improves it.

--- a/AndroidGarage/docs/design/PLAN.md
+++ b/AndroidGarage/docs/design/PLAN.md
@@ -1,3 +1,7 @@
+---
+category: plan
+status: active
+---
 # Iteration Plan
 
 Each iteration is executed by a sub-agent. The orchestrator reads the current state, dispatches the agent, writes results, commits, and increments.

--- a/AndroidGarage/docs/design/SPEC.md
+++ b/AndroidGarage/docs/design/SPEC.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # SmartGarageDoor Android App — Design Specification
 
 *This document grows with each design iteration. See HISTORY.md for decision rationale.*

--- a/AndroidGarage/docs/guides/README.md
+++ b/AndroidGarage/docs/guides/README.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # Technology Guides
 
 Portable, technology-specific lessons — intended to be useful **outside

--- a/AndroidGarage/docs/guides/compose-nav3-vm-scoping.md
+++ b/AndroidGarage/docs/guides/compose-nav3-vm-scoping.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # Compose Nav3 ViewModel scoping — multi-instance reality
 
 **Who this is for:** Compose developers using

--- a/AndroidGarage/docs/guides/kotlin-inject.md
+++ b/AndroidGarage/docs/guides/kotlin-inject.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # kotlin-inject scoping — gotchas and verification
 
 **Who this is for:** anyone using

--- a/AndroidGarage/docs/guides/r8-keep-rules.md
+++ b/AndroidGarage/docs/guides/r8-keep-rules.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # R8 keep rules — what gets stripped, how to detect, how to prevent
 
 **Who this is for:** Android developers shipping release builds with

--- a/AndroidGarage/docs/guides/reactive-auth-listener.md
+++ b/AndroidGarage/docs/guides/reactive-auth-listener.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # Reactive auth listener pattern
 
 **Who this is for:** anyone modeling authentication state in a

--- a/AndroidGarage/docs/guides/repository-api-patterns.md
+++ b/AndroidGarage/docs/guides/repository-api-patterns.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # Repository API patterns — observation, fetch, and refresh semantics
 
 **Who this is for:** anyone designing a repository that exposes an

--- a/AndroidGarage/docs/library-bugs/README.md
+++ b/AndroidGarage/docs/library-bugs/README.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # Library Bugs & Issues
 
 Known bugs or design issues in third-party libraries that affect this project. One file per issue.

--- a/AndroidGarage/docs/library-bugs/room-nullability.md
+++ b/AndroidGarage/docs/library-bugs/room-nullability.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # Room Nullability Bug
 
 ## The Problem

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # CLAUDE.md
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.

--- a/FirebaseServer/CHANGELOG.md
+++ b/FirebaseServer/CHANGELOG.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # Firebase Server Changelog
 
 Internal release history for Cloud Functions deployments. The Android app and ESP32 firmware do not read a version from the server; this log is for the maintainer and for rollback decisions.

--- a/FirebaseServer/README.md
+++ b/FirebaseServer/README.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # Garage Server
 
 A Firebase Cloud Functions server that manages garage door sensor data and notifications.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # Smart Garage Door
 **Author:** Christopher Cartland
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -77,8 +77,9 @@ Docs older than 90 days surface as **warnings** in `validate.sh` output. Warning
 **Excluded** (no front-matter required, ignored by checks):
 - `.claude/skills/` — has native Claude Code frontmatter
 - `GarageFirmware_ESP32/`, `Arduino_ESP32/` — out of primary doc scope
-- `node_modules/`, `**/build/`, `.claude/worktrees/`
+- `node_modules/`, `**/build/`, `.claude/worktrees/`, `.claude/projects/`
 - Generated content: screenshot galleries, `detekt.md`
+- `docs/archive/pr-review/` — has its own historical frontmatter convention (`pr`, `state`, `date`); self-contained archive
 
 ## 5. Trust but verify
 

--- a/docs/FIREBASE_DATABASE_REFACTOR.md
+++ b/docs/FIREBASE_DATABASE_REFACTOR.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # FirebaseServer Database Refactor Plan
 
 Centralize `TimeSeriesDatabase` usage in `FirebaseServer/` behind typed

--- a/docs/FIREBASE_DEPLOY_SETUP.md
+++ b/docs/FIREBASE_DEPLOY_SETUP.md
@@ -1,3 +1,8 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
 # Firebase Server Operations
 
 Long-term maintenance guide for the Firebase Cloud Functions that back the Smart Garage Door app. Covers deploy, rollback, monitoring, cost hygiene, and recovery of the CI pipeline.

--- a/docs/archive/FIREBASE_HANDLER_TESTING_PLAN.md
+++ b/docs/archive/FIREBASE_HANDLER_TESTING_PLAN.md
@@ -1,3 +1,7 @@
+---
+category: archive
+status: shipped
+---
 # Firebase Handler Testing Plan
 
 Complete the handler-test coverage that the database refactor plan

--- a/docs/archive/FIREBASE_HARDENING_PLAN.md
+++ b/docs/archive/FIREBASE_HARDENING_PLAN.md
@@ -1,3 +1,7 @@
+---
+category: archive
+status: shipped
+---
 # Firebase Server Hardening Plan
 
 Covers two non-refactor tranches: (A) replacing hardcoded

--- a/scripts/check-doc-frontmatter.sh
+++ b/scripts/check-doc-frontmatter.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# check-doc-frontmatter.sh
+#
+# Validates the YAML front-matter contract defined in docs/AGENTS.md
+# against every in-scope markdown file in the repo.
+#
+# Contract:
+#   ---
+#   category: reference | plan | archive
+#   status:   active | shipped | superseded
+#   last_verified: YYYY-MM-DD       (required when category=reference + status=active)
+#   superseded_by: path/to/doc.md   (required iff status=superseded; forbidden otherwise)
+#   ---
+#
+# `last_verified` older than 90 days surfaces as a warning. Warnings
+# never fail the build. Only contract violations (missing required
+# fields, invalid enum values, missing front-matter block, mismatched
+# superseded_by rules) cause exit 1.
+#
+# Skill files in .claude/skills/ have their own native Claude Code
+# frontmatter and are excluded. ESP32 dirs (GarageFirmware_ESP32/,
+# Arduino_ESP32/) are out of primary scope and excluded.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RED=$'\033[0;31m'
+YELLOW=$'\033[0;33m'
+RESET=$'\033[0m'
+
+ERRORS=0
+WARNINGS=0
+
+err() {
+    printf '%serror%s %s\n' "$RED" "$RESET" "$1" >&2
+    ERRORS=$((ERRORS + 1))
+}
+
+warn() {
+    printf '%swarn%s  %s\n' "$YELLOW" "$RESET" "$1"
+    WARNINGS=$((WARNINGS + 1))
+}
+
+# In-scope directories. Exclusions are handled below.
+SCOPE=(
+    "$REPO_ROOT/AndroidGarage"
+    "$REPO_ROOT/FirebaseServer/README.md"
+    "$REPO_ROOT/FirebaseServer/CHANGELOG.md"
+    "$REPO_ROOT/docs"
+    "$REPO_ROOT/README.md"
+    "$REPO_ROOT/CLAUDE.md"
+)
+
+# Directories / file patterns to skip (relative to REPO_ROOT for dir checks,
+# anywhere for path-fragment matches).
+should_skip() {
+    local path="$1"
+    case "$path" in
+        */node_modules/*) return 0 ;;
+        */build/*) return 0 ;;
+        */.gradle/*) return 0 ;;
+        */.claude/skills/*) return 0 ;;
+        */.claude/worktrees/*) return 0 ;;
+        */.claude/projects/*) return 0 ;;
+        */android-screenshot-tests/*SCREENSHOT_GALLERY.md) return 0 ;;
+        */android-screenshot-tests/collections/*) return 0 ;;
+        */detekt.md) return 0 ;;
+        */GarageFirmware_ESP32/*) return 0 ;;
+        */Arduino_ESP32/*) return 0 ;;
+        # PR-review files have their own historical frontmatter convention
+        # (pr/state/date). Treated as a self-contained archive; not held
+        # to the AGENTS.md contract.
+        */pr-review/*) return 0 ;;
+    esac
+    return 1
+}
+
+# Today in epoch seconds (portable: macOS uses BSD date, Linux GNU date).
+TODAY_EPOCH=$(date +%s)
+
+date_to_epoch() {
+    # Accepts YYYY-MM-DD; outputs epoch seconds. Returns non-zero on parse failure.
+    local d="$1"
+    if date -j -f "%Y-%m-%d" "$d" "+%s" 2>/dev/null; then
+        return 0
+    fi
+    if date -d "$d" "+%s" 2>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
+validate_file() {
+    local file="$1"
+    local rel="${file#$REPO_ROOT/}"
+
+    # First line must be the front-matter open delimiter.
+    local first_line
+    first_line=$(head -1 "$file" 2>/dev/null || true)
+    if [ "$first_line" != "---" ]; then
+        err "$rel:1: missing YAML front-matter (first line must be '---')"
+        return
+    fi
+
+    # Find the closing delimiter line number (look in the first 30 lines).
+    local close_line
+    close_line=$(awk 'NR>1 && /^---$/ { print NR; exit }' "$file")
+    if [ -z "$close_line" ]; then
+        err "$rel:1: front-matter block has no closing '---'"
+        return
+    fi
+
+    # Extract the YAML lines (between line 2 and close_line-1).
+    local yaml
+    yaml=$(sed -n "2,$((close_line - 1))p" "$file")
+
+    local category status last_verified superseded_by
+    category=$(printf '%s\n' "$yaml" | awk -F': *' '$1=="category"{print $2; exit}')
+    status=$(printf '%s\n'   "$yaml" | awk -F': *' '$1=="status"{print $2; exit}')
+    last_verified=$(printf '%s\n' "$yaml" | awk -F': *' '$1=="last_verified"{print $2; exit}')
+    superseded_by=$(printf '%s\n' "$yaml" | awk -F': *' '$1=="superseded_by"{print $2; exit}')
+
+    # category required, enum.
+    case "$category" in
+        reference|plan|archive) ;;
+        "") err "$rel: missing required field 'category'" ;;
+        *)  err "$rel: invalid 'category' value '$category' (allowed: reference|plan|archive)" ;;
+    esac
+
+    # status required, enum.
+    case "$status" in
+        active|shipped|superseded) ;;
+        "") err "$rel: missing required field 'status'" ;;
+        *)  err "$rel: invalid 'status' value '$status' (allowed: active|shipped|superseded)" ;;
+    esac
+
+    # superseded_by required iff status=superseded.
+    if [ "$status" = "superseded" ]; then
+        if [ -z "$superseded_by" ]; then
+            err "$rel: status=superseded requires 'superseded_by' field"
+        else
+            local target="$REPO_ROOT/$superseded_by"
+            if [ ! -f "$target" ]; then
+                err "$rel: superseded_by target '$superseded_by' does not exist"
+            fi
+        fi
+    elif [ -n "$superseded_by" ]; then
+        err "$rel: 'superseded_by' is forbidden unless status=superseded"
+    fi
+
+    # last_verified required when category=reference + status=active.
+    if [ "$category" = "reference" ] && [ "$status" = "active" ]; then
+        if [ -z "$last_verified" ]; then
+            err "$rel: category=reference + status=active requires 'last_verified' (YYYY-MM-DD)"
+        elif ! [[ "$last_verified" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+            err "$rel: 'last_verified' must be ISO date YYYY-MM-DD, got '$last_verified'"
+        else
+            local lv_epoch
+            if lv_epoch=$(date_to_epoch "$last_verified"); then
+                local age_days=$(( (TODAY_EPOCH - lv_epoch) / 86400 ))
+                if [ "$age_days" -gt 90 ]; then
+                    warn "$rel: last_verified is $age_days days old (>90 day soft threshold)"
+                fi
+            else
+                err "$rel: could not parse last_verified date '$last_verified'"
+            fi
+        fi
+    fi
+}
+
+# Walk the scoped paths.
+for entry in "${SCOPE[@]}"; do
+    if [ ! -e "$entry" ]; then
+        continue
+    fi
+    if [ -f "$entry" ]; then
+        case "$entry" in
+            *.md) validate_file "$entry" ;;
+        esac
+    elif [ -d "$entry" ]; then
+        while IFS= read -r -d '' file; do
+            if should_skip "$file"; then
+                continue
+            fi
+            validate_file "$file"
+        done < <(find "$entry" -name '*.md' -type f -print0)
+    fi
+done
+
+if [ "$ERRORS" -gt 0 ]; then
+    printf '\n%s%d error(s)%s, %d warning(s).\n' "$RED" "$ERRORS" "$RESET" "$WARNINGS" >&2
+    exit 1
+fi
+
+if [ "$WARNINGS" -gt 0 ]; then
+    printf '\n%d warning(s).\n' "$WARNINGS"
+fi
+
+exit 0

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -116,6 +116,10 @@ step "Screenshot tests (compile)"
 $GRADLE :android-screenshot-tests:compileDebugScreenshotTestKotlin \
     && pass "screenshot test compilation" || fail "screenshot test compilation"
 
+step "Documentation front-matter (AGENTS.md contract)"
+"$REPO_ROOT/scripts/check-doc-frontmatter.sh" \
+    && pass "doc front-matter" || fail "doc front-matter"
+
 step "Room schema drift check"
 # After compilation, Room KSP generates schema JSON files.
 # If they differ from what's committed, the schema changed without being tracked.


### PR DESCRIPTION
## Summary
Adds the YAML front-matter contract defined in `docs/AGENTS.md` to every in-scope markdown file. Wires `scripts/check-doc-frontmatter.sh` into `scripts/validate.sh`.

## Validator behavior
- **Hard error** — missing front-matter, missing required field (`category`, `status`, `last_verified` for active references), invalid enum value, missing/forbidden `superseded_by`.
- **Warn-only forever** — `last_verified` more than 90 days old. Warnings never block CI or merging. They're a discoverability signal.

## Front-matter applied (35 files)
- **23 reference + active** — CLAUDE.md, all the active references (ARCHITECTURE, DECISIONS, TESTING, DI_SINGLETON_REQUIREMENTS, R8_INSTRUMENTED_TESTS, 6 guides, 2 library-bugs, design/{SPEC,HISTORY}, 2 changelogs, 2 READMEs, 2 Firebase docs)
- **4 plan + active** — MIGRATION, MIGRATION_PLAN, design/PLAN, design/INSTRUCTIONS
- **7 archive + shipped** — POSTMORTEM, DI-MIGRATION, 3 design PLANs, 2 Firebase plans
- **1 archive + superseded** — VIEWMODEL_SCOPING_ISSUE → POSTMORTEM_ANDROID_170

## Scope exclusions (in validator + AGENTS.md)
- `.claude/skills/` — native Claude Code frontmatter
- `GarageFirmware_ESP32/`, `Arduino_ESP32/` — out of primary scope
- `node_modules`, `build`, `.claude/worktrees`, `.claude/projects`
- Generated content (screenshot galleries, detekt)
- `docs/archive/pr-review/` — 387 files with their own historical `pr`/`state`/`date` frontmatter; self-contained archive

## Test plan
- [x] `./scripts/check-doc-frontmatter.sh` exits 0 with no output
- [x] Validator catches missing front-matter, invalid enum values (verified manually pre-commit)
- [x] Wired into `validate.sh` between Screenshot tests and Room schema check

🤖 Generated with [Claude Code](https://claude.com/claude-code)