### PR TITLE
refactor: Replace looping door animation with tween + spring

### DIFF
--- a/AndroidGarage/android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/GarageDoorScreenshotTest.kt
+++ b/AndroidGarage/android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/GarageDoorScreenshotTest.kt
@@ -5,10 +5,14 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.android.tools.screenshot.PreviewTest
 import com.chriscartland.garage.ui.ClosedPreview
 import com.chriscartland.garage.ui.ClosingPreview
+import com.chriscartland.garage.ui.ClosingTooLongPreview
+import com.chriscartland.garage.ui.ErrorSensorConflictPreview
 import com.chriscartland.garage.ui.GarageIconPreview
 import com.chriscartland.garage.ui.MidwayPreview
+import com.chriscartland.garage.ui.OpenMisalignedPreview
 import com.chriscartland.garage.ui.OpenPreview
 import com.chriscartland.garage.ui.OpeningPreview
+import com.chriscartland.garage.ui.OpeningTooLongPreview
 import com.chriscartland.garage.ui.theme.AppTheme
 
 @PreviewTest
@@ -92,5 +96,61 @@ fun GarageDoorMidwayPreviewTest() {
 fun GarageIconPreviewTest() {
     AppTheme {
         GarageIconPreview()
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun GarageDoorOpeningTooLongPreviewTest() {
+    AppTheme {
+        OpeningTooLongPreview()
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun GarageDoorClosingTooLongPreviewTest() {
+    AppTheme {
+        ClosingTooLongPreview()
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun GarageDoorOpenMisalignedPreviewTest() {
+    AppTheme {
+        OpenMisalignedPreview()
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun GarageDoorErrorSensorConflictPreviewTest() {
+    AppTheme {
+        ErrorSensorConflictPreview()
     }
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/AnimatableGarageDoor.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/AnimatableGarageDoor.kt
@@ -17,15 +17,8 @@
 
 package com.chriscartland.garage.ui
 
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -40,7 +33,6 @@ import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
@@ -49,6 +41,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.ColorUtils
+import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
 import java.time.Duration
 
@@ -64,49 +57,119 @@ const val MIDWAY_POSITION = -0.35f
 const val OPENING_STATIC_POSITION = -0.65f
 const val OPEN_POSITION = -0.75f
 
-@Composable
-private fun GarageDoorWithOverlay(
-    doorOffset: Float,
-    modifier: Modifier = Modifier,
-    color: Color = Color(0xFF3C5232),
-    animate: Boolean = false,
-    animationTarget: Float = doorOffset,
-    duration: Duration = DEFAULT_GARAGE_DOOR_ANIMATION_DURATION,
-    overlay: @Composable (BoxScope.() -> Unit)? = null,
-) {
-    val currentOffset = if (animate) {
-        val transition = rememberInfiniteTransition(label = "garageDoor")
-        val animatedValue by transition.animateFloat(
-            initialValue = doorOffset,
-            targetValue = animationTarget,
-            animationSpec = infiniteRepeatable(
-                animation = tween(duration.toMillis().toInt(), easing = LinearEasing),
-                repeatMode = RepeatMode.Restart,
-            ),
-            label = "doorOffset",
-        )
-        animatedValue
-    } else {
-        doorOffset
-    }
+internal enum class OverlayKind { NONE, ARROW_UP, ARROW_DOWN, WARNING }
 
-    Box(
-        modifier = modifier.aspectRatio(GARAGE_DOOR_ASPECT_RATIO),
-        contentAlignment = Alignment.Center,
-    ) {
-        GarageDoorCanvas(
-            doorOffset = currentOffset,
-            modifier = Modifier.fillMaxSize(),
-            color = color,
-        )
-        if (overlay != null) {
-            overlay()
+/**
+ * Pure mappings from [DoorPosition] to the visual primitives used by
+ * [GarageIcon]. Same state always produces the same outputs — animation
+ * trajectories depend on current value, but the *targets* don't. See
+ * `AndroidGarage/docs/DOOR_ANIMATION.md` for the contract.
+ *
+ * Each `when` is exhaustive (no `else`) so adding a [DoorPosition] value
+ * forces a decision at compile time.
+ */
+object DoorAnimation {
+    /** Target offset to animate toward for the given state. */
+    fun targetPositionFor(doorPosition: DoorPosition): Float =
+        when (doorPosition) {
+            DoorPosition.UNKNOWN -> MIDWAY_POSITION
+            DoorPosition.CLOSED -> CLOSED_POSITION
+            DoorPosition.OPENING -> OPEN_POSITION
+            DoorPosition.OPENING_TOO_LONG -> MIDWAY_POSITION
+            DoorPosition.OPEN -> OPEN_POSITION
+            DoorPosition.OPEN_MISALIGNED -> OPEN_POSITION
+            DoorPosition.CLOSING -> CLOSED_POSITION
+            DoorPosition.CLOSING_TOO_LONG -> MIDWAY_POSITION
+            DoorPosition.ERROR_SENSOR_CONFLICT -> MIDWAY_POSITION
         }
-    }
+
+    /**
+     * Initial Animatable seed for a given state.
+     *
+     * For motion states (OPENING/CLOSING) the seed is the "from" end so the
+     * tween animates the full motion when the icon first composes (e.g., app
+     * open, screen return mid-motion). For all other states, seed = target so
+     * the icon renders at rest with no animation on first frame.
+     *
+     * Trade-off: when the app opens with a door in motion, the icon ignores
+     * the server's lastChangeTimeSeconds and animates from the "from" end.
+     * Computing elapsed time would require a clock-drift correction we don't
+     * have. See `AndroidGarage/docs/DOOR_ANIMATION.md` § Trade-offs.
+     */
+    fun initialPositionFor(doorPosition: DoorPosition): Float =
+        when (doorPosition) {
+            DoorPosition.OPENING -> CLOSED_POSITION
+            DoorPosition.CLOSING -> OPEN_POSITION
+            DoorPosition.UNKNOWN,
+            DoorPosition.CLOSED,
+            DoorPosition.OPENING_TOO_LONG,
+            DoorPosition.OPEN,
+            DoorPosition.OPEN_MISALIGNED,
+            DoorPosition.CLOSING_TOO_LONG,
+            DoorPosition.ERROR_SENSOR_CONFLICT,
+            -> targetPositionFor(doorPosition)
+        }
+
+    /**
+     * Which animation spec family applies.
+     *
+     * - `false` → tween (linear) for OPENING/CLOSING — matches a real garage
+     *   door's roughly constant-speed motion.
+     * - `true` → spring (slow, no overshoot) for terminal/error/unknown —
+     *   states "settle" to their target.
+     */
+    fun useSpringFor(doorPosition: DoorPosition): Boolean =
+        when (doorPosition) {
+            DoorPosition.OPENING, DoorPosition.CLOSING -> false
+            DoorPosition.UNKNOWN,
+            DoorPosition.CLOSED,
+            DoorPosition.OPENING_TOO_LONG,
+            DoorPosition.OPEN,
+            DoorPosition.OPEN_MISALIGNED,
+            DoorPosition.CLOSING_TOO_LONG,
+            DoorPosition.ERROR_SENSOR_CONFLICT,
+            -> true
+        }
+
+    /**
+     * Snapshot offset for a non-animated render — used when
+     * `GarageIcon(static = true)`. For motion states the snapshot is a
+     * mid-cycle position so the door visibly looks "in motion" without
+     * actually animating.
+     */
+    fun staticPositionFor(doorPosition: DoorPosition): Float =
+        when (doorPosition) {
+            DoorPosition.OPENING -> OPENING_STATIC_POSITION
+            DoorPosition.CLOSING -> CLOSING_STATIC_POSITION
+            DoorPosition.UNKNOWN,
+            DoorPosition.CLOSED,
+            DoorPosition.OPENING_TOO_LONG,
+            DoorPosition.OPEN,
+            DoorPosition.OPEN_MISALIGNED,
+            DoorPosition.CLOSING_TOO_LONG,
+            DoorPosition.ERROR_SENSOR_CONFLICT,
+            -> targetPositionFor(doorPosition)
+        }
+
+    /** Which overlay icon to draw on top of the door, if any. */
+    internal fun overlayFor(doorPosition: DoorPosition): OverlayKind =
+        when (doorPosition) {
+            DoorPosition.OPENING -> OverlayKind.ARROW_UP
+            DoorPosition.CLOSING -> OverlayKind.ARROW_DOWN
+            DoorPosition.UNKNOWN,
+            DoorPosition.OPENING_TOO_LONG,
+            DoorPosition.CLOSING_TOO_LONG,
+            DoorPosition.ERROR_SENSOR_CONFLICT,
+            -> OverlayKind.WARNING
+            DoorPosition.CLOSED,
+            DoorPosition.OPEN,
+            DoorPosition.OPEN_MISALIGNED,
+            -> OverlayKind.NONE
+        }
 }
 
 @Composable
-private fun DirectionOverlay(
+internal fun DirectionOverlay(
     rotationDegrees: Float,
     contentDescription: String,
 ) {
@@ -129,7 +192,7 @@ private fun DirectionOverlay(
 }
 
 @Composable
-private fun WarningOverlay() {
+internal fun WarningOverlay() {
     Box(
         modifier = Modifier
             .fillMaxWidth(0.3f)
@@ -143,78 +206,6 @@ private fun WarningOverlay() {
             contentDescription = "Warning Symbol",
             modifier = Modifier.fillMaxSize(0.6f),
         )
-    }
-}
-
-@Composable
-fun Opening(
-    modifier: Modifier = Modifier,
-    color: Color = LocalDoorStatusColorScheme.current.openFresh,
-    static: Boolean = false,
-) {
-    GarageDoorWithOverlay(
-        doorOffset = if (static) OPENING_STATIC_POSITION else CLOSED_POSITION,
-        modifier = modifier,
-        color = color,
-        animate = !static,
-        animationTarget = OPEN_POSITION,
-    ) {
-        DirectionOverlay(-90f, "Up Arrow")
-    }
-}
-
-@Composable
-fun Closing(
-    modifier: Modifier = Modifier,
-    color: Color = LocalDoorStatusColorScheme.current.openFresh,
-    static: Boolean = false,
-) {
-    GarageDoorWithOverlay(
-        doorOffset = if (static) CLOSING_STATIC_POSITION else OPEN_POSITION,
-        modifier = modifier,
-        color = color,
-        animate = !static,
-        animationTarget = CLOSED_POSITION,
-    ) {
-        DirectionOverlay(90f, "Down Arrow")
-    }
-}
-
-@Composable
-fun Closed(
-    modifier: Modifier = Modifier,
-    color: Color = LocalDoorStatusColorScheme.current.closedFresh,
-) {
-    GarageDoorWithOverlay(
-        doorOffset = CLOSED_POSITION,
-        modifier = modifier,
-        color = color,
-    )
-}
-
-@Composable
-fun Open(
-    modifier: Modifier = Modifier,
-    color: Color = LocalDoorStatusColorScheme.current.openFresh,
-) {
-    GarageDoorWithOverlay(
-        doorOffset = OPEN_POSITION,
-        modifier = modifier,
-        color = color,
-    )
-}
-
-@Composable
-fun Midway(
-    modifier: Modifier = Modifier,
-    color: Color = LocalDoorStatusColorScheme.current.openFresh,
-) {
-    GarageDoorWithOverlay(
-        doorOffset = MIDWAY_POSITION,
-        modifier = modifier,
-        color = color,
-    ) {
-        WarningOverlay()
     }
 }
 
@@ -232,50 +223,46 @@ object GarageColors {
 
 // --- Previews ---
 
+private const val PREVIEW_BOX_DP = 400
+private const val PREVIEW_ICON_HEIGHT_DP = 200
+private const val PREVIEW_ICON_WIDTH_DP = 300
+
+@Composable
+private fun PreviewBox(content: @Composable (Modifier) -> Unit) {
+    Box(
+        modifier = Modifier.size(PREVIEW_BOX_DP.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        content(
+            Modifier
+                .wrapContentSize()
+                .heightIn(max = PREVIEW_ICON_HEIGHT_DP.dp)
+                .widthIn(max = PREVIEW_ICON_WIDTH_DP.dp),
+        )
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 fun OpeningPreview() {
-    Box(
-        modifier = Modifier.size(400.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        Opening(
-            modifier = Modifier
-                .wrapContentSize()
-                .heightIn(max = 200.dp)
-                .widthIn(max = 300.dp),
-        )
-    }
+    PreviewBox { mod -> GarageIcon(DoorPosition.OPENING, modifier = mod, static = true) }
 }
 
 @Preview(showBackground = true)
 @Composable
 fun ClosingPreview() {
-    Box(
-        modifier = Modifier.size(400.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        Closing(
-            modifier = Modifier
-                .wrapContentSize()
-                .heightIn(max = 200.dp)
-                .widthIn(max = 300.dp),
-        )
-    }
+    PreviewBox { mod -> GarageIcon(DoorPosition.CLOSING, modifier = mod, static = true) }
 }
 
 @Preview(showBackground = true)
 @Composable
 fun ClosedPreview() {
-    Box(
-        modifier = Modifier.size(400.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        Closed(
-            modifier = Modifier
-                .wrapContentSize()
-                .heightIn(max = 200.dp)
-                .widthIn(max = 300.dp),
+    PreviewBox { mod ->
+        GarageIcon(
+            doorPosition = DoorPosition.CLOSED,
+            modifier = mod,
+            static = true,
+            color = LocalDoorStatusColorScheme.current.closedFresh,
         )
     }
 }
@@ -283,31 +270,35 @@ fun ClosedPreview() {
 @Preview(showBackground = true)
 @Composable
 fun OpenPreview() {
-    Box(
-        modifier = Modifier.size(400.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        Open(
-            modifier = Modifier
-                .wrapContentSize()
-                .heightIn(max = 200.dp)
-                .widthIn(max = 300.dp),
-        )
-    }
+    PreviewBox { mod -> GarageIcon(DoorPosition.OPEN, modifier = mod, static = true) }
 }
 
 @Preview(showBackground = true)
 @Composable
 fun MidwayPreview() {
-    Box(
-        modifier = Modifier.size(400.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        Midway(
-            modifier = Modifier
-                .wrapContentSize()
-                .heightIn(max = 200.dp)
-                .widthIn(max = 300.dp),
-        )
-    }
+    PreviewBox { mod -> GarageIcon(DoorPosition.UNKNOWN, modifier = mod, static = true) }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun OpeningTooLongPreview() {
+    PreviewBox { mod -> GarageIcon(DoorPosition.OPENING_TOO_LONG, modifier = mod, static = true) }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ClosingTooLongPreview() {
+    PreviewBox { mod -> GarageIcon(DoorPosition.CLOSING_TOO_LONG, modifier = mod, static = true) }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun OpenMisalignedPreview() {
+    PreviewBox { mod -> GarageIcon(DoorPosition.OPEN_MISALIGNED, modifier = mod, static = true) }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ErrorSensorConflictPreview() {
+    PreviewBox { mod -> GarageIcon(DoorPosition.ERROR_SENSOR_CONFLICT, modifier = mod, static = true) }
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/GarageIcon.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/GarageIcon.kt
@@ -17,36 +17,125 @@
 
 package com.chriscartland.garage.ui
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import com.chriscartland.garage.domain.model.DoorPosition
+import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
+import java.time.Duration
 
 /**
- * Renders the garage door for a given [DoorPosition].
+ * Renders the garage door icon for a [DoorPosition].
  *
- * The modifier from the caller flows directly to the door composable —
- * no intermediate wrapper Boxes. The door applies its own aspect ratio
- * internally, so callers only need to provide size constraints.
+ * Animation contract: see `AndroidGarage/docs/DOOR_ANIMATION.md`. In short:
+ * - Target offset is a pure function of `doorPosition`
+ *   ([targetPositionFor]) — no dependency on the current animation value.
+ * - Motion states (OPENING/CLOSING) tween linearly over [duration].
+ * - Terminal/error states settle via a slow, no-bounce spring.
+ *
+ * @param static when `true`, render at [staticPositionFor] (no animation,
+ *   no Animatable). Used by past-event snapshots in the recent events list.
  */
 @Composable
 fun GarageIcon(
     doorPosition: DoorPosition,
     modifier: Modifier = Modifier,
     static: Boolean = false,
-    color: Color = Color.Blue,
+    color: Color = LocalDoorStatusColorScheme.current.openFresh,
+    duration: Duration = DEFAULT_GARAGE_DOOR_ANIMATION_DURATION,
 ) {
-    when (doorPosition) {
-        DoorPosition.UNKNOWN -> Midway(modifier = modifier, color = color)
-        DoorPosition.CLOSED -> Closed(modifier = modifier, color = color)
-        DoorPosition.OPENING -> Opening(modifier = modifier, static = static, color = color)
-        DoorPosition.OPENING_TOO_LONG -> Midway(modifier = modifier, color = color)
-        DoorPosition.OPEN -> Open(modifier = modifier, color = color)
-        DoorPosition.OPEN_MISALIGNED -> Open(modifier = modifier, color = color)
-        DoorPosition.CLOSING -> Closing(modifier = modifier, static = static, color = color)
-        DoorPosition.CLOSING_TOO_LONG -> Midway(modifier = modifier, color = color)
-        DoorPosition.ERROR_SENSOR_CONFLICT -> Midway(modifier = modifier, color = color)
+    if (static) {
+        DoorIconBox(
+            doorOffset = DoorAnimation.staticPositionFor(doorPosition),
+            doorPosition = doorPosition,
+            modifier = modifier,
+            color = color,
+        )
+    } else {
+        AnimatedDoorIcon(
+            doorPosition = doorPosition,
+            modifier = modifier,
+            color = color,
+            duration = duration,
+        )
+    }
+}
+
+@Composable
+private fun AnimatedDoorIcon(
+    doorPosition: DoorPosition,
+    modifier: Modifier,
+    color: Color,
+    duration: Duration,
+) {
+    // Hoisted Animatable: one position state for this icon instance.
+    // LaunchedEffect is keyed on the enum so same-value re-emits do not
+    // restart the animation. The pure mappings (target/initial/spec) are
+    // defined in AnimatableGarageDoor.kt.
+    val position = remember { Animatable(DoorAnimation.initialPositionFor(doorPosition)) }
+    LaunchedEffect(doorPosition) {
+        val target = DoorAnimation.targetPositionFor(doorPosition)
+        if (DoorAnimation.useSpringFor(doorPosition)) {
+            position.animateTo(
+                targetValue = target,
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioNoBouncy,
+                    stiffness = Spring.StiffnessVeryLow,
+                ),
+                initialVelocity = 0f,
+            )
+        } else {
+            position.animateTo(
+                targetValue = target,
+                animationSpec = tween(
+                    durationMillis = duration.toMillis().toInt(),
+                    easing = LinearEasing,
+                ),
+            )
+        }
+    }
+    DoorIconBox(
+        doorOffset = position.value,
+        doorPosition = doorPosition,
+        modifier = modifier,
+        color = color,
+    )
+}
+
+@Composable
+private fun DoorIconBox(
+    doorOffset: Float,
+    doorPosition: DoorPosition,
+    modifier: Modifier,
+    color: Color,
+) {
+    Box(
+        modifier = modifier.aspectRatio(GARAGE_DOOR_ASPECT_RATIO),
+        contentAlignment = Alignment.Center,
+    ) {
+        GarageDoorCanvas(
+            doorOffset = doorOffset,
+            modifier = Modifier.fillMaxSize(),
+            color = color,
+        )
+        when (DoorAnimation.overlayFor(doorPosition)) {
+            OverlayKind.NONE -> Unit
+            OverlayKind.ARROW_UP -> DirectionOverlay(-90f, "Up Arrow")
+            OverlayKind.ARROW_DOWN -> DirectionOverlay(90f, "Down Arrow")
+            OverlayKind.WARNING -> WarningOverlay()
+        }
     }
 }
 
@@ -55,5 +144,6 @@ fun GarageIcon(
 fun GarageIconPreview() {
     GarageIcon(
         doorPosition = DoorPosition.OPENING,
+        static = true,
     )
 }

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/GarageDoorAnimationMappingTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/GarageDoorAnimationMappingTest.kt
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui
+
+import com.chriscartland.garage.domain.model.DoorPosition
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the door-animation mapping contract. See `AndroidGarage/docs/DOOR_ANIMATION.md`.
+ *
+ * Each mapping is an exhaustive `when` over [DoorPosition], so adding a new
+ * enum value fails to compile until every mapping is updated. These tests pin
+ * the *values* so a wrong update is also caught.
+ */
+class GarageDoorAnimationMappingTest {
+    // --- targetPositionFor ----------------------------------------------------
+
+    @Test
+    fun targetPositionFor_unknown_isMidway() {
+        assertEquals(MIDWAY_POSITION, DoorAnimation.targetPositionFor(DoorPosition.UNKNOWN))
+    }
+
+    @Test
+    fun targetPositionFor_closed_isClosed() {
+        assertEquals(CLOSED_POSITION, DoorAnimation.targetPositionFor(DoorPosition.CLOSED))
+    }
+
+    @Test
+    fun targetPositionFor_opening_isOpen() {
+        assertEquals(OPEN_POSITION, DoorAnimation.targetPositionFor(DoorPosition.OPENING))
+    }
+
+    @Test
+    fun targetPositionFor_openingTooLong_isMidway() {
+        assertEquals(MIDWAY_POSITION, DoorAnimation.targetPositionFor(DoorPosition.OPENING_TOO_LONG))
+    }
+
+    @Test
+    fun targetPositionFor_open_isOpen() {
+        assertEquals(OPEN_POSITION, DoorAnimation.targetPositionFor(DoorPosition.OPEN))
+    }
+
+    @Test
+    fun targetPositionFor_openMisaligned_isOpen() {
+        assertEquals(OPEN_POSITION, DoorAnimation.targetPositionFor(DoorPosition.OPEN_MISALIGNED))
+    }
+
+    @Test
+    fun targetPositionFor_closing_isClosed() {
+        assertEquals(CLOSED_POSITION, DoorAnimation.targetPositionFor(DoorPosition.CLOSING))
+    }
+
+    @Test
+    fun targetPositionFor_closingTooLong_isMidway() {
+        assertEquals(MIDWAY_POSITION, DoorAnimation.targetPositionFor(DoorPosition.CLOSING_TOO_LONG))
+    }
+
+    @Test
+    fun targetPositionFor_errorSensorConflict_isMidway() {
+        assertEquals(MIDWAY_POSITION, DoorAnimation.targetPositionFor(DoorPosition.ERROR_SENSOR_CONFLICT))
+    }
+
+    // --- initialPositionFor ---------------------------------------------------
+
+    @Test
+    fun initialPositionFor_opening_startsAtClosed() {
+        // Motion states start at the "from" end so the tween animates the full
+        // motion when the icon first composes.
+        assertEquals(CLOSED_POSITION, DoorAnimation.initialPositionFor(DoorPosition.OPENING))
+    }
+
+    @Test
+    fun initialPositionFor_closing_startsAtOpen() {
+        assertEquals(OPEN_POSITION, DoorAnimation.initialPositionFor(DoorPosition.CLOSING))
+    }
+
+    @Test
+    fun initialPositionFor_terminalStates_startAtTarget() {
+        // No first-frame animation for terminal/error states.
+        for (state in nonMotionStates) {
+            assertEquals(
+                "Initial position for $state should equal target",
+                DoorAnimation.targetPositionFor(state),
+                DoorAnimation.initialPositionFor(state),
+            )
+        }
+    }
+
+    // --- useSpringFor ---------------------------------------------------------
+
+    @Test
+    fun useSpringFor_motionStates_useTween() {
+        assertEquals(false, DoorAnimation.useSpringFor(DoorPosition.OPENING))
+        assertEquals(false, DoorAnimation.useSpringFor(DoorPosition.CLOSING))
+    }
+
+    @Test
+    fun useSpringFor_nonMotionStates_useSpring() {
+        for (state in nonMotionStates) {
+            assertTrue("$state should use spring", DoorAnimation.useSpringFor(state))
+        }
+    }
+
+    // --- staticPositionFor ----------------------------------------------------
+
+    @Test
+    fun staticPositionFor_opening_isOpeningSnapshot() {
+        // Static snapshot of OPENING should look "in motion" (mid-cycle), not
+        // identical to OPEN.
+        assertEquals(OPENING_STATIC_POSITION, DoorAnimation.staticPositionFor(DoorPosition.OPENING))
+    }
+
+    @Test
+    fun staticPositionFor_closing_isClosingSnapshot() {
+        assertEquals(CLOSING_STATIC_POSITION, DoorAnimation.staticPositionFor(DoorPosition.CLOSING))
+    }
+
+    @Test
+    fun staticPositionFor_nonMotionStates_matchTarget() {
+        for (state in nonMotionStates) {
+            assertEquals(
+                "Static position for $state should equal target",
+                DoorAnimation.targetPositionFor(state),
+                DoorAnimation.staticPositionFor(state),
+            )
+        }
+    }
+
+    // --- overlayFor -----------------------------------------------------------
+
+    @Test
+    fun overlayFor_opening_isArrowUp() {
+        assertEquals(OverlayKind.ARROW_UP, DoorAnimation.overlayFor(DoorPosition.OPENING))
+    }
+
+    @Test
+    fun overlayFor_closing_isArrowDown() {
+        assertEquals(OverlayKind.ARROW_DOWN, DoorAnimation.overlayFor(DoorPosition.CLOSING))
+    }
+
+    @Test
+    fun overlayFor_warningStates_areWarning() {
+        val warningStates = listOf(
+            DoorPosition.UNKNOWN,
+            DoorPosition.OPENING_TOO_LONG,
+            DoorPosition.CLOSING_TOO_LONG,
+            DoorPosition.ERROR_SENSOR_CONFLICT,
+        )
+        for (state in warningStates) {
+            assertEquals(
+                "$state should use warning overlay",
+                OverlayKind.WARNING,
+                DoorAnimation.overlayFor(state),
+            )
+        }
+    }
+
+    @Test
+    fun overlayFor_terminalStates_areNone() {
+        val terminalStates = listOf(
+            DoorPosition.CLOSED,
+            DoorPosition.OPEN,
+            DoorPosition.OPEN_MISALIGNED,
+        )
+        for (state in terminalStates) {
+            assertEquals("$state should have no overlay", OverlayKind.NONE, DoorAnimation.overlayFor(state))
+        }
+    }
+
+    // --- Exhaustiveness sanity checks ----------------------------------------
+
+    @Test
+    fun everyDoorPosition_hasValidTarget() {
+        // The `when` is exhaustive at compile time; this is a runtime sanity
+        // check that every value falls in the allowed offset range.
+        for (state in DoorPosition.values()) {
+            val target = DoorAnimation.targetPositionFor(state)
+            assertTrue(
+                "$state target $target outside valid offset range [OPEN_POSITION, CLOSED_POSITION]",
+                target in OPEN_POSITION..CLOSED_POSITION,
+            )
+        }
+    }
+
+    @Test
+    fun everyDoorPosition_hasOverlay() {
+        // Total function — no DoorPosition produces a null/missing overlay.
+        for (state in DoorPosition.values()) {
+            assertNotNull("$state has no overlay", DoorAnimation.overlayFor(state))
+        }
+    }
+
+    private val nonMotionStates = DoorPosition
+        .values()
+        .filter { it != DoorPosition.OPENING && it != DoorPosition.CLOSING }
+}

--- a/AndroidGarage/docs/DECISIONS.md
+++ b/AndroidGarage/docs/DECISIONS.md
@@ -1399,3 +1399,68 @@ If that grep returns nothing, the config is not doing work on this codebase and 
 - PR (dropped) — `chore/upload-native-debug-symbols` branch, tested locally and discarded after inspection showed empty symbol output.
 - [AGP docs: Include native symbol files](https://developer.android.com/studio/build/native-debug-symbols) — describes `debugSymbolLevel` and which `.so` files it can process.
 - [Firebase Crashlytics NDK](https://firebase.google.com/docs/crashlytics/ndk-reports) — separate mechanism, only relevant if Crashlytics is adopted.
+
+## ADR-025: Door Animation — Tween During Motion, Spring at Rest
+
+### Status
+
+Accepted — 2026-04-25.
+
+### Context
+
+The garage door icon (`GarageIcon`) translates the server-reported `DoorPosition` into a vertical door offset. Before this decision, motion states animated via `rememberInfiniteTransition` with a 12-second linear `tween` looped indefinitely (`infiniteRepeatable`), and the composable tree swapped to a static frame on terminal state. This produced two visible bugs:
+
+1. While a door was opening or closing, the icon cycled through opening → closed → opening forever, never settling at the predicted target.
+2. When the sensor confirmed the terminal state, the composable swap snapped the icon from "wherever it happened to be in the loop" to the terminal position — a discontinuous jump.
+
+### Decision
+
+Replace the looping animation with a single hoisted `Animatable<Float>` driven by `LaunchedEffect(doorPosition)` that calls `animateTo(target, spec)` on every state change. Two animation specs:
+
+- **Tween** (linear, 12s) for `OPENING` and `CLOSING` — matches the roughly constant-speed motion of a real garage door.
+- **Spring** (`StiffnessVeryLow`, `DampingRatioNoBouncy`, `initialVelocity = 0f`) for terminal/error/unknown — settles to target with no overshoot.
+
+The target offset is a **pure function of state alone** (`targetPositionFor(state)`), never of the current animation value. Same state always produces the same target. Mappings are exhaustive `when` over `DoorPosition` with no `else`, so adding an enum value fails to compile until every mapping is updated.
+
+The contract — full state table, position constants, trade-offs, verification map — lives in [`DOOR_ANIMATION.md`](DOOR_ANIMATION.md).
+
+### Rationale
+
+**Why hoist the `Animatable` above the state-routing `when`.** The pre-refactor `GarageIcon` dispatched to per-state composables (`Opening`, `Closing`, `Open`, `Closed`, `Midway`), each owning its own animation state. State changes destroyed and re-created the animation, defeating the premise of "one continuous animation across state changes." The hoisted `Animatable` keeps a single position state across the lifetime of the icon.
+
+**Why pure target.** Animation behavior must be deterministic and unit-testable. If the target depended on the current animation value (e.g., "spring to mid-position only if we're not already past it"), the same state could produce different visual outcomes depending on timing. That's untestable and surprising. With a pure target, the *trajectory* (how the spring or tween gets there) is owned by the framework — that physics is correct by construction and doesn't need test coverage.
+
+**Why ignore `lastChangeTimeSeconds` for initial position.** When the app opens with the door already in motion, we could compute elapsed time (`now() - lastChangeTimeSeconds`) and seed the icon at the predicted current position. But clock drift between the device and the server is large enough that this would silently put the icon in a wrong position — a worse failure mode than starting from the "from" end and animating the full motion. Computing drift correctly would require a server-side time-sync endpoint and persistent measurement. Out of scope.
+
+**Why no `|current - target| < ε` skip.** A skip rule would make behavior depend on current animation value, defeating the "target is pure" principle. If `current ≈ target`, the spring is a near-noop with no perceived movement — there is no cost to letting it run.
+
+### Consequences
+
+- The animation never gets "stuck" looping; every state change converges to its target.
+- Mid-motion transitions (e.g., `OPENING → CLOSING`) reverse smoothly via `Animatable.animateTo` cancelling the in-flight tween and starting a new one from the current value.
+- `TOO_LONG` and error states spring to `MIDWAY_POSITION`. From `0.95` this means the icon visibly moves backward to `0.5` — that visible movement *is* the state-change signal, paired with existing color/glyph overlays already in the UI.
+- Opening the app mid-motion shows the icon "starting over" from the from-end rather than at the door's literal current position. Accepted trade-off.
+- Per-state composables (`Opening`, `Closing`, `Open`, `Closed`, `Midway`) are removed. The single `GarageIcon` is the public composable; previews call it with `static = true` for the recent events list use case.
+
+### Verification
+
+| Layer | What it verifies |
+|-------|------------------|
+| Unit (`GarageDoorAnimationMappingTest`) | All five pure mappings return the documented value for every `DoorPosition` |
+| Compile-time | Exhaustive `when` over `DoorPosition` — adding a value breaks the build |
+| Screenshot (`GarageDoorScreenshotTest`) | Each `DoorPosition` renders as expected in light + dark themes (static = true so no `mainClock` flakiness) |
+
+Intermediate-frame screenshot tests (e.g., 25/50/75% of motion) were considered and rejected: the AGP `screenshot` plugin does not expose `mainClock`, so deterministic mid-animation captures would require switching to Paparazzi/Roborazzi. Out of scope for the value gained.
+
+### When this decision might change
+
+- A future feature requires the icon to mirror the door's literal current position mid-motion (e.g., a "door %" indicator). Would need a clock-drift correction strategy first.
+- We adopt Compose Multiplatform for the iOS port. The mapping functions are pure Kotlin and would move to a shared module; the `Animatable` use is already idiomatic and portable.
+- A new `DoorPosition` value is added with motion semantics that don't fit "tween linearly to terminal." Would need a third spec branch.
+
+### References
+
+- [`DOOR_ANIMATION.md`](DOOR_ANIMATION.md) — the full contract, state table, and update procedure
+- [`AnimatableGarageDoor.kt`](../androidApp/src/main/java/com/chriscartland/garage/ui/AnimatableGarageDoor.kt) — mapping functions and overlays
+- [`GarageIcon.kt`](../androidApp/src/main/java/com/chriscartland/garage/ui/GarageIcon.kt) — `Animatable` host
+- [`GarageDoorAnimationMappingTest`](../androidApp/src/test/java/com/chriscartland/garage/ui/GarageDoorAnimationMappingTest.kt) — pinned mapping tests

--- a/AndroidGarage/docs/DOOR_ANIMATION.md
+++ b/AndroidGarage/docs/DOOR_ANIMATION.md
@@ -1,0 +1,124 @@
+---
+category: reference
+status: active
+last_verified: 2026-04-25
+---
+
+# Door Animation
+
+Contract for the animated `GarageIcon` rendered in `DoorStatusCard` and the recent events list. The icon translates a [`DoorPosition`](../domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/DoorPosition.kt) into a vertical door offset and animates between offsets as the state changes.
+
+See ADR-025 in [`DECISIONS.md`](DECISIONS.md) for the design decision that motivated this contract.
+
+## Design principle
+
+**Target = pure function of state.** Same `DoorPosition` always produces the same target offset, regardless of where the animation currently is. The animation framework owns the *trajectory* (current value, current velocity, spec → next frame); the app owns the *target* (state → offset).
+
+Five pure mappings on the [`DoorAnimation`](../androidApp/src/main/java/com/chriscartland/garage/ui/AnimatableGarageDoor.kt) object:
+
+| Function | Returns | Used by |
+|----------|---------|---------|
+| `DoorAnimation.targetPositionFor(state)` | offset to animate toward | `LaunchedEffect` |
+| `DoorAnimation.initialPositionFor(state)` | seed value for `Animatable` on first composition | `remember { Animatable(...) }` |
+| `DoorAnimation.useSpringFor(state)` | `false` → tween (motion); `true` → spring (settle) | `LaunchedEffect` |
+| `DoorAnimation.staticPositionFor(state)` | offset to render when `static = true` (no animation) | recent events list |
+| `DoorAnimation.overlayFor(state)` | which overlay icon (arrow up/down, warning, none) to draw | `DoorIconBox` |
+
+Each is an exhaustive `when` over `DoorPosition` with no `else`. Adding a new enum value fails to compile until every mapping is updated.
+
+## State table
+
+| State | `target` | `initial` | spec | overlay |
+|-------|----------|-----------|------|---------|
+| `UNKNOWN` | `MIDWAY_POSITION` | target | spring | warning |
+| `CLOSED` | `CLOSED_POSITION` | target | spring | none |
+| `OPENING` | `OPEN_POSITION` | `CLOSED_POSITION` | tween (linear, 12s) | arrow up |
+| `OPENING_TOO_LONG` | `MIDWAY_POSITION` | target | spring | warning |
+| `OPEN` | `OPEN_POSITION` | target | spring | none |
+| `OPEN_MISALIGNED` | `OPEN_POSITION` | target | spring | none |
+| `CLOSING` | `CLOSED_POSITION` | `OPEN_POSITION` | tween (linear, 12s) | arrow down |
+| `CLOSING_TOO_LONG` | `MIDWAY_POSITION` | target | spring | warning |
+| `ERROR_SENSOR_CONFLICT` | `MIDWAY_POSITION` | target | spring | warning |
+
+Position constants in `AnimatableGarageDoor.kt`:
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `CLOSED_POSITION` | `0.0f` | Door fully closed, panels at rest in frame |
+| `MIDWAY_POSITION` | `-0.35f` | Mid-cycle position used for warning / unknown states |
+| `OPEN_POSITION` | `-0.75f` | Door fully open |
+| `OPENING_STATIC_POSITION` | `-0.65f` | Mid-cycle snapshot for `static = true` opening |
+| `CLOSING_STATIC_POSITION` | `-0.20f` | Mid-cycle snapshot for `static = true` closing |
+
+Negative offsets correspond to the door sliding upward (opening). The `GarageDoorCanvas` translates panels by `doorOffset * containerHeight`.
+
+## Spring spec
+
+```kotlin
+spring(
+    dampingRatio = Spring.DampingRatioNoBouncy,    // 1.0 — critically damped, zero overshoot
+    stiffness = Spring.StiffnessVeryLow,           // 50 — slow settle
+)
+```
+
+`initialVelocity = 0f` is passed explicitly so a tween → spring transition does not carry over the tween's residual velocity past the target. This keeps terminal arrivals visually still after settling.
+
+## Tween spec
+
+```kotlin
+tween(
+    durationMillis = DEFAULT_GARAGE_DOOR_ANIMATION_DURATION.toMillis().toInt(),  // 12000
+    easing = LinearEasing,
+)
+```
+
+Linear easing matches the roughly constant-speed motion of a real garage door.
+
+## Trade-offs
+
+**No elapsed-time-based start position.** When the app opens with the door already in motion, the icon starts at the "from" end (`initialPositionFor`) and animates the full motion from scratch. We do not compute `now() - lastChangeTimeSeconds` to seed the position mid-motion because clock drift between the device and the server is significant — relying on it would put the icon in a wrong position silently. The visible cost is that opening the app mid-motion shows the icon "starting over" rather than catching up to physical reality. The animation is now an indicator of *state*, not an attempt to mirror the door's literal current position.
+
+**Always animate to target on state change.** No `|current - target| < ε` skip — that would make behavior depend on current animation value, defeating the "target is pure" principle. If `current ≈ target`, the spring is a near-noop with no perceived movement.
+
+**No client-side direction-flip debounce.** If the server emits `Opening → Closing → Opening` rapidly, the icon visibly waffles. That's the correct response to what the server reported; jitter is a server bug to fix at the source, not paper over in the client.
+
+## Verification
+
+| Layer | What it verifies | Where |
+|-------|------------------|-------|
+| Unit (mapping) | Each `DoorAnimation.*For` function returns the documented value for every `DoorPosition` | [`GarageDoorAnimationMappingTest`](../androidApp/src/test/java/com/chriscartland/garage/ui/GarageDoorAnimationMappingTest.kt) |
+| Compile-time | Every `DoorPosition` enum value is mapped (exhaustive `when`, no `else`) | The compiler — adding a new enum value breaks the build |
+| Screenshot | The icon renders as expected for each state in light + dark themes | [`GarageDoorScreenshotTest`](../android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/GarageDoorScreenshotTest.kt), regenerate via `./scripts/generate-android-screenshots.sh` |
+
+Screenshot tests use `static = true` so they render deterministically (no `mainClock`-dependent animation frames). The current AGP `screenshot` plugin renders Compose previews and does not expose `mainClock`; adding intermediate-frame screenshots would require switching to Paparazzi/Roborazzi and is intentionally out of scope.
+
+## Updating the contract
+
+To add a new `DoorPosition` value:
+
+1. Add the enum value in [`DoorPosition.kt`](../domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/DoorPosition.kt). The compiler will fail every `when` in the mapping functions.
+2. Decide the target/initial/spec/overlay for the new state and update each function.
+3. Update this doc's state table.
+4. Update [`GarageDoorAnimationMappingTest`](../androidApp/src/test/java/com/chriscartland/garage/ui/GarageDoorAnimationMappingTest.kt) with assertions for the new value.
+5. Add a `@Preview` in `AnimatableGarageDoor.kt` and a screenshot test in `GarageDoorScreenshotTest.kt` so the visual is captured.
+
+To change a target/spec for an existing state:
+
+1. Update the appropriate mapping function.
+2. Update the state table above.
+3. Update the test to pin the new value.
+4. Regenerate screenshots.
+
+## Out of scope (deferred)
+
+- **Per-direction empirical duration estimate.** Average completed motion durations from the event history (separately for opening and closing) and feed `tween` `durationMillis`. Tracked as a follow-up — current behavior is hardcoded 12s.
+- **Out-of-order event guard at the data layer.** If the repository emits a stale `OPENING` after a fresh `OPEN`, the icon dutifully animates the wrong direction. A monotonicity guard in `NetworkDoorRepository` would fix it; deferred unless we observe the bug in production.
+- **Reduced-motion handling.** Compose `tween`/`spring` already honor `Settings.Global.ANIMATOR_DURATION_SCALE` since Compose 1.2. No custom `LocalAccessibilityManager` handling is needed unless we measure a problem.
+
+## References
+
+- [`AnimatableGarageDoor.kt`](../androidApp/src/main/java/com/chriscartland/garage/ui/AnimatableGarageDoor.kt) — pure mapping functions, position constants, overlays
+- [`GarageIcon.kt`](../androidApp/src/main/java/com/chriscartland/garage/ui/GarageIcon.kt) — composable that hosts the `Animatable` and `LaunchedEffect`
+- [`GarageDoorCanvas.kt`](../androidApp/src/main/java/com/chriscartland/garage/ui/GarageDoorCanvas.kt) — Canvas-based door rendering driven by `doorOffset`
+- [`DoorPosition.kt`](../domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/DoorPosition.kt) — the enum
+- [`DECISIONS.md`](DECISIONS.md) ADR-025 — design decision that motivated this contract


### PR DESCRIPTION
## Summary

- Replace `rememberInfiniteTransition` (12s linear loop, hard snap on terminal state) with a single hoisted `Animatable<Float>` driven by `LaunchedEffect(doorPosition)`. Motion states tween linearly to terminal; terminal/error states settle via slow no-bounce spring (`StiffnessVeryLow`, `DampingRatioNoBouncy`).
- Target offset is now a **pure function of state alone** — five exhaustive `when` mappings on a new `DoorAnimation` object, no `else` branches. Adding a `DoorPosition` value fails the build until every mapping is updated.
- Adds [`docs/DOOR_ANIMATION.md`](AndroidGarage/docs/DOOR_ANIMATION.md) (full state table, trade-offs, verification map), ADR-025 in [`DECISIONS.md`](AndroidGarage/docs/DECISIONS.md), unit tests pinning every mapping, and `@Preview` coverage for the four states that previously had no preview (`OPENING_TOO_LONG`, `CLOSING_TOO_LONG`, `OPEN_MISALIGNED`, `ERROR_SENSOR_CONFLICT`).

## Design highlights

- **Single hoisted `Animatable`.** Pre-refactor, `GarageIcon` dispatched to per-state composables that each owned their own animation — state changes destroyed the animation. Now one `Animatable` lives across state transitions; `LaunchedEffect` is keyed on the enum so same-value re-emits don't restart.
- **Pure target.** Trajectory (the path from current to target) depends on physics. Target depends only on state. Same `DoorPosition` always produces the same target, regardless of where the animation is.
- **No elapsed-time math.** Server/client clock drift is significant; relying on `lastChangeTimeSeconds` to seed mid-motion would silently misposition the icon. Trade-off: opening the app mid-motion shows the icon "starting over" rather than catching up to physical reality.

## Test plan

- [x] `./scripts/validate.sh` — passes (spotless, lint, unit tests, domain tests, debug build, screenshot test compilation, schema drift check)
- [ ] Verify on device: Closed → Opening → Open looks smooth (no loop, no snap)
- [ ] Verify on device: Mid-motion direction flip (Opening → Closing) reverses smoothly
- [ ] Verify on device: TOO_LONG / Error springs to midway as documented
- [ ] Verify recent events list still renders past events with `static = true` snapshots
- [ ] Regenerate screenshots via `./scripts/generate-android-screenshots.sh` after merge — colors for `ClosedPreview` are explicit now and the four new previews need reference PNGs

🤖 Generated with [Claude Code](https://claude.com/claude-code)