### PR TITLE
ci: Auto-create issue on Android/Firebase release failure

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -7,6 +7,10 @@ on:
     tags:
       - 'server/[0-9]*'
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   verify-ci:
     name: Firebase Deploy Verify CI
@@ -61,3 +65,32 @@ jobs:
       - name: Deploy to Firebase
         run: firebase deploy --only functions --project "${{ secrets.FIREBASE_PROJECT_ID }}"
         working-directory: FirebaseServer
+
+  # Track release failures via a single GitHub issue (auto-create on failure,
+  # auto-close on the next successful release). Mirrors the post-merge CI pattern.
+  track-failure:
+    name: Track Firebase Release Failure
+    if: always()
+    needs: [verify-ci, deploy]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Determine overall result
+        id: result
+        run: |
+          VERIFY="${{ needs.verify-ci.result }}"
+          DEPLOY="${{ needs.deploy.result }}"
+          if [[ "$VERIFY" == "failure" || "$DEPLOY" == "failure" ]]; then
+            echo "overall=failure" >> $GITHUB_OUTPUT
+          elif [[ "$VERIFY" == "success" && "$DEPLOY" == "success" ]]; then
+            echo "overall=success" >> $GITHUB_OUTPUT
+          else
+            # Cancelled or skipped — neither create nor close an issue.
+            echo "overall=skipped" >> $GITHUB_OUTPUT
+          fi
+      - if: steps.result.outputs.overall != 'skipped'
+        uses: ./.github/actions/ci-failure-tracker
+        with:
+          label: release-failure/firebase
+          result: ${{ steps.result.outputs.overall }}
+          workflow-name: "Firebase Deploy (tag: ${{ github.ref_name }})"

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   release:
@@ -89,3 +90,18 @@ jobs:
           VERSION_CODE="${{ steps.validate.outputs.version_code }}"
           TAG="android/$VERSION_CODE"
           echo "::notice title=Android Release::Released $TAG to Play Store internal track (versionCode=$VERSION_CODE, package=com.chriscartland.garage)"
+
+  # Track release failures via a single GitHub issue (auto-create on failure,
+  # auto-close on the next successful release). Mirrors the post-merge CI pattern.
+  track-failure:
+    name: Track Android Release Failure
+    if: always()
+    needs: [release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/ci-failure-tracker
+        with:
+          label: release-failure/android
+          result: ${{ needs.release.result == 'success' && 'success' || 'failure' }}
+          workflow-name: "Android Release (tag: ${{ github.ref_name }})"


### PR DESCRIPTION
## Summary

Adds release-failure tracking to both `release-android.yml` and `firebase-deploy.yml` using the existing `.github/actions/ci-failure-tracker` composite action (already in use by post-merge CI).

- One open GitHub Issue per workflow at a time
- Auto-create on failure, auto-close on next success
- Labels: `release-failure/android`, `release-failure/firebase`
- Issue body includes run URL, commit, and originating PR

Motivated by the silent failure of android/177 — the Play Store rejected the upload (whatsnew over 500 bytes), the workflow showed red, but nothing surfaced an actionable issue. The user only noticed when the deploy didn't complete.

## Test plan

- [x] YAML edits use the existing composite action (already battle-tested by post-merge CI)
- [ ] Auto-merge once CI passes
- [ ] First failure of either workflow will exercise the issue-creation path

🤖 Generated with [Claude Code](https://claude.com/claude-code)