### PR TITLE
fix(android-test): Update AuthStateUIPropagationTest for HomeMapper bridge

### DIFF
--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/AuthStateUIPropagationTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/AuthStateUIPropagationTest.kt
@@ -24,16 +24,16 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.DisplayName
+import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.model.Email
 import com.chriscartland.garage.domain.model.FirebaseIdToken
-import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.domain.model.User
-import com.google.accompanist.permissions.ExperimentalPermissionsApi
-import com.google.accompanist.permissions.PermissionState
-import com.google.accompanist.permissions.PermissionStatus
+import com.chriscartland.garage.ui.home.HomeMapper
+import com.chriscartland.garage.ui.home.HomeStatusDisplay
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Rule
 import org.junit.Test
+import com.chriscartland.garage.ui.home.HomeContent as HomeStatelessContent
 
 /**
  * Verifies that auth state changes propagate to the Compose UI.
@@ -47,8 +47,11 @@ import org.junit.Test
  *
  * Layer 1: Static rendering — HomeContent shows the right UI for each AuthState.
  * Layer 2: Dynamic — StateFlow change triggers recomposition.
+ *
+ * Targets the stateless Home Composable in `ui.home` (post-mapper extraction);
+ * the legacy `ui.HomeContent` is now a DI-resolving bridge unsuitable for a
+ * unit-style instrumented test.
  */
-@OptIn(ExperimentalPermissionsApi::class)
 class AuthStateUIPropagationTest {
     @get:Rule
     val composeTestRule = createComposeRule()
@@ -59,51 +62,45 @@ class AuthStateUIPropagationTest {
         idToken = FirebaseIdToken(idToken = "test-token", exp = Long.MAX_VALUE),
     )
 
-    private val grantedPermission = object : PermissionState {
-        override val permission = "android.permission.POST_NOTIFICATIONS"
-        override val status = PermissionStatus.Granted
-
-        override fun launchPermissionRequest() {}
-    }
+    private val unknownStatus = HomeStatusDisplay(
+        doorPosition = DoorPosition.UNKNOWN,
+        stateLabel = "Unknown",
+        sinceLine = "Last change time unknown",
+    )
 
     // --- Layer 1: Static rendering ---
 
     @Test
     fun unknownAuthStateShowsCheckingText() {
         composeTestRule.setContent {
-            HomeContent(
-                currentDoorEvent = LoadingResult.Complete(null),
-                authState = AuthState.Unknown,
-                notificationPermissionState = grantedPermission,
+            HomeStatelessContent(
+                status = unknownStatus,
+                authState = HomeMapper.toHomeAuthState(AuthState.Unknown),
             )
         }
-        composeTestRule.onNodeWithText("Checking authentication...").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Checking sign-in…").assertIsDisplayed()
     }
 
     @Test
     fun unauthenticatedShowsSignInButton() {
         composeTestRule.setContent {
-            HomeContent(
-                currentDoorEvent = LoadingResult.Complete(null),
-                authState = AuthState.Unauthenticated,
-                notificationPermissionState = grantedPermission,
+            HomeStatelessContent(
+                status = unknownStatus,
+                authState = HomeMapper.toHomeAuthState(AuthState.Unauthenticated),
             )
         }
-        composeTestRule.onNodeWithText("Sign to access garage remote button").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Sign in with Google").assertIsDisplayed()
     }
 
     @Test
     fun authenticatedDoesNotShowSignInButton() {
         composeTestRule.setContent {
-            HomeContent(
-                currentDoorEvent = LoadingResult.Complete(null),
-                authState = AuthState.Authenticated(testUser),
-                notificationPermissionState = grantedPermission,
+            HomeStatelessContent(
+                status = unknownStatus,
+                authState = HomeMapper.toHomeAuthState(AuthState.Authenticated(testUser)),
             )
         }
-        composeTestRule
-            .onNodeWithText("Sign to access garage remote button")
-            .assertDoesNotExist()
+        composeTestRule.onNodeWithText("Sign in with Google").assertDoesNotExist()
     }
 
     // --- Layer 2: Dynamic — StateFlow drives recomposition ---
@@ -114,29 +111,22 @@ class AuthStateUIPropagationTest {
 
         composeTestRule.setContent {
             val authState by authStateFlow.collectAsState()
-            HomeContent(
-                currentDoorEvent = LoadingResult.Complete(null),
-                authState = authState,
-                notificationPermissionState = grantedPermission,
+            HomeStatelessContent(
+                status = unknownStatus,
+                authState = HomeMapper.toHomeAuthState(authState),
             )
         }
 
         // Initially shows sign-in button
-        composeTestRule
-            .onNodeWithText("Sign to access garage remote button")
-            .assertIsDisplayed()
+        composeTestRule.onNodeWithText("Sign in with Google").assertIsDisplayed()
 
         // Simulate sign-in completing
         authStateFlow.value = AuthState.Authenticated(testUser)
         composeTestRule.waitForIdle()
 
         // Sign-in button should be gone
-        composeTestRule
-            .onNodeWithText("Sign to access garage remote button")
-            .assertDoesNotExist()
-        composeTestRule
-            .onNodeWithText("Checking authentication...")
-            .assertDoesNotExist()
+        composeTestRule.onNodeWithText("Sign in with Google").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Checking sign-in…").assertDoesNotExist()
     }
 
     @Test
@@ -145,26 +135,21 @@ class AuthStateUIPropagationTest {
 
         composeTestRule.setContent {
             val authState by authStateFlow.collectAsState()
-            HomeContent(
-                currentDoorEvent = LoadingResult.Complete(null),
-                authState = authState,
-                notificationPermissionState = grantedPermission,
+            HomeStatelessContent(
+                status = unknownStatus,
+                authState = HomeMapper.toHomeAuthState(authState),
             )
         }
 
         // Initially no sign-in button (authenticated)
-        composeTestRule
-            .onNodeWithText("Sign to access garage remote button")
-            .assertDoesNotExist()
+        composeTestRule.onNodeWithText("Sign in with Google").assertDoesNotExist()
 
         // Simulate sign-out
         authStateFlow.value = AuthState.Unauthenticated
         composeTestRule.waitForIdle()
 
         // Sign-in button should appear
-        composeTestRule
-            .onNodeWithText("Sign to access garage remote button")
-            .assertIsDisplayed()
+        composeTestRule.onNodeWithText("Sign in with Google").assertIsDisplayed()
     }
 
     @Test
@@ -173,19 +158,18 @@ class AuthStateUIPropagationTest {
 
         composeTestRule.setContent {
             val authState by authStateFlow.collectAsState()
-            HomeContent(
-                currentDoorEvent = LoadingResult.Complete(null),
-                authState = authState,
-                notificationPermissionState = grantedPermission,
+            HomeStatelessContent(
+                status = unknownStatus,
+                authState = HomeMapper.toHomeAuthState(authState),
             )
         }
 
-        composeTestRule.onNodeWithText("Checking authentication...").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Checking sign-in…").assertIsDisplayed()
 
         authStateFlow.value = AuthState.Authenticated(testUser)
         composeTestRule.waitForIdle()
 
-        composeTestRule.onNodeWithText("Checking authentication...").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Checking sign-in…").assertDoesNotExist()
     }
 
     @Test
@@ -194,26 +178,21 @@ class AuthStateUIPropagationTest {
 
         composeTestRule.setContent {
             val authState by authStateFlow.collectAsState()
-            HomeContent(
-                currentDoorEvent = LoadingResult.Complete(null),
-                authState = authState,
-                notificationPermissionState = grantedPermission,
+            HomeStatelessContent(
+                status = unknownStatus,
+                authState = HomeMapper.toHomeAuthState(authState),
             )
         }
 
         // Sign in
         authStateFlow.value = AuthState.Authenticated(testUser)
         composeTestRule.waitForIdle()
-        composeTestRule
-            .onNodeWithText("Sign to access garage remote button")
-            .assertDoesNotExist()
+        composeTestRule.onNodeWithText("Sign in with Google").assertDoesNotExist()
 
         // Sign out
         authStateFlow.value = AuthState.Unauthenticated
         composeTestRule.waitForIdle()
-        composeTestRule
-            .onNodeWithText("Sign to access garage remote button")
-            .assertIsDisplayed()
+        composeTestRule.onNodeWithText("Sign in with Google").assertIsDisplayed()
 
         // Sign in again with different token
         val newUser = testUser.copy(
@@ -221,8 +200,6 @@ class AuthStateUIPropagationTest {
         )
         authStateFlow.value = AuthState.Authenticated(newUser)
         composeTestRule.waitForIdle()
-        composeTestRule
-            .onNodeWithText("Sign to access garage remote button")
-            .assertDoesNotExist()
+        composeTestRule.onNodeWithText("Sign in with Google").assertDoesNotExist()
     }
 }


### PR DESCRIPTION
## Summary

Fixes post-merge CI failure on main (issue #604) caused by PR #603.

PR #603 turned `ui/HomeContent.kt` into a DI-resolving bridge and moved the stateless layout to `ui/home/HomeContent.kt` with a new signature (`status: HomeStatusDisplay`, `authState: HomeAuthState`). The instrumented test was still calling the old shape (`currentDoorEvent`, `authState: AuthState`, `notificationPermissionState`), so `compileDebugAndroidTestKotlin` failed in `Android Post-Merge CI` (validate.sh doesn't compile instrumented tests, so it slipped past pre-submit).

## What changed

- Test now targets the **stateless** `ui.home.HomeContent` (not the DI-resolving bridge — the bridge is unsuitable for unit-style instrumented tests).
- `AuthState` → `HomeAuthState` via `HomeMapper.toHomeAuthState`, so the StateFlow → recomposition path under test exercises the production bridge logic end-to-end.
- Text matchers updated to the new copy: `"Sign in with Google"` (was `"Sign to access garage remote button"`), `"Checking sign-in…"` (was `"Checking authentication..."`).
- Permission-state arg dropped — it's not part of the auth-state propagation chain.

## Test plan

- [x] `:androidApp:compileDebugAndroidTestKotlin` passes locally
- [x] `./scripts/validate.sh` passes
- [ ] Post-merge CI on main turns green again, auto-closing #604

🤖 Generated with [Claude Code](https://claude.com/claude-code)