### PR TITLE
fix(android): Spotless violation in android-screenshot-tests build script

### DIFF
--- a/AndroidGarage/android-screenshot-tests/build.gradle.kts
+++ b/AndroidGarage/android-screenshot-tests/build.gradle.kts
@@ -117,7 +117,8 @@ tasks.whenTaskAdded {
             // Selective clean: only wipe ALL references on a full update.
             // Subset runs (`--tests`) and the sequential script preserve siblings.
             if (taskName == "updateDebugScreenshotTest" &&
-                !isSequentialScript && !passedTestsArg
+                !isSequentialScript &&
+                !passedTestsArg
             ) {
                 if (refDirCapture.exists()) {
                     refDirCapture.deleteRecursively()


### PR DESCRIPTION
## Summary

ktlint requires each operand of a multi-line `&&` chain on its own line when the `if` already breaks across lines. PR #615 left two operands on one line in the screenshot OOM gate's selective-clean predicate. Pre-submit cached the prior task result; post-merge ran fresh and caught it.

```kotlin
// Before
if (taskName == "updateDebugScreenshotTest" &&
    !isSequentialScript && !passedTestsArg
)

// After
if (taskName == "updateDebugScreenshotTest" &&
    !isSequentialScript &&
    !passedTestsArg
)
```

Closes #616.

## Test plan

- [x] `./gradlew :android-screenshot-tests:spotlessKotlinGradleCheck --no-build-cache --rerun-tasks --no-configuration-cache` passes locally (the same flags I used to reproduce the failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)