### PR TITLE
docs: TL;DR for DI_SINGLETON_REQUIREMENTS + status banner for MIGRATION_PLAN

### DIFF
--- a/AndroidGarage/docs/DI_SINGLETON_REQUIREMENTS.md
+++ b/AndroidGarage/docs/DI_SINGLETON_REQUIREMENTS.md
@@ -1,9 +1,11 @@
 ---
 category: reference
 status: active
-last_verified: 2026-04-24
+last_verified: 2026-04-25
 ---
 # DI Singleton Requirements and Verification
+
+> **TL;DR for adding a new `@Singleton` provider:** every `@Singleton` provider must be (1) reachable via an `abstract val x: T` entry point on `AppComponent` (otherwise kotlin-inject silently skips caching) and (2) declared as a `@Provides fun` whose body takes its dependencies as parameters — never call a sibling `provideX()` from inside the body. Validate with `./gradlew -p AndroidGarage checkSingletonCaching`. The kotlin-inject background — what the rule means and why it works — is in [`guides/kotlin-inject.md`](guides/kotlin-inject.md); this doc is the Smart Garage Door-specific contract and the android/170 recovery.
 
 Reference for the kotlin-inject `@Singleton` scoping bug discovered during
 the android/170 snooze-state investigation (2026-04-19). Captures what

--- a/AndroidGarage/docs/MIGRATION_PLAN.md
+++ b/AndroidGarage/docs/MIGRATION_PLAN.md
@@ -1,8 +1,11 @@
 ---
 category: plan
 status: active
+last_verified: 2026-04-25
 ---
 # Migration Plan — ADR-021 + ADR-022
+
+> **Status (2026-04-25):** Phase 1 shipped 2026-04-19 (PRs #358–#366). Phase 2 is **deferred** — re-open only if a new state-y bug surfaces. Phase 3 (iOS) defers to [`MIGRATION.md`](MIGRATION.md) Phase 38.
 
 Rollout plan for the state-ownership principles (ADR-021) and the
 repository-owns-`StateFlow` shape (ADR-022). Motivated by the


### PR DESCRIPTION
## Summary
- DI_SINGLETON_REQUIREMENTS.md: add a one-paragraph TL;DR at the top so contributors adding a new `@Singleton` provider don't have to read the full android/170 postmortem to know the rule. Cross-links to `guides/kotlin-inject.md`.
- MIGRATION_PLAN.md: add a visible status banner — Phase 1 shipped 2026-04-19 (PRs #358–#366), Phase 2 deferred, Phase 3 → MIGRATION.md Phase 38. Surfaces completion that was previously only inferable from buried date references.

Both changes flagged by 20-agent doc analysis as the highest-leverage clarity wins for these specific files.

## Test plan
- [x] `scripts/check-doc-frontmatter.sh` passes
- [x] Internal links verified (`guides/kotlin-inject.md`, `MIGRATION.md`)
- [x] No content reorganization — additive only, preserves existing structure
- [ ] CI: docs-only fast path

🤖 Generated with [Claude Code](https://claude.com/claude-code)