### PR TITLE
chore(android): Bump 2.5.1 → 2.6.0 + Function List changelog

### DIFF
--- a/AndroidGarage/CHANGELOG.md
+++ b/AndroidGarage/CHANGELOG.md
@@ -15,6 +15,10 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
 
+## 2.6.0
+- New **Function List** screen on the Settings tab. Tapping "Function list" opens a screen with quick-access buttons for the actions you'd otherwise reach across multiple tabs: open or close the garage door, refresh the door status or history, snooze notifications for an hour, sign in or sign out. Reachable via an up-arrow back to Settings.
+- Function List is gated by a server-maintained email allowlist. Out of the box the screen shows "Access not enabled for your account" — only users explicitly added to the allowlist (in the Firebase console) see the buttons.
+
 ## 2.5.1
 - Faster re-tap after a cancelled remote-button confirmation. The "Cancelled" state now clears in 2 seconds (was 10), and the confirmation tap window is extended to 8 seconds (was 5). Re-tapping to retry happens immediately instead of waiting for the long banner.
 - Updated clock and calendar icons in the door status card to standard Material designs (stopwatch + calendar grid). Functionally equivalent; visually slightly heavier.

--- a/AndroidGarage/distribution/whatsnew/whatsnew-en-US
+++ b/AndroidGarage/distribution/whatsnew/whatsnew-en-US
@@ -1,1 +1,1 @@
-2.5: Smoother garage door animation.
+2.6: New Function List screen on Settings — quick access to common actions, gated by a server-maintained allowlist.

--- a/AndroidGarage/version.properties
+++ b/AndroidGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.5.1
+versionName=2.6.0


### PR DESCRIPTION
## Summary

Minor bump for the Function List screen shipped in PR #573 (new user-facing capability per the versioning rule). Adds the `## 2.6.0` `CHANGELOG.md` entry + Play Store whatsnew line. The release-android script gates on the `## X.Y.Z` heading existing before the tag is pushed.

## Test plan

- [x] `versionName=2.6.0` matches `## 2.6.0` heading.
- [x] whatsnew updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)