### PR TITLE
feat(usecase): LiveClock UseCase + remove rememberLiveNow from UI

### DIFF
--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/di/ComponentGraphTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/di/ComponentGraphTest.kt
@@ -140,6 +140,12 @@ class ComponentGraphTest {
     }
 
     @Test
+    fun liveClockIsSingleton() {
+        val c = component
+        assertSame("LiveClock must be singleton", c.liveClock, c.liveClock)
+    }
+
+    @Test
     fun appDatabaseIsSingleton() {
         val c = component
         assertSame("AppDatabase must be singleton", c.appDatabase, c.appDatabase)

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/AppStartup.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/AppStartup.kt
@@ -22,6 +22,7 @@ import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.usecase.AppLoggerViewModel
 import com.chriscartland.garage.usecase.CheckInStalenessManager
 import com.chriscartland.garage.usecase.FcmRegistrationManager
+import com.chriscartland.garage.usecase.LiveClock
 
 /**
  * App startup actions. Extracted from MainActivity for testability.
@@ -32,11 +33,13 @@ import com.chriscartland.garage.usecase.FcmRegistrationManager
 class AppStartup(
     private val fcmRegistrationManager: FcmRegistrationManager,
     private val checkInStalenessManager: CheckInStalenessManager,
+    private val liveClock: LiveClock,
     private val appLoggerViewModel: AppLoggerViewModel,
 ) {
     /**
-     * Performs startup actions: FCM registration, staleness tracking, and logging.
-     * Returns the list of actions taken (for testing/logging).
+     * Performs startup actions: FCM registration, staleness tracking,
+     * live-clock ticker, and logging. Returns the list of actions taken
+     * (for testing/logging).
      */
     fun run(): List<String> {
         val actions = mutableListOf<String>()
@@ -48,6 +51,10 @@ class AppStartup(
         Logger.d { "AppStartup: Starting check-in staleness manager" }
         checkInStalenessManager.start()
         actions.add("startCheckInStaleness")
+
+        Logger.d { "AppStartup: Starting live clock" }
+        liveClock.start()
+        actions.add("startLiveClock")
 
         appLoggerViewModel.log(AppLoggerKeys.ON_CREATE_FCM_SUBSCRIBE_TOPIC)
         actions.add("logFcmSubscribe")

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -70,6 +70,7 @@ import com.chriscartland.garage.usecase.DefaultAppSettingsViewModel
 import com.chriscartland.garage.usecase.DefaultAuthViewModel
 import com.chriscartland.garage.usecase.DefaultDoorViewModel
 import com.chriscartland.garage.usecase.DefaultFunctionListViewModel
+import com.chriscartland.garage.usecase.DefaultLiveClock
 import com.chriscartland.garage.usecase.DefaultReceiveFcmDoorEventUseCase
 import com.chriscartland.garage.usecase.DefaultRemoteButtonViewModel
 import com.chriscartland.garage.usecase.DeregisterFcmUseCase
@@ -79,6 +80,7 @@ import com.chriscartland.garage.usecase.FetchCurrentDoorEventUseCase
 import com.chriscartland.garage.usecase.FetchFcmStatusUseCase
 import com.chriscartland.garage.usecase.FetchRecentDoorEventsUseCase
 import com.chriscartland.garage.usecase.FetchSnoozeStatusUseCase
+import com.chriscartland.garage.usecase.LiveClock
 import com.chriscartland.garage.usecase.LogAppEventUseCase
 import com.chriscartland.garage.usecase.ObserveAppLogCountUseCase
 import com.chriscartland.garage.usecase.ObserveAuthStateUseCase
@@ -155,6 +157,7 @@ abstract class AppComponent(
     abstract val featureAllowlistRepository: FeatureAllowlistRepository
     abstract val fcmRegistrationManager: FcmRegistrationManager
     abstract val checkInStalenessManager: CheckInStalenessManager
+    abstract val liveClock: LiveClock
     abstract val receiveFcmDoorEventUseCase: ReceiveFcmDoorEventUseCase
     abstract val appClock: AppClock
     abstract val dispatcherProvider: DispatcherProvider
@@ -199,6 +202,7 @@ abstract class AppComponent(
         deregisterFcm: DeregisterFcmUseCase,
         fcmRegistrationManager: FcmRegistrationManager,
         checkInStalenessManager: CheckInStalenessManager,
+        liveClock: LiveClock,
     ): DefaultDoorViewModel =
         DefaultDoorViewModel(
             observeDoorEvents,
@@ -209,6 +213,7 @@ abstract class AppComponent(
             deregisterFcm,
             fcmRegistrationManager,
             checkInStalenessManager,
+            liveClock,
         )
 
     @Provides
@@ -525,9 +530,29 @@ abstract class AppComponent(
         )
 
     @Provides
+    @Singleton
+    fun provideLiveClock(
+        appClock: AppClock,
+        applicationScope: CoroutineScope,
+        dispatchers: DispatcherProvider,
+    ): LiveClock =
+        DefaultLiveClock(
+            clock = appClock,
+            scope = applicationScope,
+            dispatcher = dispatchers.io,
+        )
+
+    @Provides
     fun provideAppStartup(
         fcmRegistrationManager: FcmRegistrationManager,
         checkInStalenessManager: CheckInStalenessManager,
+        liveClock: LiveClock,
         appLoggerViewModel: DefaultAppLoggerViewModel,
-    ): AppStartup = AppStartup(fcmRegistrationManager, checkInStalenessManager, appLoggerViewModel)
+    ): AppStartup =
+        AppStartup(
+            fcmRegistrationManager,
+            checkInStalenessManager,
+            liveClock,
+            appLoggerViewModel,
+        )
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
@@ -26,10 +26,8 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -43,7 +41,6 @@ import com.chriscartland.garage.ui.history.HistoryContent
 import com.chriscartland.garage.ui.history.HistoryMapper
 import com.chriscartland.garage.usecase.AppLoggerViewModel
 import com.chriscartland.garage.usecase.DoorViewModel
-import kotlinx.coroutines.delay
 import java.time.Instant
 import java.time.ZoneId
 
@@ -58,10 +55,15 @@ fun DoorHistoryContent(
     val resolvedAppLoggerViewModel = appLoggerViewModel ?: viewModel { component.appLoggerViewModel }
     val recentDoorEvents by resolvedDoorViewModel.recentDoorEvents.collectAsState()
     val isCheckInStale by resolvedDoorViewModel.isCheckInStale.collectAsState()
+    // `now` is driven by the VM's LiveClock-backed StateFlow (10s tick) —
+    // `rememberLiveNow()` no longer exists; the ticker is owned by the
+    // UseCase layer and lives across the app, not per-Composable.
+    val nowEpochSeconds by resolvedDoorViewModel.nowEpochSeconds.collectAsState()
+    val now = remember(nowEpochSeconds) { Instant.ofEpochSecond(nowEpochSeconds) }
     DoorHistoryContent(
         recentDoorEvents = recentDoorEvents,
         isCheckInStale = isCheckInStale,
-        now = rememberLiveNow(),
+        now = now,
         zone = ZoneId.systemDefault(),
         modifier = modifier,
         onFetchRecentDoorEvents = {
@@ -124,26 +126,6 @@ fun DoorHistoryContent(
         )
     }
     ReportDrawnWhen { recentDoorEvents is LoadingResult.Complete }
-}
-
-/**
- * Returns an [Instant] that updates every 30 seconds (so the most-recent
- * row's "X and counting" duration stays live without spamming
- * recomposition). Returns a fixed timestamp under [LocalInspectionMode] so
- * screenshot tests and IDE previews stay deterministic.
- */
-@Composable
-private fun rememberLiveNow(): Instant {
-    if (LocalInspectionMode.current) {
-        return remember { Instant.parse("2026-04-29T10:27:00Z") }
-    }
-    val state = produceState(initialValue = Instant.now()) {
-        while (true) {
-            delay(30_000L)
-            value = Instant.now()
-        }
-    }
-    return state.value
 }
 
 @PreviewScreenSizes

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -22,11 +22,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.lifecycle.viewmodel.compose.viewModel
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.auth.rememberGoogleSignIn
@@ -43,7 +41,6 @@ import com.chriscartland.garage.usecase.DoorViewModel
 import com.chriscartland.garage.usecase.RemoteButtonViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
-import kotlinx.coroutines.delay
 import java.time.Instant
 import java.time.ZoneId
 import com.chriscartland.garage.ui.home.HomeContent as HomeContentInternal
@@ -81,7 +78,11 @@ fun HomeContent(
     val notificationPermissionState = rememberNotificationPermissionState()
     var permissionRequestCount by remember { mutableIntStateOf(0) }
 
-    val now = rememberLiveNow()
+    // `now` is driven by the VM's LiveClock-backed StateFlow (10s tick) —
+    // `rememberLiveNow()` no longer exists; the ticker is owned by the
+    // UseCase layer and lives across the app, not per-Composable.
+    val nowEpochSeconds by resolvedDoorViewModel.nowEpochSeconds.collectAsState()
+    val now = remember(nowEpochSeconds) { Instant.ofEpochSecond(nowEpochSeconds) }
     val zone = remember { ZoneId.systemDefault() }
 
     val status = HomeMapper.toHomeStatusDisplay(currentDoorEvent, now, zone)
@@ -135,27 +136,4 @@ fun HomeContent(
         onSignIn = { googleSignIn.launchSignIn() },
     )
     ReportDrawnWhen { currentDoorEvent is LoadingResult.Complete }
-}
-
-/**
- * Returns an [Instant] that updates every 30s so the "Since X · Y" duration
- * text refreshes without a per-second recomposition. Returns a fixed
- * timestamp under [LocalInspectionMode] so previews stay deterministic.
- *
- * Sibling of `DoorHistoryContent.rememberLiveNow` — kept private to each
- * call site rather than shared, since the previews use the same fixed
- * reference instant for visual consistency across tabs.
- */
-@Composable
-private fun rememberLiveNow(): Instant {
-    if (LocalInspectionMode.current) {
-        return remember { Instant.parse("2026-04-29T12:00:00Z") }
-    }
-    val state = produceState(initialValue = Instant.now()) {
-        while (true) {
-            delay(30_000L)
-            value = Instant.now()
-        }
-    }
-    return state.value
 }

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/AppStartupTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/AppStartupTest.kt
@@ -26,6 +26,7 @@ import com.chriscartland.garage.testcommon.FakeDoorFcmRepository
 import com.chriscartland.garage.testcommon.FakeDoorRepository
 import com.chriscartland.garage.usecase.AppLoggerViewModel
 import com.chriscartland.garage.usecase.CheckInStalenessManager
+import com.chriscartland.garage.usecase.DefaultLiveClock
 import com.chriscartland.garage.usecase.FcmRegistrationManager
 import com.chriscartland.garage.usecase.LogAppEventUseCase
 import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
@@ -62,6 +63,13 @@ class AppStartupTest {
             clock = AppClock { 0L },
         )
 
+    private fun createLiveClock(scope: TestScope): DefaultLiveClock =
+        DefaultLiveClock(
+            clock = AppClock { 0L },
+            scope = scope.backgroundScope,
+            dispatcher = testDispatcher,
+        )
+
     private class FakeAppLoggerViewModel : AppLoggerViewModel {
         val loggedKeys = mutableListOf<String>()
 
@@ -85,7 +93,8 @@ class AppStartupTest {
         val fcmManager = createFcmManager(scope)
         val stalenessManager = createStalenessManager(scope)
         val appLoggerViewModel = FakeAppLoggerViewModel()
-        val actions = AppStartup(fcmManager, stalenessManager, appLoggerViewModel)
+        val liveClock = createLiveClock(scope)
+        val actions = AppStartup(fcmManager, stalenessManager, liveClock, appLoggerViewModel)
 
         actions.run()
 
@@ -101,12 +110,18 @@ class AppStartupTest {
         val fcmManager = createFcmManager(scope)
         val stalenessManager = createStalenessManager(scope)
         val appLoggerViewModel = FakeAppLoggerViewModel()
-        val actions = AppStartup(fcmManager, stalenessManager, appLoggerViewModel)
+        val liveClock = createLiveClock(scope)
+        val actions = AppStartup(fcmManager, stalenessManager, liveClock, appLoggerViewModel)
 
         val result = actions.run()
 
         assertEquals(
-            listOf("startFcmRegistration", "startCheckInStaleness", "logFcmSubscribe"),
+            listOf(
+                "startFcmRegistration",
+                "startCheckInStaleness",
+                "startLiveClock",
+                "logFcmSubscribe",
+            ),
             result,
         )
     }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorViewModel.kt
@@ -39,6 +39,14 @@ interface DoorViewModel {
     /** True when the last check-in is older than the staleness threshold (11 min). */
     val isCheckInStale: StateFlow<Boolean>
 
+    /**
+     * Wall-clock time as epoch seconds, ticking on the [LiveClock] cadence
+     * (10s by default). UI bridges collect this and convert to a platform
+     * [java.time.Instant] before passing into mappers — replaces the
+     * per-Composable `rememberLiveNow()` that previously lived in the UI.
+     */
+    val nowEpochSeconds: StateFlow<Long>
+
     fun deregisterFcm()
 
     fun fetchCurrentDoorEvent()
@@ -55,12 +63,16 @@ class DefaultDoorViewModel(
     private val deregisterFcmUseCase: DeregisterFcmUseCase,
     private val fcmRegistrationManager: FcmRegistrationManager,
     private val checkInStalenessManager: CheckInStalenessManager,
+    private val liveClock: LiveClock,
     private val fetchOnInit: Boolean = true,
 ) : ViewModel(),
     DoorViewModel {
     // ADR-022: expose the manager's StateFlow by reference — no mirror.
     override val fcmRegistrationStatus: StateFlow<FcmRegistrationStatus> =
         fcmRegistrationManager.registrationStatus
+
+    // ADR-022: pass through LiveClock's StateFlow — no mirror.
+    override val nowEpochSeconds: StateFlow<Long> = liveClock.nowEpochSeconds
 
     private val _currentDoorEvent =
         MutableStateFlow<LoadingResult<DoorEvent?>>(LoadingResult.Loading(null))

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/LiveClock.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/LiveClock.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import co.touchlab.kermit.Logger
+import com.chriscartland.garage.domain.coroutines.AppClock
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * App-scoped live clock that emits the current wall-clock time at a fixed
+ * cadence. ViewModels combine this with their domain flows to drive
+ * "Since X · Y" / "N seconds ago" durations, replacing per-Composable
+ * tickers (`rememberLiveNow()`) that lived in the UI layer.
+ *
+ * Why a UseCase: time-driven UI updates are a side effect with a lifecycle.
+ * The previous pattern spawned a `produceState` coroutine inside each
+ * `@Composable` and was duplicated across files (Home, History). Centralizing
+ * the tick keeps the clock consistent across screens, lets tests advance time
+ * deterministically (via [AppClock] + a test dispatcher), and removes
+ * `LaunchedEffect`-shaped concerns from the UI layer.
+ *
+ * Per ADR-019, the ticker runs on `externalScope` so it survives
+ * configuration changes and screen pauses.
+ *
+ * The default tick interval is 10s — fine-grained enough for the device
+ * heartbeat indicator (PR C) and short enough that the Home/History "Since"
+ * line stays visually current without burning recompositions on every frame.
+ * Mappers produce stable strings, so 10s ticks that don't change the string
+ * are no-ops in Compose.
+ */
+interface LiveClock {
+    /**
+     * Current wall-clock time as epoch seconds, ticking on the configured
+     * cadence. Always emits the most recent value to new subscribers.
+     */
+    val nowEpochSeconds: StateFlow<Long>
+
+    /**
+     * Begin ticking. Idempotent — calling twice is a no-op. Typically called
+     * from `AppStartup` so the clock runs for the lifetime of the process.
+     */
+    fun start()
+}
+
+class DefaultLiveClock(
+    private val clock: AppClock,
+    private val scope: CoroutineScope,
+    private val dispatcher: CoroutineDispatcher,
+    private val intervalMillis: Long = DEFAULT_TICK_INTERVAL_MS,
+) : LiveClock {
+    private val _nowEpochSeconds = MutableStateFlow(clock.nowEpochSeconds())
+    override val nowEpochSeconds: StateFlow<Long> = _nowEpochSeconds
+
+    private var tickJob: Job? = null
+
+    override fun start() {
+        if (tickJob?.isActive == true) {
+            Logger.d { "LiveClock: already running" }
+            return
+        }
+        tickJob = scope.launch(dispatcher) {
+            while (true) {
+                delay(intervalMillis)
+                _nowEpochSeconds.value = clock.nowEpochSeconds()
+            }
+        }
+    }
+
+    companion object {
+        /** 10 seconds — fast enough for sub-minute heartbeat granularity. */
+        const val DEFAULT_TICK_INTERVAL_MS = 10_000L
+    }
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DoorViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DoorViewModelTest.kt
@@ -91,6 +91,11 @@ class DoorViewModelTest {
             dispatcher = testDispatcher,
             clock = AppClock { 0L },
         )
+        val liveClock = DefaultLiveClock(
+            clock = AppClock { 0L },
+            scope = scope,
+            dispatcher = testDispatcher,
+        )
         val vm = DefaultDoorViewModel(
             observeDoorEvents = ObserveDoorEventsUseCase(doorRepository),
             logAppEvent = LogAppEventUseCase(appLoggerRepository),
@@ -100,6 +105,7 @@ class DoorViewModelTest {
             deregisterFcmUseCase = DeregisterFcmUseCase(doorFcmRepository),
             fcmRegistrationManager = fcmManager,
             checkInStalenessManager = stalenessManager,
+            liveClock = liveClock,
             fetchOnInit = fetchOnInit,
         )
         testDispatcher.scheduler.runCurrent()

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/LiveClockTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/LiveClockTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.testcommon.FakeClock
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LiveClockTest {
+    @Test
+    fun nowEpochSeconds_initialValueMatchesClock() =
+        runTest {
+            val clock = FakeClock(nowSeconds = 1_000L)
+            val liveClock = DefaultLiveClock(
+                clock = clock,
+                scope = backgroundScope,
+                dispatcher = StandardTestDispatcher(testScheduler),
+                intervalMillis = 10_000L,
+            )
+
+            assertEquals(1_000L, liveClock.nowEpochSeconds.value)
+        }
+
+    @Test
+    fun start_emitsNewValueAfterEachInterval() =
+        runTest {
+            val clock = FakeClock(nowSeconds = 1_000L)
+            val liveClock = DefaultLiveClock(
+                clock = clock,
+                scope = backgroundScope,
+                dispatcher = StandardTestDispatcher(testScheduler),
+                intervalMillis = 10_000L,
+            )
+
+            liveClock.start()
+            runCurrent()
+            assertEquals(1_000L, liveClock.nowEpochSeconds.value)
+
+            // Advance by one tick interval; clock should report the new "now".
+            clock.advanceSeconds(10L)
+            advanceTimeBy(10_000L)
+            runCurrent()
+            assertEquals(1_010L, liveClock.nowEpochSeconds.value)
+
+            // Two more intervals.
+            clock.advanceSeconds(20L)
+            advanceTimeBy(20_000L)
+            runCurrent()
+            assertEquals(1_030L, liveClock.nowEpochSeconds.value)
+        }
+
+    @Test
+    fun start_isIdempotent() =
+        runTest {
+            val clock = FakeClock(nowSeconds = 0L)
+            val liveClock = DefaultLiveClock(
+                clock = clock,
+                scope = backgroundScope,
+                dispatcher = StandardTestDispatcher(testScheduler),
+                intervalMillis = 10_000L,
+            )
+
+            liveClock.start()
+            liveClock.start()
+            liveClock.start()
+            runCurrent()
+
+            // Advance one interval; if multiple tick jobs were running, the value
+            // would still match clock (single-source) — but if anything bad
+            // happened (e.g. cancelled ticker), the value would stop updating.
+            clock.advanceSeconds(10L)
+            advanceTimeBy(10_000L)
+            runCurrent()
+            assertEquals(10L, liveClock.nowEpochSeconds.value)
+        }
+}


### PR DESCRIPTION
## Summary

PR **B of 3** in the FCM/clock/heartbeat series. Stacked on PR A (#610). Merge order: A → B → C.

The Home and History tabs each ran a private `@Composable rememberLiveNow()` that spawned a `produceState` coroutine ticking `now` every 30s. This kept time math in the UI layer, duplicated the ticker, and may have contributed to a user-reported bug where durations stopped updating until pull-to-refresh.

This pulls the ticker into a UseCase.

## What changed

**New: `LiveClock`** (`usecase/`, commonMain)
- Interface + `DefaultLiveClock` impl
- `nowEpochSeconds: StateFlow<Long>` ticks at 10s on `applicationScope`
- `start()` is idempotent
- 3 unit tests (initial value, tick interval, idempotency)

**Updated: `DoorViewModel`**
- Takes `LiveClock` constructor param
- Exposes `nowEpochSeconds: StateFlow<Long>` (pass-through, no mirror per ADR-022)

**Updated: UI bridges (`ui/HomeContent.kt`, `ui/DoorHistoryContent.kt`)**
- `rememberLiveNow()` helpers **deleted**
- Bridges now collect `doorViewModel.nowEpochSeconds`, convert to `Instant`, pass to existing mappers
- Composables own no ticker

**Updated: `AppStartup`**
- New `startLiveClock` action runs `liveClock.start()` alongside FCM + staleness managers

## DI / tests

- New abstract entry point `liveClock: LiveClock` on AppComponent
- New `@Provides @Singleton fun provideLiveClock(...)`
- DoorViewModel + AppStartup providers updated to inject it
- `ComponentGraphTest`: new `liveClockIsSingleton` assertSame check
- `DoorViewModelTest`: constructor signature updated to inject DefaultLiveClock
- `AppStartupTest`: covers new `startLiveClock` action

## Why 10s tick

Fast enough for the upcoming device-heartbeat indicator (PR C, "Nm Ms" precision). Mappers produce stable strings, so 10s ticks that don't change the visible string are no-ops in Compose.

## Test plan

- [x] All new + updated unit tests pass
- [x] `./scripts/validate.sh` passes (incl. `compileDebugAndroidTestKotlin`)
- [x] `checkSingletonCaching` passes — `LiveClock` reachable via abstract entry point
- [ ] After merge: verify `Since X · Y` on Home + per-row durations on History tick visibly without pull-to-refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)