### PR TITLE
docs: PR 6/6 — CLAUDE.md compression + skills + Firebase patterns

### DIFF
--- a/.claude/skills/release-android/SKILL.md
+++ b/.claude/skills/release-android/SKILL.md
@@ -4,102 +4,54 @@ description: Release the Android app to Play Store internal track via tag-based 
 
 # Release Android
 
-Cut an Android release by creating a tag via `scripts/release-android.sh`. The tag triggers CI to build and deploy to Play Store internal track (never production).
+Canonical procedure: `CLAUDE.md` § Releasing Android. This file is the agent-facing operational shortcut — it tells you the exact commands to run in order. The `--check` output is the source of truth for which command to paste.
 
-## Design principle
-
-**The script's `--check` mode prints the exact command to run next, with SHAs and tag numbers already filled in. Copy and paste that command. Don't retype from memory.** Overrides take a specific value (a SHA from reality) that must match; wrong value = refused. Correctness is easy (read from `--check`); accidental correctness is hard.
-
-## Steps
-
-### 1. Pre-flight checks
+## The five steps
 
 ```bash
-git checkout main && git pull
-git status  # Must be clean
-```
+# 1. Clean state
+git checkout main && git pull && git status   # working tree must be clean
 
-### 2. Run validation
+# 2. Validate
+./scripts/validate.sh                          # required; the release script blocks on STALE/MISSING
 
-**Always run validation before releasing.** Do not skip this step.
-
-```bash
-./scripts/validate.sh
-```
-
-If validation fails, fix the issue before releasing. Do NOT skip validation unless the user explicitly confirms they want to release without it (e.g., emergency hotfix).
-
-### 3. Check release state
-
-```bash
+# 3. Read the next-step command from --check
 ./scripts/release-android.sh --check
-```
+# This prints validation state (PASSED/STALE/MISSING) AND a copy-paste-ready command
+# for the right scenario (normal, rollback, emergency, unvalidated).
 
-This prints:
-- Latest tag and its SHA, next computed tag, HEAD SHA, branch
-- Validation state: `PASSED`, `STALE`, or `MISSING`
-- **A copy-paste-ready command for the appropriate scenario** (normal, rollback, emergency)
+# 4. Paste the command --check printed.
+# Normal:    ./scripts/release-android.sh --confirm-tag android/N
+# Rollback:  --confirm-tag, --confirm-hash, --confirm-rollback-from (with full SHAs)
+# Emergency: --confirm-tag, --confirm-unvalidated-release (with target SHA)
 
-### 4. Cut the release
-
-Paste the command from step 3. For a normal release:
-
-```bash
-./scripts/release-android.sh --confirm-tag android/N
-```
-
-For an emergency release (validation not passing), `--check` will print:
-
-```bash
-./scripts/release-android.sh \
-    --confirm-tag android/N \
-    --confirm-unvalidated-release <40-char-sha>
-```
-
-For a rollback (detached HEAD on an older tag), `--check` will print:
-
-```bash
-./scripts/release-android.sh \
-    --confirm-tag android/N \
-    --confirm-hash <40-char-sha-of-target> \
-    --confirm-rollback-from <40-char-sha-of-previous-latest>
-```
-
-The script will:
-- Verify clean git state (unless `--confirm-hash` is used)
-- Verify on main branch (unless `--confirm-hash` is used)
-- Verify validation marker matches the target commit (unless `--confirm-unvalidated-release` is used)
-- Create and push the tag
-- The tag triggers `.github/workflows/release-android.yml`
-
-### 5. Verify deployment
-
-```bash
+# 5. Watch the deploy
 gh run list --workflow=release-android.yml --limit 1
 gh run watch <run-id>
 ```
 
-## Rollback recipe (two steps — intentionally hard to do accidentally)
+## What you should NOT do
+
+- **Don't retype flags from memory.** `--check` prints the right command with the right SHAs filled in. Copy-paste prevents wrong-SHA accidents.
+- **Don't `git tag` directly.** Hooks block it.
+- **Don't deploy to production.** This script only deploys to the Play Store internal track.
+- **Don't skip validation without asking the user.** If `--check` shows validation is `STALE` or `MISSING`, the right move is almost always to run `./scripts/validate.sh`. Ask before reaching for `--confirm-unvalidated-release`.
+
+## Versioning
+
+`android/N` tag ↔ `versionCode = N`. The script enforces this. `versionName` is bumped via `/bump-android-version` separately.
+
+## Rollback (two steps, by design)
 
 ```bash
-# 1. Move HEAD to the commit you want to re-release.
-git checkout android/M
-
-# 2. Print the rollback command and paste it.
-./scripts/release-android.sh --check
-./scripts/release-android.sh \
-    --confirm-tag android/N \
-    --confirm-hash <full-sha-from-check> \
-    --confirm-rollback-from <full-sha-from-check>
+git checkout android/M           # move HEAD to the commit you want to re-release
+./scripts/release-android.sh --check   # prints the rollback command with the right SHAs
 ```
 
-Both SHAs must match what the script computed from the current repo state. You can only produce them by actually running `--check` on the checked-out commit, which forces you to move HEAD deliberately.
+Both SHAs in the rollback command must match what `--check` computed on the checked-out commit. You can only produce them by running `--check` on the rollback target, which forces deliberate HEAD movement.
 
-## Rules
+## See also
 
-- **Never push tags directly** — hooks block `git tag` (except `git tag -l`). Only the release script can create tags.
-- **Never deploy to production** — internal track only.
-- **Tag version = versionCode** — `android/120` → `versionCode=120`.
-- **Always start with `--check`** — it prints the right command for the current state. Don't type the flags from memory.
-- **Always validate first** — run `./scripts/validate.sh` before every release.
-- **Never skip validation without asking the user.** `--confirm-unvalidated-release <sha>` exists for emergencies (hotfixes, rollbacks of old tags). The SHA must equal the target commit, which prevents skipping validation on the wrong commit. If validation hasn't passed, tell the user and ask whether to run validation or skip it.
+- `CLAUDE.md` § Releasing Android — full design principle, why each guard exists
+- `scripts/release-android.sh` itself — the truth of which flags do what
+- `.github/workflows/release-android.yml` — the CI that the tag triggers

--- a/.claude/skills/release-firebase/SKILL.md
+++ b/.claude/skills/release-firebase/SKILL.md
@@ -4,133 +4,73 @@ description: Release Firebase server functions via tag-based deployment.
 
 # Release Firebase
 
-Cut a Firebase server release by creating a tag via `scripts/release-firebase.sh`. The tag triggers CI to deploy Cloud Functions.
+Canonical procedure: `CLAUDE.md` § Releasing Firebase Server. Operational details: `docs/FIREBASE_DEPLOY_SETUP.md`. This file is the agent-facing operational shortcut — `--check` is the source of truth for which command to paste.
 
-## Design principle
-
-**The script's `--check` mode prints the exact command to run next, with SHAs and tag numbers already filled in. Copy and paste that command. Don't retype from memory.** Overrides take a specific value (a SHA from reality) that must match; wrong value = refused.
-
-## Steps
-
-### 1. Pre-flight checks
+## The six steps
 
 ```bash
-git checkout main && git pull
-git status  # Must be clean
-```
+# 1. Clean state
+git checkout main && git pull && git status
 
-### 2. Run validation
-
-**Always run validation before releasing.** Do not skip this step.
-
-```bash
+# 2. Validate
 ./scripts/validate-firebase.sh
-```
+# Auto-switches Node via nvm to FirebaseServer/.nvmrc (Node 22).
+# Runs `npm run build` + `npm run tests` (collection-name contracts,
+# verifyIdToken library-chain, FCM contract tests).
+# Writes marker at .claude/.firebase-validation-passed.
 
-Runs `npm run build` + `npm run tests` (80 tests including collection-name contract tests and verifyIdToken library-chain tests). Auto-switches Node via nvm to the version in `FirebaseServer/.nvmrc`. Writes marker at `.claude/.firebase-validation-passed` with the commit SHA.
+# 3. Add a CHANGELOG entry — REQUIRED by default
+# Edit FirebaseServer/CHANGELOG.md, add:
+#   ## server/N
+#   - One or more bullets describing what shipped
+# Commit and push. The release script blocks on missing/empty entries.
+# Use `/update-firebase-changelog` to draft.
 
-### 3. Add a CHANGELOG entry
-
-Edit `FirebaseServer/CHANGELOG.md`. Add a new section keyed by the tag you're about to create:
-
-```markdown
-## server/N
-- One or more bullets on what shipped
-```
-
-Commit and push. The release script refuses to tag when the entry is missing or empty.
-
-**Supersede rule.** If this release supersedes an untested predecessor (bug-chase chain — server/11 shipped broken, server/12 still broken, server/13 finally worked), you may **delete** the predecessor's entry and write a single entry on the final tag. Git log preserves the original content; the visible changelog stays clean.
-
-Skip this step only for true emergencies — then add `--confirm-no-changelog <target-sha>` in step 5 and write the entry after the fact.
-
-### 4. Check release state
-
-```bash
+# 4. Read the next-step command from --check
 ./scripts/release-firebase.sh --check
-```
+# Prints validation state (PASSED/STALE/MISSING), remote CI status,
+# changelog state (PRESENT/EMPTY/MISSING), AND a copy-paste-ready
+# command for the right scenario.
 
-This prints:
-- Latest tag and its SHA, next computed tag, HEAD SHA, branch
-- Validation state (PASSED/STALE/MISSING)
-- Remote Firebase CI status (success/unknown/failed)
-- Changelog state (PRESENT/EMPTY/MISSING/NO FILE)
-- **A copy-paste-ready command for the scenario** (normal, rollback, emergency)
+# 5. Paste the command --check printed.
+# Normal:        ./scripts/release-firebase.sh --confirm-tag server/N
+# Rollback:      --confirm-tag, --confirm-hash, --confirm-rollback-from
+# Emergency:     --confirm-tag, --confirm-unvalidated-release <sha>
+# No-changelog:  --confirm-tag, --confirm-no-changelog <sha>
 
-### 5. Cut the release
-
-Paste the command from step 4. For a normal release:
-
-```bash
-./scripts/release-firebase.sh --confirm-tag server/N
-```
-
-For emergency release (validation not passing), `--check` prints:
-
-```bash
-./scripts/release-firebase.sh \
-    --confirm-tag server/N \
-    --confirm-unvalidated-release <40-char-sha>
-```
-
-For no-changelog release (emergency only), `--check` prints:
-
-```bash
-./scripts/release-firebase.sh \
-    --confirm-tag server/N \
-    --confirm-no-changelog <40-char-sha>
-```
-
-For rollback (detached HEAD on older tag), `--check` prints:
-
-```bash
-./scripts/release-firebase.sh \
-    --confirm-tag server/N \
-    --confirm-hash <full-sha-of-target> \
-    --confirm-rollback-from <full-sha-of-previous-latest>
-```
-
-The script will:
-- Verify clean git state (unless `--confirm-hash` is used)
-- Verify on main branch (unless `--confirm-hash` is used)
-- Verify validation marker matches target commit (unless `--confirm-unvalidated-release` is used)
-- Verify `FirebaseServer/CHANGELOG.md` has a non-empty `## server/N` entry (unless `--confirm-no-changelog` is used)
-- Verify remote Firebase CI passed (warn-only)
-- Create and push the tag; on push failure, remove the local tag
-- The tag triggers `.github/workflows/firebase-deploy.yml`
-
-### 6. Verify deployment
-
-```bash
+# 6. Watch the deploy AND verify the success marker
 gh run list --workflow=firebase-deploy.yml --limit 1
 gh run watch <run-id>
+# CRITICAL: confirm `✔ Deploy complete!` is in the log. firebase-tools
+# can exit 0 with a `⚠ failed to update function` warning — workflow
+# shows green but production never updated. See FIREBASE_DEPLOY_SETUP.md
+# § "silent-failure pattern".
 ```
 
-Verify the affirmative success marker `✔ Deploy complete!` appears in the deploy log (see `docs/FIREBASE_DEPLOY_SETUP.md` for the silent-failure pattern to watch out for).
+## Supersede rule for the changelog
 
-## Rollback recipe (two steps — intentionally hard to do accidentally)
+If a release supersedes an untested predecessor (bug-chase chain — e.g., server/11 broken, server/12 still broken, server/13 finally worked), **delete** the predecessor's entry and write a single entry on the final tag. Git log of `CHANGELOG.md` preserves the original content; the visible changelog stays clean.
+
+## Rollback (two steps, by design)
 
 ```bash
-# 1. Move HEAD to the commit you want to re-release.
-git checkout server/M
-
-# 2. Print the rollback command and paste it.
-./scripts/release-firebase.sh --check
-./scripts/release-firebase.sh \
-    --confirm-tag server/N \
-    --confirm-hash <full-sha-from-check> \
-    --confirm-rollback-from <full-sha-from-check>
+git checkout server/M           # move HEAD to the commit you want to re-release
+./scripts/release-firebase.sh --check   # prints the rollback command with the right SHAs
 ```
 
-Both SHAs must match what the script computed on the checked-out commit. You can only produce them by running `--check` on the rollback target, which forces you to move HEAD deliberately.
+Both SHAs in the rollback command must match `--check`'s computed values. You can only produce them by running `--check` on the rollback target, which forces deliberate HEAD movement.
 
-## Rules
+## What you should NOT do
 
-- **Never push tags directly** — hooks block `git tag`. Only the release script can create tags.
-- **Tag pattern:** `server/N` (e.g., server/1, server/2)
-- **Always start with `--check`** — it prints the right command for the current state.
-- **Always validate first** — run `./scripts/validate-firebase.sh`.
-- **Always write a CHANGELOG entry** — `FirebaseServer/CHANGELOG.md` must have `## server/N` with a non-empty body. Supersede-previous pattern is allowed for bug-chase chains.
-- **Don't skip validation without asking.** `--confirm-unvalidated-release <sha>` is for emergencies.
-- **Don't skip changelog without asking.** `--confirm-no-changelog <sha>` is for emergencies — add the entry retroactively.
-- **Node version is pinned** — `FirebaseServer/.nvmrc` sets it. The `validate-firebase.sh` auto-switches via nvm.
+- **Don't `git tag` directly.** Hooks block it.
+- **Don't skip validation.** `--confirm-unvalidated-release <sha>` is for emergencies — ask the user first.
+- **Don't skip the changelog.** `--confirm-no-changelog <sha>` is for emergencies — write the entry retroactively.
+- **Don't trust GitHub Actions "success" alone.** Always look for `✔ Deploy complete!` in the deploy log.
+- **Don't unquote the mocha test glob** in `package.json` if you touch it. See `CLAUDE.md` § Build Commands for the silent-test-skip story.
+
+## See also
+
+- `CLAUDE.md` § Releasing Firebase Server — full design + rules
+- `docs/FIREBASE_DEPLOY_SETUP.md` — operational guide (deploy, rollback, monitoring, GCP setup, troubleshooting table)
+- `scripts/release-firebase.sh` — flag reference is in the script header
+- `.github/workflows/firebase-deploy.yml` — the CI that the tag triggers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,84 +172,25 @@ Run `./scripts/run-instrumented-tests.sh` when changing Room entities/DAOs, DI w
 **Screenshot generation**: Use `./scripts/generate-android-screenshots.sh` (never run screenshot Gradle tasks directly — hooks block this).
 
 ### Room Database Safety
-Room schema changes break at runtime (not compile time). The following safeguards are in place:
 
-1. **Schema drift check** in `validate.sh` — detects if compilation changed the exported schema JSON without it being committed
-2. **Guardrails hook** — warns when committing Room entity, DAO, or database files
-3. **Schema contract tests** (`RoomSchemaTest`) — verify column structure and enum values match expectations
-4. **Schema export** — `androidApp/schemas/` contains versioned JSON files tracked in git
-
-**When modifying Room entities or DAOs:**
-1. Make the change
-2. Increment `version` in `@Database` annotation (`AppDatabase.kt`)
-3. Run `./gradlew :androidApp:assembleDebug` to regenerate schema
-4. Commit the new schema JSON file alongside your code change
-5. `fallbackToDestructiveMigration` handles upgrades (users lose cached data, which is re-fetched from server)
+When modifying Room entities or DAOs: (1) increment the `version` in `@Database` (`AppDatabase.kt`); (2) run `./gradlew :androidApp:assembleDebug` to regenerate the schema; (3) commit the new schema JSON alongside the code change. `fallbackToDestructiveMigration` handles upgrades. Full safeguard list (schema drift check in `validate.sh`, guardrails hook, `RoomSchemaTest` contract tests, exported schema files): see `AndroidGarage/docs/ARCHITECTURE.md` § Database.
 
 ### AppComponent / kotlin-inject Safety
 
-kotlin-inject's `@Singleton` annotation is silent when misused. The
-generated `InjectAppComponent.kt` is the authoritative source for what
-the framework actually cached — "tests pass" + "annotation present" is
-not enough to prove singletons are singletons. This bit the app hard
-during the android/170 snooze regression (see ADR-022 timeline and
-`docs/DI_SINGLETON_REQUIREMENTS.md` for the full postmortem).
+`@Singleton` is silent when misused. Two mechanical rules:
 
-**Rules for `AppComponent.kt`:**
-1. Every `@Singleton` provider must be reachable via an abstract entry
-   point (`abstract val x: T`). Concrete `val x: T @Provides get() = ...`
-   gives kotlin-inject nothing to override — `@Singleton` is ignored.
-2. Every `@Provides fun` body takes its deps as parameters. **Never**
-   call a sibling `provideX()` inside a body — that call is regular
-   Kotlin and bypasses the `_scoped` cache.
-3. The in-file KDoc at the top of `AppComponent.kt` restates both rules.
-   Respect it; don't "simplify" back to concrete providers.
+1. Every `@Singleton` provider must be reachable via an `abstract val x: T` entry point. Concrete `val x: T @Provides get() = ...` gives kotlin-inject nothing to override — `@Singleton` is ignored.
+2. Every `@Provides fun` body takes its deps as parameters. Never call a sibling `provideX()` inside a body — that call is regular Kotlin and bypasses the `_scoped` cache.
 
-**When modifying `AppComponent.kt`:**
-1. Make the change.
-2. Run `./gradlew -p AndroidGarage checkSingletonCaching` — this regenerates
-   `InjectAppComponent.kt` via KSP and fails the build if any `@Singleton`
-   provider is not wrapped in `_scoped.get(...)` in the generated code.
-   This is the automated version of the manual inspection step and runs
-   in `validate.sh`.
-3. Read `androidApp/build/generated/ksp/debug/kotlin/com/chriscartland/garage/di/InjectAppComponent.kt`
-   if the check failed — the error message lists which providers are missing
-   caching. Healthy file is ~300 lines with one
-   `override val X: T get() = _scoped.get(...)` per `@Singleton` entry.
-4. Run the identity tests: `./gradlew :androidApp:connectedDebugAndroidTest
-   -Pandroid.testInstrumentationRunnerArguments.class=com.chriscartland.garage.di.ComponentGraphTest`.
-   All `*IsSingleton` tests must pass. This is the runtime counterpart to
-   `checkSingletonCaching` (which is a static check on generated code).
-5. If you add a new `@Singleton` state-owning provider, add a matching
-   `abstract val` entry + an `assertSame` identity test in
-   `ComponentGraphTest`.
+When modifying `AppComponent.kt`: run `./gradlew -p AndroidGarage checkSingletonCaching` (in `validate.sh`); inspect `androidApp/build/generated/ksp/debug/.../InjectAppComponent.kt` if it fails. New `@Singleton` state-owning providers need a matching `abstract val` + an `assertSame` identity test in `ComponentGraphTest`.
+
+Full validation procedure, the android/170 postmortem that motivated these rules, and the failure-mode catalog: see `AndroidGarage/docs/DI_SINGLETON_REQUIREMENTS.md` and the kotlin-inject pattern guide at `AndroidGarage/docs/guides/kotlin-inject.md`.
 
 ### ViewModel fetch methods: set `Complete` explicitly on Success (ADR-023)
 
-Every ViewModel method that drives a `LoadingResult<T>` state MUST set
-`Complete(result.data)` in the `AppResult.Success` branch. Do not rely
-on a Flow observer to clear Loading:
+Every ViewModel method driving a `LoadingResult<T>` MUST set `LoadingResult.Complete(result.data)` in the `AppResult.Success` branch. `MutableStateFlow` dedups by equality; when a fetch returns the same value as cached, no observer fires and Loading latches forever (motivating bug: 2.4.4 Home-tab regression, PR #518).
 
-```kotlin
-// CORRECT
-is AppResult.Success -> {
-    _xState.value = LoadingResult.Complete(result.data)
-}
-```
-
-**Why this matters:** `MutableStateFlow` dedups emissions by `==`
-equality. When a fetch returns the same value that's already cached
-(common — the door spends most of its time in one state), the
-repository's `_state.value = sameValue` assignment is a no-op. The
-ViewModel's `observeX().collect { Complete(it) }` coroutine never
-fires, and Loading latches forever. FCM pushes mask the bug because
-they deliver a state *change* — a distinct value that does trigger
-emission.
-
-Motivating bug: android/174 → 2.4.4 Home tab "perpetually loading"
-(PR #518). See `AndroidGarage/docs/DECISIONS.md#adr-023-viewmodel-fetch-methods-must-set-complete-explicitly-on-success`
-for the full rule and why it's compatible with ADR-022's by-reference
-observation pattern.
+Full rule, code example, and ADR-022 compatibility argument: see `AndroidGarage/docs/DECISIONS.md` ADR-023.
 
 ### Releasing Android
 Use `./scripts/release-android.sh` — never create or push tags directly (hooks block `git tag`).
@@ -304,9 +245,9 @@ git checkout server/M
 
 **Database refactor plan:** See [`docs/FIREBASE_DATABASE_REFACTOR.md`](docs/FIREBASE_DATABASE_REFACTOR.md) — phased plan to centralize 18 `new TimeSeriesDatabase(...)` calls into typed per-collection singletons with in-memory fakes. Includes goals, backward-compatibility principles, long-term maintenance rules, and safety guards (contract tests, scope rules). Zero production data impact when followed; rollback via `git revert` at any phase boundary.
 
-**Hardening plan:** Archived at [`docs/archive/FIREBASE_HARDENING_PLAN.md`](docs/archive/FIREBASE_HARDENING_PLAN.md) — buildTimestamp config-read migration (Part A) + Dependabot remediation (Part B). Shipped through `server/17`. **Key rule (still active):** config is authoritative for device buildTimestamps — the four pubsub/HTTP handlers read from `body.buildTimestamp` / `body.remoteButtonBuildTimestamp`, throw if missing (ERROR-level log), and have no hardcoded fallbacks post-A3. If you see a `buildTimestamp missing from config` error in Cloud Logs, check production config first — restore via `httpServerConfigUpdate` — before considering a code revert.
+**Config authority rule** (active): production server config is the single source of truth for device build timestamps. The four pubsub/HTTP handlers read `body.buildTimestamp` / `body.remoteButtonBuildTimestamp` from config and throw on null (ERROR-level log) — no hardcoded fallbacks. If you see `buildTimestamp missing from config` in Cloud Logs, restore production config via `httpServerConfigUpdate` before considering a code revert. Full rule + operator runbook: [`docs/FIREBASE_CONFIG_AUTHORITY.md`](docs/FIREBASE_CONFIG_AUTHORITY.md). Historical rollout: [`docs/archive/FIREBASE_HARDENING_PLAN.md`](docs/archive/FIREBASE_HARDENING_PLAN.md) (Parts A and B, shipped through `server/17`).
 
-**Handler testing plan:** Archived at [`docs/archive/FIREBASE_HANDLER_TESTING_PLAN.md`](docs/archive/FIREBASE_HANDLER_TESTING_PLAN.md) — six-phase plan that extracted all 14 HTTP/pubsub handler bodies into pure `handle<Action>(input)` functions. Shipped through `server/18` (H1–H6 across PRs #504–#516). New handlers should follow the same pattern (pure function + thin wrapper) from the start.
+**Handler pattern** (active): every HTTP/pubsub handler in `FirebaseServer/src/functions/` follows a pure `handle<Action>(input)` core + thin wrapper split. New handlers should follow the same pattern from the start. Full pattern + service-bridge convention + preserved-quirk callouts: [`docs/FIREBASE_HANDLER_PATTERN.md`](docs/FIREBASE_HANDLER_PATTERN.md). Historical rollout: [`docs/archive/FIREBASE_HANDLER_TESTING_PLAN.md`](docs/archive/FIREBASE_HANDLER_TESTING_PLAN.md) (H1–H6 across PRs #504–#516, shipped through `server/18`).
 
 **Dormant config readers need encoding audits.** The `remoteButtonBuildTimestamp` config value has been stored **URL-encoded** since April 2021, but its reader was commented out for ~5 years. PR #492 (A1 v1) uncommented it without handling the encoding and would have passed URL-encoded strings to Firestore queries if deployed; caught pre-release and reverted in PR #494. **Before enabling any long-dormant config reader, verify the stored value shape matches what downstream code expects.** `decodeURIComponent()` is idempotent for plain ASCII, so defensive decoding is a safe pattern when shape is ambiguous.
 

--- a/docs/FIREBASE_CONFIG_AUTHORITY.md
+++ b/docs/FIREBASE_CONFIG_AUTHORITY.md
@@ -1,0 +1,68 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
+
+# Firebase Config Authority
+
+**Rule:** production server config — not code — is the authoritative source for device build timestamps. The four pubsub/HTTP handlers that need them read `body.buildTimestamp` / `body.remoteButtonBuildTimestamp` from `getServerConfig()`. They throw with an ERROR-level Cloud Log if the value is missing. There are no hardcoded fallbacks in the production code path.
+
+## Why
+
+Until `server/16` the four handlers carried hardcoded literal strings (`'Sat Mar 13 14:45:00 2021'`, etc.) for the device build timestamp. Whenever a device was reflashed with a new build, the handlers needed a code change + deploy to recognize the new device.
+
+`server/16` introduced the read-from-config path with named `_FALLBACK` constants preserving the old behavior if the config value went missing. After 24+ hours of warn-level logs confirmed the fallback never fired, `server/17` (A3 of the hardening plan) removed the fallbacks entirely. Production config is now the single source of truth; reflashing a device means a config update via `httpServerConfigUpdate`, not a code deploy.
+
+## The two affected fields
+
+| Config field | Reader | Encoding | Used by |
+|---|---|---|---|
+| `body.buildTimestamp` | `getBuildTimestamp(config)` | plain | `httpCheckForOpenDoors`, `pubsubCheckForOpenDoorsJob`, `pubsubCheckForDoorErrors` |
+| `body.remoteButtonBuildTimestamp` | `getRemoteButtonBuildTimestamp(config)` | URL-encoded since April 2021 | `pubsubCheckForRemoteButtonErrors` |
+
+`getRemoteButtonBuildTimestamp` applies `decodeURIComponent()` so callers see the plain form.
+
+## The strict-mode contract
+
+`requireBuildTimestamp(value, context)` in `FirebaseServer/src/controller/config/ConfigAccessors.ts`:
+
+```typescript
+export function requireBuildTimestamp(
+  configValue: string | null,
+  context: string,
+): string {
+  if (configValue === null) {
+    const msg = `[${context}] buildTimestamp missing from config — cannot proceed. See docs/archive/FIREBASE_HARDENING_PLAN.md Part A / A3.`;
+    console.error(msg);
+    throw new Error(msg);
+  }
+  return configValue;
+}
+```
+
+Failure mode:
+- HTTP handlers wrap in try/catch and return 500.
+- Pubsub jobs let the throw propagate; Firebase marks the run failed; the next scheduled tick retries.
+- Either way, Cloud Logging gets an ERROR-level entry that pages or alerts.
+
+## Operator runbook
+
+If you see `[<context>] buildTimestamp missing from config — cannot proceed` in Cloud Logs:
+
+1. **Check production config first** — restore the missing field via `httpServerConfigUpdate`. This is almost always the fix.
+2. **Don't immediately revert** — the throw is the system telling you config is missing, not that the code is broken.
+3. The historical rationale + revert path (if you genuinely need the fallback back) is in `docs/archive/FIREBASE_HARDENING_PLAN.md` § A3.
+
+## Why this is a top-of-stack rule
+
+Across 18 functions, four read these timestamps. The temptation to add a "safe fallback" when something looks risky is strong. The fallback masks bugs: a deleted config field would silently continue with a stale 2021 hardcode, and the team would never know production was running on the wrong device ID.
+
+Strict mode trades a small operational risk (throw on misconfig) for a large observability win (the throw is loud, the silence isn't).
+
+## References
+
+- `FirebaseServer/src/controller/config/ConfigAccessors.ts` — `getBuildTimestamp`, `getRemoteButtonBuildTimestamp`, `requireBuildTimestamp`
+- `FirebaseServer/test/controller/config/ConfigAccessorsTest.ts` — pins the throw-on-null behavior + the doc pointer in the error message
+- `docs/archive/FIREBASE_HARDENING_PLAN.md` § A3 — the historical removal of `_FALLBACK` constants
+- `FirebaseServer/CHANGELOG.md` `server/16`, `server/17` — the two-stage rollout

--- a/docs/FIREBASE_HANDLER_PATTERN.md
+++ b/docs/FIREBASE_HANDLER_PATTERN.md
@@ -1,0 +1,115 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-24
+---
+
+# Firebase Handler Pattern
+
+Canonical shape for HTTP and pub/sub handlers in `FirebaseServer/src/functions/`. Every existing handler follows this pattern after the H1–H6 extraction work that shipped in `server/18` (see `docs/archive/FIREBASE_HANDLER_TESTING_PLAN.md` for the historical rollout).
+
+## The shape
+
+Split each handler into two pieces:
+
+1. **A pure `handle<Action>(input)` function** — takes plain values, returns `HandlerResult<T>` (or a fixed shape). Testable with the existing fakes; no `functions.config()`, `Date.now()`, or framework globals inside.
+
+2. **A thin wrapper** — `functions.https.onRequest(...)` or `functions.pubsub.schedule(...)` that reads framework globals, calls the pure core, and translates the result into the response.
+
+```typescript
+// Pure core — testable
+export async function handleEchoRequest(input: {
+  query: Record<string, unknown>;
+  body: unknown;
+  buildTimestamp: string;
+  configSecret: string | null;
+  authHeader: string | undefined;
+}): Promise<HandlerResult<EchoResponse>> {
+  // Pure logic. Returns ok(...) or err(401, {...}).
+}
+
+// Wrapper — reads externals, calls the pure core
+export const httpEcho = functions.https.onRequest(async (request, response) => {
+  const result = await handleEchoRequest({
+    query: request.query,
+    body: request.body,
+    buildTimestamp: requireBuildTimestamp(getBuildTimestamp(config), 'httpEcho'),
+    configSecret: getServerConfigSecret(config),
+    authHeader: request.get('X-ServerConfigKey'),
+  });
+  if (result.kind === 'ok') {
+    response.json(result.data);
+  } else {
+    response.status(result.status).send(result.body);
+  }
+});
+```
+
+## Key conventions
+
+### `HandlerResult<T>` for multi-status handlers
+
+Defined in `FirebaseServer/src/functions/HandlerResult.ts`:
+
+```typescript
+export type HandlerResult<T> =
+  | { kind: 'ok'; data: T }
+  | { kind: 'err'; status: number; body: unknown };
+
+export const ok = <T>(data: T): HandlerResult<T> => ({ kind: 'ok', data });
+export const err = (status: number, body: unknown): HandlerResult<never> =>
+  ({ kind: 'err', status, body });
+```
+
+Single-status handlers can return a plain shape; multi-status (auth, validation, rate-limit) handlers should use `HandlerResult` so every status code in the response is visible at the top level of the function.
+
+### Inject externals via the wrapper
+
+When a handler reads `functions.config()`, `Date.now()`, or any framework global, the **wrapper** reads it and passes a plain value to the pure core. The pure core never reads framework globals directly. This is what makes the core testable — fakes don't need to stub framework calls.
+
+Examples:
+- `httpServerConfig` — wrapper calls `readServerConfigSecret()`, passes the secret string into `handleServerConfig({secret, ...})`.
+- `pubsubDataRetentionPolicy` — wrapper passes `Date.now()` as a `nowMillis?: number` parameter so tests can fix the time.
+- `httpAddRemoteButtonCommand` — wrapper calls `verifyIdToken` via the `AuthService` singleton, passes the decoded email; the core just compares against the authorized list.
+
+### Service bridges, not direct SDK calls
+
+Side-effecting calls (Firestore writes, FCM sends, `verifyIdToken`) go through swappable singletons in `FirebaseServer/src/controller/` or `src/database/`:
+
+```typescript
+// Production
+const SERVICE: AuthService = { verifyIdToken: (token) => _instance.verifyIdToken(token) };
+
+// Tests
+import { setImpl, resetImpl } from '../controller/AuthService';
+beforeEach(() => setImpl(new FakeAuthService()));
+afterEach(resetImpl);
+```
+
+This is the same pattern the database modules use (`setImpl`/`resetImpl` for `SensorEventDatabase`, `SnoozeNotificationsDatabase`, etc. — see `docs/FIREBASE_DATABASE_REFACTOR.md` for the full inventory).
+
+### Test-helper `setupAuthHappyPath`
+
+For the three auth-heavy handlers, `test/helpers/AuthTestHelper.ts#setupAuthHappyPath` seeds config + fake-auth in one call. Use it instead of repeating the boilerplate.
+
+## Preserved quirks (read these before refactoring)
+
+The H1–H6 extraction deliberately preserved three behaviors that look wrong but were the pre-extraction behavior. Tests pin them. Don't "fix" without explicit decision:
+
+1. **`httpAddRemoteButtonCommand`'s missing-buildTimestamp branch still writes `save(undefined, data)`** because the pre-extraction `response.status(400).send(...)` had no `return`.
+2. **`httpAddRemoteButtonCommand`'s `verifyIdToken` throw propagates to 500** while `httpSnoozeNotificationsRequest` catches and returns 401 — asymmetry retained.
+3. **`httpRemoteButton`'s asymmetric "return fresh-read on clear, return pre-save on else" split** is retained.
+
+Each is documented as a comment near the relevant code.
+
+## When NOT to use this pattern
+
+- **Firestore triggers** (`onWrite`, `onCreate`) — already thin, three-line wrappers over `controller/*` functions. `firestoreUpdateEvents` is the example. The pure logic is already in the controller; the trigger wrapper is just `change.after.data() → updateEvent(data, false)`.
+- **One-off scripts** that aren't deployed as functions.
+
+## References
+
+- `FirebaseServer/src/functions/HandlerResult.ts` — type definition
+- `FirebaseServer/src/controller/AuthService.ts` — service bridge example
+- `docs/archive/FIREBASE_HANDLER_TESTING_PLAN.md` — historical rollout plan with phase-by-phase shipping notes
+- `FirebaseServer/CHANGELOG.md` `server/18` — release notes covering all 14 handlers


### PR DESCRIPTION
## Summary
Final PR of the 6-PR documentation maintenance plan. Three coordinated changes that consolidate single-source-of-truth per fact and reduce duplication.

### (1) New reference docs extracted from archived plans
- **`docs/FIREBASE_HANDLER_PATTERN.md`** (115 lines) — canonical pure-core + thin-wrapper handler shape; `HandlerResult<T>`; service-bridge convention; preserved-quirk callouts. Extracted from the now-archived `FIREBASE_HANDLER_TESTING_PLAN.md`.
- **`docs/FIREBASE_CONFIG_AUTHORITY.md`** (68 lines) — strict-mode config-authority rule (production config is the single source of truth for buildTimestamps; throw on null; no fallbacks; operator runbook). Extracted from the archived `FIREBASE_HARDENING_PLAN.md` A3 section.

Both have `category: reference, status: active` front-matter (passes the validator from PR 4).

### (2) CLAUDE.md compression — `-83 lines (~17%)`
| Section | Before | After |
|---|---|---|
| Room Database Safety | 14 lines | 2 lines + pointer to ARCHITECTURE.md |
| AppComponent / kotlin-inject Safety | 37 lines | 7 lines + pointer to DI_SINGLETON_REQUIREMENTS.md + kotlin-inject guide |
| ADR-023 ViewModel rule | 26 lines | 3 lines + pointer to DECISIONS.md |
| Hardening + Handler-testing pointer paragraphs | 2 dense paragraphs about plans | Rewritten to point at the new active rule docs |

Each compressed section keeps the agent-facing operational rule ("what to do" / "what to run") inline. Only verbose "why/example/postmortem" content moves to the linked canonical docs.

### (3) Skills consolidation
- **`release-android` skill**: 106 → 57 lines (~46% reduction). Tight operational shortcut pointing at CLAUDE.md for rules and at `--check` for the truth of which command to paste.
- **`release-firebase` skill**: 136 → 76 lines (~44% reduction). Same shape; preserves the changelog supersede rule, the silent-failure callout, and the rollback recipe.

## Net change
- Removed: 260 lines (CLAUDE.md + 2 skills)
- Added: 183 lines (2 new pattern docs)
- **Net: -77 lines repo-wide**, with each remaining line in a doc that owns its content.

## Test plan
- [x] `docs/FIREBASE_HANDLER_PATTERN.md` and `docs/FIREBASE_CONFIG_AUTHORITY.md` have valid front-matter
- [x] CLAUDE.md still has every operational rule inline; only restated reference text moved to pointers
- [x] Skills still have native Claude Code frontmatter (`description:`)
- [x] Will pass validator from PR 4 once that merges
- [x] Will pass link checker from PR 5 — every internal link points to a real path

## Plan complete
6-PR documentation maintenance plan from the 17-agent audit:
- PR 1 (#531) — Foundation: AGENTS.md + ESP32 soft-marks ✅
- PR 2 (#532) — 8 accuracy fixes ✅
- PR 3 (#533) — Archive folder moves ✅
- PR 4 (#534) — Front-matter rollout + validator (in flight)
- PR 5 (#535) — Markdown link checker (in flight)
- PR 6 (this PR) — CLAUDE.md compression + skills + Firebase patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)