### PR TITLE
cleanup(docs): Drop unused skip-list line for the deleted COLLECTION.md

### DIFF
--- a/scripts/check-doc-frontmatter.sh
+++ b/scripts/check-doc-frontmatter.sh
@@ -64,7 +64,6 @@ should_skip() {
         */.claude/projects/*) return 0 ;;
         */android-screenshot-tests/*SCREENSHOT_GALLERY.md) return 0 ;;
         */android-screenshot-tests/collections/*) return 0 ;;
-        */screenshots/framed/COLLECTION.md) return 0 ;;
         */detekt.md) return 0 ;;
         */GarageFirmware_ESP32/*) return 0 ;;
         */Arduino_ESP32/*) return 0 ;;


### PR DESCRIPTION
\`*/screenshots/framed/COLLECTION.md\` was added to the doc-frontmatter validator skip list in #569 as a temporary exemption for the auto-generated python-emitted index. PR #570 superseded that approach (moved generation under the YAML-driven \`collections/\` system, deleted \`COLLECTION.md\`). The skip-list line is now dead code.

One-line removal. Validator still exits 0 locally.