### PR TITLE
chore(ci): Add DataStoreSingletonCheckTask (defense-in-depth for @Singleton)

### DIFF
--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -172,6 +172,18 @@ tasks.register<architecture.SingletonCachingCheckTask>("checkSingletonCaching") 
     dependsOn(":androidApp:kspDebugKotlin")
 }
 
+tasks.register<architecture.DataStoreSingletonCheckTask>("checkDataStoreSingleton") {
+    sourceDirs = listOf(
+        "$rootDir/androidApp/src/main/java",
+    )
+    // Names match the providers in androidApp/.../di/AppComponent.kt that
+    // hold the only DataStore<Preferences> and Room AppDatabase instances.
+    guardedMethods = listOf(
+        "provideAppSettings",
+        "provideAppDatabase",
+    )
+}
+
 tasks.register<architecture.NoRawDispatchersTask>("checkNoRawDispatchers") {
     sourceDirs = listOf(
         "$rootDir/androidApp/src/main/java",

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/DataStoreSingletonCheckTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/DataStoreSingletonCheckTask.kt
@@ -1,0 +1,145 @@
+package architecture
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Enforces a `@Singleton` (or other configured scope) annotation on every
+ * `@Provides fun <name>(...)` listed in [guardedMethods]. These methods
+ * return single-instance backing classes that **crash or corrupt state**
+ * when constructed twice for the same on-disk file:
+ *
+ *  - `DataStore<Preferences>` — second instance throws
+ *    `IllegalStateException: There are multiple DataStores active for the
+ *     same file`.
+ *  - Room `AppDatabase` — second instance can deadlock or corrupt the SQLite
+ *    file under concurrent writes.
+ *
+ * This is the static-analysis half of a defense-in-depth pair with
+ * `:checkSingletonCaching` (which validates kotlin-inject's *generated*
+ * `_scoped.get(...)` calls). This task validates the *annotation* on the
+ * source file; the other task validates the generated cache code. Together
+ * they cover both "forgot the @Singleton annotation" and "annotation was
+ * present but the cache wasn't generated for it" failure modes.
+ *
+ * Adapted from
+ * https://github.com/cartland/battery-butler `DataStoreSingletonCheckTask`.
+ *
+ * Why a fresh check rather than just relying on `:checkSingletonCaching`:
+ * the existing check enumerates which `@Singleton` providers exist and
+ * verifies each has a corresponding `_scoped.get(...)` call in the
+ * generated component. If a developer forgets the annotation entirely, the
+ * provider isn't in the enumeration — and the existing check is silent.
+ * This task closes that gap by forcing the annotation on the named
+ * methods.
+ */
+abstract class DataStoreSingletonCheckTask : DefaultTask() {
+    @get:Input
+    var sourceDirs: List<String> = emptyList()
+
+    /**
+     * Names of `@Provides fun` methods that MUST carry a singleton scope
+     * annotation. Match is on the literal `fun <name>(` in the source.
+     */
+    @get:Input
+    var guardedMethods: List<String> = listOf(
+        "provideAppSettings",
+        "provideAppDatabase",
+    )
+
+    /**
+     * Annotations that satisfy the singleton requirement. This repo uses
+     * a single `@Singleton` annotation; the list is overridable for parity
+     * with other DI components that introduce sibling scopes.
+     */
+    @get:Input
+    var scopeAnnotations: List<String> = listOf(
+        "@Singleton",
+    )
+
+    private val providesPattern = Regex("""@Provides""")
+
+    @TaskAction
+    fun check() {
+        val violations = mutableListOf<String>()
+
+        sourceDirs.forEach { dir ->
+            val rootFile = File(dir)
+            if (!rootFile.exists()) return@forEach
+
+            rootFile
+                .walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .filter { !it.path.contains("/build/") }
+                .filter { !it.path.contains("/test/") && !it.path.contains("/androidTest/") }
+                .forEach { file ->
+                    val lines = file.readLines()
+                    val relativePath = file.relativeTo(rootFile).path
+
+                    lines.forEachIndexed { index, line ->
+                        val trimmed = line.trim()
+                        // Skip comments / KDoc.
+                        if (trimmed.startsWith("//") || trimmed.startsWith("*")) return@forEachIndexed
+
+                        val matchedMethod = guardedMethods.firstOrNull { name ->
+                            trimmed.contains("fun $name(")
+                        } ?: return@forEachIndexed
+
+                        // Look back up to 5 lines for the `@Provides` and
+                        // scope annotations. Annotations on Kotlin
+                        // functions can stack on separate lines or share
+                        // the same line as the `fun` declaration.
+                        val lookbackStart = maxOf(0, index - 5)
+                        val precedingLines = lines.subList(lookbackStart, index + 1)
+
+                        val hasProvidesAnnotation = precedingLines.any { providesPattern.containsMatchIn(it) }
+                        // Skip if it's not a @Provides function — the
+                        // method name might also appear in plain
+                        // interface declarations or test fakes.
+                        if (!hasProvidesAnnotation) return@forEachIndexed
+
+                        val hasScopeAnnotation = precedingLines.any { precedingLine ->
+                            scopeAnnotations.any { ann -> precedingLine.trim().contains(ann) }
+                        }
+
+                        if (!hasScopeAnnotation) {
+                            violations.add(
+                                "$relativePath:${index + 1}: $matchedMethod() is missing a singleton scope annotation",
+                            )
+                        }
+                    }
+                }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    append("DataStoreSingletonCheck FAILED: ")
+                    append(violations.size)
+                    append(" violation(s).\n\n")
+                    violations.forEach { append("  - $it\n") }
+                    append("\n")
+                    append("These `@Provides` methods MUST carry a singleton scope annotation\n")
+                    append("(${scopeAnnotations.joinToString(" or ")}).\n\n")
+                    append("Why this is enforced statically:\n")
+                    append("  - DataStore<Preferences>: second instance for the same file throws\n")
+                    append("    IllegalStateException at runtime.\n")
+                    append("  - Room AppDatabase: second instance can deadlock or corrupt the SQLite\n")
+                    append("    file under concurrent writes.\n\n")
+                    append("Fix: add `@Singleton` directly above the `@Provides` annotation.\n\n")
+                    append("Defense-in-depth note: this is paired with `:checkSingletonCaching`,\n")
+                    append("which validates kotlin-inject's generated `_scoped.get(...)` cache.\n")
+                    append("Together they catch (a) forgot-the-annotation and (b) annotation-was-\n")
+                    append("present-but-cache-was-not-generated failure modes.\n")
+                },
+            )
+        }
+
+        logger.lifecycle(
+            "DataStoreSingletonCheck passed: ${guardedMethods.size} guarded methods verified.",
+        )
+    }
+}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -43,6 +43,9 @@ $GRADLE checkSingletonGuard && pass "singleton guard" || fail "singleton guard"
 step "Singleton caching (kotlin-inject generated _scoped.get matches @Singleton)"
 $GRADLE checkSingletonCaching && pass "singleton caching" || fail "singleton caching"
 
+step "DataStore + Room singleton annotations (provideAppSettings, provideAppDatabase)"
+$GRADLE checkDataStoreSingleton && pass "datastore singleton" || fail "datastore singleton"
+
 step "No raw Dispatchers (ADR-005 — VM/UseCase must inject DispatcherProvider)"
 $GRADLE checkNoRawDispatchers && pass "no raw dispatchers" || fail "no raw dispatchers"
 


### PR DESCRIPTION
## Summary
Adds `:checkDataStoreSingleton`, a static check that fails the build if a `@Provides` method named `provideAppSettings` or `provideAppDatabase` is missing a `@Singleton` scope annotation. Adapted from [battery-butler's `DataStoreSingletonCheckTask`](https://github.com/cartland/battery-butler/blob/main/buildSrc/src/main/kotlin/datastoreguard/DataStoreSingletonCheckTask.kt).

## Why
Both `DataStore<Preferences>` and Room `AppDatabase` are single-instance contracts:
- `DataStore<Preferences>` — second instance for the same file throws `IllegalStateException: There are multiple DataStores active for the same file`.
- Room `AppDatabase` — second instance can deadlock or corrupt the SQLite file under concurrent writes.

Under kotlin-inject, the `@Singleton` annotation is the only thing preventing duplicate instantiation. Forgetting it = production crash on second access.

## Defense-in-depth pair with the existing `:checkSingletonCaching`
The existing check enumerates all `@Singleton` providers and verifies each has a corresponding `_scoped.get(...)` call in the generated component. **It's silent if the annotation is missing entirely** — the provider isn't in the enumeration to begin with.

This new check closes that gap by enforcing the annotation on the named methods directly.

| Check | Validates |
|---|---|
| `:checkSingletonCaching` | Annotation took effect → `_scoped.get` exists in generated code |
| `:checkDataStoreSingleton` (new) | Annotation exists on the source file at all |

## Test plan
- [x] `./gradlew checkDataStoreSingleton` → "DataStoreSingletonCheck passed: 2 guarded methods verified."
- [x] Existing code passes (provideAppSettings + provideAppDatabase both already have `@Singleton`).
- [x] `./scripts/validate.sh` PASS — full suite including the new step between `checkSingletonCaching` and `checkNoRawDispatchers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)