### PR TITLE
Gate Settings "Function list" entry button on featureFunctionList allowlist

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -177,7 +177,11 @@ abstract class AppComponent(
     ): DefaultAppLoggerViewModel = DefaultAppLoggerViewModel(logAppEvent, observeAppLogCount, dispatchers)
 
     @Provides
-    fun provideAppSettingsViewModel(appSettings: AppSettingsUseCase): DefaultAppSettingsViewModel = DefaultAppSettingsViewModel(appSettings)
+    fun provideAppSettingsViewModel(
+        appSettings: AppSettingsUseCase,
+        observeFeatureAccess: ObserveFeatureAccessUseCase,
+        dispatchers: DispatcherProvider,
+    ): DefaultAppSettingsViewModel = DefaultAppSettingsViewModel(appSettings, observeFeatureAccess, dispatchers)
 
     @Provides
     fun provideDoorViewModel(

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
@@ -81,6 +81,7 @@ fun ProfileContent(
     val snoozeAction by buttonViewModel.snoozeAction.collectAsState()
     val userCardExpanded by settingsViewModel.profileUserCardExpanded.collectAsState()
     val appCardExpanded by settingsViewModel.profileAppCardExpanded.collectAsState()
+    val functionListAccess by settingsViewModel.functionListAccess.collectAsState()
     val appVersion = LocalContext.current.AppVersion()
 
     LaunchedEffect(Unit) {
@@ -112,6 +113,7 @@ fun ProfileContent(
         appCardExpanded = appCardExpanded,
         onAppCardExpandedChange = { settingsViewModel.setProfileAppCardExpanded(it) },
         onNavigateToFunctionList = onNavigateToFunctionList,
+        functionListAccess = functionListAccess,
     )
 }
 
@@ -134,6 +136,7 @@ fun ProfileContent(
     appCardExpanded: Boolean? = true,
     onAppCardExpandedChange: (Boolean) -> Unit = {},
     onNavigateToFunctionList: () -> Unit = {},
+    functionListAccess: Boolean? = null,
 ) {
     val cardColors = CardDefaults.cardColors(
         containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
@@ -188,12 +191,16 @@ fun ProfileContent(
                 )
             }
         }
-        item {
-            Button(
-                onClick = onNavigateToFunctionList,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text(text = "Function list")
+        // Gate on `== true` only — `null` (loading/signed-out/error) and
+        // `false` (server denies) both deny. See docs/FEATURE_FLAGS.md.
+        if (functionListAccess == true) {
+            item {
+                Button(
+                    onClick = onNavigateToFunctionList,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(text = "Function list")
+                }
             }
         }
         item {
@@ -234,6 +241,7 @@ fun ProfileContentPreview() {
                     // No-op for preview.
                 }
             },
+            functionListAccess = true,
         )
     }
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppSettingsViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppSettingsViewModel.kt
@@ -19,6 +19,7 @@ package com.chriscartland.garage.usecase
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.chriscartland.garage.domain.coroutines.DispatcherProvider
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -35,6 +36,22 @@ interface AppSettingsViewModel {
     /** Null until DataStore loads — callers should skip rendering until non-null. */
     val profileAppCardExpanded: StateFlow<Boolean?>
 
+    /**
+     * Per-user access decision for the Function List feature, used to gate the
+     * Settings-screen entry button.
+     *
+     * - `null` — not yet fetched, fetch failed, or signed out (gate closed).
+     * - `false` — server says this user is NOT on the allowlist (gate closed).
+     * - `true` — server says this user IS on the allowlist (gate open).
+     *
+     * **Tri-state is load-bearing.** Both `null` and `false` deny. Gate UI on
+     * `== true` only; never on `!= false`. Full convention in
+     * `docs/FEATURE_FLAGS.md`. The Function List screen has its own
+     * independent gate via `FunctionListViewModel.accessGranted`; this flag
+     * is a UI hint to hide the entry point and is not a security boundary.
+     */
+    val functionListAccess: StateFlow<Boolean?>
+
     fun setFcmDoorTopic(topic: String)
 
     fun setProfileUserCardExpanded(expanded: Boolean)
@@ -46,6 +63,8 @@ interface AppSettingsViewModel {
 
 class DefaultAppSettingsViewModel(
     private val settings: AppSettingsUseCase,
+    private val observeFeatureAccessUseCase: ObserveFeatureAccessUseCase,
+    private val dispatchers: DispatcherProvider,
 ) : ViewModel(),
     AppSettingsViewModel {
     // ADR-017 Rule 6: explicit MutableStateFlow + collect, no stateIn in ViewModels.
@@ -61,6 +80,9 @@ class DefaultAppSettingsViewModel(
     private val _profileAppCardExpanded = MutableStateFlow<Boolean?>(null)
     override val profileAppCardExpanded: StateFlow<Boolean?> = _profileAppCardExpanded
 
+    private val _functionListAccess = MutableStateFlow<Boolean?>(null)
+    override val functionListAccess: StateFlow<Boolean?> = _functionListAccess
+
     init {
         viewModelScope.launch {
             settings.observeFcmDoorTopic().collect { _fcmDoorTopic.value = it }
@@ -73,6 +95,9 @@ class DefaultAppSettingsViewModel(
         }
         viewModelScope.launch {
             settings.observeProfileAppCardExpanded().collect { _profileAppCardExpanded.value = it }
+        }
+        viewModelScope.launch(dispatchers.io) {
+            observeFeatureAccessUseCase.functionList().collect { _functionListAccess.value = it }
         }
     }
 

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAppSettingsViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAppSettingsViewModelTest.kt
@@ -1,6 +1,9 @@
 package com.chriscartland.garage.usecase
 
+import com.chriscartland.garage.domain.model.FeatureAllowlist
 import com.chriscartland.garage.testcommon.FakeAppSettingsRepository
+import com.chriscartland.garage.testcommon.FakeFeatureAllowlistRepository
+import com.chriscartland.garage.testcommon.TestDispatcherProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -13,11 +16,20 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DefaultAppSettingsViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
     private val settings = FakeAppSettingsRepository()
+    private val featureAllowlistRepository = FakeFeatureAllowlistRepository()
+
+    private fun createViewModel(): DefaultAppSettingsViewModel =
+        DefaultAppSettingsViewModel(
+            settings = AppSettingsUseCase(settings),
+            observeFeatureAccessUseCase = ObserveFeatureAccessUseCase(featureAllowlistRepository),
+            dispatchers = TestDispatcherProvider(testDispatcher),
+        )
 
     @BeforeTest
     fun setUp() {
@@ -32,7 +44,7 @@ class DefaultAppSettingsViewModelTest {
     @Test
     fun initialStateReflectsSettings() =
         runTest(testDispatcher) {
-            val viewModel = DefaultAppSettingsViewModel(AppSettingsUseCase(settings))
+            val viewModel = createViewModel()
             advanceUntilIdle()
 
             assertEquals("", viewModel.fcmDoorTopic.value)
@@ -44,7 +56,7 @@ class DefaultAppSettingsViewModelTest {
     @Test
     fun setFcmDoorTopicUpdatesFlowAndSetting() =
         runTest(testDispatcher) {
-            val viewModel = DefaultAppSettingsViewModel(AppSettingsUseCase(settings))
+            val viewModel = createViewModel()
             advanceUntilIdle()
 
             viewModel.setFcmDoorTopic("new-topic")
@@ -57,7 +69,7 @@ class DefaultAppSettingsViewModelTest {
     @Test
     fun setProfileUserCardExpandedUpdatesFlowAndSetting() =
         runTest(testDispatcher) {
-            val viewModel = DefaultAppSettingsViewModel(AppSettingsUseCase(settings))
+            val viewModel = createViewModel()
             advanceUntilIdle()
 
             viewModel.setProfileUserCardExpanded(false)
@@ -70,7 +82,7 @@ class DefaultAppSettingsViewModelTest {
     @Test
     fun setProfileLogCardExpandedUpdatesFlowAndSetting() =
         runTest(testDispatcher) {
-            val viewModel = DefaultAppSettingsViewModel(AppSettingsUseCase(settings))
+            val viewModel = createViewModel()
             advanceUntilIdle()
 
             viewModel.setProfileLogCardExpanded(true)
@@ -83,7 +95,7 @@ class DefaultAppSettingsViewModelTest {
     @Test
     fun setProfileAppCardExpandedUpdatesFlowAndSetting() =
         runTest(testDispatcher) {
-            val viewModel = DefaultAppSettingsViewModel(AppSettingsUseCase(settings))
+            val viewModel = createViewModel()
             advanceUntilIdle()
 
             viewModel.setProfileAppCardExpanded(false)
@@ -99,10 +111,38 @@ class DefaultAppSettingsViewModelTest {
             settings.fcmDoorTopic.set("pre-existing")
             settings.profileLogCardExpanded.set(true)
 
-            val vm = DefaultAppSettingsViewModel(AppSettingsUseCase(settings))
+            val vm = createViewModel()
             advanceUntilIdle()
 
             assertEquals("pre-existing", vm.fcmDoorTopic.value)
             assertEquals(true, vm.profileLogCardExpanded.value)
+        }
+
+    @Test
+    fun functionListAccessIsNullBeforeAllowlistResolves() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+            assertNull(viewModel.functionListAccess.value)
+        }
+
+    @Test
+    fun functionListAccessReflectsAllowlistTrue() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel()
+            featureAllowlistRepository.setAllowlist(FeatureAllowlist(functionList = true))
+            advanceUntilIdle()
+            assertEquals(true, viewModel.functionListAccess.value)
+        }
+
+    @Test
+    fun functionListAccessReflectsAllowlistFalse() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel()
+            featureAllowlistRepository.setAllowlist(FeatureAllowlist(functionList = false))
+            advanceUntilIdle()
+            // Distinguish "false" from "null" — both deny but the tri-state
+            // is load-bearing per docs/FEATURE_FLAGS.md.
+            assertEquals(false, viewModel.functionListAccess.value)
         }
 }


### PR DESCRIPTION
## Summary
- Hide the **Function list** entry button in the Settings (Profile) screen when the signed-in user is not on the `featureFunctionListAllowedEmails` allowlist.
- The Function List screen itself is unchanged — `FunctionListViewModel` still self-gates via the same flag, so this is a UI hint, not a security boundary (`docs/FEATURE_FLAGS.md`).
- Reuses the existing PR #573 server/wire flag — no new endpoint, no new Firestore field, no wire-contract change.

## Files touched
- `AppSettingsViewModel` — new `functionListAccess: StateFlow<Boolean?>` with load-bearing tri-state KDoc (null/false deny; gate on `== true` only). Constructor gains `ObserveFeatureAccessUseCase` + `DispatcherProvider` deps.
- `AppComponent.provideAppSettingsViewModel` — extended signature; both new deps already had `@Provides` registrations, so no new entry points / `ComponentGraphTest` deltas.
- `ProfileContent` — collects the new flow, threads it through the stateless overload, gates the button `item { ... }` on `== true`. Preview still renders the button (`functionListAccess = true`).
- `DefaultAppSettingsViewModelTest` — tri-state tests mirroring `DefaultFunctionListViewModelTest.accessGranted*` (null pre-resolve, true open, false explicit deny).

## Test plan
- [x] `./scripts/validate.sh` — PASS (spotless, lint, unit tests, domain tests, debug build, screenshot test compile, Room schema, screen-VM cardinality, AGENTS front-matter, whatsnew length).
- [ ] Manual sanity (post-merge): with an allowlisted email, button shows; remove email → next refetch hides button.
- [ ] Worth confirming the Settings screen still renders nothing in the slot for non-allowlisted users (no placeholder, no spacer artifact) since the LazyColumn skips the item entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)