### PR TITLE
docs(CLAUDE.md): Fix DI-MIGRATION link + add ask-before-PR workflow rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ idf.py menuconfig      # Enable fake implementations for testing
 - **Repositories** (impls in `data/`, interfaces in `domain/`): `DoorRepository`, `AuthRepository`, `RemoteButtonRepository`, `SnoozeRepository`, `DoorFcmRepository`, `ServerConfigRepository`, `AppLoggerRepository`, `AppSettingsRepository` — `PushRepository` was split into `RemoteButtonRepository` + `SnoozeRepository` in #203
 - **Typed errors**: `AppResult<D, E>` and `NetworkResult<T>` with sealed error types — exhaustive `when`, no `else`. See ADR-010, ADR-011
 - **Platform bridges**: `AuthBridge`, `MessagingBridge` decouple Firebase SDK — enables unit testing and future iOS
-- **DI**: kotlin-inject (`AppComponent`) — Hilt fully removed. See `docs/archive/DI-MIGRATION.md`
+- **DI**: kotlin-inject (`AppComponent`) — Hilt fully removed. See `AndroidGarage/docs/archive/DI-MIGRATION.md`
 - **Local storage**: Room database with offline-first caching
 - **Network**: Ktor HTTP client + kotlinx.serialization, `NetworkResult<T>` at data source boundary
 
@@ -269,6 +269,8 @@ The app requires secrets in `local.properties` (decrypted from GPG at build time
 - Scripts: `release/decrypt-secrets.sh`, `release/clean-secrets.sh`
 
 ### PR Workflow
+- **After modifying files, ask the user what to do with them.** Never end a session with a dirty tree without surfacing the question. Don't open a PR, commit, or revert autonomously — ask first. The user usually wants fast PR creation, but wants to confirm scope and timing each time files change.
+- **Auto-merge — first-PR ask.** On the first PR of a session, ask whether to enable auto-merge. Offer three answers: one-time (this PR only), session default (apply to every later PR you open in this session), or no. Once a session default is given, don't re-ask about auto-merge — but still ask before opening each subsequent PR.
 - Always create feature branches — never push to main
 - Always `--squash --delete-branch` when merging PRs
 - Never use `--admin` to bypass CI — enforce_admins is enabled


### PR DESCRIPTION
## Summary
Two changes to CLAUDE.md:

1. **Link fix** (line 95): `docs/archive/DI-MIGRATION.md` → `AndroidGarage/docs/archive/DI-MIGRATION.md` — the file is under `AndroidGarage/`, not `/docs/`. Surfaced by 20-agent doc analysis (agent A17 cross-reference audit).

2. **New PR Workflow rules** (top of section):
   - **After modifying files, ask the user what to do with them.** Don't open a PR, commit, or revert autonomously. Never end a session with a dirty tree without surfacing the question.
   - **Auto-merge — first-PR ask.** On the first PR of a session, ask whether to enable auto-merge. Three answers: one-time / session default / no. Once a session default is given, don't re-ask about auto-merge — but still ask before opening each subsequent PR.

## Why
Existing PR Workflow guidance covered *how* to make PRs (squash, branches, parallel non-conflicting) but never *when* to make one. Agents (this one included) were leaving dirty trees at session end. The new rules close that gap and codify the user's preferred interaction pattern.

## Safety
- Per agent A19's load-bearing audit, this section is read by agents but not parsed by scripts. The bullet wording is safe to extend.
- No existing rule wording was changed; only two new bullets added at the top.

## Test plan
- [x] `scripts/check-doc-frontmatter.sh` passes
- [x] DI-MIGRATION.md target verified at `AndroidGarage/docs/archive/DI-MIGRATION.md`
- [ ] CI: docs-only fast path

🤖 Generated with [Claude Code](https://claude.com/claude-code)