### PR TITLE
chore(ci): Bump actions/upload-artifact v4 → v6 (Node 20 deprecation)

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -70,7 +70,7 @@ jobs:
         run: ./release/clean-secrets.sh
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-reports
           path: AndroidGarage/androidApp/build/reports/tests/
@@ -131,7 +131,7 @@ jobs:
         run: ./release/clean-secrets.sh
       - name: Upload debug APK
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: debug-apk
           path: AndroidGarage/androidApp/build/outputs/apk/debug/
@@ -158,7 +158,7 @@ jobs:
         working-directory: AndroidGarage
         run: ./release/clean-secrets.sh
       - name: Upload release AAB
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-aab
           path: AndroidGarage/androidApp/build/outputs/bundle/release/

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -70,7 +70,7 @@ jobs:
           ls "$AAB_DIR"/*.aab
 
       - name: Upload release AAB artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-aab-${{ steps.validate.outputs.version_code }}
           path: AndroidGarage/androidApp/build/outputs/bundle/release/


### PR DESCRIPTION
## Summary
Bumps `actions/upload-artifact` from `@v4` to `@v6` in 4 call sites:
- `.github/workflows/ci-checks.yml` × 3 (test reports, debug APK, release AAB)
- `.github/workflows/release-android.yml` × 1 (release AAB artifact for the deploy job)

## Why
GitHub flagged Node 20 deprecation on `upload-artifact@v4`. v6 ships with the Node 24 runtime; same inputs and behaviour for the call patterns this repo uses (single-name, no merge/glob override). Mandatory cutover for Actions runtime is **2026-06-02**.

v7 is also available but ships breaking API changes around merge behaviour we don't depend on; v6 is the conservative Node-24-native target.

## Risk + mitigation
- **Risk:** v6 changes upload behaviour, default retention, or artifact-name semantics.
- **Catch:** PR CI uploads in all 4 call sites — debug APK, release AAB (twice), test reports — and the deploy job downloads the release AAB on the same run.
- **Rollback:** revert. Doesn't affect build output, just upload logistics.
- **Release-safe:** ✅ even a bad upload doesn't corrupt the build; the deploy job's download step would fail loudly.

Part of the dependency-upgrade plan. Sibling PRs (setup-java #581, firebase-admin, js-yaml) open in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)