### PR TITLE
docs: Pin screen-padding convention in Main.kt

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -195,6 +195,12 @@ fun AppNavigation(
                 rememberViewModelStoreNavEntryDecorator<Screen>(),
             ),
             modifier = Modifier.padding(innerPadding),
+            // Screen-padding convention: every nav entry gets
+            // `padding(horizontal = 16.dp)` applied here. This is the
+            // SINGLE source of horizontal screen padding — child
+            // Composables must NOT re-apply it. PR #589 doubled the
+            // Settings card to 32dp by adding a second 16dp wrapper
+            // inside the screen's content; #593 was the fix.
             entryProvider = entryProvider {
                 entry<Screen.Home> {
                     HomeContent(


### PR DESCRIPTION
## Summary
Adds a one-line code comment near `entryProvider` in `Main.kt` flagging that the nav-entry wrapper is the **single source** of `padding(horizontal = 16.dp)` for every screen. Child Composables must NOT re-apply it.

## Why
PR #589 silently doubled the Settings card to 32dp by adding a second 16dp wrapper inside `SettingsSection` on top of the existing nav-entry padding. The bug shipped in 2.7.0 (`android/183`) and was fixed in 2.7.1 (`android/184`, PR #593). The comment makes the convention obvious to future agents reviewing or adding screen content, preventing the same shape of regression.

## Test plan
- [x] Comment-only change. CI fast-path eligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)