### PR TITLE
chore: Bump versionName 2.7.1 → 2.8.0 (History tab redesign)

### DIFF
--- a/AndroidGarage/distribution/whatsnew/whatsnew-en-US
+++ b/AndroidGarage/distribution/whatsnew/whatsnew-en-US
@@ -1,1 +1,1 @@
-2.7: Settings tab redesigned — sectioned list, half-sheet snooze picker, dedicated Diagnostics screen. Same capabilities, easier to navigate.
+2.8: History tab redesigned — sectioned list grouped by day, paired Open/Closed events with durations, anomaly handling, and pull-to-refresh.

--- a/AndroidGarage/version.properties
+++ b/AndroidGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.7.1
+versionName=2.8.0


### PR DESCRIPTION
## Summary

Minor bump for the History tab redesign + pull-to-refresh that landed in #598 and #599.

- \`versionName\` → 2.8.0
- Play Store whatsnew replaced (rolling, single entry, 143 / 500 bytes)

CHANGELOG entry will land in a follow-up PR before tagging android/185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)