### PR TITLE
docs: Broaden battery-butler reference to include build/check patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,7 +399,7 @@ Do not just tell the user to run it — the next Stop hook fires before they can
 - Tests must add value — no coverage for coverage's sake
 - Prefer fakes over Mockito mocks (aligns with KMP migration target)
 - CI is the deployment gate — if CI passes, the app is safe to ship
-- Reference: [battery-butler](https://github.com/cartland/battery-butler) for testing patterns
+- Reference: [battery-butler](https://github.com/cartland/battery-butler) for testing patterns AND build/check infrastructure (it has a richer `buildSrc/` plugin set — `PreviewCoverageCheckTask` was ported from there in #629; `PreviewTimeCheckTask`, more sophisticated `ImportBoundaryCheckTask`, etc. are unported reference patterns)
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
One-line CLAUDE.md tweak: expand the existing battery-butler reference (currently labeled "for testing patterns") to also mention build/check infrastructure. Cites #629 (PreviewCoverageCheckTask port) and lists unported reference patterns (PreviewTimeCheckTask, richer ImportBoundaryCheckTask).

Docs-only — fast-path CI.

## Context
This is a dump-context PR following a session that landed two infrastructure PRs:
- #628 — Tier 1 enforcement (mocha glob, strip-types, release/* block) + cite existing checks
- #629 — PreviewCoverageCheckTask + 6 new screenshot tests (coverage 64/70 → 70/70)

The session also surfaced a process lesson now captured in memory ("investigate before proposing infra"): I initially proposed adopting battery-butler's `NamingConventionCheckTask` to enforce ADR-008/009, but a parallel agent investigation revealed those ADRs are already enforced by `checkNoImplSuffix` and `checkNoBareTopLevelFunctions` Gradle tasks with zero current violations. CLAUDE.md was just under-citing them. Future infrastructure proposals should default to multi-agent investigation first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)