### PR TITLE
feat(usecase): Route FCM door events through ReceiveFcmDoorEventUseCase

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -70,6 +70,7 @@ import com.chriscartland.garage.usecase.DefaultAppSettingsViewModel
 import com.chriscartland.garage.usecase.DefaultAuthViewModel
 import com.chriscartland.garage.usecase.DefaultDoorViewModel
 import com.chriscartland.garage.usecase.DefaultFunctionListViewModel
+import com.chriscartland.garage.usecase.DefaultReceiveFcmDoorEventUseCase
 import com.chriscartland.garage.usecase.DefaultRemoteButtonViewModel
 import com.chriscartland.garage.usecase.DeregisterFcmUseCase
 import com.chriscartland.garage.usecase.EnsureFreshIdTokenUseCase
@@ -85,6 +86,7 @@ import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
 import com.chriscartland.garage.usecase.ObserveFeatureAccessUseCase
 import com.chriscartland.garage.usecase.ObserveSnoozeStateUseCase
 import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
+import com.chriscartland.garage.usecase.ReceiveFcmDoorEventUseCase
 import com.chriscartland.garage.usecase.RegisterFcmUseCase
 import com.chriscartland.garage.usecase.SignInWithGoogleUseCase
 import com.chriscartland.garage.usecase.SignOutUseCase
@@ -153,6 +155,7 @@ abstract class AppComponent(
     abstract val featureAllowlistRepository: FeatureAllowlistRepository
     abstract val fcmRegistrationManager: FcmRegistrationManager
     abstract val checkInStalenessManager: CheckInStalenessManager
+    abstract val receiveFcmDoorEventUseCase: ReceiveFcmDoorEventUseCase
     abstract val appClock: AppClock
     abstract val dispatcherProvider: DispatcherProvider
     abstract val networkButtonDataSource: NetworkButtonDataSource
@@ -294,6 +297,18 @@ abstract class AppComponent(
         doorRepository: DoorRepository,
         doorFcmRepository: DoorFcmRepository,
     ): RegisterFcmUseCase = RegisterFcmUseCase(doorRepository, doorFcmRepository)
+
+    @Provides
+    fun provideReceiveFcmDoorEventUseCase(
+        doorRepository: DoorRepository,
+        appLoggerRepository: AppLoggerRepository,
+        applicationScope: CoroutineScope,
+    ): ReceiveFcmDoorEventUseCase =
+        DefaultReceiveFcmDoorEventUseCase(
+            doorRepository = doorRepository,
+            appLoggerRepository = appLoggerRepository,
+            externalScope = applicationScope,
+        )
 
     @Provides
     fun provideDeregisterFcmUseCase(doorFcmRepository: DoorFcmRepository): DeregisterFcmUseCase = DeregisterFcmUseCase(doorFcmRepository)

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
@@ -30,8 +30,7 @@ class FCMService : FirebaseMessagingService() {
     private val handler: FcmMessageHandler by lazy {
         val component = (application as GarageApplication).component
         FcmMessageHandler(
-            doorRepository = component.doorRepository,
-            appLoggerRepository = component.appLoggerRepository,
+            receiveFcmDoorEvent = component.receiveFcmDoorEventUseCase,
         )
     }
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FcmMessageHandler.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FcmMessageHandler.kt
@@ -19,22 +19,21 @@ package com.chriscartland.garage.fcm
 
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.FcmPayloadParser
-import com.chriscartland.garage.domain.model.AppLoggerKeys
-import com.chriscartland.garage.domain.repository.AppLoggerRepository
-import com.chriscartland.garage.domain.repository.DoorRepository
+import com.chriscartland.garage.usecase.ReceiveFcmDoorEventUseCase
 
 /**
  * Handles FCM door event messages. Extracted from FCMService for testability.
  *
- * Parses the FCM data payload and inserts the resulting DoorEvent into the repository.
- * Returns true if the event was successfully parsed and inserted.
+ * Parses the FCM data payload and routes the resulting DoorEvent to a UseCase
+ * that owns persistence + logging — this thin handler is just the parser.
+ * Returns true if the event was successfully parsed and handed off.
  */
 class FcmMessageHandler(
-    private val doorRepository: DoorRepository,
-    private val appLoggerRepository: AppLoggerRepository,
+    private val receiveFcmDoorEvent: ReceiveFcmDoorEventUseCase,
 ) {
     /**
-     * Process an FCM data message. Returns true if a DoorEvent was parsed and inserted.
+     * Process an FCM data message. Returns true if a DoorEvent was parsed and
+     * forwarded to [ReceiveFcmDoorEventUseCase].
      */
     suspend fun handleDoorMessage(data: Map<String, String>): Boolean {
         if (data.isEmpty()) {
@@ -46,8 +45,7 @@ class FcmMessageHandler(
             return false
         }
         Logger.d { "DoorData: $doorEvent" }
-        doorRepository.insertDoorEvent(doorEvent)
-        appLoggerRepository.log(AppLoggerKeys.FCM_DOOR_RECEIVED)
+        receiveFcmDoorEvent(doorEvent)
         return true
     }
 }

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/fcm/FcmMessageHandlerTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/fcm/FcmMessageHandlerTest.kt
@@ -17,11 +17,9 @@
 
 package com.chriscartland.garage.fcm
 
-import com.chriscartland.garage.domain.model.AppLoggerKeys
+import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
-import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
-import com.chriscartland.garage.testcommon.FakeDoorRepository
-import kotlinx.coroutines.flow.first
+import com.chriscartland.garage.usecase.ReceiveFcmDoorEventUseCase
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -30,9 +28,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class FcmMessageHandlerTest {
-    private val doorRepository = FakeDoorRepository()
-    private val appLoggerRepository = FakeAppLoggerRepository()
-    private val handler = FcmMessageHandler(doorRepository, appLoggerRepository)
+    private val receiveFcmDoorEvent = RecordingReceiveFcmDoorEventUseCase()
+    private val handler = FcmMessageHandler(receiveFcmDoorEvent)
 
     private fun makePayload(
         type: String? = "CLOSED",
@@ -53,9 +50,7 @@ class FcmMessageHandlerTest {
             val result = handler.handleDoorMessage(emptyMap())
 
             assertFalse(result)
-            // No event should have been inserted — currentDoorEvent should still be default.
-            val event = doorRepository.currentDoorEvent.first()
-            assertNull(event?.doorPosition)
+            assertNull(receiveFcmDoorEvent.lastEvent)
         }
 
     @Test
@@ -65,17 +60,16 @@ class FcmMessageHandlerTest {
             val result = handler.handleDoorMessage(mapOf("message" to "hello"))
 
             assertFalse(result)
-            val event = doorRepository.currentDoorEvent.first()
-            assertNull(event?.doorPosition)
+            assertNull(receiveFcmDoorEvent.lastEvent)
         }
 
     @Test
-    fun handleDoorMessage_validPayload_insertsAndReturnsTrue() =
+    fun handleDoorMessage_validPayload_forwardsParsedEvent() =
         runTest {
             val result = handler.handleDoorMessage(makePayload())
 
             assertTrue(result)
-            val event = doorRepository.currentDoorEvent.first()
+            val event = receiveFcmDoorEvent.lastEvent
             assertEquals(DoorPosition.CLOSED, event?.doorPosition)
             assertEquals("The door is closed.", event?.message)
             assertEquals(1000L, event?.lastChangeTimeSeconds)
@@ -83,13 +77,22 @@ class FcmMessageHandlerTest {
         }
 
     @Test
-    fun handleDoorMessage_validPayload_logsEvent() =
+    fun handleDoorMessage_validPayload_invokesUseCaseExactlyOnce() =
         runTest {
             handler.handleDoorMessage(makePayload())
 
-            assertTrue(
-                "Expected FCM_DOOR_RECEIVED to be logged",
-                appLoggerRepository.loggedKeys.contains(AppLoggerKeys.FCM_DOOR_RECEIVED),
-            )
+            assertEquals(1, receiveFcmDoorEvent.invocationCount)
         }
+}
+
+private class RecordingReceiveFcmDoorEventUseCase : ReceiveFcmDoorEventUseCase {
+    var invocationCount: Int = 0
+        private set
+    var lastEvent: DoorEvent? = null
+        private set
+
+    override fun invoke(event: DoorEvent) {
+        invocationCount += 1
+        lastEvent = event
+    }
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ReceiveFcmDoorEventUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ReceiveFcmDoorEventUseCase.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.AppLoggerKeys
+import com.chriscartland.garage.domain.model.DoorEvent
+import com.chriscartland.garage.domain.repository.AppLoggerRepository
+import com.chriscartland.garage.domain.repository.DoorRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Receives a [DoorEvent] that arrived via FCM and persists it through the
+ * repository layer, so the rest of the app sees it the same way as a
+ * pull-to-refresh fetch — Home/History tabs auto-update via the existing
+ * StateFlow observers.
+ *
+ * Why a UseCase boundary: the FCM service is a thin Android shell that should
+ * not reach directly into a repository. Routing FCM-arrived events through a
+ * UseCase keeps the Android layer dumb and lets the persistence work survive
+ * the FCM service's lifecycle (its `serviceScope` cancels in `onDestroy`,
+ * which can fire as soon as `onMessageReceived` returns).
+ *
+ * Per ADR-019, all repository side-effects MUST run on `externalScope` —
+ * implementations dispatch the insert there.
+ */
+interface ReceiveFcmDoorEventUseCase {
+    operator fun invoke(event: DoorEvent)
+}
+
+class DefaultReceiveFcmDoorEventUseCase(
+    private val doorRepository: DoorRepository,
+    private val appLoggerRepository: AppLoggerRepository,
+    private val externalScope: CoroutineScope,
+) : ReceiveFcmDoorEventUseCase {
+    override fun invoke(event: DoorEvent) {
+        externalScope.launch {
+            doorRepository.insertDoorEvent(event)
+            appLoggerRepository.log(AppLoggerKeys.FCM_DOOR_RECEIVED)
+        }
+    }
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ReceiveFcmDoorEventUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ReceiveFcmDoorEventUseCaseTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.AppLoggerKeys
+import com.chriscartland.garage.domain.model.DoorEvent
+import com.chriscartland.garage.domain.model.DoorPosition
+import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
+import com.chriscartland.garage.testcommon.FakeDoorRepository
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ReceiveFcmDoorEventUseCaseTest {
+    @Test
+    fun invoke_insertsEventIntoRepository() =
+        runTest {
+            val doorRepo = FakeDoorRepository()
+            val loggerRepo = FakeAppLoggerRepository()
+            val useCase = DefaultReceiveFcmDoorEventUseCase(
+                doorRepository = doorRepo,
+                appLoggerRepository = loggerRepo,
+                externalScope = backgroundScope,
+            )
+            val event = DoorEvent(
+                doorPosition = DoorPosition.OPEN,
+                message = "Door opened",
+                lastChangeTimeSeconds = 1000L,
+                lastCheckInTimeSeconds = 1100L,
+            )
+
+            useCase(event)
+            runCurrent()
+
+            assertEquals(event, doorRepo.currentDoorEvent.value)
+        }
+
+    @Test
+    fun invoke_logsFcmDoorReceived() =
+        runTest {
+            val doorRepo = FakeDoorRepository()
+            val loggerRepo = FakeAppLoggerRepository()
+            val useCase = DefaultReceiveFcmDoorEventUseCase(
+                doorRepository = doorRepo,
+                appLoggerRepository = loggerRepo,
+                externalScope = backgroundScope,
+            )
+
+            useCase(DoorEvent(doorPosition = DoorPosition.CLOSED))
+            runCurrent()
+
+            assertTrue(
+                loggerRepo.loggedKeys.contains(AppLoggerKeys.FCM_DOOR_RECEIVED),
+                "Expected FCM_DOOR_RECEIVED to be logged after invoke()",
+            )
+        }
+
+    @Test
+    fun invoke_runsOnExternalScope_notCallerScope() =
+        runTest {
+            // The caller (FCMService) cancels its scope in onDestroy. The use case
+            // must dispatch the insert onto externalScope so the work survives
+            // (ADR-019). This test enforces that contract: invoke() returns
+            // synchronously without performing the insert on the caller's stack.
+            val doorRepo = FakeDoorRepository()
+            val loggerRepo = FakeAppLoggerRepository()
+            val useCase = DefaultReceiveFcmDoorEventUseCase(
+                doorRepository = doorRepo,
+                appLoggerRepository = loggerRepo,
+                externalScope = backgroundScope,
+            )
+            val event = DoorEvent(doorPosition = DoorPosition.OPEN, lastChangeTimeSeconds = 42L)
+
+            useCase(event)
+            // Without runCurrent(), the launched coroutine has not executed yet.
+            // The repo should still hold its default (FakeDoorRepository's seed).
+            assertEquals(DoorEvent(), doorRepo.currentDoorEvent.value)
+
+            runCurrent()
+            // After draining the dispatcher, the work is done.
+            assertEquals(event, doorRepo.currentDoorEvent.value)
+        }
+}


### PR DESCRIPTION
## Summary

PR **A of 3** in the FCM/clock/heartbeat fix series. Each PR stacks; merge order: A → B → C.

Routes FCM-arrived door events through a new UseCase boundary so persistence + logging run on the application-lifecycle `externalScope`, not on FCMService's short-lived `serviceScope`. Per ADR-019, all repository side-effects MUST run on `externalScope`.

## What changed

**New: `ReceiveFcmDoorEventUseCase`** (`usecase/`, commonMain)
- Interface + `DefaultReceiveFcmDoorEventUseCase` impl
- `invoke(event)` dispatches the insert + log onto `externalScope.launch{}` and returns immediately
- 3 unit tests cover insert, log, and async-dispatch contract

**Updated: `FcmMessageHandler`**
- Now takes `ReceiveFcmDoorEventUseCase` instead of `DoorRepository` + `AppLoggerRepository` directly
- Becomes a thin parser; all persistence side-effects sit behind the UseCase boundary
- Existing parser-level test coverage preserved; uses a small in-test fake of the use case

**Updated: `FCMService` + `AppComponent`**
- FCMService resolves the use case from the component
- New abstract entry point `receiveFcmDoorEventUseCase` + `@Provides` binding wired with `applicationScope`

## Why three PRs

| | Scope |
|---|---|
| **A** *(this)* | UseCase boundary for FCM ingestion (ADR-019 compliance) |
| **B** *(next)* | `LiveClock` UseCase + ViewModel exposes `StateFlow<HomeStatusDisplay>` etc.; deletes `rememberLiveNow()` from Composables |
| **C** | Device check-in section on Home + History; removes the legacy TopAppBar pill |

Stacked because B + C both touch `DoorViewModel.kt`; serialized via auto-merge.

## Test plan

- [x] 3 new unit tests pass
- [x] `./scripts/validate.sh` passes (now includes `compileDebugAndroidTestKotlin` from #606)
- [x] FcmMessageHandlerTest still covers parser behavior end-to-end
- [ ] Manual smoke after merge: FCM-pushed door event reaches the Home tab without pull-to-refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)