### PR TITLE
chore(firebase): Override uuid to ^14.0.0 (closes last Dependabot alert)

### DIFF
--- a/FirebaseServer/package-lock.json
+++ b/FirebaseServer/package-lock.json
@@ -9,7 +9,7 @@
         "express": "4.21.2",
         "firebase-admin": "13.8.0",
         "firebase-functions": "6.4.0",
-        "uuid": "14.0.0"
+        "uuid": "^14.0.0"
       },
       "devDependencies": {
         "@types/chai": "4.3.20",
@@ -384,16 +384,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@google-cloud/storage/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -2732,19 +2722,6 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
-    "node_modules/firebase-admin/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/firebase-functions": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.4.0.tgz",
@@ -2901,20 +2878,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/gaxios/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/gcp-metadata": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
@@ -3062,20 +3025,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/google-gax/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/google-logging-utils": {
@@ -4918,20 +4867,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/teeny-request/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/through2": {
       "version": "2.0.5",

--- a/FirebaseServer/package.json
+++ b/FirebaseServer/package.json
@@ -17,7 +17,7 @@
     "express": "4.21.2",
     "firebase-admin": "13.8.0",
     "firebase-functions": "6.4.0",
-    "uuid": "14.0.0"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@types/chai": "4.3.20",
@@ -42,7 +42,8 @@
     "qs": "^6.14.2",
     "path-to-regexp": "0.1.13",
     "fast-xml-parser": "^5.7.0",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.1.1",
+    "uuid": "^14.0.0"
   },
   "engines": {
     "node": "22"


### PR DESCRIPTION
## Summary
Forces every transitive uuid resolution in `FirebaseServer/` to **14.0.0** by adding a top-level override and relaxing the direct dep from `"14.0.0"` (exact) to `"^14.0.0"` (npm refuses to allow the override against an exact pin).

After regen, `npm ls uuid` shows every transitive caller deduped to 14.0.0 (was: a mix of 8.3.2 / 9.0.1 / 11.1.0 via firebase-admin's `@google-cloud/storage` / `google-gax` / `gaxios` / `teeny-request` subtree).

## Resolves
The 5th and final Dependabot alert (#67):
- **uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided** — vulnerable range `< 14.0.0` (Dependabot's formal range is broader than the human-readable summary), fix 14.0.0.

After this merges, **all 5 of the original Dependabot alerts close**.

## Risk + mitigation
- **Risk class:** Bucket C (Firebase runtime). Forces a major-version uuid bump on transitive callers — `firebase-admin` / `@google-cloud/storage` were using uuid v8/v9/v11.
- **Why this is safe in practice:** uuid's API surface for `v4()` (the only call site google-cloud uses internally for request IDs) is unchanged across v8 → v14. The CVE is specifically about the optional `buf` parameter, which these callers don't supply. v14 is also already the top-level direct dep — we know it works for the project.
- **Pre-merge catch:** `./scripts/validate-firebase.sh` passes — build + lint + **250 unit tests** including handler tests, FCM contract tests, and the `uuid v4 contract` test (verifies 36-char canonical form + uniqueness).
- **Post-merge gate:** the next `server/N` tag-push is the production proof. Watch for `✔ Deploy complete!` in the deploy log; if any google-cloud-storage call path silently misbehaves, surface area is around request-tracing — would manifest as missing or malformed log correlation IDs.
- **Rollback:** `git checkout server/M` two-step rollback per `release-firebase.sh --check`.

Final PR in the dependency-upgrade plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)