### PR TITLE
chore: Trim whatsnew + add length check + skill updates

### DIFF
--- a/.claude/skills/bump-android-version/SKILL.md
+++ b/.claude/skills/bump-android-version/SKILL.md
@@ -47,35 +47,39 @@ Apply the increment type to the current version:
 
 Write the new version to the file.
 
-### 4. (minor/major only) Draft the Play Store whatsnew entry
+### 4. (minor/major only) Replace the Play Store whatsnew
 
-For **minor** and **major** bumps, the Play Store gets a release note. For **patch** bumps, skip this step — patches roll up into the previous minor/major entry.
+For **minor** and **major** bumps, the Play Store gets a release note. For **patch** bumps, skip this step — patches roll up into the next minor/major's entry.
 
-The whatsnew file `AndroidGarage/distribution/whatsnew/whatsnew-en-US` is a flat list, newest first, one line per minor/major:
+`AndroidGarage/distribution/whatsnew/whatsnew-en-US` is **rolling, current-version-only**. Replace its entire content with a single entry for the new version. CHANGELOG.md is the permanent history (every version, including patches) — older whatsnew lines are already preserved there.
+
+Format:
 
 ```
-X.Y: Short user-facing description (1–2 sentences).
-2.4: Redesigned garage door button with confirmation flow and network status diagram. Improved color contrast for accessibility.
-2.3: Improved architecture and performance.
+X.Y: Short user-facing description.
 ```
 
-To draft the entry:
+- Single line preferred (matches the rest of the Play Store ecosystem).
+- Multiline allowed for minors when one line can't capture the change. Major releases can use multiple lines.
+- Whole file must stay under **500 bytes** (`scripts/check-whatsnew-length.sh` enforces; `validate.sh` calls it). Google Play rejects the upload otherwise — see release-failure tombstone `android/177` for the original incident.
 
-1. Read the current whatsnew file to see the established style.
-2. Find the commits since the last whatsnew entry (`git log --oneline <last-tag>..HEAD`) — focus on user-visible changes only.
-3. Draft a 1–2 sentence description in the same style. Match the tone of recent entries: direct, plain language, no jargon, no "we"/"I."
-4. **Present the draft to the user and wait for confirmation or edits before writing it.** Offer 2–3 phrasings if the right wording isn't obvious.
-5. After the user confirms, prepend the line to `whatsnew-en-US` (newest at top — note the line uses `X.Y`, not `X.Y.Z`).
+To draft:
+
+1. Find user-visible commits since the last whatsnew/release: `git log --oneline <last-tag>..HEAD`.
+2. Draft in the same style as recent CHANGELOG entries: direct, plain language, no jargon, no "we"/"I."
+3. **Present the draft to the user and wait for confirmation or edits before writing.** Offer 2–3 phrasings if the right wording isn't obvious. Confirm length stays under 500 bytes.
+4. After the user confirms, **overwrite** `whatsnew-en-US` with just the new entry. Do not prepend; do not preserve older lines. (CHANGELOG.md owns history.)
 
 ### 5. Create PR
 
 - Branch: `chore/bump-version-X.Y.Z`
-- Commit: `chore: Bump versionName to X.Y.Z` — for minor/major, the same commit also includes the whatsnew prepend
+- Commit: `chore: Bump versionName to X.Y.Z` — for minor/major, the same commit also includes the whatsnew replacement
 - Create PR with `--base main` and enable auto-merge
 
 ## Rules
 
 - Modify only `AndroidGarage/version.properties` (always) and `AndroidGarage/distribution/whatsnew/whatsnew-en-US` (minor/major only) — nothing else
-- Do not update the changelog (use `/update-android-changelog` for that)
-- Patches must not touch whatsnew — they roll up
+- Whatsnew is rolling — **replace**, never accumulate. CHANGELOG.md is the permanent history.
+- Do not update the changelog here (use `/update-android-changelog` for that)
+- Patches must not touch whatsnew — they roll up into the next minor/major
 - Confirm both the version bump *and* the whatsnew description with the user before creating the PR

--- a/.claude/skills/update-android-changelog/SKILL.md
+++ b/.claude/skills/update-android-changelog/SKILL.md
@@ -8,6 +8,8 @@ user-invocable: true
 
 Add an entry to `AndroidGarage/CHANGELOG.md` for the current version based on recent changes.
 
+`CHANGELOG.md` is the **permanent history** — every version (patch, minor, major) gets an entry. The Play Store `whatsnew/whatsnew-en-US` is the rolling, current-version-only counterpart maintained by `/bump-android-version`. When a minor/major ships, the whatsnew text gets distilled here too (or the changelog entry covers the same ground), so older whatsnew lines are never lost when whatsnew is overwritten.
+
 ## Steps
 
 ### 1. Read current version and changelog

--- a/AndroidGarage/distribution/whatsnew/whatsnew-en-US
+++ b/AndroidGarage/distribution/whatsnew/whatsnew-en-US
@@ -1,6 +1,1 @@
 2.5: Smoother garage door animation.
-2.4: Redesigned garage door button with confirmation flow and network status diagram. Improved color contrast for accessibility.
-2.3: Improved architecture and performance.
-2.2: New colors and design!
-2.1: Snooze the garage notifications! When the garage is open, you can snooze everyone's notifications for a limited time. The feature will only be enabled for the current garage door position.
-2.0: Brand new app! Built with Jetpack Compose for easier UI iteration.

--- a/scripts/check-whatsnew-length.sh
+++ b/scripts/check-whatsnew-length.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Check Play Store whatsnew files do not exceed Google's 500-character per-language limit.
+#
+# Background: Google Play rejects an upload if any per-language whatsnew file exceeds 500
+# characters. The release workflow learns this only at upload time (after a 5-minute build),
+# leaves a tombstone tag, and requires a re-release on a new tag. This script catches the
+# regression locally and in pre-submit CI via validate.sh.
+#
+# Exits 0 if all files pass, non-zero with a diagnostic on the first violation.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+WHATSNEW_DIR="AndroidGarage/distribution/whatsnew"
+MAX_BYTES=500
+FAIL=0
+
+if [ ! -d "$WHATSNEW_DIR" ]; then
+  echo "check-whatsnew-length: directory $WHATSNEW_DIR not found"
+  exit 1
+fi
+
+for file in "$WHATSNEW_DIR"/whatsnew-*; do
+  [ -f "$file" ] || continue
+  bytes=$(wc -c < "$file" | tr -d ' ')
+  name=$(basename "$file")
+  if [ "$bytes" -gt "$MAX_BYTES" ]; then
+    echo "FAIL: $name is $bytes bytes (max $MAX_BYTES)"
+    echo "  Google Play rejects whatsnew files over $MAX_BYTES bytes per language."
+    echo "  Fix: trim $file or replace older entries (CHANGELOG.md is the permanent history)."
+    FAIL=1
+  else
+    echo "OK:   $name ($bytes / $MAX_BYTES bytes)"
+  fi
+done
+
+exit $FAIL

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -120,6 +120,10 @@ step "Documentation front-matter (AGENTS.md contract)"
 "$REPO_ROOT/scripts/check-doc-frontmatter.sh" \
     && pass "doc front-matter" || fail "doc front-matter"
 
+step "Play Store whatsnew length (Google Play 500-char limit)"
+"$REPO_ROOT/scripts/check-whatsnew-length.sh" \
+    && pass "whatsnew length" || fail "whatsnew length"
+
 step "Room schema drift check"
 # After compilation, Room KSP generates schema JSON files.
 # If they differ from what's committed, the schema changed without being tracked.


### PR DESCRIPTION
## Summary

Recovers from the failed android/177 release (Google Play rejected upload because whatsnew-en-US was 504 bytes; per-language max is 500) and adds prevention so the same failure can't recur silently.

- **whatsnew-en-US** trimmed to just the current minor's entry. `CHANGELOG.md` is the permanent history (already has 2.0–2.4.4 documented); whatsnew is now rolling, current-version-only.
- **`scripts/check-whatsnew-length.sh`** — new standalone script that runs `wc -c < 500` against every `whatsnew-*` file. Called from `validate.sh` as a separate step (per-user request).
- **`bump-android-version` skill** — now overwrites whatsnew (not prepend). Documents the 500-byte limit and references the validator. Notes single-line preferred for minor bumps; multiline allowed.
- **`update-android-changelog` skill** — short note explaining the permanent-history-vs-rolling-whatsnew split.

The android/177 tag stays as a failed-deploy tombstone (no destructive ops). The 2.5 release will ship as android/178 on the new commit.

## Test plan

- [x] `./scripts/check-whatsnew-length.sh` — passes (37 / 500 bytes)
- [x] `./scripts/validate.sh` — passes including new step
- [ ] Auto-merge once CI passes
- [ ] Re-release as android/178 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)