### PR TITLE
chore: Add Play Store whatsnew entry for 2.5

### DIFF
--- a/AndroidGarage/distribution/whatsnew/whatsnew-en-US
+++ b/AndroidGarage/distribution/whatsnew/whatsnew-en-US
@@ -1,3 +1,4 @@
+2.5: Smoother garage door animation.
 2.4: Redesigned garage door button with confirmation flow and network status diagram. Improved color contrast for accessibility.
 2.3: Improved architecture and performance.
 2.2: New colors and design!


### PR DESCRIPTION
## Summary

Adds the 2.5 entry to `AndroidGarage/distribution/whatsnew/whatsnew-en-US`. Pairs with PR #540 (versionName bump 2.4.4 → 2.5.0).

```
2.5: Smoother garage door animation.
```

The 2.5.0 release ships the door-animation refactor (PR #539) — `Animatable`-driven tween + spring replacing the old looping animation.

## Test plan

- [x] Only `whatsnew-en-US` modified
- [ ] Auto-merge once CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)