### PR TITLE
ui(android): Move Settings Tools section to bottom; animate visibility

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
@@ -17,6 +17,7 @@
 
 package com.chriscartland.garage.ui.settings
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -151,20 +152,6 @@ fun SettingsContent(
             }
         }
 
-        if (showToolsSection) {
-            item {
-                SettingsSection(label = "Tools") {
-                    SettingsRow(
-                        icon = Icons.AutoMirrored.Outlined.List,
-                        title = "Function list",
-                        subtitle = null,
-                        showChevron = true,
-                        onClick = onFunctionListTap,
-                    )
-                }
-            }
-        }
-
         item {
             SettingsSection(label = "About") {
                 SettingsRow(
@@ -200,6 +187,20 @@ fun SettingsContent(
                         subtitle = null,
                         showChevron = true,
                         onClick = onDiagnosticsTap,
+                    )
+                }
+            }
+        }
+
+        item {
+            AnimatedVisibility(visible = showToolsSection) {
+                SettingsSection(label = "Tools") {
+                    SettingsRow(
+                        icon = Icons.AutoMirrored.Outlined.List,
+                        title = "Function list",
+                        subtitle = null,
+                        showChevron = true,
+                        onClick = onFunctionListTap,
                     )
                 }
             }


### PR DESCRIPTION
## Summary
- Reorder Settings sections: Account / Notifications / **About / Tools** (was Account / Notifications / **Tools / About**).
- Wrap Tools section in `AnimatedVisibility(visible = showToolsSection)` so it expands/collapses smoothly when the allowlist gate flips, instead of popping in/out.

## Test plan
- [x] `./scripts/validate.sh` passes locally
- [ ] Screenshot baselines for `SettingsContentSignedOutPreview`, `SettingsContentSignedInBasicPreview`, `SettingsContentSignedInAllowlistedPreview` will need to be regenerated post-merge (Tools section moved + ordering changed). Current screenshot test compiles; image comparison is image-tracking only per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)