### PR TITLE
chore: Bump versionName to 2.9.0 (minor — Home redesign whatsnew)

### DIFF
--- a/AndroidGarage/CHANGELOG.md
+++ b/AndroidGarage/CHANGELOG.md
@@ -15,6 +15,9 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
 
+## 2.9.0
+- No code changes from 2.8.0. Re-tags the same APK behavior under a fresh `versionName` so the Play Store "What's New" surface mentions the **Home tab redesign** (which shipped to internal track in `android/187` as part of 2.8.0 — see the 2.8.0 entry below for full feature list). Patch 2.8.1 is bypassed; it contained only CI-script and skill changes that don't affect the APK.
+
 ## 2.8.0
 - **History tab redesigned** to a Material 3 sectioned list grouped by day. Each row uses the GarageIcon door art for its leading visual and shows the duration of *that* state ("Open for 6 min" / "Closed for 22 min" / "Since 10:15 AM · 12 min and counting" for the most recent). Anomalies (sensor conflict, stuck opening/closing, unknown state) are surfaced inline with their own door-art variant.
 - **Misalignments merge into the previous Open** instead of cluttering the list as a separate row — `OPEN_MISALIGNED` sets a flag on the Opened it follows and shows a "Door was misaligned" tag below the duration.

--- a/AndroidGarage/distribution/whatsnew/whatsnew-en-US
+++ b/AndroidGarage/distribution/whatsnew/whatsnew-en-US
@@ -1,1 +1,1 @@
-2.8: History tab redesigned — sectioned list grouped by day, paired Open/Closed events with durations, anomaly handling, and pull-to-refresh.
+2.9: Home tab redesigned — sectioned card layout matching History and Settings, status with live duration, and pull-to-refresh.

--- a/AndroidGarage/version.properties
+++ b/AndroidGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.8.1
+versionName=2.9.0


### PR DESCRIPTION
## Summary

Minor bump 2.8.1 → 2.9.0 so the Play Store "What's New" panel mentions the Home tab redesign. The redesign already shipped to internal track in `android/187` (= 2.8.0); this re-tags the same APK behavior under a fresh versionName.

## Changes

- **`version.properties`**: 2.8.1 → 2.9.0 (skips the bypassed 2.8.1 patch).
- **`distribution/whatsnew/whatsnew-en-US`** (rolling, replace-only): now `"2.9: Home tab redesigned — sectioned card layout matching History and Settings, status with live duration, and pull-to-refresh."` (130 bytes / 500 limit).
- **`CHANGELOG.md`**: adds a `## 2.9.0` entry that documents the no-code re-tag and refers readers to 2.8.0 for the actual feature list.

## Why minor, not patch

Patches don't get whatsnew per the rule at the top of `CHANGELOG.md` ("Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up"). Since the goal here is to surface Home on the Play Store, minor is the appropriate vehicle.

## Test plan

- [x] Whatsnew under 500 bytes (130/500)
- [x] Only `version.properties`, whatsnew, and `CHANGELOG.md` modified
- [ ] Once merged: `./scripts/validate.sh` then `./scripts/release-android.sh --check` to release as `android/188`

🤖 Generated with [Claude Code](https://claude.com/claude-code)