### PR TITLE
chore: Close validate.sh androidTest gap and fix /repo-check workflow names

### DIFF
--- a/.claude/skills/repo-check/SKILL.md
+++ b/.claude/skills/repo-check/SKILL.md
@@ -22,16 +22,22 @@ Report: count, any with conflicts (DIRTY), any without auto-merge.
 ### 2. CI Health
 
 ```bash
-# Latest post-merge run on main
-gh run list --branch main --workflow "Post-Merge CI" --limit 1 \
+# Latest Android post-merge run on main
+gh run list --branch main --workflow "Android Post-Merge CI" --limit 1 \
   --json conclusion,headSha,createdAt \
   --jq '.[0] | {conclusion, sha: .headSha[:7], date: .createdAt[:10]}'
 
-# Any open CI failure issues
+# Latest Firebase post-merge run on main
+gh run list --branch main --workflow "Firebase Post-Merge CI" --limit 1 \
+  --json conclusion,headSha,createdAt \
+  --jq '.[0] | {conclusion, sha: .headSha[:7], date: .createdAt[:10]}'
+
+# Any open CI failure issues (both labels)
 gh issue list --label "ci-failure/post-merge" --state open --json number,title --jq '.[]'
+gh issue list --label "ci-failure/firebase-post-merge" --state open --json number,title --jq '.[]'
 ```
 
-Report: last post-merge result, any open failure issues.
+Report: last post-merge result for each, any open failure issues. The exact workflow names matter — `gh run list --workflow "Post-Merge CI"` (without the platform prefix) returns nothing.
 
 ### 3. Recent Releases
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,9 @@ Firestore Functions: Event-driven processing on data changes
 ## Development Workflow
 
 ### Local Validation
-Run `./scripts/validate.sh` before pushing. It mirrors CI: spotless (all modules), lint, unit tests (3 variants), domain tests, debug build, screenshot test compilation, and Room schema drift check. Writes a validation marker so the git-guardrails hook can warn on stale pushes.
+Run `./scripts/validate.sh` before pushing. It mirrors CI: spotless (all modules), lint, unit tests (3 variants), domain tests, debug build, screenshot test compilation, instrumented test compilation, and Room schema drift check. Writes a validation marker so the git-guardrails hook can warn on stale pushes.
+
+The `compileDebugAndroidTestKotlin` step (added after #604) catches signature-breaking changes to public Composables that `androidTest/` sources call — these used to slip past pre-submit because validate.sh didn't compile that source set, then surface only in the post-merge instrumented-tests job. Running the test rules still requires a device; the compile step does not.
 
 ### Instrumented Tests
 Run `./scripts/run-instrumented-tests.sh` when changing Room entities/DAOs, DI wiring (AppComponent), navigation, or Activity lifecycle code. Requires a connected device or emulator. Not part of `validate.sh` (too slow for every run). A git hook warns on push when these files are changed.

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -122,6 +122,15 @@ step "Screenshot tests (compile)"
 $GRADLE :android-screenshot-tests:compileDebugScreenshotTestKotlin \
     && pass "screenshot test compilation" || fail "screenshot test compilation"
 
+# androidTest sources compile here (no device / runtime needed). Catches
+# signature-breaking changes to public Composables that test sources call.
+# Closes the gap that produced #604: PR #603 changed HomeContent's signature,
+# AuthStateUIPropagationTest still called the old shape, and the failure only
+# surfaced in post-merge CI's instrumented-tests job. Compile is fast (~2s).
+step "Instrumented tests (compile)"
+$GRADLE :androidApp:compileDebugAndroidTestKotlin \
+    && pass "instrumented test compilation" || fail "instrumented test compilation"
+
 step "Documentation front-matter (AGENTS.md contract)"
 "$REPO_ROOT/scripts/check-doc-frontmatter.sh" \
     && pass "doc front-matter" || fail "doc front-matter"


### PR DESCRIPTION
## Summary

Two small fixes from the 2026-04-30 session that produced #604.

### 1. `validate.sh` now compiles `androidTest/` sources

PR #603 changed `HomeContent`'s public signature; `AuthStateUIPropagationTest` still called the old shape, but `validate.sh` didn't compile that source set, so the failure surfaced only in post-merge CI's instrumented-tests job (creating issue #604). Adding `:androidApp:compileDebugAndroidTestKotlin` after the screenshot-test compile step closes the gap.

- Compile-only step (~2s); no device required.
- Test rules still need a device — that's the existing `run-instrumented-tests.sh` flow.
- `CLAUDE.md` § Local Validation updated to mention the new step and the gap it closes.

### 2. `/repo-check` skill now uses the real workflow names

The skill ran `gh run list --workflow "Post-Merge CI"` which returns nothing — the actual workflow names are `Android Post-Merge CI` and `Firebase Post-Merge CI`. Skill now:

- Lists both Android + Firebase post-merge runs.
- Lists both `ci-failure/post-merge` and `ci-failure/firebase-post-merge` issues.
- Warns that the platform prefix is mandatory.

## Test plan

- [x] `./scripts/validate.sh` passes (new step included)
- [x] `compileDebugAndroidTestKotlin` already passed locally during the #605 fix
- [ ] `/repo-check` invocation post-merge returns workflow data

🤖 Generated with [Claude Code](https://claude.com/claude-code)