### PR TITLE
docs: Note animated-preview gotcha in update-android-screenshots skill

### DIFF
--- a/.claude/skills/update-android-screenshots/SKILL.md
+++ b/.claude/skills/update-android-screenshots/SKILL.md
@@ -72,6 +72,7 @@ Screenshots render differently across platforms (macOS vs Linux CI). To avoid th
 - `updateDebugScreenshotTest` and `validateDebugScreenshotTest` can't run in the same Gradle invocation
 - To force single-invocation: `./gradlew :android-screenshot-tests:updateDebugScreenshotTest -PforceAllScreenshots`
 - Preview composables must be deterministic — use fixed `Instant.parse(...)` for timestamps, never `Clock.System.now()` or `Random`
+- Animated composables (`rememberInfiniteTransition`, `Animatable`, `animateFloatAsState`) render at an arbitrary frame in screenshot tests. Wrap previews of animated UI in a static-mode rendering path — e.g. `GarageIcon(static = true)` — so the screenshot is deterministic. Caught when `OpeningPreview` was rendering at the start frame (offset 0.0) and looked identical to `Closed`; PR #543 fixed it by routing previews through `static = true` so they share the recent events list's `staticPositionFor` mapping.
 - Reference PNGs are committed to git but are NOT validated in CI
 - The gallery markdown is auto-generated — do not edit it manually
 - Previews that depend on `rememberAppComponent()` render blank in screenshot tests — use stateless overloads instead


### PR DESCRIPTION
## Summary

Adds a single bullet to the `update-android-screenshots` skill noting that animated composables (`rememberInfiniteTransition`, `Animatable`, `animateFloatAsState`) capture an arbitrary frame in screenshot tests, and the fix is to route previews through a static rendering path.

Caught during the door-animation refactor (PRs #539 → #543): the old `OpeningPreview` rendered at offset 0.0 because `rememberInfiniteTransition` started at the "from" end and the screenshot captured the first frame. The fix was to switch previews to `GarageIcon(static = true)` so they share the recent-events-list snapshot mapping.

## Test plan

- [x] Only `.claude/skills/update-android-screenshots/SKILL.md` modified
- [ ] Auto-merge once CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)