### PR TITLE
checks: Enforce mocha-glob + strip-types pins; block release/* push; cite existing checks

### DIFF
--- a/.claude/hooks/git-guardrails.sh
+++ b/.claude/hooks/git-guardrails.sh
@@ -47,6 +47,12 @@ if echo "$STRIPPED" | grep -qE '\bgit\s+push\b'; then
     if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; then
       deny "BLOCKED: You are on '$CURRENT_BRANCH'. Switch to a feature branch before pushing."
     fi
+    # Block release/* — long-lived 'release' branch on origin causes
+    # "directory file conflict" rejections for any release/<sub> ref.
+    # CLAUDE.md documents the workaround (use changelog/*, docs/*, etc.).
+    if [[ "$CURRENT_BRANCH" =~ ^release/ ]]; then
+      deny "BLOCKED: Cannot push to release/* branches. Origin has a long-lived 'release' branch that blocks release/<sub> refs (directory file conflict). Rename to changelog/*, docs/*, hardening/*, or another prefix."
+    fi
   fi
 
   # Block --force, allow --force-with-lease on feature branches

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,9 +56,7 @@ firebase deploy --only functions
 
 `scripts/firebase-npm.sh` auto-sources nvm and switches to the Node version in `FirebaseServer/.nvmrc`, then forwards args to `npm --prefix FirebaseServer`. `scripts/validate-firebase.sh` does the same auto-switch before running the full validation. Manual `nvm use` is not needed.
 
-**Node version pitfall:** Node 22.18+ and Node 24 enable native TypeScript type-stripping by default (`process.features.typescript === 'strip'`). That path breaks `import * as admin from 'firebase-admin'` when mocha loads `.ts` files via `ts-node/register` — `admin.initializeApp` becomes undefined. The `tests` npm script pins `NODE_OPTIONS='--no-experimental-strip-types'` so ts-node's loader owns compilation. If you ever see `TypeError: admin.initializeApp is not a function` in unit tests, check that this env var is still set.
-
-**Mocha glob pitfall:** The `tests` script uses **single-quoted** `'test/**/*.ts'`. npm invokes scripts via `sh`, where `**` degrades to `*` without globstar — so if the glob is unquoted, it matches only one directory deep and silently skips tests nested deeper (e.g. anything in `test/controller/fcm/`). PR #486 surfaced 84 tests that had been silently skipped for months by quoting the glob so mocha (which supports globstar natively) does the expansion. **Never unquote this glob.** If you add a new test directory and your tests aren't running, that's probably why.
+**Mocha glob + Node strip-types pitfalls — both now enforced.** `validate-firebase.sh` asserts that the `tests` script in `FirebaseServer/package.json` (a) single-quotes the glob `'test/**/*.ts'` (PR #486 — unquoted glob silently skipped 84 tests for months because sh's `**` degrades to `*` without globstar) and (b) pins `NODE_OPTIONS='--no-experimental-strip-types'` (Node 22.18+/24 native strip-types breaks `import * as admin from 'firebase-admin'` under mocha+ts-node). If either assertion fails, the message explains the why; don't unquote the glob and don't drop the env var.
 
 <!-- not-actively-maintained: ESP32 firmware build/deploy docs are out of primary documentation scope (focus is Android + Firebase server). See GarageFirmware_ESP32/README.md for active firmware guidance. -->
 
@@ -426,9 +424,9 @@ Push notifications are the hardest feature to verify in production. If topic nam
 - FCM-related code: `FCMService`, `DoorFcmRepository`, `FcmPayloadParser`, topic subscription flow
 
 ### Code Patterns
-- No bare top-level functions — group in a named `object {}` for discoverability (Composables exempt). See ADR-009
+- No bare top-level functions — group in a named `object {}` for discoverability (Composables exempt). Enforced by `checkNoBareTopLevelFunctions` (in `validate.sh`). See ADR-009
 - No extension functions on generic types (e.g., `FcmPayloadParser.parse(data)` not `Map.asDoorEvent()`)
-- No `*Impl` suffix on implementations — use descriptive prefixes (`Network*`, `Cached*`, `Firebase*`, `Default*`). See ADR-008
+- No `*Impl` suffix on implementations — use descriptive prefixes (`Network*`, `Cached*`, `Firebase*`, `Default*`). Enforced by `checkNoImplSuffix` (in `validate.sh`). See ADR-008
 - Generic naming over platform-specific terms for app-scoped classes: `AppStartup.run()` not `AppStartupActions.onActivityCreated()`. App-scoped code should be platform-agnostic (KMP target). Only call sites in Activities know about Android lifecycles
 - **Composable params for production-visible UI must be required, not nullable-with-default.** A `null` default lets fixtures (previews, instrumented tests) silently omit a piece of UI that production always renders, and the framed README screenshot then diverges from what users see. Make the type system enforce parity. Canonical example: `HomeContent.deviceCheckIn` flipped from `DeviceCheckInDisplay? = null` to required in #625, which surfaced 7 silent test gaps the same day. Apply the same rule to any new Composable param whose absence would be a UI bug
 

--- a/scripts/validate-firebase.sh
+++ b/scripts/validate-firebase.sh
@@ -59,6 +59,26 @@ npm --prefix "$REPO_ROOT/FirebaseServer" run build \
     && pass "npm run build" \
     || fail "npm run build"
 
+# Mocha pre-conditions (single-quoted glob + strip-types pin).
+# Both pitfalls are silent: a wrong glob silently skips nested test
+# directories (PR #486 — 84 tests went unnoticed for months); a missing
+# NODE_OPTIONS pin silently breaks `import * as admin from 'firebase-admin'`
+# under Node 22.18+/24's default native strip-types path.
+# CLAUDE.md cites both — these assertions make the cite enforceable.
+step "Mocha glob is single-quoted"
+if grep -qF "'test/**/*.ts'" "$REPO_ROOT/FirebaseServer/package.json"; then
+    pass "tests script uses single-quoted glob"
+else
+    fail "FirebaseServer/package.json 'tests' script must use SINGLE-quoted glob 'test/**/*.ts'. Unquoted globs let sh expand them with no globstar, silently skipping nested directories."
+fi
+
+step "NODE_OPTIONS pins --no-experimental-strip-types"
+if grep -qF -- "--no-experimental-strip-types" "$REPO_ROOT/FirebaseServer/package.json"; then
+    pass "NODE_OPTIONS pinned"
+else
+    fail "FirebaseServer/package.json 'tests' script must pin NODE_OPTIONS='--no-experimental-strip-types'. Without it, Node 22.18+/24 native strip-types breaks 'import * as admin from firebase-admin' under mocha+ts-node."
+fi
+
 # Tests (mocha) — includes collection-name contract tests and
 # verifyIdToken library-chain tests
 step "Tests (mocha)"


### PR DESCRIPTION
## Summary
Three small enforcement additions, plus a CLAUDE.md cleanup that cites existing checks instead of leaving them as bare conventions.

1. **\`scripts/validate-firebase.sh\`** asserts \`FirebaseServer/package.json\`'s \`tests\` script (a) single-quotes \`'test/**/*.ts'\` (PR #486 — 84 tests silently skipped for months when unquoted) and (b) pins \`NODE_OPTIONS='--no-experimental-strip-types'\` (Node 22.18+/24 native strip-types breaks \`import * as admin from 'firebase-admin'\`). Both pitfalls were doc-only; now the script enforces them.

2. **\`.claude/hooks/git-guardrails.sh\`** blocks \`git push\` from \`release/*\` branches. Origin has a long-lived \`release\` branch that causes "directory file conflict" rejections. CLAUDE.md documented the workaround; the hook now fails fast with that guidance.

3. **CLAUDE.md** cleanup:
   - Two paragraphs (mocha glob, strip-types) collapsed into one pointer at the new assertions
   - ADR-008 (no \`*Impl\`) and ADR-009 (no bare top-level functions) now cite their existing enforcement tasks (\`checkNoImplSuffix\`, \`checkNoBareTopLevelFunctions\`) — previously the conventions read like guidance you had to remember.

## Why this PR is small
This session's investigation showed that \`AndroidGarage/buildSrc/\` is already mature (20+ Task classes including the two ADR enforcers above), and ADR-008/009 already have zero current violations. The bigger-leverage adoption (\`PreviewCoverageCheckTask\` from battery-butler) is coming as a follow-up PR.

## Test plan
- [x] \`./scripts/validate-firebase.sh\` runs both new assertions and passes
- [x] \`bash -n .claude/hooks/git-guardrails.sh\` syntax-clean
- [ ] Verify on next branch: pushing from a hypothetical \`release/foo\` would block (will be exercised naturally if anyone ever names one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)