### PR TITLE
feat(history): Pull-to-refresh on the History tab

### DIFF
--- a/AndroidGarage/android-screenshot-tests/SCREENSHOT_GALLERY.md
+++ b/AndroidGarage/android-screenshot-tests/SCREENSHOT_GALLERY.md
@@ -2,7 +2,7 @@
 
 # Screenshot Gallery
 
-Generated on Wed Apr 29 08:47:51 PDT 2026
+Generated on Wed Apr 29 08:59:28 PDT 2026
 
 ## Table of Contents
 - [ComponentsScreenshotTestKt](#componentsscreenshottestkt)

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
@@ -118,6 +118,8 @@ fun DoorHistoryContent(
         }
         HistoryContent(
             days = days,
+            isRefreshing = recentDoorEvents is LoadingResult.Loading,
+            onRefresh = onFetchRecentDoorEvents,
             modifier = Modifier.fillMaxWidth(),
         )
     }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryContent.kt
@@ -32,6 +32,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.History
 import androidx.compose.material.icons.outlined.WarningAmber
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
@@ -39,6 +40,7 @@ import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -124,27 +126,41 @@ data class HistoryDay(
  * Stateless: callers pass already-grouped, already-formatted [HistoryDay]
  * instances. The pairing/grouping pipeline (DoorEvent → HistoryDay) is
  * Phase 3 production work.
+ *
+ * @param isRefreshing drives the M3 pull-to-refresh spinner. Production
+ *   callers tie this to the `LoadingResult.Loading` flag of the underlying
+ *   events flow.
+ * @param onRefresh fires when the user completes a downward pull gesture.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HistoryContent(
     days: List<HistoryDay>,
     modifier: Modifier = Modifier,
+    isRefreshing: Boolean = false,
+    onRefresh: () -> Unit = {},
 ) {
-    LazyColumn(
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
+        onRefresh = onRefresh,
         modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(vertical = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        if (days.isEmpty()) {
-            item { HistoryEmptyState() }
-        } else {
-            days.forEach { day ->
-                item(key = day.label) {
-                    HistoryDaySection(day = day)
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (days.isEmpty()) {
+                item { HistoryEmptyState() }
+            } else {
+                days.forEach { day ->
+                    item(key = day.label) {
+                        HistoryDaySection(day = day)
+                    }
                 }
             }
+            item { Spacer(modifier = Modifier.height(8.dp)) }
         }
-        item { Spacer(modifier = Modifier.height(8.dp)) }
     }
 }
 


### PR DESCRIPTION
## Summary

Restores the refresh affordance that was retired in #598. The new History tab supports **pull-to-refresh** — drag down on the list to fetch the latest events. The Material 3 spinner is shown while the fetch is in flight and clears when the result becomes `Complete` (or `Error`, which surfaces the existing retry card).

The legacy "tap any event card to refresh" behavior was hidden — most users wouldn't have known to use it. Pull-to-refresh is the standard Android gesture for this and surfaces the affordance via the spinner indicator.

## Changes

- `HistoryContent` (stateless) gains `isRefreshing: Boolean = false` and `onRefresh: () -> Unit = {}` parameters; body wrapped in M3 `PullToRefreshBox`.
- `DoorHistoryContent` (stateless) wires `isRefreshing` to `recentDoorEvents is LoadingResult.Loading` and `onRefresh` to the existing `onFetchRecentDoorEvents`. No new ViewModel calls; the gesture flows through the same fetch path the legacy click did.

## Test plan

- [x] \`./scripts/validate.sh\` — all checks pass
- [x] 93 \`HistoryMapperTest\` tests — pass (no mapper changes)
- [x] Screenshots regenerated — 112 total, 0 blank
- [ ] Manual: pull-to-refresh on a real device shows the spinner and fetches

🤖 Generated with [Claude Code](https://claude.com/claude-code)