### PR TITLE
feat(android): Device check-in section on Home + History; retire TopAppBar pill

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
@@ -39,6 +39,8 @@ import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.presentation.demoDoorEvents
 import com.chriscartland.garage.ui.history.HistoryContent
 import com.chriscartland.garage.ui.history.HistoryMapper
+import com.chriscartland.garage.ui.home.DeviceCheckIn
+import com.chriscartland.garage.ui.home.DeviceCheckInDisplay
 import com.chriscartland.garage.usecase.AppLoggerViewModel
 import com.chriscartland.garage.usecase.DoorViewModel
 import java.time.Instant
@@ -54,17 +56,23 @@ fun DoorHistoryContent(
     val resolvedDoorViewModel = doorViewModel ?: viewModel { component.doorViewModel }
     val resolvedAppLoggerViewModel = appLoggerViewModel ?: viewModel { component.appLoggerViewModel }
     val recentDoorEvents by resolvedDoorViewModel.recentDoorEvents.collectAsState()
+    val currentDoorEvent by resolvedDoorViewModel.currentDoorEvent.collectAsState()
     val isCheckInStale by resolvedDoorViewModel.isCheckInStale.collectAsState()
     // `now` is driven by the VM's LiveClock-backed StateFlow (10s tick) —
     // `rememberLiveNow()` no longer exists; the ticker is owned by the
     // UseCase layer and lives across the app, not per-Composable.
     val nowEpochSeconds by resolvedDoorViewModel.nowEpochSeconds.collectAsState()
     val now = remember(nowEpochSeconds) { Instant.ofEpochSecond(nowEpochSeconds) }
+    val deviceCheckIn = DeviceCheckIn.format(
+        lastCheckInSeconds = currentDoorEvent.data?.lastCheckInTimeSeconds,
+        nowSeconds = nowEpochSeconds,
+    )
     DoorHistoryContent(
         recentDoorEvents = recentDoorEvents,
         isCheckInStale = isCheckInStale,
         now = now,
         zone = ZoneId.systemDefault(),
+        deviceCheckIn = deviceCheckIn,
         modifier = modifier,
         onFetchRecentDoorEvents = {
             resolvedAppLoggerViewModel.log(AppLoggerKeys.USER_FETCH_RECENT_DOOR)
@@ -83,6 +91,7 @@ fun DoorHistoryContent(
     zone: ZoneId,
     modifier: Modifier = Modifier,
     isCheckInStale: Boolean = false,
+    deviceCheckIn: DeviceCheckInDisplay? = null,
     onFetchRecentDoorEvents: () -> Unit = {},
     onResetFcm: () -> Unit = {},
 ) {
@@ -120,6 +129,7 @@ fun DoorHistoryContent(
         }
         HistoryContent(
             days = days,
+            deviceCheckIn = deviceCheckIn,
             isRefreshing = recentDoorEvents is LoadingResult.Loading,
             onRefresh = onFetchRecentDoorEvents,
             modifier = Modifier.fillMaxWidth(),

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -33,6 +33,7 @@ import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.permissions.rememberNotificationPermissionState
+import com.chriscartland.garage.ui.home.DeviceCheckIn
 import com.chriscartland.garage.ui.home.HomeAlert
 import com.chriscartland.garage.ui.home.HomeMapper
 import com.chriscartland.garage.usecase.AppLoggerViewModel
@@ -93,6 +94,10 @@ fun HomeContent(
         notificationRequestCount = permissionRequestCount,
     )
     val homeAuthState = HomeMapper.toHomeAuthState(authState)
+    val deviceCheckIn = DeviceCheckIn.format(
+        lastCheckInSeconds = currentDoorEvent.data?.lastCheckInTimeSeconds,
+        nowSeconds = nowEpochSeconds,
+    )
 
     HomeContentInternal(
         status = status,
@@ -100,6 +105,7 @@ fun HomeContent(
         modifier = modifier,
         remoteButtonState = buttonState,
         alerts = alerts,
+        deviceCheckIn = deviceCheckIn,
         isRefreshing = currentDoorEvent is LoadingResult.Loading,
         onRefresh = {
             resolvedAppLoggerViewModel.log(AppLoggerKeys.USER_FETCH_CURRENT_DOOR)

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -22,10 +22,8 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.DateRange
@@ -40,7 +38,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
@@ -53,12 +50,10 @@ import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import com.chriscartland.garage.ui.settings.DiagnosticsScreen
 import com.chriscartland.garage.ui.theme.AppTheme
-import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
 import com.chriscartland.garage.usecase.AppLoggerViewModel
 import com.chriscartland.garage.usecase.AuthViewModel
 import com.chriscartland.garage.usecase.DoorViewModel
 import kotlinx.serialization.Serializable
-import java.time.Instant
 
 @Composable
 fun GarageApp(
@@ -124,13 +119,6 @@ fun AppNavigation(
     doorViewModel: DoorViewModel,
     appLoggerViewModel: AppLoggerViewModel,
 ) {
-    val currentDoorEvent by doorViewModel.currentDoorEvent.collectAsState()
-    val lastCheckInTime = currentDoorEvent.data?.lastCheckInTimeSeconds?.let {
-        Instant.ofEpochSecond(it)
-    }
-    val isCheckInStale by doorViewModel.isCheckInStale.collectAsState()
-    val doorColor = currentDoorEvent.data.color(LocalDoorStatusColorScheme.current, isStale = isCheckInStale)
-    val onDoorColor = currentDoorEvent.data.onColor(LocalDoorStatusColorScheme.current, isStale = isCheckInStale)
     // Nav3: back stack is a simple mutable list of Screen objects.
     // Using remember (not rememberSaveable) because Screen objects aren't Bundle-saveable.
     // For tab navigation this is fine — process death just restarts on Home tab.
@@ -163,18 +151,11 @@ fun AppNavigation(
                         }
                     }
                 },
-                actions = {
-                    CheckInRow(
-                        lastCheckIn = lastCheckInTime,
-                        isCheckInStale = isCheckInStale,
-                        pillColors = PillColors(
-                            // Match the door color
-                            backgroundColor = doorColor,
-                            contentColor = onDoorColor,
-                        ),
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                },
+                // Device-heartbeat indicator was retired from the TopAppBar in
+                // PR C of the FCM/clock/heartbeat series; the same data is now
+                // surfaced as a "Device" section row inside Home and History
+                // (see `DeviceCheckInSection`), in the new M3 sectioned-list
+                // visual language. The TopAppBar carries title + nav only.
             )
         },
         bottomBar = {

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryContent.kt
@@ -50,6 +50,8 @@ import androidx.compose.ui.unit.dp
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.ui.GarageIcon
+import com.chriscartland.garage.ui.home.DeviceCheckInDisplay
+import com.chriscartland.garage.ui.home.DeviceCheckInSection
 import com.chriscartland.garage.ui.theme.DoorColorState
 import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
 import com.chriscartland.garage.ui.theme.doorColorSet
@@ -137,6 +139,7 @@ data class HistoryDay(
 fun HistoryContent(
     days: List<HistoryDay>,
     modifier: Modifier = Modifier,
+    deviceCheckIn: DeviceCheckInDisplay? = null,
     isRefreshing: Boolean = false,
     onRefresh: () -> Unit = {},
 ) {
@@ -150,6 +153,23 @@ fun HistoryContent(
             contentPadding = PaddingValues(vertical = 16.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
+            if (deviceCheckIn != null) {
+                item(key = "device") {
+                    Column {
+                        Text(
+                            text = "DEVICE",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier
+                                .padding(start = 16.dp, top = 8.dp, bottom = 8.dp),
+                        )
+                        DeviceCheckInSection(
+                            display = deviceCheckIn,
+                            modifier = Modifier.padding(horizontal = 16.dp),
+                        )
+                    }
+                }
+            }
             if (days.isEmpty()) {
                 item { HistoryEmptyState() }
             } else {

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/DeviceCheckInSection.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/DeviceCheckInSection.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui.home
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.SignalCellular4Bar
+import androidx.compose.material.icons.outlined.SignalWifiOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+
+/**
+ * Display state for the "Device" section row that appears on Home and
+ * History tabs. Carries pre-formatted strings so the Composable stays
+ * stateless and unit tests cover the formatting logic directly.
+ *
+ * @param durationLabel e.g. "Just now", "30 sec ago", "1 min 30 sec ago".
+ * @param isStale true once the heartbeat is older than the staleness
+ *   threshold (`CHECK_IN_STALE_THRESHOLD_SECONDS`, 11 min). Drives the
+ *   icon flip + supporting copy.
+ */
+data class DeviceCheckInDisplay(
+    val durationLabel: String,
+    val isStale: Boolean,
+)
+
+/**
+ * Pure-function formatter for the device check-in label. Driven by
+ * [com.chriscartland.garage.usecase.LiveClock]'s 10s tick, so the seconds
+ * component naturally updates on each tick.
+ *
+ * @param lastCheckInSeconds epoch-seconds of the most recent device
+ *   heartbeat (`DoorEvent.lastCheckInTimeSeconds`). Null when no event
+ *   has been received yet.
+ * @param nowSeconds epoch-seconds of the current wall-clock — typically
+ *   `LiveClock.nowEpochSeconds.value`.
+ * @param staleThresholdSeconds heartbeat age past which the indicator
+ *   flips to stale. Defaults to 11 minutes (matches
+ *   `CheckInStalenessManager.CHECK_IN_STALE_THRESHOLD_SECONDS`).
+ */
+object DeviceCheckIn {
+    fun format(
+        lastCheckInSeconds: Long?,
+        nowSeconds: Long,
+        staleThresholdSeconds: Long = STALE_THRESHOLD_SECONDS,
+    ): DeviceCheckInDisplay {
+        if (lastCheckInSeconds == null) {
+            return DeviceCheckInDisplay(durationLabel = "No data yet", isStale = false)
+        }
+        val age = (nowSeconds - lastCheckInSeconds).coerceAtLeast(0L)
+        val label = when {
+            age < SECONDS_PER_MIN -> if (age < 10) "Just now" else "$age sec ago"
+            age < SECONDS_PER_HOUR -> {
+                val minutes = age / SECONDS_PER_MIN
+                val seconds = age % SECONDS_PER_MIN
+                if (seconds == 0L) "$minutes min ago" else "$minutes min $seconds sec ago"
+            }
+            age < SECONDS_PER_DAY -> {
+                val hours = age / SECONDS_PER_HOUR
+                val minutes = (age % SECONDS_PER_HOUR) / SECONDS_PER_MIN
+                if (minutes == 0L) "$hours hr ago" else "$hours hr $minutes min ago"
+            }
+            else -> {
+                val days = age / SECONDS_PER_DAY
+                if (days == 1L) "1 day ago" else "$days days ago"
+            }
+        }
+        return DeviceCheckInDisplay(
+            durationLabel = label,
+            isStale = age > staleThresholdSeconds,
+        )
+    }
+
+    private const val SECONDS_PER_MIN = 60L
+    private const val SECONDS_PER_HOUR = 3_600L
+    private const val SECONDS_PER_DAY = 86_400L
+
+    /** Mirrors `CheckInStalenessManager.CHECK_IN_STALE_THRESHOLD_SECONDS`. */
+    const val STALE_THRESHOLD_SECONDS = 11L * 60
+}
+
+/**
+ * Sectioned-list row that surfaces the device's most recent heartbeat
+ * age, separate from the door's last state-change. Always visible on
+ * Home and History — fits the new M3 sectioned-list aesthetic
+ * (`surfaceContainer` rounded surface, leading icon, ListItem row).
+ *
+ * Stateless — caller passes a pre-formatted [DeviceCheckInDisplay].
+ */
+@Composable
+fun DeviceCheckInSection(
+    display: DeviceCheckInDisplay,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        shape = MaterialTheme.shapes.large,
+    ) {
+        ListItem(
+            headlineContent = { Text("Last contact") },
+            supportingContent = { Text(display.durationLabel) },
+            leadingContent = {
+                Icon(
+                    imageVector = if (display.isStale) {
+                        Icons.Outlined.SignalWifiOff
+                    } else {
+                        Icons.Filled.SignalCellular4Bar
+                    },
+                    contentDescription = if (display.isStale) {
+                        "Device offline"
+                    } else {
+                        "Device online"
+                    },
+                    tint = if (display.isStale) {
+                        MaterialTheme.colorScheme.error
+                    } else {
+                        MaterialTheme.colorScheme.primary
+                    },
+                )
+            },
+            colors = ListItemDefaults.colors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainer,
+            ),
+            modifier = Modifier.clip(MaterialTheme.shapes.large),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DeviceCheckInSectionFreshPreview() {
+    DeviceCheckInSection(
+        display = DeviceCheckInDisplay(durationLabel = "30 sec ago", isStale = false),
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DeviceCheckInSectionAgingPreview() {
+    DeviceCheckInSection(
+        display = DeviceCheckInDisplay(durationLabel = "5 min 20 sec ago", isStale = false),
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DeviceCheckInSectionStalePreview() {
+    DeviceCheckInSection(
+        display = DeviceCheckInDisplay(durationLabel = "23 min ago", isStale = true),
+    )
+}

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
@@ -148,6 +148,7 @@ fun HomeContent(
     modifier: Modifier = Modifier,
     remoteButtonState: RemoteButtonState = RemoteButtonState.Ready,
     alerts: List<HomeAlert> = emptyList(),
+    deviceCheckIn: DeviceCheckInDisplay? = null,
     isRefreshing: Boolean = false,
     onRefresh: () -> Unit = {},
     onAlertAction: (HomeAlert) -> Unit = {},
@@ -180,6 +181,14 @@ fun HomeContent(
             item(key = "status") {
                 HomeSection(label = "Status") {
                     HomeStatusCardBody(status = status)
+                }
+            }
+
+            if (deviceCheckIn != null) {
+                item(key = "device") {
+                    HomeSection(label = "Device") {
+                        DeviceCheckInSection(display = deviceCheckIn)
+                    }
                 }
             }
 

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/home/DeviceCheckInTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/home/DeviceCheckInTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui.home
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DeviceCheckInTest {
+    @Test
+    fun format_nullLastCheckIn_returnsNoDataLabel() {
+        val display = DeviceCheckIn.format(lastCheckInSeconds = null, nowSeconds = 1_000L)
+        assertEquals("No data yet", display.durationLabel)
+        assertFalse(display.isStale)
+    }
+
+    @Test
+    fun format_zeroAge_returnsJustNow() {
+        val display = DeviceCheckIn.format(lastCheckInSeconds = 1_000L, nowSeconds = 1_000L)
+        assertEquals("Just now", display.durationLabel)
+    }
+
+    @Test
+    fun format_underTenSeconds_returnsJustNow() {
+        // The LiveClock ticks at 10s; "Just now" covers ages < 10s so we
+        // never show the awkward "9 sec ago" between ticks.
+        val display = DeviceCheckIn.format(lastCheckInSeconds = 1_000L, nowSeconds = 1_009L)
+        assertEquals("Just now", display.durationLabel)
+    }
+
+    @Test
+    fun format_tenSeconds_returnsSecondsLabel() {
+        val display = DeviceCheckIn.format(lastCheckInSeconds = 1_000L, nowSeconds = 1_010L)
+        assertEquals("10 sec ago", display.durationLabel)
+    }
+
+    @Test
+    fun format_thirtySeconds_returnsSecondsLabel() {
+        val display = DeviceCheckIn.format(lastCheckInSeconds = 1_000L, nowSeconds = 1_030L)
+        assertEquals("30 sec ago", display.durationLabel)
+    }
+
+    @Test
+    fun format_oneMinuteEven_omitsSecondsComponent() {
+        val display = DeviceCheckIn.format(lastCheckInSeconds = 1_000L, nowSeconds = 1_060L)
+        assertEquals("1 min ago", display.durationLabel)
+    }
+
+    @Test
+    fun format_oneMinuteThirtySeconds_includesSecondsComponent() {
+        val display = DeviceCheckIn.format(lastCheckInSeconds = 1_000L, nowSeconds = 1_090L)
+        assertEquals("1 min 30 sec ago", display.durationLabel)
+    }
+
+    @Test
+    fun format_belowStaleThreshold_isNotStale() {
+        // 10 minutes < 11 minute threshold
+        val display = DeviceCheckIn.format(lastCheckInSeconds = 0L, nowSeconds = 600L)
+        assertFalse(display.isStale)
+    }
+
+    @Test
+    fun format_atStaleThreshold_isNotStale() {
+        // Threshold is exclusive (> threshold, not >=)
+        val display = DeviceCheckIn.format(lastCheckInSeconds = 0L, nowSeconds = 660L)
+        assertFalse(display.isStale)
+    }
+
+    @Test
+    fun format_aboveStaleThreshold_isStale() {
+        // 11 min + 1 sec
+        val display = DeviceCheckIn.format(lastCheckInSeconds = 0L, nowSeconds = 661L)
+        assertTrue(display.isStale)
+    }
+
+    @Test
+    fun format_oneHourEven_omitsMinutesComponent() {
+        val display = DeviceCheckIn.format(lastCheckInSeconds = 0L, nowSeconds = 3_600L)
+        assertEquals("1 hr ago", display.durationLabel)
+    }
+
+    @Test
+    fun format_oneHourTwentyMinutes_includesMinutesComponent() {
+        val display = DeviceCheckIn.format(lastCheckInSeconds = 0L, nowSeconds = 4_800L)
+        assertEquals("1 hr 20 min ago", display.durationLabel)
+    }
+
+    @Test
+    fun format_oneDay_returnsSingularDayLabel() {
+        val display = DeviceCheckIn.format(lastCheckInSeconds = 0L, nowSeconds = 86_400L)
+        assertEquals("1 day ago", display.durationLabel)
+    }
+
+    @Test
+    fun format_threeDays_returnsPluralDaysLabel() {
+        val display = DeviceCheckIn.format(lastCheckInSeconds = 0L, nowSeconds = 86_400L * 3)
+        assertEquals("3 days ago", display.durationLabel)
+    }
+
+    @Test
+    fun format_negativeAge_clampedToJustNow() {
+        // Clock skew protection: if `now` is somehow earlier than the check-in,
+        // we don't render "-30 sec ago".
+        val display = DeviceCheckIn.format(lastCheckInSeconds = 1_000L, nowSeconds = 970L)
+        assertEquals("Just now", display.durationLabel)
+        assertFalse(display.isStale)
+    }
+}


### PR DESCRIPTION
## Summary

PR **C of 3** in the FCM/clock/heartbeat series. Stacked on PR B (#611), which is stacked on PR A (#610, merged). Merge order: A → B → C.

Adds an always-on **Device** section to Home and History tabs showing the duration since the device's most recent heartbeat. Distinct from the door's last state-change duration: a closed door for 3 days with a healthy 30s heartbeat is a different signal from a 30s-old state change.

Replaces the legacy `CheckInRow` TopAppBar pill — the only chrome widget left from before the 2.7/2.8 redesign.

## What changed

**New: `DeviceCheckInSection`** (`ui/home/DeviceCheckInSection.kt`)
- `DeviceCheckInDisplay(durationLabel, isStale)` data class
- `DeviceCheckIn.format(lastCheckInSeconds, nowSeconds)` pure formatter (14 unit tests)
- Stateless `@Composable DeviceCheckInSection(display)` — surfaceContainer rounded surface, ListItem row, signal-bars / signal-off icon flip

**Updated: stateless Home + History layouts**
- Each takes optional `deviceCheckIn: DeviceCheckInDisplay?`
- Home renders a `HomeSection(label = "Device")` between Status and action
- History renders a "DEVICE" header + section at the top of the LazyColumn

**Updated: bridges + Main.kt**
- Bridges compute display via `DeviceCheckIn.format(...)` from `currentDoorEvent.data?.lastCheckInTimeSeconds` + `nowEpochSeconds`
- `CheckInRow` removed from TopAppBar actions slot, unused locals cleaned

## Format rules

| Age | Label |
|---|---|
| null | "No data yet" |
| < 10 sec | "Just now" |
| < 1 min | "Ns ago" |
| < 1 hr | "Nm ago" / "Nm Ss ago" |
| < 1 day | "Nh ago" / "Nh Mm ago" |
| ≥ 1 day | "1 day ago" / "N days ago" |

\`isStale\` = age > 11 min (matches \`CheckInStalenessManager\`).

## Test plan

- [x] 14 unit tests cover null, zero, sub-10s, boundaries, plurals, stale, clock-skew
- [x] \`./scripts/validate.sh\` passes
- [ ] After merge: visually inspect Home + History on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)