### PR TITLE
ci: PR 5/6 — Markdown link checker

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -1,0 +1,68 @@
+name: Docs — Markdown link check
+
+# Validates internal cross-references and anchors in every markdown
+# file in the repo. External URLs are intentionally skipped (see
+# .markdown-link-check.json — they're too flaky to gate on).
+#
+# This sits outside the Android/Firebase CI gates because it's
+# repo-wide and runs in <30s. Required check on PRs that touch
+# any .md file.
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '.markdown-link-check.json'
+      - '.github/workflows/docs-link-check.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**/*.md'
+      - '.markdown-link-check.json'
+      - '.github/workflows/docs-link-check.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  link-check:
+    name: Markdown links
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install markdown-link-check
+        run: npm install -g markdown-link-check@3.13.7
+
+      - name: Check internal links
+        run: |
+          # Find every markdown file in scope. Excludes mirror what
+          # docs/AGENTS.md §4.4 says is in scope (Android, Firebase,
+          # docs/, root README + CLAUDE.md), and what's excluded
+          # (skills, ESP32, build dirs, worktrees, generated content,
+          # pr-review which has its own historical frontmatter).
+          set -euo pipefail
+          mapfile -t FILES < <(find . \
+            -name '*.md' -type f \
+            ! -path './node_modules/*' \
+            ! -path '*/build/*' \
+            ! -path '*/.gradle/*' \
+            ! -path './.claude/skills/*' \
+            ! -path './.claude/worktrees/*' \
+            ! -path './.claude/projects/*' \
+            ! -path './GarageFirmware_ESP32/*' \
+            ! -path './Arduino_ESP32/*' \
+            ! -path '*/android-screenshot-tests/SCREENSHOT_GALLERY.md' \
+            ! -path '*/android-screenshot-tests/collections/*' \
+            ! -path '*/detekt.md' \
+            ! -path './docs/archive/pr-review/*' \
+            -print)
+          echo "Checking ${#FILES[@]} markdown files..."
+          STATUS=0
+          for f in "${FILES[@]}"; do
+            echo ""
+            echo "--- $f ---"
+            markdown-link-check --quiet --config .markdown-link-check.json "$f" || STATUS=1
+          done
+          exit $STATUS

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "External URLs are skipped entirely — they're flaky (rate limits, intermittent 5xx, expired blog posts). Internal cross-references and anchors are what matters for this repo's docs-as-code contract; broken inbound links are how docs decay invisibly.",
+  "ignorePatterns": [
+    { "pattern": "^https?://" }
+  ],
+  "timeout": "10s",
+  "retryOn429": true,
+  "retryCount": 2
+}


### PR DESCRIPTION
## Summary
Adds a GitHub Actions job that runs `markdown-link-check` on every in-scope markdown file in PRs that touch docs. Catches broken cross-references and missing anchors automatically — load-bearing for an agent-driven repo where docs link to each other extensively.

## Config — `.markdown-link-check.json`
- **Skips ALL external URLs.** They're too flaky to gate on: rate limits, intermittent 5xx, expired blog posts.
- **Checks internal cross-references** — relative paths to `.md` files, anchors within docs.

## Workflow — `.github/workflows/docs-link-check.yml`
- Triggers on PRs that change `*.md`, the link-check config, or the workflow itself
- Also runs on push to main (post-merge guard)
- Excludes match `docs/AGENTS.md` §4.4 scope rules:
  - `.claude/skills/` (native Claude Code frontmatter)
  - `.claude/worktrees/`, `.claude/projects/`, `build/`, `node_modules/`
  - `GarageFirmware_ESP32/`, `Arduino_ESP32/`
  - Generated content (screenshot galleries, detekt)
  - `docs/archive/pr-review/` (387 archival files; self-contained)

## Test plan
- [x] Workflow triggers only on .md changes (path-filter matches the existing CI pattern)
- [ ] First PR run will validate every internal link in the repo — any pre-existing breaks surface here
- [x] Excludes match validator script's exclusions for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)