### PR TITLE
chore: Bump versionName to 2.5.0

### DIFF
--- a/AndroidGarage/version.properties
+++ b/AndroidGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.4.4
+versionName=2.5.0


### PR DESCRIPTION
## Summary

Bumps `versionName` from 2.4.4 → 2.5.0 to mark the door-animation refactor (PR #539) with a Play Store whatsnew entry.

Per the versioning rule, the animation refactor is technically UI polish (no new capability), but a minor bump is being used deliberately so the change appears in the Play Store distribution notes.

## Test plan

- [x] Only `AndroidGarage/version.properties` modified
- [ ] Auto-merge once CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)