### PR TITLE
docs: Dump session context — git tag-membership workaround

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,8 @@ Full rule, code example, and ADR-022 compatibility argument: see `AndroidGarage/
 ### Releasing Android
 Use `./scripts/release-android.sh` — never create or push tags directly (hooks block `git tag`).
 
+**Tag-membership checks:** the hook also blocks `git tag --contains <sha>` (any `git tag` invocation except `git tag -l`). To ask "is commit X in tag Y?", use `git merge-base --is-ancestor <sha> <tag>` instead — same answer, hook-friendly.
+
 ```bash
 ./scripts/release-android.sh              # Interactive (terminal only)
 ./scripts/release-android.sh --check      # Print state + copy-paste-ready next command


### PR DESCRIPTION
## Summary
Adds the `git merge-base --is-ancestor <sha> <tag>` workaround to `CLAUDE.md` under the Releasing Android section. The git-guardrails hook blocks `git tag --contains` along with all other `git tag` invocations except `git tag -l`, so the natural way to ask "is commit X in tag Y?" needed a hook-friendly equivalent.

Used several times during the 2026-04-24 doc audit to identify which `server/N` tag actually shipped each Phase 5/6/9/10 PR of the Firebase database refactor.

## Where the rest of the session's knowledge landed
- `docs/AGENTS.md` (the documentation contract — PR #531)
- `scripts/check-doc-frontmatter.sh` + `validate.sh` integration (PR #534)
- `.github/workflows/docs-link-check.yml` + `.markdown-link-check.json` (PR #535)
- `docs/FIREBASE_HANDLER_PATTERN.md` + `docs/FIREBASE_CONFIG_AUTHORITY.md` — active rules extracted from archived plans (PR #536)
- `AndroidGarage/docs/archive/`, `docs/archive/` folders for shipped plans (PR #533)

## Memory-only (not in repo)
- `feedback_no_npx_smoke_tests.md` — user dislikes `npx --yes` for local CI-tool smoke tests
- `feedback_tag_membership_without_git_tag.md` — same workaround as in this PR (memory tracks the operational lesson; CLAUDE.md tracks the user-facing rule)
- `project_doc_architecture_2026_04_24.md` — pointer for future agent sessions to read AGENTS.md first

## Test plan
- [x] Docs-only fast path

🤖 Generated with [Claude Code](https://claude.com/claude-code)