### PR TITLE
fix(android): Restore Home animations broken by recent merges

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/GarageIcon.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/GarageIcon.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.tooling.preview.Preview
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
@@ -48,6 +49,10 @@ import java.time.Duration
  *
  * @param static when `true`, render at [staticPositionFor] (no animation,
  *   no Animatable). Used by past-event snapshots in the recent events list.
+ *   Always treated as `true` under [LocalInspectionMode] (Studio previews +
+ *   screenshot tests) so reference PNGs are deterministic — Layoutlib can't
+ *   advance `LaunchedEffect`, so an animated `OPENING` would otherwise
+ *   render at the start frame and look identical to `CLOSED`.
  */
 @Composable
 fun GarageIcon(
@@ -57,7 +62,7 @@ fun GarageIcon(
     color: Color = LocalDoorStatusColorScheme.current.openFresh,
     duration: Duration = DEFAULT_GARAGE_DOOR_ANIMATION_DURATION,
 ) {
-    if (static) {
+    if (static || LocalInspectionMode.current) {
         DoorIconBox(
             doorOffset = DoorAnimation.staticPositionFor(doorPosition),
             doorPosition = doorPosition,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -86,7 +86,7 @@ fun HomeContent(
     val now = remember(nowEpochSeconds) { Instant.ofEpochSecond(nowEpochSeconds) }
     val zone = remember { ZoneId.systemDefault() }
 
-    val status = HomeMapper.toHomeStatusDisplay(currentDoorEvent, now, zone)
+    val status = HomeMapper.toHomeStatusDisplay(currentDoorEvent, now, zone, isCheckInStale)
     val alerts = HomeMapper.toHomeAlerts(
         currentDoorEvent = currentDoorEvent,
         isCheckInStale = isCheckInStale,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
@@ -84,6 +84,8 @@ data class HomeStatusDisplay(
     val stateLabel: String,
     val sinceLine: String,
     val warning: String? = null,
+    /** Drives the muted "stale" door color and disables animation when true. */
+    val isStale: Boolean = false,
 )
 
 /** Auth-gated bottom card variant. */
@@ -247,7 +249,7 @@ private fun HomeSection(
 
 @Composable
 private fun HomeStatusCardBody(status: HomeStatusDisplay) {
-    val colorSet = LocalDoorStatusColorScheme.current.doorColorSet(isStale = false)
+    val colorSet = LocalDoorStatusColorScheme.current.doorColorSet(isStale = status.isStale)
     val doorColor = when (DoorEvent(doorPosition = status.doorPosition).doorColorState()) {
         DoorColorState.OPEN -> colorSet.open
         DoorColorState.CLOSED -> colorSet.closed
@@ -266,9 +268,12 @@ private fun HomeStatusCardBody(status: HomeStatusDisplay) {
                 .height(180.dp),
             contentAlignment = Alignment.Center,
         ) {
+            // Live state — animate motion (OPENING/CLOSING tween, terminal/error
+            // spring). History rows stay `static = true` because they show past
+            // snapshots, not the current motion.
             GarageIcon(
                 doorPosition = status.doorPosition,
-                static = true,
+                static = false,
                 color = doorColor,
                 modifier = Modifier.size(160.dp),
             )

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeMapper.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeMapper.kt
@@ -41,11 +41,14 @@ object HomeMapper {
      * @param now used for "Since X · Y" duration computation.
      * @param zone used to compute the local-day boundary for whether to show
      *   "9:47 AM" vs. "Apr 28, 9:47 PM".
+     * @param isCheckInStale picks the muted door-color variant when the
+     *   device hasn't checked in recently.
      */
     fun toHomeStatusDisplay(
         currentDoorEvent: LoadingResult<DoorEvent?>,
         now: Instant,
         zone: ZoneId,
+        isCheckInStale: Boolean = false,
     ): HomeStatusDisplay {
         val event = currentDoorEvent.data
         val doorPosition = event?.doorPosition ?: DoorPosition.UNKNOWN
@@ -54,6 +57,7 @@ object HomeMapper {
             stateLabel = stateLabel(doorPosition),
             sinceLine = sinceLine(event?.lastChangeTimeSeconds, now, zone),
             warning = warning(event),
+            isStale = isCheckInStale,
         )
     }
 

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/LiveClock.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/LiveClock.kt
@@ -43,11 +43,12 @@ import kotlinx.coroutines.launch
  * Per ADR-019, the ticker runs on `externalScope` so it survives
  * configuration changes and screen pauses.
  *
- * The default tick interval is 10s — fine-grained enough for the device
- * heartbeat indicator (PR C) and short enough that the Home/History "Since"
- * line stays visually current without burning recompositions on every frame.
- * Mappers produce stable strings, so 10s ticks that don't change the string
- * are no-ops in Compose.
+ * The default tick interval is 1s. The "Since X · Y" line and the device
+ * heartbeat row both display single-second granularity in the leading
+ * bucket ("12 sec ago", "Since 9:47 AM · 3 sec"); a 10s tick made those
+ * counters jump in 10-second steps and felt frozen. Mappers produce stable
+ * strings, so 1s ticks that don't change the string are no-ops in Compose
+ * (StateFlow's equality dedup).
  */
 interface LiveClock {
     /**
@@ -88,7 +89,7 @@ class DefaultLiveClock(
     }
 
     companion object {
-        /** 10 seconds — fast enough for sub-minute heartbeat granularity. */
-        const val DEFAULT_TICK_INTERVAL_MS = 10_000L
+        /** 1 second — matches the per-Composable tickers it replaced. */
+        const val DEFAULT_TICK_INTERVAL_MS = 1_000L
     }
 }


### PR DESCRIPTION
## Summary

Three regressions surfaced after the Home redesign (#603) and the LiveClock migration (#611). All three are user-visible bugs on the Home tab.

### 1. Door icon stopped animating
Legacy `DoorStatusCard` passed `static = false` → tween (OPENING/CLOSING) + spring (terminal/error). The new `home/HomeContent.HomeStatusCardBody` hardcoded `static = true`, freezing the icon. Restore `static = false` for the live status. History rows stay `static = true` (intentional — past snapshots).

### 2. Live-duration tick rate dropped from 1 s → 10 s
The old `rememberDurationSince` per-Composable ticker used `delay(1_000L)`. LiveClock (which replaced it) ticked at 10 s, so "Since 9:47 AM · 12 sec" jumped in 10-second increments and the device check-in row felt frozen. Drop the LiveClock interval to 1 s. `MutableStateFlow` dedups by equality, so unchanged formatted strings are no-op recompositions; cost is one `delay(1_000L)` and a single epoch-second StateFlow set per second.

### 3. Stale-state door coloring lost
`home/HomeContent` hardcoded `doorColorSet(isStale = false)`. Stale device check-in no longer muted the door color. Thread `isCheckInStale` through `HomeMapper.toHomeStatusDisplay` → new `HomeStatusDisplay.isStale` field → consumed by `HomeStatusCardBody`.

## Screenshot determinism

`GarageIcon` now treats `LocalInspectionMode` as forced-static, regardless of the `static` parameter. Studio previews and screenshot tests don't run `LaunchedEffect` long enough to advance the `Animatable`, so an animated `OPENING` would otherwise render at the start frame (CLOSED) — caught by PR #543 originally; this re-introduces the determinism guarantee at the `GarageIcon` level so callers don't have to know about it.

## Test plan

- [x] `./scripts/validate.sh` passes
- [ ] Manual on-device: open the app while the door is `OPENING` → icon visibly tweens to OPEN
- [ ] Manual on-device: watch the "Since X · Y" line — increments every second
- [ ] Manual on-device: trigger stale heartbeat → door color goes muted

🤖 Generated with [Claude Code](https://claude.com/claude-code)