### PR TITLE
docs: Fix stale refs in ARCHITECTURE.md + FirebaseServer/README.md

### DIFF
--- a/AndroidGarage/docs/ARCHITECTURE.md
+++ b/AndroidGarage/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 ---
 category: reference
 status: active
-last_verified: 2026-04-24
+last_verified: 2026-04-25
 ---
 # Architecture
 
@@ -145,7 +145,7 @@ Packages under `androidApp/src/main/java/com/chriscartland/garage/`:
 1. UI → `RemoteButtonViewModel.onButtonTap()` → `ButtonStateMachine.onTap()`
 2. State machine: Ready → Preparing (500ms) → AwaitingConfirmation (5s timeout) → tap → SendingToServer
 3. On confirm: `onSubmit` callback → `PushRemoteButtonUseCase` checks auth, refreshes token if expired
-4. `PushRepository.push(idToken, buttonAckToken)` → POST `/addRemoteButtonCommand`
+4. `RemoteButtonRepository.push(idToken, buttonAckToken)` → POST `/addRemoteButtonCommand` (PushRepository was split into `RemoteButtonRepository` + `SnoozeRepository` in PR #203)
 5. State machine observes `pushButtonStatus`: SendingToServer → SendingToDoor (server ack) → Succeeded (door moves)
 6. Failure paths: ServerFailed / DoorFailed → Ready after display delay
 7. All transitions atomic via single Channel consumer; testable with virtual time
@@ -161,7 +161,7 @@ Packages under `androidApp/src/main/java/com/chriscartland/garage/`:
 
 ## Dependency Injection (kotlin-inject)
 
-All dependencies wired in `AppComponent` (see `docs/archive/DI-MIGRATION.md` for the Hilt→kotlin-inject migration history and `docs/DI_SINGLETON_REQUIREMENTS.md` for `@Singleton` correctness rules).
+All dependencies wired in `AppComponent` (see `archive/DI-MIGRATION.md` for the Hilt→kotlin-inject migration history and `DI_SINGLETON_REQUIREMENTS.md` for `@Singleton` correctness rules).
 
 Entry points exposed by `AppComponent` (abstract vals — required for `@Singleton` caching, see CLAUDE.md):
 
@@ -183,7 +183,7 @@ Safety rails enforced by `validate.sh`:
 ## State Management
 
 - **`LoadingResult<T>`** (sealed class): `Loading(data?)`, `Complete(data?)`, `Error(exception)`. Used by DoorViewModel to represent fetch state.
-- **`RemoteButtonState`** (sealed): Ready, Arming, Armed, NotConfirmed, Sending, Sent, Received, SendingTimeout, SentTimeout. Unified state for the remote garage button — combines tap-to-confirm interaction and network/door request lifecycle. Owned by `ButtonStateMachine` in `usecase/`.
+- **`RemoteButtonState`** (sealed): `Ready`, `Preparing`, `AwaitingConfirmation`, `Cancelled`, `SendingToServer`, `SendingToDoor`, `Succeeded`, `ServerFailed`, `DoorFailed`. Unified state for the remote garage button — combines tap-to-confirm interaction with network/door request tracking. Owned by `ButtonStateMachine` in `usecase/`. See [`RemoteButtonState.kt`](../domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/RemoteButtonState.kt) for the full state diagram in KDoc.
 - **`SnoozeState`** (sealed): Loading, NotSnoozing, Snoozing(until). Always-visible current snooze status from server.
 - **`SnoozeAction`** (sealed): Idle, Sending, Succeeded.{Cleared, Set}, Failed.{NotAuthenticated, MissingData, NetworkError}. Overlay on top of SnoozeState; auto-resets to Idle after 10s.
 - **`AuthState`** (sealed): Unknown, Unauthenticated, Authenticated(user). Drives sign-in UI.

--- a/FirebaseServer/README.md
+++ b/FirebaseServer/README.md
@@ -1,7 +1,7 @@
 ---
 category: reference
 status: active
-last_verified: 2026-04-24
+last_verified: 2026-04-25
 ---
 # Garage Server
 
@@ -76,7 +76,7 @@ Update the server configuration in `serverConfig.json`, then push it to the serv
 curl -H "Content-Type: application/json" -H "X-ServerConfigKey: $SERVER_CONFIG_UPDATE_KEY" https://us-central1-escape-echo.cloudfunctions.net/serverConfigUpdate -d @serverConfig.json
 ```
 
-Example config payload (illustrative — the live values are managed in production via `httpServerConfigUpdate`; see `docs/FIREBASE_HARDENING_PLAN.md` for the buildTimestamp config-authority rule shipped in `server/16` / `server/17`):
+Example config payload (illustrative — the live values are managed in production via `httpServerConfigUpdate`; see [`docs/FIREBASE_CONFIG_AUTHORITY.md`](../docs/FIREBASE_CONFIG_AUTHORITY.md) for the buildTimestamp config-authority rule shipped in `server/16` / `server/17`):
 
 ```json
 {
@@ -121,11 +121,16 @@ firebase init
 ```
 
 ### Deployment
-Deploy to Firebase:
+
+**Production deploys are tag-driven.** Use [`scripts/release-firebase.sh`](../scripts/release-firebase.sh) — it validates locally, requires a `## server/N` entry in [`CHANGELOG.md`](CHANGELOG.md), pushes the tag, and the GitHub Actions workflow deploys. Always start with `--check`:
 
 ```bash
-firebase deploy
+./scripts/release-firebase.sh --check    # Prints the next command, with SHA + tag pre-filled
 ```
+
+Full deploy procedure, rollback, monitoring, GCP setup, and troubleshooting: [`docs/FIREBASE_DEPLOY_SETUP.md`](../docs/FIREBASE_DEPLOY_SETUP.md). Release rules and the changelog gate: [`CLAUDE.md` § Releasing Firebase Server](../CLAUDE.md#releasing-firebase-server).
+
+A direct `firebase deploy` from a developer machine is **not the supported path** for production — it skips CI validation and the changelog gate.
 
 ## License
 


### PR DESCRIPTION
## Summary
- ARCHITECTURE.md: fix broken DI-MIGRATION.md link path; replace stale `RemoteButtonState` enum values; fix stale `PushRepository.push(...)` reference
- FirebaseServer/README.md: redirect from archived `FIREBASE_HARDENING_PLAN.md` to active `FIREBASE_CONFIG_AUTHORITY.md`; replace bare `firebase deploy` with pointer to `release-firebase.sh` + `docs/FIREBASE_DEPLOY_SETUP.md`
- `last_verified` bumped to 2026-04-25 on both

Surfaced by a 20-agent doc analysis run (this session). All link targets verified to exist.

## Test plan
- [x] `scripts/check-doc-frontmatter.sh` passes locally
- [x] Internal link targets verified (`AndroidGarage/docs/archive/DI-MIGRATION.md`, `docs/FIREBASE_CONFIG_AUTHORITY.md`, `scripts/release-firebase.sh`, `docs/FIREBASE_DEPLOY_SETUP.md`)
- [x] `RemoteButtonState` values match `domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/RemoteButtonState.kt`
- [ ] CI: docs-only fast path (paths-filter should match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)