### PR TITLE
release: Gate Android release on AndroidGarage/CHANGELOG.md entry

### DIFF
--- a/.claude/skills/bump-android-version/SKILL.md
+++ b/.claude/skills/bump-android-version/SKILL.md
@@ -83,3 +83,9 @@ To draft:
 - Do not update the changelog here (use `/update-android-changelog` for that)
 - Patches must not touch whatsnew — they roll up into the next minor/major
 - Confirm both the version bump *and* the whatsnew description with the user before creating the PR
+
+## Companion: update CHANGELOG.md before releasing
+
+`AndroidGarage/CHANGELOG.md` is a separate file from this bump and is **required by the release script** — `./scripts/release-android.sh` blocks the tag push if `## X.Y.Z` (the new versionName) is missing or has an empty body. The whatsnew you set here covers the Play Store; the changelog is the permanent internal history.
+
+After this bump merges, run `/update-android-changelog` to draft the matching entry, OR include the changelog edit in the same PR if the user-facing description is already settled. The release-android skill will tell you the gate has failed if it's missed, but catching it earlier saves a round trip.

--- a/.claude/skills/release-android/SKILL.md
+++ b/.claude/skills/release-android/SKILL.md
@@ -6,7 +6,7 @@ description: Release the Android app to Play Store internal track via tag-based 
 
 Canonical procedure: `CLAUDE.md` § Releasing Android. This file is the agent-facing operational shortcut — it tells you the exact commands to run in order. The `--check` output is the source of truth for which command to paste.
 
-## The five steps
+## The six steps
 
 ```bash
 # 1. Clean state
@@ -15,17 +15,26 @@ git checkout main && git pull && git status   # working tree must be clean
 # 2. Validate
 ./scripts/validate.sh                          # required; the release script blocks on STALE/MISSING
 
-# 3. Read the next-step command from --check
+# 3. Add a CHANGELOG entry — REQUIRED by default
+# Edit AndroidGarage/CHANGELOG.md, add:
+#   ## X.Y.Z          (X.Y.Z = current versionName from version.properties)
+#   - One or more bullets describing user-facing changes
+# Commit and push. The release script blocks on missing/empty entries.
+# Use `/update-android-changelog` to draft.
+
+# 4. Read the next-step command from --check
 ./scripts/release-android.sh --check
-# This prints validation state (PASSED/STALE/MISSING) AND a copy-paste-ready command
-# for the right scenario (normal, rollback, emergency, unvalidated).
+# Prints validation state (PASSED/STALE/MISSING), versionName, changelog
+# state (PRESENT/EMPTY/MISSING), AND a copy-paste-ready command for the
+# right scenario (normal, rollback, emergency, unvalidated, no-changelog).
 
-# 4. Paste the command --check printed.
-# Normal:    ./scripts/release-android.sh --confirm-tag android/N
-# Rollback:  --confirm-tag, --confirm-hash, --confirm-rollback-from (with full SHAs)
-# Emergency: --confirm-tag, --confirm-unvalidated-release (with target SHA)
+# 5. Paste the command --check printed.
+# Normal:        ./scripts/release-android.sh --confirm-tag android/N
+# Rollback:      --confirm-tag, --confirm-hash, --confirm-rollback-from (with full SHAs)
+# Emergency:     --confirm-tag, --confirm-unvalidated-release (with target SHA)
+# No-changelog:  --confirm-tag, --confirm-no-changelog <sha>
 
-# 5. Watch the deploy
+# 6. Watch the deploy
 gh run list --workflow=release-android.yml --limit 1
 gh run watch <run-id>
 ```
@@ -36,6 +45,7 @@ gh run watch <run-id>
 - **Don't `git tag` directly.** Hooks block it.
 - **Don't deploy to production.** This script only deploys to the Play Store internal track.
 - **Don't skip validation without asking the user.** If `--check` shows validation is `STALE` or `MISSING`, the right move is almost always to run `./scripts/validate.sh`. Ask before reaching for `--confirm-unvalidated-release`.
+- **Don't skip the changelog.** `AndroidGarage/CHANGELOG.md` is the permanent history (every version, including patches). The Play Store whatsnew is rolling and only covers minor/major bumps. `--confirm-no-changelog <sha>` is for emergencies — write the entry retroactively.
 
 ## Versioning
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,10 @@ The script computes the next tag as `android/<highest + 1>`. The `--confirm-tag`
 
 **Validation is required by default.** Run `./scripts/validate.sh` before releasing. If validation hasn't passed on the commit, the release script will block. For emergencies use `--confirm-unvalidated-release <sha>` — the SHA must equal the target commit. Always ask the user before skipping validation.
 
+**Changelog entry is required by default.** `AndroidGarage/CHANGELOG.md` must have a `## X.Y.Z` heading (matching `versionName` in `version.properties`) with a non-empty body before the tag can be pushed. The release script parses `versionName` and looks for the heading; missing or empty bodies block the release. Draft with `/update-android-changelog`. For emergencies use `--confirm-no-changelog <sha>` — the SHA must equal the target commit. Add the entry retroactively after a no-changelog release.
+
+The changelog and the Play Store whatsnew are different files: `CHANGELOG.md` is the permanent internal history (every version, patches included); `distribution/whatsnew/` is rolling and only covers the current minor/major. Missing changelog entries silently went unnoticed through 2.5.0 (added in #548) — the gate closes that gap.
+
 **Rollback requires two steps** (intentionally hard to do accidentally):
 ```bash
 git checkout android/M                 # 1. move HEAD to the commit you want to re-release

--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -52,6 +52,7 @@ CONFIRM_TAG=""
 CONFIRM_HASH=""
 CONFIRM_ROLLBACK_FROM=""
 CONFIRM_UNVALIDATED_RELEASE=""
+CONFIRM_NO_CHANGELOG=""
 DRY_RUN=false
 
 show_help() {
@@ -75,6 +76,9 @@ Override flags (all require a specific value from --check output):
   --confirm-unvalidated-release <sha>
                                     Release without validation marker match.
                                     SHA must equal the target commit.
+  --confirm-no-changelog <sha>      Release without a CHANGELOG entry for the
+                                    current versionName. SHA must equal the
+                                    target commit. Add the entry retroactively.
 
 Help:
   -h, --help                Show this help
@@ -106,6 +110,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --confirm-unvalidated-release)
             CONFIRM_UNVALIDATED_RELEASE="$2"
+            shift 2
+            ;;
+        --confirm-no-changelog)
+            CONFIRM_NO_CHANGELOG="$2"
             shift 2
             ;;
         --dry-run)
@@ -183,6 +191,56 @@ if [ -f "$VALIDATION_FILE" ]; then
     fi
 fi
 
+# versionName from version.properties on the target commit. CHANGELOG.md
+# uses the human-readable X.Y.Z heading (not the android/N tag), so this
+# is the key we look up.
+VERSION_PROPERTIES="$REPO_ROOT/AndroidGarage/version.properties"
+VERSION_NAME=""
+if [ -f "$VERSION_PROPERTIES" ]; then
+    VERSION_NAME=$(grep -E '^versionName=' "$VERSION_PROPERTIES" 2>/dev/null | head -1 | cut -d= -f2 | tr -d '[:space:]')
+fi
+
+# CHANGELOG state for the versionName we're about to release.
+#   present  : `## X.Y.Z` heading exists and has non-empty body
+#   empty    : heading exists but body is whitespace-only
+#   missing  : no heading for this versionName
+#   no_file  : AndroidGarage/CHANGELOG.md does not exist
+#   no_ver   : versionName could not be parsed from version.properties
+#
+# Matching rules:
+# - Lines inside fenced code blocks (```...```) are ignored, in case the
+#   docs intro ever embeds an example release heading.
+# - Heading must be `^## X.Y.Z` followed by end-of-line or whitespace, so
+#   `## 2.5` does not falsely match `2.5.1`.
+CHANGELOG_FILE="$REPO_ROOT/AndroidGarage/CHANGELOG.md"
+CHANGELOG_STATE="no_file"
+CHANGELOG_BODY=""
+if [ -z "$VERSION_NAME" ]; then
+    CHANGELOG_STATE="no_ver"
+elif [ -f "$CHANGELOG_FILE" ]; then
+    CHANGELOG_BODY=$(awk -v ver="$VERSION_NAME" '
+        BEGIN { in_fence = 0; found = 0 }
+        /^```/ { in_fence = !in_fence; next }
+        in_fence { next }
+        $0 ~ ("^## "ver"([ ]|$)") { found = 1; next }
+        found && /^## / { exit }
+        found { print }
+    ' "$CHANGELOG_FILE")
+    HEADING_FOUND=$(awk -v ver="$VERSION_NAME" '
+        BEGIN { in_fence = 0 }
+        /^```/ { in_fence = !in_fence; next }
+        in_fence { next }
+        $0 ~ ("^## "ver"([ ]|$)") { print "yes"; exit }
+    ' "$CHANGELOG_FILE")
+    if [ -n "$(echo "$CHANGELOG_BODY" | tr -d '[:space:]')" ]; then
+        CHANGELOG_STATE="present"
+    elif [ "$HEADING_FOUND" = "yes" ]; then
+        CHANGELOG_STATE="empty"
+    else
+        CHANGELOG_STATE="missing"
+    fi
+fi
+
 # Rollback detection: target commit is already tagged (not the latest),
 # usually because the user ran `git checkout android/M` on an older tag.
 EXISTING_TAGS_ON_TARGET=$(git tag -l 'android/[0-9]*' --points-at "$TARGET_COMMIT" 2>/dev/null | sort -t/ -k2 -n || true)
@@ -213,6 +271,20 @@ if [ "$MODE" = "check" ]; then
             ;;
     esac
 
+    if [ -n "$VERSION_NAME" ]; then
+        echo "versionName:  $VERSION_NAME"
+    else
+        echo -e "versionName:  ${YELLOW}NOT FOUND${RESET} (could not parse AndroidGarage/version.properties)"
+    fi
+
+    case "$CHANGELOG_STATE" in
+        present) echo -e "Changelog:    ${GREEN}PRESENT${RESET} (entry for $VERSION_NAME in AndroidGarage/CHANGELOG.md)" ;;
+        empty)   echo -e "Changelog:    ${YELLOW}EMPTY${RESET} (heading for $VERSION_NAME has no body)" ;;
+        missing) echo -e "Changelog:    ${YELLOW}MISSING${RESET} (no heading for $VERSION_NAME in AndroidGarage/CHANGELOG.md)" ;;
+        no_file) echo -e "Changelog:    ${YELLOW}NO FILE${RESET} (AndroidGarage/CHANGELOG.md does not exist)" ;;
+        no_ver)  echo -e "Changelog:    ${YELLOW}SKIPPED${RESET} (versionName not found in version.properties)" ;;
+    esac
+
     if [ -n "$EXISTING_TAGS_ON_TARGET" ]; then
         echo "Target tags:  $(echo "$EXISTING_TAGS_ON_TARGET" | tr '\n' ' ')"
     fi
@@ -229,17 +301,21 @@ if [ "$MODE" = "check" ]; then
         echo "      --confirm-hash $TARGET_COMMIT \\"
         echo "      --confirm-rollback-from $LATEST_TAG_SHA"
         echo ""
+        EXTRAS=()
         if [ "$VALIDATION_STATE" != "matches" ]; then
-            echo "If you also need to skip validation (expected for old rollback targets), append:"
-            echo "      --confirm-unvalidated-release $TARGET_COMMIT"
+            EXTRAS+=("--confirm-unvalidated-release $TARGET_COMMIT")
+        fi
+        if [ "$CHANGELOG_STATE" != "present" ] && [ "$CHANGELOG_STATE" != "no_ver" ]; then
+            EXTRAS+=("--confirm-no-changelog $TARGET_COMMIT")
+        fi
+        if [ ${#EXTRAS[@]} -gt 0 ]; then
+            echo "Append the following for the conditions flagged above:"
+            for extra in "${EXTRAS[@]}"; do
+                echo "      $extra"
+            done
             echo ""
         fi
-    elif [ "$VALIDATION_STATE" = "matches" ]; then
-        echo "Copy and run this command to release:"
-        echo ""
-        echo "  ./scripts/release-android.sh --confirm-tag $NEW_TAG"
-        echo ""
-    else
+    elif [ "$VALIDATION_STATE" != "matches" ]; then
         echo "Validation is not passing for HEAD. Two options:"
         echo ""
         echo "(1) Run validation, then re-run --check (recommended):"
@@ -250,6 +326,30 @@ if [ "$MODE" = "check" ]; then
         echo "    ./scripts/release-android.sh \\"
         echo "        --confirm-tag $NEW_TAG \\"
         echo "        --confirm-unvalidated-release $TARGET_COMMIT"
+        echo ""
+    elif [ "$CHANGELOG_STATE" != "present" ] && [ "$CHANGELOG_STATE" != "no_ver" ]; then
+        echo "No CHANGELOG entry for $VERSION_NAME. Two options:"
+        echo ""
+        echo "(1) Add an entry, commit, push, re-run --check (recommended):"
+        echo ""
+        echo "    Use /update-android-changelog or edit AndroidGarage/CHANGELOG.md"
+        echo "    and add at the top (above the previous version):"
+        echo ""
+        echo "      ## $VERSION_NAME"
+        echo "      - <one or more bullets describing user-facing changes>"
+        echo ""
+        echo "    Then: git commit + push, ./scripts/validate.sh, ./scripts/release-android.sh --check"
+        echo ""
+        echo "(2) Release WITHOUT a changelog entry (emergency only):"
+        echo ""
+        echo "    ./scripts/release-android.sh \\"
+        echo "        --confirm-tag $NEW_TAG \\"
+        echo "        --confirm-no-changelog $TARGET_COMMIT"
+        echo ""
+    else
+        echo "Copy and run this command to release:"
+        echo ""
+        echo "  ./scripts/release-android.sh --confirm-tag $NEW_TAG"
         echo ""
     fi
 
@@ -377,6 +477,47 @@ else
         echo "  ./scripts/release-android.sh --check"
         exit 1
     fi
+fi
+
+# === Gate: CHANGELOG entry ===
+# AndroidGarage/CHANGELOG.md must have a `## X.Y.Z` heading with a non-empty
+# body for the current versionName. The Play Store whatsnew is rolling and
+# only covers minor/major bumps — the changelog is the permanent history,
+# every version (patch included). Mirrors the Firebase changelog gate.
+#
+# If versionName cannot be parsed (no_ver), skip the gate entirely — the
+# validation step would already have failed for any real release.
+if [ "$CHANGELOG_STATE" = "present" ]; then
+    FIRST_LINE=$(echo "$CHANGELOG_BODY" | grep -m1 -E '[^[:space:]]' || echo "")
+    echo -e "${GREEN}Changelog entry found for $VERSION_NAME.${RESET}"
+    if [ -n "$FIRST_LINE" ]; then
+        echo "  First line: $(echo "$FIRST_LINE" | head -c 120)"
+    fi
+elif [ "$CHANGELOG_STATE" = "no_ver" ]; then
+    echo -e "${YELLOW}Skipping changelog gate: versionName not found in version.properties.${RESET}"
+elif [ -n "$CONFIRM_NO_CHANGELOG" ]; then
+    if [ "$CONFIRM_NO_CHANGELOG" != "$TARGET_COMMIT" ]; then
+        echo -e "${RED}Error: --confirm-no-changelog SHA does not match target commit.${RESET}"
+        echo "  Expected (target commit): $TARGET_COMMIT"
+        echo "  Got:                      $CONFIRM_NO_CHANGELOG"
+        echo ""
+        echo "Run --check to see the correct value."
+        exit 1
+    fi
+    echo -e "${YELLOW}WARNING: Releasing without CHANGELOG entry (--confirm-no-changelog).${RESET}"
+    echo "  Add an entry to AndroidGarage/CHANGELOG.md after the fact."
+    echo ""
+else
+    case "$CHANGELOG_STATE" in
+        missing) REASON="no heading for $VERSION_NAME in AndroidGarage/CHANGELOG.md" ;;
+        empty)   REASON="heading for $VERSION_NAME exists but body is empty" ;;
+        no_file) REASON="AndroidGarage/CHANGELOG.md does not exist" ;;
+        *)       REASON="unknown" ;;
+    esac
+    echo -e "${RED}Error: CHANGELOG gate failed ($REASON).${RESET}"
+    echo ""
+    echo "Run --check to see how to fix (write the entry, or emergency override)."
+    exit 1
 fi
 
 # Existing tags on this commit (informational).

--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -194,10 +194,29 @@ fi
 # versionName from version.properties on the target commit. CHANGELOG.md
 # uses the human-readable X.Y.Z heading (not the android/N tag), so this
 # is the key we look up.
+#
+# Parser tolerates `versionName=2.5.0` and `versionName = 2.5.0` (.properties
+# files allow whitespace around `=`). The trailing tr removes surrounding
+# whitespace, including CR from CRLF line endings.
 VERSION_PROPERTIES="$REPO_ROOT/AndroidGarage/version.properties"
 VERSION_NAME=""
 if [ -f "$VERSION_PROPERTIES" ]; then
-    VERSION_NAME=$(grep -E '^versionName=' "$VERSION_PROPERTIES" 2>/dev/null | head -1 | cut -d= -f2 | tr -d '[:space:]')
+    VERSION_NAME=$(awk -F= '/^[[:space:]]*versionName[[:space:]]*=/ {
+        sub(/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*/, "")
+        gsub(/[[:space:]]/, "")
+        print
+        exit
+    }' "$VERSION_PROPERTIES")
+fi
+
+# Escape regex special chars in versionName so values like `2.5.0` or
+# `2.5.0-rc.1` are matched literally in awk's extended-regex pattern.
+# Only `.`, `+`, `*`, `?`, `(`, `)`, `[`, `]`, `{`, `}`, `^`, `$`, `\`, `|`
+# need to be escaped in a `## X` heading match. We use a single sed pass.
+VERSION_NAME_RE=""
+if [ -n "$VERSION_NAME" ]; then
+    # shellcheck disable=SC2001
+    VERSION_NAME_RE=$(echo "$VERSION_NAME" | sed 's/[][\\.+*?(){}^$|]/\\&/g')
 fi
 
 # CHANGELOG state for the versionName we're about to release.
@@ -206,19 +225,22 @@ fi
 #   missing  : no heading for this versionName
 #   no_file  : AndroidGarage/CHANGELOG.md does not exist
 #   no_ver   : versionName could not be parsed from version.properties
+#              — treated as a hard failure in the gate (can't ship a
+#              release whose version we can't read)
 #
 # Matching rules:
 # - Lines inside fenced code blocks (```...```) are ignored, in case the
 #   docs intro ever embeds an example release heading.
 # - Heading must be `^## X.Y.Z` followed by end-of-line or whitespace, so
-#   `## 2.5` does not falsely match `2.5.1`.
+#   `## 2.5` does not falsely match `2.5.1`. Dots are escaped in the
+#   pattern so the match is literal.
 CHANGELOG_FILE="$REPO_ROOT/AndroidGarage/CHANGELOG.md"
 CHANGELOG_STATE="no_file"
 CHANGELOG_BODY=""
 if [ -z "$VERSION_NAME" ]; then
     CHANGELOG_STATE="no_ver"
 elif [ -f "$CHANGELOG_FILE" ]; then
-    CHANGELOG_BODY=$(awk -v ver="$VERSION_NAME" '
+    CHANGELOG_BODY=$(awk -v ver="$VERSION_NAME_RE" '
         BEGIN { in_fence = 0; found = 0 }
         /^```/ { in_fence = !in_fence; next }
         in_fence { next }
@@ -226,7 +248,7 @@ elif [ -f "$CHANGELOG_FILE" ]; then
         found && /^## / { exit }
         found { print }
     ' "$CHANGELOG_FILE")
-    HEADING_FOUND=$(awk -v ver="$VERSION_NAME" '
+    HEADING_FOUND=$(awk -v ver="$VERSION_NAME_RE" '
         BEGIN { in_fence = 0 }
         /^```/ { in_fence = !in_fence; next }
         in_fence { next }
@@ -315,6 +337,14 @@ if [ "$MODE" = "check" ]; then
             done
             echo ""
         fi
+    elif [ "$CHANGELOG_STATE" = "no_ver" ]; then
+        echo -e "${RED}Cannot release: versionName not found in AndroidGarage/version.properties.${RESET}"
+        echo ""
+        echo "Fix version.properties — expected a line like:"
+        echo "    versionName=X.Y.Z"
+        echo ""
+        echo "Then re-run: ./scripts/release-android.sh --check"
+        echo ""
     elif [ "$VALIDATION_STATE" != "matches" ]; then
         echo "Validation is not passing for HEAD. Two options:"
         echo ""
@@ -327,7 +357,7 @@ if [ "$MODE" = "check" ]; then
         echo "        --confirm-tag $NEW_TAG \\"
         echo "        --confirm-unvalidated-release $TARGET_COMMIT"
         echo ""
-    elif [ "$CHANGELOG_STATE" != "present" ] && [ "$CHANGELOG_STATE" != "no_ver" ]; then
+    elif [ "$CHANGELOG_STATE" != "present" ]; then
         echo "No CHANGELOG entry for $VERSION_NAME. Two options:"
         echo ""
         echo "(1) Add an entry, commit, push, re-run --check (recommended):"
@@ -494,7 +524,10 @@ if [ "$CHANGELOG_STATE" = "present" ]; then
         echo "  First line: $(echo "$FIRST_LINE" | head -c 120)"
     fi
 elif [ "$CHANGELOG_STATE" = "no_ver" ]; then
-    echo -e "${YELLOW}Skipping changelog gate: versionName not found in version.properties.${RESET}"
+    echo -e "${RED}Error: versionName could not be parsed from AndroidGarage/version.properties.${RESET}"
+    echo "  Expected a line like: versionName=X.Y.Z"
+    echo "  Fix version.properties before releasing — do not use --confirm-no-changelog for this."
+    exit 1
 elif [ -n "$CONFIRM_NO_CHANGELOG" ]; then
     if [ "$CONFIRM_NO_CHANGELOG" != "$TARGET_COMMIT" ]; then
         echo -e "${RED}Error: --confirm-no-changelog SHA does not match target commit.${RESET}"


### PR DESCRIPTION
## Summary

Mirrors the Firebase release-script changelog gate (#463) on the Android side. `scripts/release-android.sh` now parses `versionName` from `AndroidGarage/version.properties`, looks for a `## X.Y.Z` heading with non-empty body in `AndroidGarage/CHANGELOG.md`, and blocks the tag push if the entry is missing or empty.

Why this matters: 2.5.0 shipped as `android/178` with no changelog entry. The Play Store whatsnew was updated, but the permanent internal history was missed because the pipeline only checked whatsnew. The matching CHANGELOG entry landed in #548; this PR closes the detection gap so it can't happen silently again.

## Changes

- `scripts/release-android.sh` — parse versionName (whitespace-tolerant, regex-escaped), extract changelog state with the same fenced-code-block-aware awk approach as `release-firebase.sh`, surface state in `--check`, gate the tag push, emit a copy-paste-ready fix recipe when missing.
- `--confirm-no-changelog <sha>` emergency override (SHA must equal target commit, mirroring existing override-confirm-reality pattern).
- `CLAUDE.md` § Releasing Android — documents the gate and clarifies the CHANGELOG vs Play Store whatsnew split.
- `.claude/skills/release-android` — adds "step 3: write changelog entry" to the procedure, "Don't skip the changelog" to the don'ts.
- `.claude/skills/bump-android-version` — cross-link to `/update-android-changelog` so the bump-then-release flow surfaces both files.

## Edge cases verified

Smoke-tested by spoofing `version.properties` and `CHANGELOG.md`:

- **PRESENT** — `versionName=2.5.0` with matching heading + body → green check.
- **MISSING** — `versionName=9.9.9` with no heading → yellow status, fix-recipe in `--check`.
- **EMPTY** — heading exists with no body → yellow status, gate fails.
- **NO_VER** — versionName line removed/unparseable → red status, hard fail directs to fix `version.properties` (does NOT suggest `--confirm-no-changelog`).
- **Prefix collision** — `versionName=2.5` does not falsely match `## 2.5.0` (escape + word-boundary check).
- **Exact match with longer-prefix neighbor** — `versionName=2.4` correctly matches `## 2.4` even though `## 2.4.4` is in the same file.
- **Whitespace tolerance** — `versionName = 2.5.0` (spaces around `=`) parses correctly.

## Test plan

- [x] `--check` smoke tests across all five state transitions
- [x] Help text shows the new `--confirm-no-changelog` flag
- [x] PRESENT case on this branch reports `Changelog: PRESENT (entry for 2.5.0 in AndroidGarage/CHANGELOG.md)`
- [ ] CI passes (front-matter, lints, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)