### PR TITLE
chore(ci): Bump actions/setup-java v4 → v5 (Node 20 deprecation)

### DIFF
--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/firebase-ci-checks.yml
+++ b/.github/workflows/firebase-ci-checks.yml
@@ -96,7 +96,7 @@ jobs:
       # fails at `firebase emulators:exec` with:
       #   "firebase-tools no longer supports Java version before 21"
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'


### PR DESCRIPTION
## Summary
Bumps `actions/setup-java` from `@v4` to `@v5` in both call sites:
- `.github/actions/setup-android/action.yml` (Android composite — JDK 17)
- `.github/workflows/firebase-ci-checks.yml` (Firebase CI's JDK 21 setup for emulator-based tests)

## Why
GitHub flagged Node 20 deprecation on `setup-java@v4` in the most recent release-android run. v5 (released Jan 2025) ships with the Node 24 runtime; same default inputs, same behaviour. Mandatory cutover for Actions runtime is **2026-06-02**; this clears the warning before then.

## Risk + mitigation
- **Risk:** v5 changes a default JDK distribution or input semantic.
- **Catch:** PR CI exercises both call sites — Firebase CI's emulator job (which depends on JDK 21) and every Android job (which depends on JDK 17 + Gradle cache).
- **Rollback:** revert. Action version pin only — no project-runtime change.
- **Release-safe:** ✅ green CI is sufficient signal; the next `android/N` and `server/N` tags will exercise both code paths.

Part of the dependency-upgrade plan tracked in this session. Sibling PRs (upload-artifact, firebase-admin, js-yaml) open in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)