### PR TITLE
fix(docs): Honor AGENTS.md front-matter contract

### DIFF
--- a/AndroidGarage/docs/SCREENSHOT_FRAMING_PLAN.md
+++ b/AndroidGarage/docs/SCREENSHOT_FRAMING_PLAN.md
@@ -1,6 +1,6 @@
 ---
 category: plan
-status: stable
+status: shipped
 ---
 
 # Screenshot Framing Plan

--- a/scripts/check-doc-frontmatter.sh
+++ b/scripts/check-doc-frontmatter.sh
@@ -64,6 +64,7 @@ should_skip() {
         */.claude/projects/*) return 0 ;;
         */android-screenshot-tests/*SCREENSHOT_GALLERY.md) return 0 ;;
         */android-screenshot-tests/collections/*) return 0 ;;
+        */screenshots/framed/COLLECTION.md) return 0 ;;
         */detekt.md) return 0 ;;
         */GarageFirmware_ESP32/*) return 0 ;;
         */Arduino_ESP32/*) return 0 ;;


### PR DESCRIPTION
Two doc validation errors surfaced by \`./scripts/validate.sh\` (blocking the in-flight Android release):

1. \`SCREENSHOT_FRAMING_PLAN.md\` had \`status: stable\` after the plan closed out today, but the AGENTS.md contract only allows \`active | shipped | superseded\`. Plan is done → \`status: shipped\`.
2. \`AndroidGarage/screenshots/framed/COLLECTION.md\` is auto-generated by \`scripts/frame-screenshot.py\` and doesn't carry YAML front-matter. Add it to the validator skip list, paralleling the existing exemption for \`SCREENSHOT_GALLERY.md\` and other generated collection markdown.

Both fixes verified locally — \`./scripts/check-doc-frontmatter.sh\` now exits 0.

After this lands the Android release flow can resume.