### PR TITLE
docs: Document gh pr merge --delete-branch + auto-merge gotcha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,6 +276,8 @@ The app requires secrets in `local.properties` (decrypted from GPG at build time
 - Create multiple non-conflicting PRs in parallel — don't wait for CI on each one
 - `cd` and `git -C` are blocked by hooks — run all commands from the repository root
 
+**Branch deletion is repo-level, not flag-level.** `gh pr merge --squash --delete-branch` only deletes the head branch when gh performs the merge **synchronously**. When you enable auto-merge with `gh pr merge --auto --squash --delete-branch <N>`, GitHub performs the actual merge later — and `--delete-branch` is **silently ignored** in that path. Result: stale branches accumulate post-merge. The fix is the repo-level `delete_branch_on_merge: true` setting (toggled on 2026-04-25 after a one-time cleanup of ~457 stale branches). With it enabled, every merged PR — sync or auto-merge — has its head branch auto-deleted. To verify or re-enable: `gh api repos/cartland/SmartGarageDoor --jq '.delete_branch_on_merge'` (must return `true`).
+
 ### Keeping PRs Mergeable
 Branch protection requires PRs to be up-to-date with main before merging. This means PRs merge one at a time and each merge can make others stale.
 


### PR DESCRIPTION
## Summary

Captures the operational lesson from the 2026-04-25 branch cleanup. `gh pr merge --delete-branch` is silently ignored when auto-merge fires later (vs synchronous merge); only the repo-level `delete_branch_on_merge` setting controls deletion in that path.

Audit found 473 remote / 468 local branches accumulated post-merge despite consistent `--delete-branch` use. Fix: flipped `delete_branch_on_merge: true` at the repo level and bulk-deleted 457 stale remote refs + 444 local [gone] branches.

## Changes

- `CLAUDE.md` § PR Workflow — adds a paragraph explaining the gotcha and the verification command (`gh api ... --jq '.delete_branch_on_merge'`).

## Test plan
- [x] Front-matter unchanged
- [x] Verified `delete_branch_on_merge` is now `true` on the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)