### PR TITLE
feat(remote-button): Faster recovery from missed confirmation

### DIFF
--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ButtonStateMachine.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ButtonStateMachine.kt
@@ -59,7 +59,7 @@ import kotlinx.coroutines.launch
  *
  * Failure paths:
  *   AwaitingConfirmation --(confirmationTimeoutMillis)--> Cancelled
- *     --(displayMillis)--> Ready
+ *     --(cancelledDisplayMillis)--> Ready
  *   SendingToServer --(networkTimeoutMillis)--> ServerFailed
  *     --(displayMillis)--> Ready
  *   SendingToDoor --(networkTimeoutMillis)--> DoorFailed
@@ -74,6 +74,7 @@ class ButtonStateMachine(
     private val confirmationTimeoutMillis: Long = DEFAULT_CONFIRMATION_TIMEOUT,
     private val networkTimeoutMillis: Long = DEFAULT_NETWORK_TIMEOUT,
     private val displayMillis: Long = DEFAULT_DISPLAY,
+    private val cancelledDisplayMillis: Long = DEFAULT_CANCELLED_DISPLAY,
 ) {
     private val _state = MutableStateFlow<RemoteButtonState>(RemoteButtonState.Ready)
     val state: StateFlow<RemoteButtonState> = _state
@@ -163,7 +164,7 @@ class ButtonStateMachine(
             Event.ConfirmationTimedOut -> {
                 if (current == RemoteButtonState.AwaitingConfirmation) {
                     transitionTo(RemoteButtonState.Cancelled)
-                    scheduleTimer(displayMillis, Event.DisplayTimedOut)
+                    scheduleTimer(cancelledDisplayMillis, Event.DisplayTimedOut)
                 }
             }
             Event.NetworkTimedOut -> when (current) {
@@ -274,8 +275,9 @@ class ButtonStateMachine(
 
     companion object {
         const val DEFAULT_PREPARING_DELAY = 500L
-        const val DEFAULT_CONFIRMATION_TIMEOUT = 5_000L
+        const val DEFAULT_CONFIRMATION_TIMEOUT = 8_000L
         const val DEFAULT_NETWORK_TIMEOUT = 10_000L
         const val DEFAULT_DISPLAY = 10_000L
+        const val DEFAULT_CANCELLED_DISPLAY = 2_000L
     }
 }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ButtonStateMachineTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ButtonStateMachineTest.kt
@@ -32,6 +32,7 @@ private const val PREPARING_DELAY = 500L
 private const val CONFIRMATION_TIMEOUT = 5_000L
 private const val NETWORK_TIMEOUT = 10_000L
 private const val DISPLAY = 10_000L
+private const val CANCELLED_DISPLAY = 2_000L
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ButtonStateMachineTest {
@@ -51,6 +52,7 @@ class ButtonStateMachineTest {
             confirmationTimeoutMillis = CONFIRMATION_TIMEOUT,
             networkTimeoutMillis = NETWORK_TIMEOUT,
             displayMillis = DISPLAY,
+            cancelledDisplayMillis = CANCELLED_DISPLAY,
         )
         testScheduler.runCurrent()
         return sm
@@ -144,7 +146,7 @@ class ButtonStateMachineTest {
             testScheduler.runCurrent()
             assertEquals(RemoteButtonState.Cancelled, sm.state.value)
 
-            advanceTimeBy(DISPLAY + 1)
+            advanceTimeBy(CANCELLED_DISPLAY + 1)
             testScheduler.runCurrent()
             assertEquals(RemoteButtonState.Ready, sm.state.value)
         }


### PR DESCRIPTION
## Summary

- Lengthen `AwaitingConfirmation` window from 5s → 8s so a slightly slow user is less likely to hit Cancelled.
- Flash `Cancelled` for 2s instead of 10s so retry is fast when they do miss.
- Failure-state display (`ServerFailed`, `DoorFailed`) unchanged at 10s — those still need readable error feedback.

## How

- Added `DEFAULT_CANCELLED_DISPLAY = 2_000L` and a `cancelledDisplayMillis` constructor parameter.
- Routed only the `ConfirmationTimedOut` branch through the shorter timer; the three failure branches keep `displayMillis` (10s).
- Bumped `DEFAULT_CONFIRMATION_TIMEOUT` from 5_000L to 8_000L.
- Test updated to pass `cancelledDisplayMillis` explicitly so the assertion is deterministic.

## Why this shape

Considered ~10 alternatives (tap-to-skip, tap-to-rearm, undo-after-action, hold-to-confirm, countdown ring, etc.). All other options either added new UI affordances, double-tap risk, or paradigm-shift confusion. This change is two constants + one constructor param, no new code paths, no UI changes, no race conditions.

## Test plan

- [x] `./gradlew :usecase:testDebugUnitTest` passes locally
- [ ] CI green
- [ ] Manual: tap → wait past 5s but before 8s → confirm still works
- [ ] Manual: tap → wait past 8s → see Cancelled flash briefly (~2s) → button returns to Ready quickly
- [ ] Manual: trigger ServerFailed / DoorFailed → terminal display still shows for full 10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)