### PR TITLE
chore: Bump versionName to 2.8.1

### DIFF
--- a/AndroidGarage/version.properties
+++ b/AndroidGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.8.0
+versionName=2.8.1


### PR DESCRIPTION
## Summary

Patch bump 2.8.0 → 2.8.1, opening the cycle for the next release after android/187.

No user-facing changes pending; only internal CI/docs improvements (#606). No whatsnew update — patches roll up into the next minor/major's Play Store entry.

## Test plan

- [x] `version.properties` is the only file touched
- [ ] Once merged, draft the matching `## 2.8.1` CHANGELOG entry via `/update-android-changelog` before the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)