### PR TITLE
chore(android): Allow `--tests <FQCN>` to bypass screenshot OOM gate

### DIFF
--- a/AndroidGarage/android-screenshot-tests/build.gradle.kts
+++ b/AndroidGarage/android-screenshot-tests/build.gradle.kts
@@ -74,16 +74,22 @@ tasks.register<Exec>("generateScreenshotGallery") {
 }
 
 tasks.whenTaskAdded {
-    if (name == "updateDebugScreenshotTest") {
-        if (!project.hasProperty("retainedReferenceScreenshots")) {
-            dependsOn("cleanReferenceScreenshots")
-        }
-    }
-    if (name in listOf("updateDebugScreenshotTest", "validateDebugScreenshotTest")) {
-        doFirst {
-            val isSequentialScript = project.hasProperty("retainedReferenceScreenshots")
-            val isForced = project.hasProperty("forceAllScreenshots")
-            if (!isSequentialScript && !isForced) {
+    val taskName = name
+    if (taskName in listOf("updateDebugScreenshotTest", "validateDebugScreenshotTest")) {
+        // Capture flag/property state at configuration time so the
+        // configuration cache can serialize the doFirst action. AGP's
+        // screenshot tasks aren't `Test` subclasses, so the standard
+        // filter API is unavailable — read `--tests` from the raw
+        // start-parameter task-request args instead.
+        val isSequentialScript = project.hasProperty("retainedReferenceScreenshots")
+        val isForced = project.hasProperty("forceAllScreenshots")
+        val passedTestsArg = gradle.startParameter.taskRequests
+            .flatMap { it.args }
+            .contains("--tests")
+        val refDirCapture = file("src/screenshotTestDebug/reference")
+
+        doFirst("Screenshot OOM gate") {
+            if (!isSequentialScript && !isForced && !passedTestsArg) {
                 error(
                     """
 
@@ -92,16 +98,31 @@ tasks.whenTaskAdded {
                     invocation may cause OutOfMemoryError.
                     ===========================================================
 
-                    Use the sequential script instead:
+                    Use the sequential script for the full suite:
                       ./scripts/generate-android-screenshots.sh
 
-                    To force a single-invocation run, add:
+                    Or target one class with --tests (no property needed):
+                      ./gradlew :android-screenshot-tests:$taskName \
+                        --tests com.chriscartland.garage.screenshottests.HomeRedesignScreenshotTestKt
+
+                    To force the full single-invocation run, add:
                       -PforceAllScreenshots
 
                     ===========================================================
 
                     """.trimIndent(),
                 )
+            }
+
+            // Selective clean: only wipe ALL references on a full update.
+            // Subset runs (`--tests`) and the sequential script preserve siblings.
+            if (taskName == "updateDebugScreenshotTest" &&
+                !isSequentialScript && !passedTestsArg
+            ) {
+                if (refDirCapture.exists()) {
+                    refDirCapture.deleteRecursively()
+                    println("Deleted reference screenshots: $refDirCapture")
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Standard Gradle usage `./gradlew :android-screenshot-tests:updateDebugScreenshotTest --tests <FQCN>` was previously BLOCKED by the OOM gate, even though a single-class run cannot trigger the full-suite OOM the gate exists to prevent.

This PR allows `--tests` to bypass the gate with no Gradle property required, while keeping the gate firing for plain (full-suite) invocations.

## Behavior matrix

| Invocation | Before | After |
| --- | --- | --- |
| `./gradlew :…:updateDebugScreenshotTest` | BLOCKED | BLOCKED ✓ |
| `… --tests <FQCN>` | BLOCKED | runs, no clean ✓ |
| `… -PforceAllScreenshots` | runs (full clean) | runs (full clean) ✓ |
| `./scripts/generate-android-screenshots.sh` (sets `-PretainedReferenceScreenshots`) | runs | runs ✓ |

`--tests` runs also skip the destructive `cleanReferenceScreenshots` step so siblings aren't wiped. The standalone `cleanReferenceScreenshots` task is preserved for manual use.

## Implementation note

AGP's `updateDebugScreenshotTest` / `validateDebugScreenshotTest` are `PreviewScreenshotUpdateTask` / `PreviewScreenshotValidationTask`, not `Test` subclasses, so `task.filter.includePatterns` isn't available. Detection reads `gradle.startParameter.taskRequests[].args` for the literal `--tests` token. State is captured at config time so the configuration cache can serialize the `doFirst` action.

## Test plan

- [x] Plain `./gradlew :android-screenshot-tests:updateDebugScreenshotTest` → BLOCKED message printed, build fails
- [x] `… --tests <FQCN>` → BUILD SUCCESSFUL, no references wiped
- [x] `./scripts/validate.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)