### PR TITLE
feat(android): PreviewSurface helper; sweep dark-mode previews

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/AnimatableGarageDoor.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/AnimatableGarageDoor.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.graphics.ColorUtils
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
+import com.chriscartland.garage.ui.theme.PreviewSurface
 import java.time.Duration
 
 val DEFAULT_GARAGE_DOOR_ANIMATION_DURATION: Duration = Duration.ofSeconds(12)
@@ -229,32 +230,34 @@ private const val PREVIEW_ICON_WIDTH_DP = 300
 
 @Composable
 private fun PreviewBox(content: @Composable (Modifier) -> Unit) {
-    Box(
-        modifier = Modifier.size(PREVIEW_BOX_DP.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        content(
-            Modifier
-                .wrapContentSize()
-                .heightIn(max = PREVIEW_ICON_HEIGHT_DP.dp)
-                .widthIn(max = PREVIEW_ICON_WIDTH_DP.dp),
-        )
+    PreviewSurface {
+        Box(
+            modifier = Modifier.size(PREVIEW_BOX_DP.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            content(
+                Modifier
+                    .wrapContentSize()
+                    .heightIn(max = PREVIEW_ICON_HEIGHT_DP.dp)
+                    .widthIn(max = PREVIEW_ICON_WIDTH_DP.dp),
+            )
+        }
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun OpeningPreview() {
     PreviewBox { mod -> GarageIcon(DoorPosition.OPENING, modifier = mod, static = true) }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun ClosingPreview() {
     PreviewBox { mod -> GarageIcon(DoorPosition.CLOSING, modifier = mod, static = true) }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun ClosedPreview() {
     PreviewBox { mod ->
@@ -267,37 +270,37 @@ fun ClosedPreview() {
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun OpenPreview() {
     PreviewBox { mod -> GarageIcon(DoorPosition.OPEN, modifier = mod, static = true) }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun MidwayPreview() {
     PreviewBox { mod -> GarageIcon(DoorPosition.UNKNOWN, modifier = mod, static = true) }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun OpeningTooLongPreview() {
     PreviewBox { mod -> GarageIcon(DoorPosition.OPENING_TOO_LONG, modifier = mod, static = true) }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun ClosingTooLongPreview() {
     PreviewBox { mod -> GarageIcon(DoorPosition.CLOSING_TOO_LONG, modifier = mod, static = true) }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun OpenMisalignedPreview() {
     PreviewBox { mod -> GarageIcon(DoorPosition.OPEN_MISALIGNED, modifier = mod, static = true) }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun ErrorSensorConflictPreview() {
     PreviewBox { mod -> GarageIcon(DoorPosition.ERROR_SENSOR_CONFLICT, modifier = mod, static = true) }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorStatusCard.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorStatusCard.kt
@@ -22,8 +22,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
@@ -32,7 +30,6 @@ import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -49,6 +46,7 @@ import com.chriscartland.garage.presentation.demoDoorEvents
 import com.chriscartland.garage.ui.theme.DoorColorState
 import com.chriscartland.garage.ui.theme.DoorStatusColorScheme
 import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
+import com.chriscartland.garage.ui.theme.PreviewSurface
 import com.chriscartland.garage.ui.theme.doorColorSet
 import com.chriscartland.garage.ui.theme.doorColorState
 import java.time.Instant
@@ -191,10 +189,10 @@ private fun DoorPosition.toFriendlyName(): String =
         DoorPosition.ERROR_SENSOR_CONFLICT -> "Error: Sensor Conflict"
     }
 
-@Preview(showBackground = true)
+@Preview(heightDp = 300)
 @Composable
 fun DoorStatusCardPreview() {
-    Surface(modifier = Modifier.fillMaxWidth().height(300.dp)) {
+    PreviewSurface {
         DoorStatusCard(
             demoDoorEvents.firstOrNull(),
             modifier = Modifier.fillMaxSize(),

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/FunctionListContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/FunctionListContent.kt
@@ -19,13 +19,11 @@ package com.chriscartland.garage.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -38,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.chriscartland.garage.auth.rememberGoogleSignIn
 import com.chriscartland.garage.di.rememberAppComponent
+import com.chriscartland.garage.ui.theme.PreviewSurface
 import com.chriscartland.garage.usecase.FunctionListViewModel
 
 @Composable
@@ -123,15 +122,14 @@ private fun FunctionButton(
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun FunctionListContentPreview() {
     // Pass explicit lambdas so Kotlin picks the stateless inner overload —
     // the DI wrapper above this calls rememberAppComponent(), which crashes
     // Layoutlib in screenshot tests.
-    Surface(modifier = Modifier.fillMaxSize()) {
+    PreviewSurface {
         FunctionListContent(
-            modifier = Modifier.fillMaxSize(),
             accessGranted = true,
             onOpenOrCloseDoor = {},
             onRefreshDoorStatus = {},
@@ -143,12 +141,11 @@ fun FunctionListContentPreview() {
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun FunctionListContentDeniedPreview() {
-    Surface(modifier = Modifier.fillMaxSize()) {
+    PreviewSurface {
         FunctionListContent(
-            modifier = Modifier.fillMaxSize(),
             accessGranted = false,
             onOpenOrCloseDoor = {},
             onRefreshDoorStatus = {},

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/GarageDoorButton.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/GarageDoorButton.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.chriscartland.garage.domain.model.RemoteButtonState
-import com.chriscartland.garage.ui.theme.AppTheme
+import com.chriscartland.garage.ui.theme.PreviewSurface
 import com.chriscartland.garage.ui.theme.cautionContainer
 import com.chriscartland.garage.ui.theme.onCautionContainer
 
@@ -131,74 +131,74 @@ private fun RemoteButtonState.disabledLabel(): String =
 
 // region Previews
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun GarageDoorButtonReadyPreview() {
-    AppTheme {
+    PreviewSurface {
         GarageDoorButton(state = RemoteButtonState.Ready, onTap = {})
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun GarageDoorButtonPreparingPreview() {
-    AppTheme {
+    PreviewSurface {
         GarageDoorButton(state = RemoteButtonState.Preparing, onTap = {})
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun GarageDoorButtonAwaitingConfirmationPreview() {
-    AppTheme {
+    PreviewSurface {
         GarageDoorButton(state = RemoteButtonState.AwaitingConfirmation, onTap = {})
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun GarageDoorButtonCancelledPreview() {
-    AppTheme {
+    PreviewSurface {
         GarageDoorButton(state = RemoteButtonState.Cancelled, onTap = {})
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun GarageDoorButtonSendingToServerPreview() {
-    AppTheme {
+    PreviewSurface {
         GarageDoorButton(state = RemoteButtonState.SendingToServer, onTap = {})
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun GarageDoorButtonSendingToDoorPreview() {
-    AppTheme {
+    PreviewSurface {
         GarageDoorButton(state = RemoteButtonState.SendingToDoor, onTap = {})
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun GarageDoorButtonSucceededPreview() {
-    AppTheme {
+    PreviewSurface {
         GarageDoorButton(state = RemoteButtonState.Succeeded, onTap = {})
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun GarageDoorButtonServerFailedPreview() {
-    AppTheme {
+    PreviewSurface {
         GarageDoorButton(state = RemoteButtonState.ServerFailed, onTap = {})
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun GarageDoorButtonDoorFailedPreview() {
-    AppTheme {
+    PreviewSurface {
         GarageDoorButton(state = RemoteButtonState.DoorFailed, onTap = {})
     }
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/GarageIcon.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/GarageIcon.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
+import com.chriscartland.garage.ui.theme.PreviewSurface
 import java.time.Duration
 
 /**
@@ -139,11 +140,13 @@ private fun DoorIconBox(
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun GarageIconPreview() {
-    GarageIcon(
-        doorPosition = DoorPosition.OPENING,
-        static = true,
-    )
+    PreviewSurface {
+        GarageIcon(
+            doorPosition = DoorPosition.OPENING,
+            static = true,
+        )
+    }
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/NetworkProgressDiagram.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/NetworkProgressDiagram.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.chriscartland.garage.ui.theme.AppTheme
+import com.chriscartland.garage.ui.theme.PreviewSurface
 import com.chriscartland.garage.ui.theme.networkFailed
 import com.chriscartland.garage.ui.theme.networkNotStarted
 import com.chriscartland.garage.ui.theme.networkSucceeded
@@ -234,10 +234,10 @@ private val DIAGRAM_ICONS = listOf(
     Icons.Filled.Home,
 )
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun NetworkDiagramIdlePreview() {
-    AppTheme {
+    PreviewSurface {
         NetworkProgressDiagram(
             state = NetworkDiagramState(
                 nodes = listOf(NodeStatus.Idle, NodeStatus.Idle, NodeStatus.Idle),
@@ -248,10 +248,10 @@ fun NetworkDiagramIdlePreview() {
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun NetworkDiagramSendingToServerPreview() {
-    AppTheme {
+    PreviewSurface {
         NetworkProgressDiagram(
             state = NetworkDiagramState(
                 nodes = listOf(NodeStatus.Active, NodeStatus.Idle, NodeStatus.Idle),
@@ -262,10 +262,10 @@ fun NetworkDiagramSendingToServerPreview() {
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun NetworkDiagramSendingToDoorPreview() {
-    AppTheme {
+    PreviewSurface {
         NetworkProgressDiagram(
             state = NetworkDiagramState(
                 nodes = listOf(NodeStatus.Succeeded, NodeStatus.Active, NodeStatus.Idle),
@@ -276,10 +276,10 @@ fun NetworkDiagramSendingToDoorPreview() {
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun NetworkDiagramSucceededPreview() {
-    AppTheme {
+    PreviewSurface {
         NetworkProgressDiagram(
             state = NetworkDiagramState(
                 nodes = listOf(NodeStatus.Succeeded, NodeStatus.Succeeded, NodeStatus.Succeeded),
@@ -290,10 +290,10 @@ fun NetworkDiagramSucceededPreview() {
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun NetworkDiagramServerFailedPreview() {
-    AppTheme {
+    PreviewSurface {
         NetworkProgressDiagram(
             state = NetworkDiagramState(
                 nodes = listOf(NodeStatus.Failed, NodeStatus.Idle, NodeStatus.Idle),
@@ -304,10 +304,10 @@ fun NetworkDiagramServerFailedPreview() {
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun NetworkDiagramDoorFailedPreview() {
-    AppTheme {
+    PreviewSurface {
         NetworkProgressDiagram(
             state = NetworkDiagramState(
                 nodes = listOf(NodeStatus.Succeeded, NodeStatus.Failed, NodeStatus.Idle),

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/OldLastCheckInBanner.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/OldLastCheckInBanner.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.chriscartland.garage.R
 import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
+import com.chriscartland.garage.ui.theme.PreviewSurface
 import java.time.Instant
 
 data class PillColors(
@@ -116,38 +117,46 @@ fun OldLastCheckInBanner(
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun LastCheckInRowPreview() {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        // This is called in a RowScope by TopAppBar.
-        CheckInRow(Instant.now().minusSeconds(123), isCheckInStale = false)
+    PreviewSurface {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // This is called in a RowScope by TopAppBar.
+            CheckInRow(Instant.now().minusSeconds(123), isCheckInStale = false)
+        }
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun LastCheckInRowOldPreview() {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        // This is called in a RowScope by TopAppBar.
-        CheckInRow(Instant.now().minusSeconds(1234), isCheckInStale = true)
+    PreviewSurface {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // This is called in a RowScope by TopAppBar.
+            CheckInRow(Instant.now().minusSeconds(1234), isCheckInStale = true)
+        }
     }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun LastCheckInBannerPreview() {
-    OldLastCheckInBanner()
+    PreviewSurface {
+        OldLastCheckInBanner()
+    }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun LastCheckInBannerOldWithActionPreview() {
-    OldLastCheckInBanner(
-        action = {},
-    )
+    PreviewSurface {
+        OldLastCheckInBanner(
+            action = {},
+        )
+    }
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/RemoteButtonContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/RemoteButtonContent.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.chriscartland.garage.domain.model.RemoteButtonState
-import com.chriscartland.garage.ui.theme.AppTheme
+import com.chriscartland.garage.ui.theme.PreviewSurface
 
 private val GARAGE_DIAGRAM_ICONS = listOf(
     Icons.Filled.PhoneAndroid,
@@ -73,58 +73,58 @@ fun RemoteButtonContent(
 
 // region Previews
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun RemoteButtonContentPreview() {
-    AppTheme { RemoteButtonContent(state = RemoteButtonState.Ready, onTap = {}) }
+    PreviewSurface { RemoteButtonContent(state = RemoteButtonState.Ready, onTap = {}) }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun RemoteButtonContentPreparingPreview() {
-    AppTheme { RemoteButtonContent(state = RemoteButtonState.Preparing, onTap = {}) }
+    PreviewSurface { RemoteButtonContent(state = RemoteButtonState.Preparing, onTap = {}) }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun RemoteButtonContentAwaitingConfirmationPreview() {
-    AppTheme { RemoteButtonContent(state = RemoteButtonState.AwaitingConfirmation, onTap = {}) }
+    PreviewSurface { RemoteButtonContent(state = RemoteButtonState.AwaitingConfirmation, onTap = {}) }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun RemoteButtonContentCancelledPreview() {
-    AppTheme { RemoteButtonContent(state = RemoteButtonState.Cancelled, onTap = {}) }
+    PreviewSurface { RemoteButtonContent(state = RemoteButtonState.Cancelled, onTap = {}) }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun RemoteButtonContentSendingToServerPreview() {
-    AppTheme { RemoteButtonContent(state = RemoteButtonState.SendingToServer, onTap = {}) }
+    PreviewSurface { RemoteButtonContent(state = RemoteButtonState.SendingToServer, onTap = {}) }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun RemoteButtonContentSendingToDoorPreview() {
-    AppTheme { RemoteButtonContent(state = RemoteButtonState.SendingToDoor, onTap = {}) }
+    PreviewSurface { RemoteButtonContent(state = RemoteButtonState.SendingToDoor, onTap = {}) }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun RemoteButtonContentSucceededPreview() {
-    AppTheme { RemoteButtonContent(state = RemoteButtonState.Succeeded, onTap = {}) }
+    PreviewSurface { RemoteButtonContent(state = RemoteButtonState.Succeeded, onTap = {}) }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun RemoteButtonContentServerFailedPreview() {
-    AppTheme { RemoteButtonContent(state = RemoteButtonState.ServerFailed, onTap = {}) }
+    PreviewSurface { RemoteButtonContent(state = RemoteButtonState.ServerFailed, onTap = {}) }
 }
 
-@Preview(showBackground = true)
+@Preview
 @Composable
 fun RemoteButtonContentDoorFailedPreview() {
-    AppTheme { RemoteButtonContent(state = RemoteButtonState.DoorFailed, onTap = {}) }
+    PreviewSurface { RemoteButtonContent(state = RemoteButtonState.DoorFailed, onTap = {}) }
 }
 
 // endregion

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
@@ -60,6 +60,7 @@ import com.chriscartland.garage.ui.GarageIcon
 import com.chriscartland.garage.ui.RemoteButtonContent
 import com.chriscartland.garage.ui.theme.DoorColorState
 import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
+import com.chriscartland.garage.ui.theme.PreviewSurface
 import com.chriscartland.garage.ui.theme.doorColorSet
 import com.chriscartland.garage.ui.theme.doorColorState
 
@@ -431,22 +432,10 @@ private object HomePreviewData {
     )
 }
 
-@Composable
-private fun HomePreviewFrame(content: @Composable () -> Unit) {
-    // `@Preview(showBackground = true)` hardcodes a white background that
-    // ignores the active color scheme — making dark-mode previews look like
-    // dark cards floating on a light page. Wrap the preview body in a
-    // background-colored Surface so the page background follows the theme.
-    Surface(
-        color = MaterialTheme.colorScheme.background,
-        modifier = Modifier.fillMaxSize(),
-    ) { content() }
-}
-
 @Preview(heightDp = 900)
 @Composable
 fun HomeContentOpenSignedInPreview() =
-    HomePreviewFrame {
+    PreviewSurface {
         HomeContent(
             status = HomePreviewData.openStatus,
             authState = HomeAuthState.SignedIn,
@@ -458,7 +447,7 @@ fun HomeContentOpenSignedInPreview() =
 @Preview(heightDp = 900)
 @Composable
 fun HomeContentClosedSignedInPreview() =
-    HomePreviewFrame {
+    PreviewSurface {
         HomeContent(
             status = HomePreviewData.closedStatus,
             authState = HomeAuthState.SignedIn,
@@ -470,7 +459,7 @@ fun HomeContentClosedSignedInPreview() =
 @Preview(heightDp = 900)
 @Composable
 fun HomeContentAwaitingConfirmationPreview() =
-    HomePreviewFrame {
+    PreviewSurface {
         HomeContent(
             status = HomePreviewData.closedStatus,
             authState = HomeAuthState.SignedIn,
@@ -482,7 +471,7 @@ fun HomeContentAwaitingConfirmationPreview() =
 @Preview(heightDp = 900)
 @Composable
 fun HomeContentSendingToDoorPreview() =
-    HomePreviewFrame {
+    PreviewSurface {
         HomeContent(
             status = HomePreviewData.closedStatus,
             authState = HomeAuthState.SignedIn,
@@ -494,7 +483,7 @@ fun HomeContentSendingToDoorPreview() =
 @Preview(heightDp = 900)
 @Composable
 fun HomeContentOpeningTooLongPreview() =
-    HomePreviewFrame {
+    PreviewSurface {
         HomeContent(
             status = HomePreviewData.openingTooLongStatus,
             authState = HomeAuthState.SignedIn,
@@ -506,7 +495,7 @@ fun HomeContentOpeningTooLongPreview() =
 @Preview(heightDp = 900)
 @Composable
 fun HomeContentStaleBannerPreview() =
-    HomePreviewFrame {
+    PreviewSurface {
         HomeContent(
             status = HomePreviewData.openStatus,
             authState = HomeAuthState.SignedIn,
@@ -519,7 +508,7 @@ fun HomeContentStaleBannerPreview() =
 @Preview(heightDp = 900)
 @Composable
 fun HomeContentPermissionMissingPreview() =
-    HomePreviewFrame {
+    PreviewSurface {
         HomeContent(
             status = HomePreviewData.openStatus,
             authState = HomeAuthState.SignedIn,
@@ -532,7 +521,7 @@ fun HomeContentPermissionMissingPreview() =
 @Preview(heightDp = 900)
 @Composable
 fun HomeContentSignedOutPreview() =
-    HomePreviewFrame {
+    PreviewSurface {
         HomeContent(
             status = HomePreviewData.openStatus,
             authState = HomeAuthState.SignedOut,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/theme/PreviewSurface.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/theme/PreviewSurface.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui.theme
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * Standard preview wrapper that applies [AppTheme] and a theme-aware page background.
+ *
+ * Use instead of `@Preview(showBackground = true)` — that flag hardcodes a white
+ * background that ignores the active color scheme, so dark-mode screenshot tests
+ * render dark UI on a light page. This wrapper paints the page in
+ * [MaterialTheme.colorScheme.background], so light/dark previews look like the
+ * real app.
+ *
+ * Idempotent if a caller already wraps in [AppTheme] (e.g. screenshot tests):
+ * the inner [AppTheme] reads `isSystemInDarkTheme()` from the same configuration.
+ */
+@Composable
+fun PreviewSurface(content: @Composable () -> Unit) {
+    AppTheme {
+        Surface(
+            color = MaterialTheme.colorScheme.background,
+            modifier = Modifier.fillMaxSize(),
+        ) { content() }
+    }
+}


### PR DESCRIPTION
## Summary

`@Preview(showBackground = true)` hardcodes a white background that ignores the active color scheme — so dark-mode screenshot tests render dark UI on a light page. This PR introduces a shared `PreviewSurface` Composable that wraps content in `AppTheme` plus `Surface(color = MaterialTheme.colorScheme.background)`, making previews theme-aware in both light and dark modes.

- New `ui/theme/PreviewSurface.kt` — single source of truth for the wrap pattern.
- Replaces the duplicate private `HomePreviewFrame` in `ui/home/HomeContent.kt`.
- Sweeps 9 production-preview files: drops `showBackground = true`, wraps in `PreviewSurface`. Files where the existing pattern was `AppTheme { ... }` (RemoteButtonContent, GarageDoorButton, NetworkProgressDiagram) just swap the wrapper to `PreviewSurface` since the new helper applies `AppTheme` internally.

`TabPreviews.kt` was deliberately skipped — its previews already use `Scaffold` which paints `colorScheme.background`. Adding a Surface around it would be dead weight.

`ui/home/DeviceCheckInSection.kt` previews aren't covered here — that file is owned by the in-flight #612 stack. A follow-up will fix it after #612 lands.

## Reference PNGs

**Reference PNGs are not updated in this PR.** The screenshot generator OOM'd mid-run with the default 2 GB heap (failing on `ErrorCardPreviewTest`, which is unrelated to this sweep). Screenshots don't gate CI — they're tracked over time. A follow-up will regenerate them once the heap issue is sorted.

## Test plan

- [x] `./scripts/validate.sh` — passes (compile, lint, all tests, screenshot-test compile, instrumented-test compile, doc front-matter, whatsnew length, Room schema)
- [ ] Manual: open Android Studio previews for the swept files, confirm dark-mode renders correctly
- [ ] Follow-up PR: regenerate reference PNGs (light + dark) for all 9 swept files
- [ ] Follow-up PR (after #612 merges): apply `PreviewSurface` to `DeviceCheckInSection.kt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)