### PR TITLE
docs: Button health architecture (design doc)

### DIFF
--- a/docs/BUTTON_HEALTH_ARCHITECTURE.md
+++ b/docs/BUTTON_HEALTH_ARCHITECTURE.md
@@ -17,38 +17,31 @@ When the remote-button device hasn't checked in within the last minute, show a s
 2. **Allowlist-gated end-to-end.** Same `remoteButtonAuthorizedEmails` allowlist as the existing button feature.
 3. **Data-only FCM.** Never a system-tray notification.
 4. **Door and button concepts stay separate on Android.** Every layer gets its own button-side type.
-5. **No regressions to existing patterns.** Follows current ADRs; no shortcuts that "we'll fix later."
+5. **Strict ADR compliance.** Every new file matches existing patterns; no shortcuts.
 
-## Architectural goal note (informational, out of scope here)
+## Architectural goal note (informational)
 
-The ideal architecture is **one ViewModel per navigation destination, with all data and actions injected as UseCases.** This design adds new state to the existing `RemoteButtonViewModel` (which is already exempt from ADR-026 as a sub-component aggregator). Migrating the Home tab to a single-screen-VM aggregator is a future PR.
+The ideal architecture is **one ViewModel per navigation destination, with all data and actions injected as UseCases.** This design adds new state to the existing `RemoteButtonViewModel` (already exempt from ADR-026 as a sub-component aggregator). Migrating Home to a single-screen-VM aggregator is a future PR.
 
 ## State machine
 
-States: `UNKNOWN`, `ONLINE`, `OFFLINE`. Persisted server-side in `buttonHealthCurrent/{buildTimestamp}`. Each transition emits one data-only FCM. No-op writes (state unchanged) MUST NOT bump `stateChangedAtSeconds`.
+Persisted server-side: **`ONLINE` | `OFFLINE`** only. (`UNKNOWN` is a presentation concept on the wire/Android — see "HTTP endpoint" below.)
 
-Constants:
-- `ONLINE_THRESHOLD_SEC = 60` — fresh-poll cutoff.
-- `BOOTSTRAP_GRACE_SEC = 120` — pubsub `UNKNOWN → OFFLINE` requires no record OR last poll older than this (Firestore replication grace).
-- `FALLBACK_GRACE_SEC = 600` — pubsub `OFFLINE → ONLINE` only fires when state has been `OFFLINE` for more than this (the trigger had ample time and didn't recover).
+One constant: `ONLINE_THRESHOLD_SEC = 60`.
 
-| Trigger source | Prior | Condition | New state | FCM |
-|---|---|---|---|---|
-| Firestore trigger (poll arrived) | any | always | `ONLINE` | only on transition |
-| Pubsub (every 10 min) | `ONLINE` | last poll ≤ 60 sec ago | `ONLINE` (no-op) | no |
-| Pubsub | `ONLINE` | last poll > 60 sec ago | `OFFLINE` | yes |
-| Pubsub | `UNKNOWN` | no record OR last poll > 120 sec ago | `OFFLINE` | yes |
-| Pubsub | `UNKNOWN` | fresh poll (recovers from a dropped trigger) | `ONLINE` | yes |
-| Pubsub | `OFFLINE` | fresh poll AND OFFLINE for > 600 sec | `ONLINE` | yes |
-| Pubsub | `OFFLINE` | otherwise | `OFFLINE` (no-op) | no |
+| Trigger source | Condition | New persisted state | FCM |
+|---|---|---|---|
+| Firestore trigger (poll arrived) | always | `ONLINE` | only on transition |
+| Pubsub (every 10 min) | last poll ≤ 60 sec ago | `ONLINE` | only on transition |
+| Pubsub (every 10 min) | last poll > 60 sec ago OR no poll record | `OFFLINE` | only on transition |
 
-Worst-case OFFLINE-detection latency: ~10 min (pubsub cadence). Trigger-side recovery is sub-second.
+No-op writes (state unchanged) MUST NOT bump `stateChangedAtSeconds` and MUST NOT send FCM. Worst-case `OFFLINE`-detection latency: ~10 min. Trigger-side recovery is sub-second.
 
 ## Why a Firestore trigger, not an HTTP-handler modification
 
-The naive design appends health detection to `handleRemoteButtonPoll`. Rejected: a throw becomes a 500 to the device; added Firestore ops eat into the device's HTTP timeout. Switching to an `onWrite` trigger on `remoteButtonRequestAll/{docId}` (the collection the existing handler writes to on every poll) achieves detection without touching the device path. Mirrors the existing `firestoreUpdateEvents` pattern. Trigger failures provably cannot affect the device.
+The naive design appends health detection to `handleRemoteButtonPoll`. Rejected: a throw becomes a 500 to the device; added Firestore ops eat into the device's HTTP timeout. The trigger fires on `remoteButtonRequestAll/{docId}` (the collection the existing handler writes to on every poll), asynchronously after the device's response is on the wire. Trigger failures provably cannot affect the device. Mirrors `firestoreUpdateEvents`.
 
-The trigger re-reads `RemoteButtonRequestDatabase.getCurrent()` rather than trusting `change.after.data()`, so a Cloud-Functions retry sees the latest poll instead of a stale event payload. The trigger uses default no-retry policy (no `failurePolicy`), matching `firestoreUpdateEvents`.
+The trigger re-reads `RemoteButtonRequestDatabase.getCurrent()` rather than trusting `change.after.data()` — Cloud Functions retry triggers with the original event payload, which can become stale. Trigger uses default no-retry policy (no `failurePolicy`).
 
 ## Server design
 
@@ -56,33 +49,34 @@ The trigger re-reads `RemoteButtonRequestDatabase.getCurrent()` rather than trus
 
 ```
 buttonHealthCurrent/{buildTimestamp}
-buttonHealthAll/{auto-id}        // history; daily retention pubsub sweeps it
 
 Document shape:
-  state: 'ONLINE' | 'OFFLINE' | 'UNKNOWN'
-  stateChangedAtSeconds: number          // when this state was ENTERED (not bumped on no-op)
-  lastObservedPollAtSeconds: number | null
+  state: 'ONLINE' | 'OFFLINE'
+  stateChangedAtSeconds: number    // when this state was ENTERED (not bumped on no-op)
 ```
+
+No history collection (`buttonHealthAll`). Cloud Logs cover any actual diagnostic need.
 
 ### New files
 
 | File | Purpose |
 |---|---|
-| `database/ButtonHealthDatabase.ts` | Firestore CRUD + `setImpl`/`resetImpl` for tests. Same shape as `RemoteButtonRequestDatabase`. |
+| `database/ButtonHealthDatabase.ts` | Firestore CRUD + `setImpl`/`resetImpl`. Same shape as `RemoteButtonRequestDatabase` minus `*All`. |
 | `controller/ButtonHealthInterpreter.ts` | Pure functions: `computeHealthFromLastPoll`, `detectTransition`. |
-| `controller/ButtonHealthUpdates.ts` | `handleButtonHealthFromPollWrite(buildTimestamp)` — called by the Firestore trigger; re-reads `RemoteButtonRequestDatabase`. |
-| `controller/fcm/ButtonHealthFCM.ts` | `sendForTransition(buildTimestamp, record)`. Pattern matches `EventFCM.ts`. |
-| `model/ButtonHealthFcmTopic.ts` | `buildTimestampToButtonHealthFcmTopic` — distinct from door's; handles the URL-encoded button `buildTimestamp` with try/catch. |
+| `controller/ButtonHealthUpdates.ts` | `handleButtonHealthFromPollWrite(buildTimestamp)` — called by the trigger; re-reads `RemoteButtonRequestDatabase`. |
+| `controller/fcm/ButtonHealthFCM.ts` | `SERVICE.sendForTransition(buildTimestamp, record)` with module-level `_instance` + `setImpl`/`resetImpl`. Pattern matches `EventFCM.ts`. |
+| `model/ButtonHealthFcmTopic.ts` | `buildTimestampToButtonHealthFcmTopic` — distinct from door's; handles URL-encoded button `buildTimestamp` with try/catch. |
 | `functions/firestore/ButtonHealth.ts` | `firestoreCheckButtonHealth` — `onWrite` trigger on `remoteButtonRequestAll/{docId}`. No `failurePolicy`. |
 | `functions/pubsub/ButtonHealth.ts` | `pubsubCheckButtonHealth` — every 10 min. |
-| `functions/http/ButtonHealth.ts` | `httpButtonHealth` — mobile cold-start endpoint. Same auth chain as `handleAddRemoteButtonCommand`. |
+| `functions/http/ButtonHealth.ts` | `httpButtonHealth` — mobile cold-start. Same auth chain as `handleAddRemoteButtonCommand`. Maps "no doc" → `state: UNKNOWN` on the wire. |
 
 ### Modified files
 
 | File | Change |
 |---|---|
-| `controller/DatabaseCleaner.ts` | One-line addition to sweep `buttonHealthAll`. |
 | `index.ts` | Three new exports. |
+
+No `DatabaseCleaner.ts` change (no `*All` history collection to sweep).
 
 ### Topic builder
 
@@ -99,27 +93,27 @@ export function buildTimestampToButtonHealthFcmTopic(buildTimestamp: string): st
   if (decoded.length === 0) {
     throw new Error('buildTimestampToButtonHealthFcmTopic: empty buildTimestamp');
   }
-  // Allowed FCM topic chars: [a-zA-Z0-9-_.~%]. Replacement char `.` matches the door builder.
+  // Allowed FCM topic chars: [a-zA-Z0-9-_.~%]. Replacement `.` matches the door builder.
   const sanitized = decoded.replace(/[^a-zA-Z0-9\-_.~%]/g, '.');
   return `${TOPIC_PREFIX}${sanitized}`;
 }
 ```
 
-`ButtonHealthFcmTopicTest` pins format on both server (Mocha) and Android (commonTest), per the FCM safety rule.
+`ButtonHealthFcmTopicTest` pins format on both server (Mocha) and Android (commonTest). Test cases: empty input throws, malformed `decodeURIComponent` falls back, known-good inputs produce known-good topics.
 
 ### Wire contract
 
 NEW directory `wire-contracts/buttonHealth/`:
 
 ```
-response_online.json         { buttonState: "ONLINE",  stateChangedAtSeconds: <n>, buildTimestamp: "..." }
-response_offline.json        { buttonState: "OFFLINE", stateChangedAtSeconds: <n>, buildTimestamp: "..." }
-response_unknown.json        { buttonState: "UNKNOWN", stateChangedAtSeconds: null, buildTimestamp: "..." }
+response_online.json         { buttonState: "ONLINE",  stateChangedAtSeconds: <n>,    buildTimestamp: "..." }
+response_offline.json        { buttonState: "OFFLINE", stateChangedAtSeconds: <n>,    buildTimestamp: "..." }
+response_unknown.json        { buttonState: "UNKNOWN", stateChangedAtSeconds: null,   buildTimestamp: "..." }
 response_unauthorized.json   401
 response_forbidden_user.json 403
 ```
 
-Both server tests and Android Ktor tests load these in strict mode.
+`UNKNOWN` only appears on the wire when the server has no doc for that `buildTimestamp` (cold-start before first poll seen). Android side: `KtorButtonHealthDataSourceTest` (in `data/src/commonTest/.../buttonhealth/`) loads these in strict mode (`ignoreUnknownKeys = false`); production decode stays `ignoreUnknownKeys = true`. Mocha-side test loads the same fixtures for `httpButtonHealth`.
 
 ### FCM payload (data-only)
 
@@ -135,26 +129,29 @@ Both server tests and Android Ktor tests load these in strict mode.
 }
 ```
 
-`UNKNOWN` is server-side only; never sent over FCM. Mobile sees it only via the cold-start endpoint when no record exists.
+`UNKNOWN` is never sent over FCM.
+
+### Pubsub test convention
+
+`pubsubCheckButtonHealthTest` MUST enumerate the three state-table rows 1:1 with descriptive names (e.g., `"row 1: pubsub fresh poll → ONLINE + FCM only on transition"`). Reading the test file alongside the doc table verifies completeness in seconds.
 
 ## Android design
 
-Every layer gets its own button-health type. No shared interfaces with the door.
+Every layer gets its own button-health type. No shared interfaces with door.
 
 ### Domain (`domain/.../buttonhealth/`)
 
 ```kotlin
-enum class ButtonHealthState { UNKNOWN, ONLINE, OFFLINE }
+enum class ButtonHealthState { UNKNOWN, ONLINE, OFFLINE }   // UNKNOWN appears only when wire returns it
 
 data class ButtonHealth(
     val state: ButtonHealthState,
-    val stateChangedAtSeconds: Long?,
+    val stateChangedAtSeconds: Long?,    // null when state == UNKNOWN
 )
 
 sealed interface ButtonHealthError {
     data object Network : ButtonHealthError
     data object Forbidden : ButtonHealthError
-    data class Other(val cause: String) : ButtonHealthError
 }
 
 interface ButtonHealthRepository {
@@ -166,10 +163,22 @@ interface ButtonHealthRepository {
 
 ### Data (`data/.../buttonhealth/`)
 
-- `NetworkButtonHealthDataSource` (interface) + `KtorNetworkButtonHealthDataSource` (impl).
-- `NetworkButtonHealthRepository` — implements `ButtonHealthRepository`. ADR-008 prefix denotes strategy. All `_state` writes dispatch onto the injected `externalScope` per ADR-019. `fetchButtonHealth()` uses `withContext(externalScope.coroutineContext)` so cancellation by the caller actually cancels the work, and the suspend signature is honored.
-- `ButtonHealthFcmRepository` — separate from `DoorFcmRepository`. Methods: `subscribe(buildTimestamp)`, `unsubscribe(buildTimestamp)`. Idempotent.
+```kotlin
+@Serializable
+internal data class KtorButtonHealthResponse(
+    @SerialName("buttonState") val buttonState: String,
+    @SerialName("stateChangedAtSeconds") val stateChangedAtSeconds: Long? = null,
+    @SerialName("buildTimestamp") val buildTimestamp: String,
+)
+```
+
+Files:
+- `NetworkButtonHealthDataSource` (interface) + `KtorNetworkButtonHealthDataSource` (impl). Returns `NetworkResult<ButtonHealth>`.
+- `NetworkButtonHealthRepository` — implements `ButtonHealthRepository`. ADR-008 prefix denotes strategy. All `_state` writes dispatched onto injected `externalScope` per ADR-019 (matches `NetworkSnoozeRepository`'s `externalScope.launch { ... }.join()` pattern; preserves the suspend signature).
+- `ButtonHealthFcmRepository` — separate from `DoorFcmRepository`. Methods: `subscribe(buildTimestamp)`, `unsubscribe(buildTimestamp)`, `unsubscribeAll()`. Idempotent.
 - `ButtonHealthFcmPayloadParser` — parses `buttonHealth-*` data payloads.
+
+ADR-020 (R8): the new `@Serializable` data classes are covered by the existing generic `proguard-rules.pro` rule (`@kotlinx.serialization.Serializable class **`). Verify against release build before tagging.
 
 ### UseCase (`usecase/.../buttonhealth/`)
 
@@ -183,73 +192,105 @@ class ApplyButtonHealthFcmUseCase(private val repo: ButtonHealthRepository) {
 }
 
 class ComputeButtonHealthDisplayUseCase(
-    private val authState: StateFlow<AuthState>,
-    private val allowlistAccess: StateFlow<Boolean?>,
-    private val buttonHealth: StateFlow<LoadingResult<ButtonHealth>>,
+    private val authRepository: AuthRepository,
+    private val featureAccessRepository: FeatureAccessRepository,    // existing pattern (FunctionList allowlist)
+    private val buttonHealthRepository: ButtonHealthRepository,
     private val liveClock: LiveClock,
-    private val externalScope: CoroutineScope,
 ) {
-    operator fun invoke(): StateFlow<ButtonHealthDisplay> =
-        combine(authState, allowlistAccess, buttonHealth, liveClock.tickSeconds) { auth, allowed, health, now ->
-            computeDisplay(auth, allowed, health, now)
-        }.stateIn(externalScope, SharingStarted.Eagerly, ButtonHealthDisplay.Loading)
-}
-
-// Pure function; trivial to unit-test.
-internal fun computeDisplay(
-    auth: AuthState,
-    allowed: Boolean?,
-    health: LoadingResult<ButtonHealth>,
-    nowSeconds: Long,
-): ButtonHealthDisplay = when {
-    auth !is AuthState.SignedIn -> ButtonHealthDisplay.Unauthorized
-    allowed != true             -> ButtonHealthDisplay.Unauthorized
-    health is LoadingResult.Loading -> ButtonHealthDisplay.Loading
-    health is LoadingResult.Error   -> ButtonHealthDisplay.Loading   // transient; retry will fix
-    health is LoadingResult.Complete -> when (health.data.state) {
-        ButtonHealthState.UNKNOWN -> ButtonHealthDisplay.Unknown
-        ButtonHealthState.ONLINE  -> ButtonHealthDisplay.Online
-        ButtonHealthState.OFFLINE -> ButtonHealthDisplay.Offline(
-            durationLabel = formatDurationAgo(health.data.stateChangedAtSeconds, nowSeconds)
-        )
-    }
+    operator fun invoke(): Flow<ButtonHealthDisplay> =
+        combine(
+            authRepository.authState,
+            featureAccessRepository.access(Feature.RemoteButton),
+            buttonHealthRepository.buttonHealth,
+            liveClock.tickSeconds,
+        ) { auth, allowed, health, now ->
+            ButtonHealthDisplayLogic.compute(auth, allowed, health, now)
+        }
 }
 ```
 
-### Subscription manager (`usecase/.../buttonhealth/ButtonHealthFcmSubscriptionManager.kt`)
+Returns `Flow`, not `StateFlow` (ADR-022: no `stateIn(viewModelScope, ...)`; UseCase doesn't need to share state across collectors). Composable collects via `collectAsStateWithLifecycle(initialValue = ButtonHealthDisplay.Loading)`.
 
-ADR-015 Manager. App-scoped singleton. Started from `AppStartup` after FCM token registration completes.
+### Display sealed type
 
 ```kotlin
-class ButtonHealthFcmSubscriptionManager(
-    authState: StateFlow<AuthState>,
-    allowlistAccess: StateFlow<Boolean?>,
-    buttonBuildTimestamp: StateFlow<String?>,   // from ServerConfigRepository — handles config rotation
-    private val fcm: ButtonHealthFcmRepository,
-    private val fetchButtonHealthUseCase: FetchButtonHealthUseCase,
-    private val externalScope: CoroutineScope,
-) {
-    fun start() {
-        externalScope.launch {
-            combine(authState, allowlistAccess, buttonBuildTimestamp) { auth, allowed, buildTimestamp ->
-                Triple(auth, allowed, buildTimestamp)
-            }.distinctUntilChanged().collectLatest { (auth, allowed, buildTimestamp) ->
-                // Always unsubscribe from any prior topic before deciding whether to subscribe.
-                // Idempotent — Firebase handles unsubscribe-from-not-subscribed gracefully.
-                fcm.unsubscribeAll()
-                if (auth is AuthState.SignedIn && allowed == true && buildTimestamp != null) {
-                    fcm.subscribe(buildTimestamp)
-                    fetchButtonHealthUseCase()  // cold-start fetch
-                }
+sealed interface ButtonHealthDisplay {
+    data object Unauthorized : ButtonHealthDisplay              // user not allowlisted
+    data object Loading      : ButtonHealthDisplay              // fetch in flight, no result yet
+    data object Unknown      : ButtonHealthDisplay              // server has no doc yet
+    data object Online       : ButtonHealthDisplay              // server says ONLINE
+    data class  Offline(val durationLabel: String) : ButtonHealthDisplay   // ONLY arm that renders the pill
+}
+```
+
+### Pure derivation logic (ADR-009: grouped in an `object`)
+
+```kotlin
+internal object ButtonHealthDisplayLogic {
+    fun compute(
+        auth: AuthState,
+        allowed: Boolean?,
+        health: LoadingResult<ButtonHealth>,
+        nowSeconds: Long,
+    ): ButtonHealthDisplay {
+        // Pre-conditions as guard clauses (not enum-shaped, not exhaustive-when):
+        if (auth !is AuthState.SignedIn) return ButtonHealthDisplay.Unauthorized
+        if (allowed != true)             return ButtonHealthDisplay.Unauthorized
+
+        // Sealed-type exhaustive when on LoadingResult — compiler-enforced completeness.
+        return when (health) {
+            is LoadingResult.Loading  -> ButtonHealthDisplay.Loading
+            is LoadingResult.Error    -> ButtonHealthDisplay.Loading   // transient; retry will fix
+            is LoadingResult.Complete -> when (health.data.state) {
+                ButtonHealthState.UNKNOWN -> ButtonHealthDisplay.Unknown
+                ButtonHealthState.ONLINE  -> ButtonHealthDisplay.Online
+                ButtonHealthState.OFFLINE -> ButtonHealthDisplay.Offline(
+                    durationLabel = ButtonHealthDurationFormatter.formatAgo(
+                        health.data.stateChangedAtSeconds, nowSeconds,
+                    ),
+                )
             }
         }
     }
 }
 ```
 
-### ViewModel (modify the existing `RemoteButtonViewModel`)
+### Subscription manager (ADR-015)
 
-Add one new property. No new VM class:
+```kotlin
+class ButtonHealthFcmSubscriptionManager(
+    private val authRepository: AuthRepository,
+    private val featureAccessRepository: FeatureAccessRepository,
+    private val serverConfigRepository: ServerConfigRepository,
+    private val fcm: ButtonHealthFcmRepository,
+    private val fetchButtonHealthUseCase: FetchButtonHealthUseCase,
+    private val externalScope: CoroutineScope,
+    private val dispatcher: CoroutineDispatcher,
+) {
+    fun start() {
+        externalScope.launch(dispatcher) {
+            combine(
+                authRepository.authState,
+                featureAccessRepository.access(Feature.RemoteButton),
+                serverConfigRepository.buttonBuildTimestamp,    // handles config rotation
+            ) { auth, allowed, buildTimestamp -> Triple(auth, allowed, buildTimestamp) }
+                .distinctUntilChanged()
+                .collectLatest { (auth, allowed, buildTimestamp) ->
+                    // Always unsubscribe first — idempotent. Avoids "did Firebase Task cancel?" question.
+                    fcm.unsubscribeAll()
+                    if (auth is AuthState.SignedIn && allowed == true && buildTimestamp != null) {
+                        fcm.subscribe(buildTimestamp)
+                        fetchButtonHealthUseCase()    // cold-start fetch
+                    }
+                }
+        }
+    }
+}
+```
+
+Started from `AppStartup` after FCM token registration completes.
+
+### ViewModel (modify existing `RemoteButtonViewModel`)
 
 ```kotlin
 class RemoteButtonViewModel(
@@ -257,36 +298,19 @@ class RemoteButtonViewModel(
     computeButtonHealthDisplayUseCase: ComputeButtonHealthDisplayUseCase,
 ) : ViewModel() {
     /* existing state */
-
-    val buttonHealthDisplay: StateFlow<ButtonHealthDisplay> =
-        computeButtonHealthDisplayUseCase()
+    val buttonHealthDisplay: Flow<ButtonHealthDisplay> = computeButtonHealthDisplayUseCase()
 }
 ```
-
-No new fetch action on the VM — the Manager owns cold-start fetch. User-triggered refresh (if ever wanted) is a future addition.
-
-### Display
-
-```kotlin
-sealed interface ButtonHealthDisplay {
-    data object Unauthorized : ButtonHealthDisplay              // user not allowlisted
-    data object Loading      : ButtonHealthDisplay              // fetch in flight, no result yet
-    data object Unknown      : ButtonHealthDisplay              // server returned UNKNOWN
-    data object Online       : ButtonHealthDisplay              // server returned ONLINE
-    data class  Offline(val durationLabel: String) : ButtonHealthDisplay   // ONLY state that renders the pill
-}
-```
-
-Five arms, exhaustive `when`. Only `Offline` ever renders the pill.
 
 ### UI
 
-NEW `androidApp/.../ui/buttonhealth/RemoteOfflinePill.kt` — stateless Composable taking `display: ButtonHealthDisplay.Offline`. Renders `errorContainer` background, `Icons.Outlined.SignalWifiOff`, text `"Remote offline · {display.durationLabel}"`. TalkBack content description: `"Remote offline, last seen {durationLabel}"`.
+NEW `androidApp/.../ui/buttonhealth/RemoteOfflinePill.kt` — stateless Composable taking `display: ButtonHealthDisplay.Offline`. Renders `errorContainer` background, `Icons.Outlined.SignalWifiOff` (Material 24-viewport — avoids the Layoutlib gotcha documented in CLAUDE.md), text `"Remote offline · {display.durationLabel}"`. TalkBack `contentDescription = "Remote offline, last seen {durationLabel}"`. Has `@Preview` variants imported by a screenshot test (preview-coverage check requires this).
 
 Modify `HomeContent.kt` — pill goes in the existing `HomeSection(label = "Remote control", trailing = { ... })` slot. `RemoteButtonContent` itself is unchanged (preserves all `@Preview` callers and screenshot tests):
 
 ```kotlin
-val display by remoteButtonViewModel.buttonHealthDisplay.collectAsState()
+val display by remoteButtonViewModel.buttonHealthDisplay
+    .collectAsStateWithLifecycle(initialValue = ButtonHealthDisplay.Loading)
 
 HomeSection(
     label = "Remote control",
@@ -304,16 +328,32 @@ HomeSection(
 }
 ```
 
-Modify `FCMService.kt` — dispatch by topic prefix:
+### FCMService dispatcher (extracted for testability)
+
+Today's `FCMService` does parsing inline. Extract the topic-prefix dispatch to a pure function in `commonTest`-reachable code:
+
+```kotlin
+// in data/.../fcm/FcmTopicDispatcher.kt
+internal object FcmTopicDispatcher {
+    fun isButtonHealth(topic: String): Boolean = topic.startsWith("buttonHealth-")
+    // door dispatcher already implicit; add isXxx helpers if other features want extraction.
+}
+```
+
+`FCMService.kt`:
 
 ```kotlin
 val topic = remoteMessage.from?.removePrefix("/topics/").orEmpty()
 when {
-    topic.startsWith("buttonHealth-") ->
+    FcmTopicDispatcher.isButtonHealth(topic) ->
         ButtonHealthFcmPayloadParser.parse(data)?.let { applyButtonHealthFcmUseCase(it) }
     else -> existingDoorPayloadDispatch(data)
 }
 ```
+
+`FcmTopicDispatcherTest` in `commonTest`. Existing door FCM path remains the `else` branch (default-preserving).
+
+### AppStartup + AppComponent
 
 Modify `AppStartup.kt` — start `ButtonHealthFcmSubscriptionManager` after FCM token registration.
 
@@ -327,65 +367,67 @@ Modify `AppComponent.kt` — wire as `@Singleton` providers with matching `abstr
 
 | Concept | Name |
 |---|---|
-| State enum (server + Android) | `ONLINE`, `OFFLINE`, `UNKNOWN` |
+| Server enum | `ONLINE`, `OFFLINE` (UNKNOWN exists only on wire/Android) |
+| Android enum | `ButtonHealthState.{ONLINE, OFFLINE, UNKNOWN}` |
 | Timestamp field (wire + Android) | `stateChangedAtSeconds` |
 | Topic prefix | `buttonHealth-` |
-| Collection | `buttonHealthCurrent` / `buttonHealthAll` |
+| Collection | `buttonHealthCurrent` |
 | Functions | `httpButtonHealth`, `pubsubCheckButtonHealth`, `firestoreCheckButtonHealth` |
-| Repository impl | `NetworkButtonHealthRepository` (ADR-008) |
+| Repository impl | `NetworkButtonHealthRepository` (ADR-008 prefix) |
 | Display sealed type | `ButtonHealthDisplay.{Unauthorized, Loading, Unknown, Online, Offline}` |
+| Pure derivation | `object ButtonHealthDisplayLogic { fun compute(...) }` |
 | Pill Composable | `RemoteOfflinePill` |
 | User-visible text | `"Remote offline · {durationLabel}"` |
-
-States are connectivity-shaped (ONLINE/OFFLINE) but the feature noun is "health" — leaves room for future health signals (battery, sensor errors) without renaming.
 
 ## Safety property
 
 | Function | Device path? |
 |---|---|
 | `httpRemoteButton` (existing) | YES — unchanged |
-| `firestoreCheckButtonHealth` (NEW) | NO — fires async after device's response |
+| `firestoreCheckButtonHealth` (NEW) | NO — async after device's response |
 | `pubsubCheckButtonHealth` (NEW) | NO — scheduled |
 | `httpButtonHealth` (NEW) | NO — mobile only |
-| `pubsubDataRetentionPolicy` (existing, +1 line) | NO — sweeps history collections only |
 
 The device cannot observe whether this feature is deployed. A failure in any new code path has zero effect on the response from `httpRemoteButton`.
 
 ## Acceptable failure modes
 
-- **OFFLINE that recovers within 10 min may never reach mobile** (pubsub didn't fire while it was OFFLINE). Per requirements.
-- **Trigger-side FCM-send failure may leave mobile briefly stale**. Mobile picks up correct state on next cold-start fetch (typically next app launch). Symmetric with the above.
-- **FCM topic subscription is client-side**. A signed-in non-allowlisted user with a custom client could subscribe to `buttonHealth-<buildTimestamp>` and receive ONLINE/OFFLINE state. Allowlist is enforced only at the HTTP cold-start endpoint. Acceptable: the leaked data is "is the device online" — low value, no PII, no control surface.
-- **Data-only FCMs are not delivered to force-stopped Android apps**. Cold-start fetch handles this on next app launch.
-- **Pubsub or trigger crash during a single run** leaves state stale until the next pubsub run (≤10 min).
+- **OFFLINE that recovers within 10 min may never reach mobile.** Per requirements.
+- **Trigger-side FCM-send failure may leave mobile briefly stale.** Cold-start fetch handles this on next app launch.
+- **FCM topic subscription is client-side.** A signed-in non-allowlisted user with a custom client could subscribe to `buttonHealth-<buildTimestamp>` and receive ONLINE/OFFLINE state. Allowlist is enforced only at the HTTP cold-start endpoint. Acceptable: the leaked data is "is the device online" — low value, no PII, no control surface.
+- **Data-only FCMs are not delivered to force-stopped Android apps.** Cold-start fetch handles this on next app launch.
 
 ## Failure modes designed out
 
-- **Unauthorized user seeing the pill** — `computeDisplay`'s exhaustive `when` routes `!SignedIn` and `!allowed` to `Unauthorized`, which has no path to the pill.
-- **Topic format drift between server and Android** — pinned by `ButtonHealthFcmTopicTest` running on both sides.
+- **Unauthorized user seeing the pill** — `ButtonHealthDisplayLogic.compute` returns `Unauthorized` before any health-state branch; only `Offline` ever renders the pill.
+- **Topic format drift** — pinned by `ButtonHealthFcmTopicTest` on both sides.
 - **Payload key drift** — pinned by `wire-contracts/buttonHealth/` fixtures consumed in strict mode on both sides.
 - **`stateChangedAtSeconds` drifting forward on no-op writes** — `detectTransition` returns "no change" when state matches; no write, no FCM, timestamp preserved.
-- **Trigger retry on stale event payload** — trigger re-reads `RemoteButtonRequestDatabase.getCurrent()` rather than trusting `change.after.data()`.
-- **Device reflash (new buildTimestamp) leaving mobile subscribed to a stale topic** — Manager observes `buttonBuildTimestamp` from `ServerConfigRepository` and unsubscribes from old + subscribes to new on rotation.
+- **Trigger retry on stale event** — trigger re-reads `RemoteButtonRequestDatabase.getCurrent()`.
+- **Device reflash (new buildTimestamp) leaving mobile subscribed to a stale topic** — Manager observes `buttonBuildTimestamp` from `ServerConfigRepository`; `unsubscribeAll()` runs on every state change before the conditional subscribe.
+- **Display-state completeness drift** — `compute` uses sealed-type exhaustive `when` over `LoadingResult` and `ButtonHealthState`; the compiler enforces every arm.
 
 ## Out of scope
 
 - ESP32 firmware changes.
 - Modifying any existing function the device calls.
 - Refactoring `RemoteButtonViewModel` into a one-VM-per-screen structure (future PR).
-- Room caching of button health (state is short-lived; FCM keeps it fresh).
+- Room caching of button health.
 - New server config keys.
-- History view or "uptime" metric.
+- History / uptime metrics.
 
 ## ADR / convention compliance
 
-- **FCM safety**: adds new topic + new payload keys; existing `FcmTopicTest` and `FcmPayloadParsingTest` stay green; new `ButtonHealthFcmTopicTest` + `ButtonHealthFcmPayloadParsingTest` ship in the same PR.
-- **Handler pattern**: `httpButtonHealth` follows pure-core + thin-wrapper convention.
+- **FCM safety**: adds new topic + payload keys; existing `FcmTopicTest` and `FcmPayloadParsingTest` stay green; new `ButtonHealthFcmTopicTest` + `ButtonHealthFcmPayloadParsingTest` ship in the same PR as the topic builder + parser.
+- **Handler pattern**: `httpButtonHealth` follows pure-core + thin-wrapper.
 - **Database refactor pattern**: `ButtonHealthDatabase` follows the per-collection module pattern.
-- **Config authority**: no new server config keys; reuses existing button config.
+- **Config authority**: no new server config keys.
 - **ADR-008**: `NetworkButtonHealthRepository` (descriptive prefix).
-- **ADR-015**: subscription lifecycle in `ButtonHealthFcmSubscriptionManager`.
-- **ADR-019**: all repository state mutations dispatched onto `externalScope`.
-- **ADR-021/022**: no passthrough VM — derivation lives in `ComputeButtonHealthDisplayUseCase`.
+- **ADR-009**: pure derivation lives in `object ButtonHealthDisplayLogic`, not a bare top-level function (`checkNoBareTopLevelFunctions` enforces).
+- **ADR-015**: subscription lifecycle in `ButtonHealthFcmSubscriptionManager`, started from `AppStartup`.
+- **ADR-019**: all repository state mutations dispatched onto `externalScope` (matches `NetworkSnoozeRepository`).
+- **ADR-020**: new `@Serializable` data classes covered by the existing generic `proguard-rules.pro` rule.
+- **ADR-021/022**: no passthrough VM; no `stateIn(viewModelScope, ...)`; UseCase exposes `Flow`, Composable collects via `collectAsStateWithLifecycle`.
 - **ADR-026**: `RemoteButtonContent` (sub-component) takes no new VM dependency; pill placed in `HomeContent`'s `HomeSection` trailing slot.
 - **`DI_SINGLETON_REQUIREMENTS`**: every new `@Singleton` provider has a matching `abstract val` entry point.
+- **Test-mirroring-table convention** (this design): `pubsubCheckButtonHealthTest` enumerates the state-table rows 1:1 by name.

--- a/docs/BUTTON_HEALTH_ARCHITECTURE.md
+++ b/docs/BUTTON_HEALTH_ARCHITECTURE.md
@@ -5,77 +5,54 @@ status: active
 
 # Button Health Architecture
 
-Design for a server-detected, mobile-displayed health indicator for the remote-button ESP32 device. **Not yet implemented.** This doc is the canonical design; implementation PRs should reference it.
+Server-detected, mobile-displayed online/offline indicator for the remote-button ESP32 device. **Not yet implemented.**
 
 ## Goal
 
-Show the user a small "Remote offline" pill next to the Remote-control section title when the remote-button device hasn't checked in recently. Three states (server-side): `ONLINE`, `OFFLINE`, `UNKNOWN`. Only `OFFLINE` is visible to the user; the other two states render identically to today's UI.
+When the remote-button device hasn't checked in within the last minute, show a small "Remote offline" pill next to the Remote-control section title on the Home tab. Otherwise the UI is unchanged.
 
 ## Hard constraints
 
-1. **Zero ESP32 firmware changes.** The button device's HTTP behavior must be byte-identical to today.
-2. **Device contract preserved.** No change to request shape, response shape, response timing, or failure semantics for any endpoint the device calls. Specifically, `httpRemoteButton` must remain unmodified.
-3. **Allowlist-gated end-to-end.** Same `remoteButtonAuthorizedEmails` allowlist that already gates the button feature itself. Non-allowlisted users see no UI change vs. today.
-4. **Data-only FCM.** Never send a system-tray notification for this feature.
-5. **Door and button concepts stay separate on Android.** No shared interfaces between the door event flow and the button health flow — every layer gets its own button-side type.
+1. **Zero ESP32 firmware changes.** `httpRemoteButton` is byte-identical to today.
+2. **Allowlist-gated end-to-end.** Same `remoteButtonAuthorizedEmails` allowlist as the existing button feature.
+3. **Data-only FCM.** Never a system-tray notification.
+4. **Door and button concepts stay separate on Android.** Every layer gets its own button-side type.
+5. **No regressions to existing patterns.** Follows current ADRs; no shortcuts that "we'll fix later."
 
-## Architectural goal note (out of scope, for future work)
+## Architectural goal note (informational, out of scope here)
 
-The ideal architecture for any screen is **one ViewModel per navigation destination, with all data and actions injected as UseCases.** This design intentionally does **not** refactor toward that ideal — the existing `RemoteButtonViewModel` is already consumed by `HomeContent` (a sub-component aggregator screen exempt from ADR-026), and pulling that apart belongs in its own PR. This design adds new state to the existing `RemoteButtonViewModel` via a new injected UseCase. Future cleanup: collapse the per-sub-component VMs into one screen-level VM that aggregates the same UseCases.
+The ideal architecture is **one ViewModel per navigation destination, with all data and actions injected as UseCases.** This design adds new state to the existing `RemoteButtonViewModel` (which is already exempt from ADR-026 as a sub-component aggregator). Migrating the Home tab to a single-screen-VM aggregator is a future PR.
 
 ## State machine
 
-States: `UNKNOWN`, `ONLINE`, `OFFLINE`. Persisted server-side in `buttonHealthCurrent/{buildTimestamp}`. Each *transition* emits one data-only FCM. **No-op writes (state unchanged) MUST NOT bump `stateChangedAtSeconds`** — the UI's "Offline since X" label depends on `stateChangedAtSeconds` being the moment the state was *entered*, not the most recent observation.
+States: `UNKNOWN`, `ONLINE`, `OFFLINE`. Persisted server-side in `buttonHealthCurrent/{buildTimestamp}`. Each transition emits one data-only FCM. No-op writes (state unchanged) MUST NOT bump `stateChangedAtSeconds`.
 
-| Event | Detected by | New state | Fires FCM | Latency |
+Constants:
+- `ONLINE_THRESHOLD_SEC = 60` — fresh-poll cutoff.
+- `BOOTSTRAP_GRACE_SEC = 120` — pubsub `UNKNOWN → OFFLINE` requires no record OR last poll older than this (Firestore replication grace).
+- `FALLBACK_GRACE_SEC = 600` — pubsub `OFFLINE → ONLINE` only fires when state has been `OFFLINE` for more than this (the trigger had ample time and didn't recover).
+
+| Trigger source | Prior | Condition | New state | FCM |
 |---|---|---|---|---|
-| Poll arrives, prior state was `UNKNOWN` | Trigger | `ONLINE` | yes | < 1 sec |
-| Poll arrives, prior state was `OFFLINE` | Trigger | `ONLINE` | yes | < 1 sec |
-| Poll arrives, prior state was `ONLINE` | Trigger | `ONLINE` (no-op, no write) | no | n/a |
-| Pubsub finds last-poll > 60 sec ago, prior `ONLINE` | Pubsub | `OFFLINE` | yes | up to 10 min |
-| Pubsub finds NO record + last-poll > 2 min ago, prior `UNKNOWN` | Pubsub | `OFFLINE` | yes | up to 10 min |
-| Pubsub finds last-poll < 60 sec ago, prior `OFFLINE` for >10 min (fallback) | Pubsub | `ONLINE` | yes | up to 10 min |
-| Pubsub finds last-poll < 60 sec ago, prior `OFFLINE` for <10 min | Pubsub | (no action — trigger should have already handled) | no | n/a |
-| Pubsub finds last-poll fresh, prior `ONLINE` | Pubsub | `ONLINE` (no-op, no write) | no | n/a |
-| Pubsub finds last-poll fresh, prior `OFFLINE` for >10 min | Pubsub | `ONLINE` | yes | (this is the fallback row above) |
+| Firestore trigger (poll arrived) | any | always | `ONLINE` | only on transition |
+| Pubsub (every 10 min) | `ONLINE` | last poll ≤ 60 sec ago | `ONLINE` (no-op) | no |
+| Pubsub | `ONLINE` | last poll > 60 sec ago | `OFFLINE` | yes |
+| Pubsub | `UNKNOWN` | no record OR last poll > 120 sec ago | `OFFLINE` | yes |
+| Pubsub | `UNKNOWN` | fresh poll (recovers from a dropped trigger) | `ONLINE` | yes |
+| Pubsub | `OFFLINE` | fresh poll AND OFFLINE for > 600 sec | `ONLINE` | yes |
+| Pubsub | `OFFLINE` | otherwise | `OFFLINE` (no-op) | no |
 
-ONLINE threshold: most recent poll within `60 sec` (steady state). Bootstrap grace: `UNKNOWN → OFFLINE` requires last-poll older than `120 sec` (or no record), guarding against Firestore replication lag where the pubsub reads `RemoteButtonRequestDatabase` before a fresh first-deploy poll has propagated. Pubsub fallback grace: `OFFLINE → ONLINE` from pubsub only fires if state has been `OFFLINE` for more than 10 min (i.e., the trigger had ample time to recover and didn't), avoiding duplicate FCMs when trigger and pubsub race on the same fresh poll. Worst-case `OFFLINE`-detection latency: ~10 min (acknowledged tradeoff).
+Worst-case OFFLINE-detection latency: ~10 min (pubsub cadence). Trigger-side recovery is sub-second.
 
 ## Why a Firestore trigger, not an HTTP-handler modification
 
-The naive design appends health-detection code to `handleRemoteButtonPoll`. That was rejected because it puts new Firestore reads, new writes, and new FCM sends on the device's request path:
+The naive design appends health detection to `handleRemoteButtonPoll`. Rejected: a throw becomes a 500 to the device; added Firestore ops eat into the device's HTTP timeout. Switching to an `onWrite` trigger on `remoteButtonRequestAll/{docId}` (the collection the existing handler writes to on every poll) achieves detection without touching the device path. Mirrors the existing `firestoreUpdateEvents` pattern. Trigger failures provably cannot affect the device.
 
-- A throw in any new code becomes a `500` response to the device.
-- Each added Firestore op (~50–100ms) eats into the device's HTTP timeout budget — a budget defined in firmware we can't change and haven't measured.
-
-Switching to a Firestore `onWrite` trigger on `remoteButtonRequestAll/{docId}` (the collection the existing handler writes to on every poll) achieves the same detection without touching the device path:
-
-```
-Device → httpRemoteButton (UNCHANGED, byte-identical to today)
-                ↓
-       writes to remoteButtonRequestAll
-                ↓ (Firestore onWrite trigger; default no-retry policy)
-       firestoreCheckButtonHealth (NEW)
-                ↓
-       re-reads RemoteButtonRequestDatabase.getCurrent() (NOT the event payload — see below)
-       reads buttonHealthCurrent
-       computes transition
-       conditionally writes + sends FCM
-```
-
-The trigger fires asynchronously after the device's response is already on the wire. Trigger failures, Firestore failures, and FCM failures all have **zero effect** on the response the device receives. This mirrors the existing door-event pattern (`firestoreUpdateEvents` triggers on `updateAll/{docId}` writes).
-
-**Critical: trigger must re-read `RemoteButtonRequestDatabase.getCurrent()` rather than trust `change.after.data()`.** Cloud Functions retry triggers with the *original* event payload, which can become stale by the time the retry runs. A retry of an old poll could otherwise incorrectly compute `OFFLINE` despite the device having polled successfully many times since.
-
-**Critical: trigger MUST NOT enable `runWith({failurePolicy: true})`.** Default is no-retry, matching `firestoreUpdateEvents`. Retried instances on a buggy trigger could pile up; cost spike, no device impact.
-
-Cost: ~17,000 trigger invocations/day at the button's polling cadence. Cloud Functions invocations + Firestore reads ≈ $0.50/month *marginal* (verify total Firestore-read budget across all features before declaring negligible at the org level).
+The trigger re-reads `RemoteButtonRequestDatabase.getCurrent()` rather than trusting `change.after.data()`, so a Cloud-Functions retry sees the latest poll instead of a stale event payload. The trigger uses default no-retry policy (no `failurePolicy`), matching `firestoreUpdateEvents`.
 
 ## Server design
 
 ### Data model
-
-NEW collection, single doc per button device:
 
 ```
 buttonHealthCurrent/{buildTimestamp}
@@ -83,110 +60,86 @@ buttonHealthAll/{auto-id}        // history; daily retention pubsub sweeps it
 
 Document shape:
   state: 'ONLINE' | 'OFFLINE' | 'UNKNOWN'
-  stateChangedAtSeconds: number          // when this state was ENTERED (NOT bumped on no-op)
+  stateChangedAtSeconds: number          // when this state was ENTERED (not bumped on no-op)
   lastObservedPollAtSeconds: number | null
 ```
 
 ### New files
 
-All NEW files; no modification to any existing function file the device calls.
-
 | File | Purpose |
 |---|---|
-| `database/ButtonHealthDatabase.ts` | Firestore CRUD; `setImpl`/`resetImpl` for tests. Same shape as `RemoteButtonRequestDatabase`. |
-| `controller/ButtonHealthInterpreter.ts` | Pure functions: `computeHealthFromLastPoll(lastPollSec, nowSec)` (clamped: returns `ONLINE` if `lastPollSec > nowSec` to handle clock skew) + `detectTransition(prior, computed, nowSec)` — never bumps `stateChangedAtSeconds` on no-op. |
-| `controller/ButtonHealthUpdates.ts` | `handleButtonHealthFromPollWrite(buildTimestamp)` — called by the Firestore trigger. Re-reads `RemoteButtonRequestDatabase` (does NOT trust the event payload). |
-| `controller/fcm/ButtonHealthFCM.ts` | `sendForTransition(buildTimestamp, record)`. Pattern matches `EventFCM.ts` (`SERVICE` exported object indirection, module-level `let _instance`, `setImpl`/`resetImpl`). |
-| `model/ButtonHealthFcmTopic.ts` | `buildTimestampToButtonHealthFcmTopic(buildTimestamp)` — distinct from door's topic builder; handles the URL-encoded button `buildTimestamp` with try/catch. |
-| `functions/firestore/ButtonHealth.ts` | `firestoreCheckButtonHealth` — `onWrite` trigger on `remoteButtonRequestAll/{docId}`. Thin wrapper around `handleButtonHealthFromPollWrite`. **No `failurePolicy`.** |
-| `functions/pubsub/ButtonHealth.ts` | `pubsubCheckButtonHealth` — every 10 min. Detects `ONLINE → OFFLINE`, `UNKNOWN → OFFLINE` (with 120-sec grace), and fallback `OFFLINE → ONLINE` (only when state has been OFFLINE for >10 min). |
-| `functions/http/ButtonHealth.ts` | `httpButtonHealth` — mobile cold-start endpoint. Same auth chain as `handleAddRemoteButtonCommand` (push key + Google ID token + email allowlist). |
+| `database/ButtonHealthDatabase.ts` | Firestore CRUD + `setImpl`/`resetImpl` for tests. Same shape as `RemoteButtonRequestDatabase`. |
+| `controller/ButtonHealthInterpreter.ts` | Pure functions: `computeHealthFromLastPoll`, `detectTransition`. |
+| `controller/ButtonHealthUpdates.ts` | `handleButtonHealthFromPollWrite(buildTimestamp)` — called by the Firestore trigger; re-reads `RemoteButtonRequestDatabase`. |
+| `controller/fcm/ButtonHealthFCM.ts` | `sendForTransition(buildTimestamp, record)`. Pattern matches `EventFCM.ts`. |
+| `model/ButtonHealthFcmTopic.ts` | `buildTimestampToButtonHealthFcmTopic` — distinct from door's; handles the URL-encoded button `buildTimestamp` with try/catch. |
+| `functions/firestore/ButtonHealth.ts` | `firestoreCheckButtonHealth` — `onWrite` trigger on `remoteButtonRequestAll/{docId}`. No `failurePolicy`. |
+| `functions/pubsub/ButtonHealth.ts` | `pubsubCheckButtonHealth` — every 10 min. |
+| `functions/http/ButtonHealth.ts` | `httpButtonHealth` — mobile cold-start endpoint. Same auth chain as `handleAddRemoteButtonCommand`. |
 
-### Modified files (all changes are isolated from the device path)
+### Modified files
 
 | File | Change |
 |---|---|
-| `controller/DatabaseCleaner.ts` | One-line addition to sweep `buttonHealthAll` in the existing daily-midnight retention pubsub. |
-| `index.ts` | Three new exports: `firestoreCheckButtonHealth`, `pubsubCheckButtonHealth`, `httpButtonHealth`. |
+| `controller/DatabaseCleaner.ts` | One-line addition to sweep `buttonHealthAll`. |
+| `index.ts` | Three new exports. |
 
-### Race-condition mitigation
+### Topic builder
 
-Trigger and pubsub can race; both can read `buttonHealthCurrent`, compute, and write concurrently. Mitigations:
+```typescript
+const TOPIC_PREFIX = 'buttonHealth-';
 
-- **Last-write-wins on `buttonHealthCurrent`** is acceptable for the doc itself — the state it records will converge to truth on the next event.
-- **Duplicate FCM avoidance** comes from three places combined:
-  1. The `OFFLINE → ONLINE` pubsub fallback only fires when state has been `OFFLINE` for >10 min (so a fresh trigger-write of `ONLINE` won't be undone by a concurrent pubsub).
-  2. The trigger always re-reads `RemoteButtonRequestDatabase.getCurrent()` so a Cloud-Functions retry sees the latest poll, not a stale event.
-  3. The bootstrap grace window (120 sec) prevents a first-deploy pubsub from racing the first-poll trigger.
-- **Mobile must be idempotent on receive.** `applyFcmUpdate(update)` overwrites with the full state. If the same FCM lands twice, the result is the same. The display does not blink.
-- A small race window remains where flapping is possible (trigger writes ONLINE, pubsub *just before its fallback grace window* writes nothing — fine; trigger writes ONLINE, slow pubsub still finishes its OFFLINE write — possible. Mobile sees pill flash on, then off within seconds. Acceptable: the underlying state did flap; the display reflects reality.
+export function buildTimestampToButtonHealthFcmTopic(buildTimestamp: string): string {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(buildTimestamp);
+  } catch (_err) {
+    decoded = buildTimestamp;  // fall back to raw; sanitization makes it safe
+  }
+  if (decoded.length === 0) {
+    throw new Error('buildTimestampToButtonHealthFcmTopic: empty buildTimestamp');
+  }
+  // Allowed FCM topic chars: [a-zA-Z0-9-_.~%]. Replacement char `.` matches the door builder.
+  const sanitized = decoded.replace(/[^a-zA-Z0-9\-_.~%]/g, '.');
+  return `${TOPIC_PREFIX}${sanitized}`;
+}
+```
+
+`ButtonHealthFcmTopicTest` pins format on both server (Mocha) and Android (commonTest), per the FCM safety rule.
 
 ### Wire contract
 
 NEW directory `wire-contracts/buttonHealth/`:
 
 ```
-response_online.json        { buttonState: "ONLINE",  stateChangedAtSeconds: 1730000000, buildTimestamp: "..." }
-response_offline.json       { buttonState: "OFFLINE", stateChangedAtSeconds: 1730000000, buildTimestamp: "..." }
-response_unknown.json       { buttonState: "UNKNOWN", stateChangedAtSeconds: null,        buildTimestamp: "..." }
-response_unauthorized.json  { error: "Unauthorized (token)." }                    // 401
-response_forbidden_user.json { error: "Forbidden (user)." }                       // 403
+response_online.json         { buttonState: "ONLINE",  stateChangedAtSeconds: <n>, buildTimestamp: "..." }
+response_offline.json        { buttonState: "OFFLINE", stateChangedAtSeconds: <n>, buildTimestamp: "..." }
+response_unknown.json        { buttonState: "UNKNOWN", stateChangedAtSeconds: null, buildTimestamp: "..." }
+response_unauthorized.json   401
+response_forbidden_user.json 403
 ```
 
-Both server tests and Android Ktor tests load these in strict mode. Production decoding stays `ignoreUnknownKeys = true` for forward-compat.
+Both server tests and Android Ktor tests load these in strict mode.
 
-### FCM payload
+### FCM payload (data-only)
 
 ```json
 {
-  "topic": "buttonHealth-<sanitized-buttonBuildTimestamp>",
+  "topic": "buttonHealth-<sanitized-buildTimestamp>",
   "data": {
     "buttonState": "ONLINE" | "OFFLINE",
-    "stateChangedAtSeconds": "1730000000",
-    "buildTimestamp": "<original-buttonBuildTimestamp>"
+    "stateChangedAtSeconds": "<epoch-seconds>",
+    "buildTimestamp": "<original-buildTimestamp>"
   },
-  "android": {
-    "priority": "HIGH",
-    "collapse_key": "button_health_update"
-  }
-  // No `notification` block — data-only by design.
+  "android": { "priority": "HIGH", "collapse_key": "button_health_update" }
 }
 ```
 
-`UNKNOWN` is never sent over FCM; it's a server-side bootstrap state only. Mobile sees ONLINE or OFFLINE via FCM, and may see UNKNOWN only as the cold-start HTTP response when no record exists yet.
-
-### Topic builder
-
-The button `buildTimestamp` is stored URL-encoded in server config (since April 2021 — see `CLAUDE.md` "Dormant config readers"). The door's topic builder doesn't handle this, so the button needs its own. The character set and replacement char must match the door's builder so a future agent reading both sees one rule:
-
-```typescript
-const TOPIC_PREFIX = 'buttonHealth-';
-
-export function buildTimestampToButtonHealthFcmTopic(buildTimestamp: string): string {
-  // Match Firebase's allowed topic char set [a-zA-Z0-9-_.~%].
-  // Replacement char `.` matches the door builder; do NOT diverge.
-  let decoded: string;
-  try {
-    decoded = decodeURIComponent(buildTimestamp);  // throws on malformed input
-  } catch (_err) {
-    decoded = buildTimestamp;  // fall back to raw string; sanitization below makes it safe
-  }
-  if (decoded.length === 0) {
-    throw new Error('buildTimestampToButtonHealthFcmTopic: empty buildTimestamp');
-  }
-  const sanitized = decoded.replace(/[^a-zA-Z0-9\-_.~%]/g, '.');
-  return `${TOPIC_PREFIX}${sanitized}`;
-}
-```
-
-`ButtonHealthFcmTopicTest` pins the format on both sides per the FCM safety rule in `CLAUDE.md`. The test must include:
-- `decodeURIComponent`-throws case (e.g., `"100%25"` re-decoded → `"100%"` then attempted re-decode throws; verify fallback path).
-- Empty-input case (must throw).
-- A "two different inputs that would collide" check (must produce different topics for inputs that differ in non-sanitized chars).
+`UNKNOWN` is server-side only; never sent over FCM. Mobile sees it only via the cold-start endpoint when no record exists.
 
 ## Android design
 
-Every layer gets its own button-health type. No reuse of door interfaces.
+Every layer gets its own button-health type. No shared interfaces with the door.
 
 ### Domain (`domain/.../buttonhealth/`)
 
@@ -201,7 +154,7 @@ data class ButtonHealth(
 sealed interface ButtonHealthError {
     data object Network : ButtonHealthError
     data object Forbidden : ButtonHealthError
-    data class Unknown(val cause: String) : ButtonHealthError
+    data class Other(val cause: String) : ButtonHealthError
 }
 
 interface ButtonHealthRepository {
@@ -213,207 +166,226 @@ interface ButtonHealthRepository {
 
 ### Data (`data/.../buttonhealth/`)
 
-- `NetworkButtonHealthDataSource` (interface) + `KtorNetworkButtonHealthDataSource` (impl) — its own data source, returns `NetworkResult<ButtonHealth>`.
-- `NetworkButtonHealthRepository` — owns `MutableStateFlow<LoadingResult<ButtonHealth>>`. Implements `ButtonHealthRepository`. Name uses the "Network" prefix per ADR-008 (not `Default`, since the strategy is clearly network-backed). All state mutations dispatch onto the injected `externalScope` per ADR-019 — `fetchButtonHealth()` and `applyFcmUpdate()` both `externalScope.launch { _state.value = ... }` so caller cancellation can never strand the singleton.
-- **FCM-vs-fetch ordering rule:** `applyFcmUpdate(update)` AND the `fetchButtonHealth()` success path BOTH check `update.stateChangedAtSeconds >= current.stateChangedAtSeconds` before writing. A stale fetch result that lands after a fresher FCM is discarded. (`UNKNOWN` is treated as oldest — any non-UNKNOWN result wins over a current UNKNOWN regardless of timestamp.)
-- `ButtonHealthFcmRepository` — separate from `DoorFcmRepository`. Different topic prefix, different lifecycle (subscribe gated by allowlist; door isn't). Methods: `subscribe(buildTimestamp)`, `unsubscribe(buildTimestamp)`. Subscription is idempotent (FCM SDK handles).
-- `ButtonHealthFcmPayloadParser` — parses `buttonHealth-*` data payloads. Contract test mirrors `FcmPayloadParsingTest`.
+- `NetworkButtonHealthDataSource` (interface) + `KtorNetworkButtonHealthDataSource` (impl).
+- `NetworkButtonHealthRepository` — implements `ButtonHealthRepository`. ADR-008 prefix denotes strategy. All `_state` writes dispatch onto the injected `externalScope` per ADR-019. `fetchButtonHealth()` uses `withContext(externalScope.coroutineContext)` so cancellation by the caller actually cancels the work, and the suspend signature is honored.
+- `ButtonHealthFcmRepository` — separate from `DoorFcmRepository`. Methods: `subscribe(buildTimestamp)`, `unsubscribe(buildTimestamp)`. Idempotent.
+- `ButtonHealthFcmPayloadParser` — parses `buttonHealth-*` data payloads.
 
 ### UseCase (`usecase/.../buttonhealth/`)
 
-- `FetchButtonHealthUseCase`, `ObserveButtonHealthUseCase` — thin wrappers around the repository.
-- `ComputeButtonHealthDisplayUseCase` — returns `StateFlow<ButtonHealthDisplay>` derived from `combine(authState, allowlistAccess, buttonHealthLoadingResult)`. **No new ViewModel.** This UseCase is the derivation; consumed by the existing `RemoteButtonViewModel`.
-- `ButtonHealthFcmSubscriptionManager` (ADR-015 Manager) — observes `combine(authState, allowlistAccess)` with `collectLatest` semantics so a sign-out in flight cancels an in-progress subscribe. Owns the `subscribe` / `unsubscribe` calls plus retry. App-scoped singleton, started from `AppStartup`.
+```kotlin
+class FetchButtonHealthUseCase(private val repo: ButtonHealthRepository) {
+    suspend operator fun invoke(): AppResult<ButtonHealth, ButtonHealthError> = repo.fetchButtonHealth()
+}
 
-### ViewModel (modify the existing `RemoteButtonViewModel`)
+class ApplyButtonHealthFcmUseCase(private val repo: ButtonHealthRepository) {
+    operator fun invoke(update: ButtonHealth) = repo.applyFcmUpdate(update)
+}
 
-Add a new property to the existing `RemoteButtonViewModel`, fed by `ComputeButtonHealthDisplayUseCase`:
+class ComputeButtonHealthDisplayUseCase(
+    private val authState: StateFlow<AuthState>,
+    private val allowlistAccess: StateFlow<Boolean?>,
+    private val buttonHealth: StateFlow<LoadingResult<ButtonHealth>>,
+    private val liveClock: LiveClock,
+    private val externalScope: CoroutineScope,
+) {
+    operator fun invoke(): StateFlow<ButtonHealthDisplay> =
+        combine(authState, allowlistAccess, buttonHealth, liveClock.tickSeconds) { auth, allowed, health, now ->
+            computeDisplay(auth, allowed, health, now)
+        }.stateIn(externalScope, SharingStarted.Eagerly, ButtonHealthDisplay.Loading)
+}
+
+// Pure function; trivial to unit-test.
+internal fun computeDisplay(
+    auth: AuthState,
+    allowed: Boolean?,
+    health: LoadingResult<ButtonHealth>,
+    nowSeconds: Long,
+): ButtonHealthDisplay = when {
+    auth !is AuthState.SignedIn -> ButtonHealthDisplay.Unauthorized
+    allowed != true             -> ButtonHealthDisplay.Unauthorized
+    health is LoadingResult.Loading -> ButtonHealthDisplay.Loading
+    health is LoadingResult.Error   -> ButtonHealthDisplay.Loading   // transient; retry will fix
+    health is LoadingResult.Complete -> when (health.data.state) {
+        ButtonHealthState.UNKNOWN -> ButtonHealthDisplay.Unknown
+        ButtonHealthState.ONLINE  -> ButtonHealthDisplay.Online
+        ButtonHealthState.OFFLINE -> ButtonHealthDisplay.Offline(
+            durationLabel = formatDurationAgo(health.data.stateChangedAtSeconds, nowSeconds)
+        )
+    }
+}
+```
+
+### Subscription manager (`usecase/.../buttonhealth/ButtonHealthFcmSubscriptionManager.kt`)
+
+ADR-015 Manager. App-scoped singleton. Started from `AppStartup` after FCM token registration completes.
 
 ```kotlin
-class RemoteButtonViewModel(
-    // ...existing constructor params...
-    computeButtonHealthDisplayUseCase: ComputeButtonHealthDisplayUseCase,
-    fetchButtonHealthUseCase: FetchButtonHealthUseCase,
-) : ViewModel() {
-
-    // ...existing remote-button state...
-
-    val buttonHealthDisplay: StateFlow<ButtonHealthDisplay> =
-        computeButtonHealthDisplayUseCase()  // already a StateFlow from the UseCase
-
-    fun fetchButtonHealth() {
-        viewModelScope.launch {
-            // Loading is set by the repository when fetchButtonHealth is called
-            // (it sets _state.value = LoadingResult.Loading inside externalScope.launch)
-            fetchButtonHealthUseCase()  // result lands in repository state
+class ButtonHealthFcmSubscriptionManager(
+    authState: StateFlow<AuthState>,
+    allowlistAccess: StateFlow<Boolean?>,
+    buttonBuildTimestamp: StateFlow<String?>,   // from ServerConfigRepository — handles config rotation
+    private val fcm: ButtonHealthFcmRepository,
+    private val fetchButtonHealthUseCase: FetchButtonHealthUseCase,
+    private val externalScope: CoroutineScope,
+) {
+    fun start() {
+        externalScope.launch {
+            combine(authState, allowlistAccess, buttonBuildTimestamp) { auth, allowed, buildTimestamp ->
+                Triple(auth, allowed, buildTimestamp)
+            }.distinctUntilChanged().collectLatest { (auth, allowed, buildTimestamp) ->
+                // Always unsubscribe from any prior topic before deciding whether to subscribe.
+                // Idempotent — Firebase handles unsubscribe-from-not-subscribed gracefully.
+                fcm.unsubscribeAll()
+                if (auth is AuthState.SignedIn && allowed == true && buildTimestamp != null) {
+                    fcm.subscribe(buildTimestamp)
+                    fetchButtonHealthUseCase()  // cold-start fetch
+                }
+            }
         }
     }
 }
 ```
 
-The `fetchButtonHealth` action follows the user's stated pattern: VM calls the suspend UseCase; the repository sets `Loading` at the start of the call and writes the result on completion. `Loading` and `Unknown` are *different concepts* — `Loading` = the suspend fun is in flight; `Unknown` = the suspend fun returned `UNKNOWN`. Both render no pill but mean different things.
+### ViewModel (modify the existing `RemoteButtonViewModel`)
 
-### Display sealed type
+Add one new property. No new VM class:
+
+```kotlin
+class RemoteButtonViewModel(
+    /* existing params */,
+    computeButtonHealthDisplayUseCase: ComputeButtonHealthDisplayUseCase,
+) : ViewModel() {
+    /* existing state */
+
+    val buttonHealthDisplay: StateFlow<ButtonHealthDisplay> =
+        computeButtonHealthDisplayUseCase()
+}
+```
+
+No new fetch action on the VM — the Manager owns cold-start fetch. User-triggered refresh (if ever wanted) is a future addition.
+
+### Display
 
 ```kotlin
 sealed interface ButtonHealthDisplay {
-    data object Unauthorized : ButtonHealthDisplay              // user not allowlisted — no pill
-    data object Loading      : ButtonHealthDisplay              // suspend fun in flight, no result yet — no pill
-    data object Unknown      : ButtonHealthDisplay              // server returned UNKNOWN (no data) — no pill
-    data object Online       : ButtonHealthDisplay              // server returned ONLINE, fresh — no pill
+    data object Unauthorized : ButtonHealthDisplay              // user not allowlisted
+    data object Loading      : ButtonHealthDisplay              // fetch in flight, no result yet
+    data object Unknown      : ButtonHealthDisplay              // server returned UNKNOWN
+    data object Online       : ButtonHealthDisplay              // server returned ONLINE
     data class  Offline(val durationLabel: String) : ButtonHealthDisplay   // ONLY state that renders the pill
 }
 ```
 
-The five-arm sealed type preserves *why* the pill is hidden — `Loading` and `Unknown` look identical to the user but tell a future debugger which path led there.
-
-### `durationLabel` format
-
-`durationLabel` is computed by a pure function (`ButtonOfflineDuration.format(stateChangedAtSeconds, nowSeconds)`) ticked by the existing app-scoped `LiveClock` at 1-second cadence — same pattern as `DeviceCheckIn.format` driving `TitleBarCheckInPill`. Format mirrors the existing pill: `"5 min ago"`, `"11 min ago"`. Keeps both pills speaking the same grammar.
+Five arms, exhaustive `when`. Only `Offline` ever renders the pill.
 
 ### UI
 
-- NEW `androidApp/.../ui/buttonhealth/RemoteOfflinePill.kt` — stateless Composable taking `display: ButtonHealthDisplay.Offline` (already includes the `durationLabel`). `errorContainer` background, `Icons.Outlined.SignalWifiOff`, text format `"Remote offline · <durationLabel>"` (e.g., `"Remote offline · 11 min ago"`). TalkBack `contentDescription = "Remote offline, last checked in <durationLabel>"`.
-- Modify `RemoteButtonContent.kt` — takes a new `buttonHealthDisplay: ButtonHealthDisplay` parameter (NO ViewModel import; complies with ADR-026 sub-component rule):
+NEW `androidApp/.../ui/buttonhealth/RemoteOfflinePill.kt` — stateless Composable taking `display: ButtonHealthDisplay.Offline`. Renders `errorContainer` background, `Icons.Outlined.SignalWifiOff`, text `"Remote offline · {display.durationLabel}"`. TalkBack content description: `"Remote offline, last seen {durationLabel}"`.
+
+Modify `HomeContent.kt` — pill goes in the existing `HomeSection(label = "Remote control", trailing = { ... })` slot. `RemoteButtonContent` itself is unchanged (preserves all `@Preview` callers and screenshot tests):
 
 ```kotlin
-@Composable
-fun RemoteButtonContent(
-    state: RemoteButtonState,
-    buttonHealthDisplay: ButtonHealthDisplay,  // NEW required parameter
-    onTap: () -> Unit,
-    modifier: Modifier = Modifier,
+val display by remoteButtonViewModel.buttonHealthDisplay.collectAsState()
+
+HomeSection(
+    label = "Remote control",
+    trailing = {
+        when (val d = display) {
+            is ButtonHealthDisplay.Offline -> RemoteOfflinePill(d)
+            ButtonHealthDisplay.Unauthorized,
+            ButtonHealthDisplay.Loading,
+            ButtonHealthDisplay.Unknown,
+            ButtonHealthDisplay.Online -> Unit
+        }
+    },
 ) {
-    HomeSection(
-        title = "Remote control",
-        trailing = {
-            when (val d = buttonHealthDisplay) {
-                is ButtonHealthDisplay.Offline -> RemoteOfflinePill(display = d)
-                ButtonHealthDisplay.Unauthorized,
-                ButtonHealthDisplay.Loading,
-                ButtonHealthDisplay.Unknown,
-                ButtonHealthDisplay.Online -> Unit  // Render nothing — same as today.
-            }
-        },
-    ) { /* ...existing button... */ }
+    RemoteButtonContent(state = ..., onTap = ...)
 }
 ```
 
-- Modify `HomeContent.kt` — collect `RemoteButtonViewModel.buttonHealthDisplay` and pass to `RemoteButtonContent`.
-- Modify `androidApp/.../fcm/FCMService.kt` — dispatch by topic prefix:
+Modify `FCMService.kt` — dispatch by topic prefix:
 
 ```kotlin
+val topic = remoteMessage.from?.removePrefix("/topics/").orEmpty()
 when {
     topic.startsWith("buttonHealth-") ->
-        ButtonHealthFcmPayloadParser.parse(data)?.let { buttonHealthRepository.applyFcmUpdate(it) }
-    else -> existingDoorPayloadParser(data)
+        ButtonHealthFcmPayloadParser.parse(data)?.let { applyButtonHealthFcmUseCase(it) }
+    else -> existingDoorPayloadDispatch(data)
 }
 ```
 
-- Modify `AppStartup.kt` — start `ButtonHealthFcmSubscriptionManager`. The Manager handles all subscription lifecycle internally with `combine(authState, allowlistAccess) + collectLatest`.
-- Modify `AppComponent.kt` — wire as `@Singleton` providers with matching `abstract val` entry points (per `DI_SINGLETON_REQUIREMENTS.md`):
-  - `abstract val buttonHealthRepository: ButtonHealthRepository`
-  - `abstract val buttonHealthFcmRepository: ButtonHealthFcmRepository`
-  - `abstract val buttonHealthFcmSubscriptionManager: ButtonHealthFcmSubscriptionManager`
-  - `provideComputeButtonHealthDisplayUseCase`, `provideFetchButtonHealthUseCase` — non-`@Singleton` factories.
-  - `RemoteButtonViewModel` provider gains the two new UseCase parameters.
+Modify `AppStartup.kt` — start `ButtonHealthFcmSubscriptionManager` after FCM token registration.
 
-### Subscription lifecycle (encapsulated in `ButtonHealthFcmSubscriptionManager`)
+Modify `AppComponent.kt` — wire as `@Singleton` providers with matching `abstract val` entry points (per `DI_SINGLETON_REQUIREMENTS.md`):
+- `abstract val buttonHealthRepository: ButtonHealthRepository`
+- `abstract val buttonHealthFcmRepository: ButtonHealthFcmRepository`
+- `abstract val buttonHealthFcmSubscriptionManager: ButtonHealthFcmSubscriptionManager`
+- Non-`@Singleton` factories for the three UseCases.
 
-| Event | Action |
-|---|---|
-| `combine(authState, allowlistAccess)` emits `(SignedIn, Allowed)` | Subscribe to `buttonHealth-<buttonBuildTimestamp>`; trigger one-shot `fetchButtonHealth()` |
-| `combine(...)` emits anything else (signed-out, allowlist false) | Unsubscribe; `applyFcmUpdate` becomes a no-op until re-allowed |
-| In-flight subscribe + sign-out fires before subscribe completes | `collectLatest` cancels the in-progress subscribe; unsubscribe wins |
-| In-flight `fetchButtonHealth()` + sign-out fires before fetch completes | `collectLatest` cancels the fetch; late HTTP response (if any) is discarded by the timestamp gate (UNKNOWN is treated as oldest) and by the auth-check inside `applyFcmUpdate` (no-op when not authorized) |
-| `httpButtonHealth` returns 403 (allowlist removed) | Repository surfaces `ButtonHealthError.Forbidden`; ViewModel maps to `Unauthorized` display; Manager unsubscribes |
-
-## Naming convention summary
+## Naming summary
 
 | Concept | Name |
 |---|---|
 | State enum (server + Android) | `ONLINE`, `OFFLINE`, `UNKNOWN` |
 | Timestamp field (wire + Android) | `stateChangedAtSeconds` |
-| FCM payload field for state | `buttonState` |
 | Topic prefix | `buttonHealth-` |
-| Topic builder | `buildTimestampToButtonHealthFcmTopic` |
 | Collection | `buttonHealthCurrent` / `buttonHealthAll` |
-| HTTP endpoint | `httpButtonHealth` / `handleButtonHealth` |
-| Pubsub | `pubsubCheckButtonHealth` / `handleCheckButtonHealth` |
-| Firestore trigger | `firestoreCheckButtonHealth` / `handleButtonHealthFromPollWrite` |
-| FCM collapse key | `button_health_update` |
-| Domain types | `ButtonHealth`, `ButtonHealthState`, `ButtonHealthError`, `ButtonHealthRepository` |
-| Repository impl | `NetworkButtonHealthRepository` (ADR-008 — "Network" prefix denotes strategy) |
-| Display sealed type | `ButtonHealthDisplay.Unauthorized` / `.Loading` / `.Unknown` / `.Online` / `.Offline(durationLabel)` |
-| UseCases | `FetchButtonHealthUseCase`, `ObserveButtonHealthUseCase`, `ComputeButtonHealthDisplayUseCase` |
-| Subscription manager | `ButtonHealthFcmSubscriptionManager` (ADR-015 Manager pattern) |
+| Functions | `httpButtonHealth`, `pubsubCheckButtonHealth`, `firestoreCheckButtonHealth` |
+| Repository impl | `NetworkButtonHealthRepository` (ADR-008) |
+| Display sealed type | `ButtonHealthDisplay.{Unauthorized, Loading, Unknown, Online, Offline}` |
 | Pill Composable | `RemoteOfflinePill` |
-| User-visible text | "Remote offline" + `" · <durationLabel>"` (matches "Remote control" section title) |
+| User-visible text | `"Remote offline · {durationLabel}"` |
 
-The states are connectivity-shaped (`ONLINE`/`OFFLINE`) but the feature noun is "health" (`ButtonHealth*`, `buttonHealth-` topic). This deliberately leaves room for future health signals (battery, sensor errors) without renaming the present feature, while keeping current state names matching the user-visible "offline" string.
+States are connectivity-shaped (ONLINE/OFFLINE) but the feature noun is "health" — leaves room for future health signals (battery, sensor errors) without renaming.
 
 ## Safety property
 
-Every server change is in a function file the device does not touch:
+| Function | Device path? |
+|---|---|
+| `httpRemoteButton` (existing) | YES — unchanged |
+| `firestoreCheckButtonHealth` (NEW) | NO — fires async after device's response |
+| `pubsubCheckButtonHealth` (NEW) | NO — scheduled |
+| `httpButtonHealth` (NEW) | NO — mobile only |
+| `pubsubDataRetentionPolicy` (existing, +1 line) | NO — sweeps history collections only |
 
-| Function | Device path? | Notes |
-|---|---|---|
-| `httpRemoteButton` (existing) | YES | Unchanged — same response shape, same Firestore ops, same latency |
-| `httpAddRemoteButtonCommand` (existing) | NO | Mobile only |
-| `firestoreCheckButtonHealth` (NEW) | NO | Fires asynchronously after the device's response is sent. No `failurePolicy`. |
-| `pubsubCheckButtonHealth` (NEW) | NO | Runs on schedule |
-| `httpButtonHealth` (NEW) | NO | Mobile only |
-| `pubsubDataRetentionPolicy` (existing, modified one line) | NO | Doesn't touch device-written collections |
-
-**The device cannot observe whether this feature is deployed.** A failure in any new code path — Firestore trigger crash, Firestore read failure, FCM send failure, malformed health record — has zero effect on the response the device receives from `httpRemoteButton`. Worst case: the indicator stays stale until the next pubsub run; the button itself works exactly as today.
+The device cannot observe whether this feature is deployed. A failure in any new code path has zero effect on the response from `httpRemoteButton`.
 
 ## Acceptable failure modes
 
-- An `OFFLINE` state that recovers within 10 min may never reach mobile (pubsub didn't fire while it was OFFLINE). User stated this is acceptable.
-- FCM delivery failures are not retried — mobile re-fetches on next cold start. Eventually consistent.
-- A pubsub run that crashes mid-flight may leave state stale until the next run — bounded by 10-min cadence.
-- A brand-new install with a device that has never polled stays in `Loading → Unknown` (no pill) indefinitely. Acceptable per requirements; user has no way to distinguish "Unknown" from "Online" but this is the same as today (today there's no indicator at all).
-- During a network failure, `AllowlistAccess` returning the last-known-good value is preferred over flipping to `false` (which would unsubscribe + show `Unauthorized`); the Manager treats network failures as transient and retains the last successful allowlist verdict.
-- During a WiFi outage the device-check-in pill (existing, in Status section) AND the remote-offline pill (new) may both render. They reflect independent devices and represent the truth: two devices are unreachable. No coordination needed.
+- **OFFLINE that recovers within 10 min may never reach mobile** (pubsub didn't fire while it was OFFLINE). Per requirements.
+- **Trigger-side FCM-send failure may leave mobile briefly stale**. Mobile picks up correct state on next cold-start fetch (typically next app launch). Symmetric with the above.
+- **FCM topic subscription is client-side**. A signed-in non-allowlisted user with a custom client could subscribe to `buttonHealth-<buildTimestamp>` and receive ONLINE/OFFLINE state. Allowlist is enforced only at the HTTP cold-start endpoint. Acceptable: the leaked data is "is the device online" — low value, no PII, no control surface.
+- **Data-only FCMs are not delivered to force-stopped Android apps**. Cold-start fetch handles this on next app launch.
+- **Pubsub or trigger crash during a single run** leaves state stale until the next pubsub run (≤10 min).
 
 ## Failure modes designed out
 
-- **Unauthorized user seeing the pill** — eliminated by the five-arm sealed display: only `Offline` ever renders the pill, and `applyFcmUpdate` is a no-op when display is `Unauthorized` so a late FCM (or stale fetch) cannot leak through.
-- **Stale fetch clobbering fresher FCM update** — eliminated by the `stateChangedAtSeconds` timestamp gate in the repository (both `applyFcmUpdate` and `fetchButtonHealth` success path check it).
-- **Late fetch landing for signed-out user** — eliminated by `collectLatest` in `ButtonHealthFcmSubscriptionManager` (cancels in-flight fetch on sign-out) plus the auth check in `applyFcmUpdate`.
+- **Unauthorized user seeing the pill** — `computeDisplay`'s exhaustive `when` routes `!SignedIn` and `!allowed` to `Unauthorized`, which has no path to the pill.
 - **Topic format drift between server and Android** — pinned by `ButtonHealthFcmTopicTest` running on both sides.
-- **Payload key drift** — pinned by `wire-contracts/buttonHealth/` fixtures consumed by tests in strict mode on both sides.
-- **`stateChangedAtSeconds` drifting forward on no-op writes** — `detectTransition` returns "no change" when state matches; trigger and pubsub do nothing on no-op (no write, no FCM, `stateChangedAtSeconds` preserved).
-- **Trigger retry on stale event** — trigger re-reads `RemoteButtonRequestDatabase.getCurrent()` rather than trust `change.after.data()`.
-- **Bootstrap race between pubsub and first-poll trigger** — pubsub `UNKNOWN → OFFLINE` requires last-poll older than 120 sec (or no record), giving Firestore replication time to settle.
-- **Duplicate `OFFLINE → ONLINE` FCMs from trigger + pubsub fallback** — pubsub fallback only fires when state has been `OFFLINE` for >10 min, so the trigger's recovery path is never duplicated by a contemporaneous pubsub.
-- **Topic-builder throw on malformed `buildTimestamp`** — `decodeURIComponent` wrapped in try/catch; falls back to raw string + sanitization.
+- **Payload key drift** — pinned by `wire-contracts/buttonHealth/` fixtures consumed in strict mode on both sides.
+- **`stateChangedAtSeconds` drifting forward on no-op writes** — `detectTransition` returns "no change" when state matches; no write, no FCM, timestamp preserved.
+- **Trigger retry on stale event payload** — trigger re-reads `RemoteButtonRequestDatabase.getCurrent()` rather than trusting `change.after.data()`.
+- **Device reflash (new buildTimestamp) leaving mobile subscribed to a stale topic** — Manager observes `buttonBuildTimestamp` from `ServerConfigRepository` and unsubscribes from old + subscribes to new on rotation.
 
 ## Out of scope
 
 - ESP32 firmware changes.
-- Modifications to existing door event flow, existing button command flow, or existing pubsubs.
-- Refactoring `RemoteButtonViewModel` into a one-VM-per-screen structure (see "Architectural goal note" — that's a future PR).
-- Room caching of button health (state is short-lived; FCM keeps it fresh; cold-start endpoint reseeds in <1s).
+- Modifying any existing function the device calls.
+- Refactoring `RemoteButtonViewModel` into a one-VM-per-screen structure (future PR).
+- Room caching of button health (state is short-lived; FCM keeps it fresh).
 - New server config keys.
-- History view or "uptime" metric — `buttonHealthAll` is for diagnostics if ever needed.
-- Visible system-tray notifications.
-- Transactional `buttonHealthCurrent` writes — last-write-wins is acceptable (race-condition mitigation lives in the FCM-duplication rules, not in document-write atomicity).
+- History view or "uptime" metric.
 
-## Versioning impact
+## ADR / convention compliance
 
-- **Android**: minor bump (new user-visible capability — offline indicator). Add `distribution/whatsnew/` line and `CHANGELOG.md` entry.
-- **Firebase server**: minor entry in `FirebaseServer/CHANGELOG.md` covering the new Firestore trigger, pubsub, HTTP endpoint, and collection.
-
-## CLAUDE.md compliance
-
-- **FCM safety rule**: this feature *adds* a new topic format and new payload keys; existing `FcmTopicTest` and `FcmPayloadParsingTest` stay green. New contract tests (`ButtonHealthFcmTopicTest`, `ButtonHealthFcmPayloadParsingTest`) ship in the same PR as the topic builder and parser.
-- **Handler pattern** (`docs/FIREBASE_HANDLER_PATTERN.md`): new HTTP handler follows the pure `handle<Action>(input)` core + thin wrapper convention.
-- **Database refactor pattern** (`docs/FIREBASE_DATABASE_REFACTOR.md`): new `ButtonHealthDatabase` follows the per-collection module pattern (interface + Firestore impl + `setImpl`/`resetImpl`).
-- **Config authority** (`docs/FIREBASE_CONFIG_AUTHORITY.md`): no new server config keys; reuses existing button config (`remoteButtonBuildTimestamp`, `remoteButtonPushKey`, `remoteButtonAuthorizedEmails`); pubsub uses `requireBuildTimestamp` to throw on missing config.
-- **ADR-008** (no `*Impl` suffix): repository named `NetworkButtonHealthRepository`, not `DefaultButtonHealthRepository`.
-- **ADR-015** (app-scoped Managers): subscription lifecycle wrapped in `ButtonHealthFcmSubscriptionManager`, started from `AppStartup`.
-- **ADR-019** (repository `externalScope`): all `MutableStateFlow` writes in `NetworkButtonHealthRepository` dispatch onto the injected `externalScope`.
-- **ADR-021/022** (no passthrough VMs): no new ViewModel; derivation lives in `ComputeButtonHealthDisplayUseCase` consumed by the existing `RemoteButtonViewModel`.
-- **ADR-026** (one VM per screen + sub-components have no VMs): `RemoteButtonContent` takes `buttonHealthDisplay` as a parameter; `HomeContent` collects from `RemoteButtonViewModel` and passes down.
-- **DI_SINGLETON_REQUIREMENTS**: every new `@Singleton` provider has a matching `abstract val` entry point in `AppComponent.kt`.
+- **FCM safety**: adds new topic + new payload keys; existing `FcmTopicTest` and `FcmPayloadParsingTest` stay green; new `ButtonHealthFcmTopicTest` + `ButtonHealthFcmPayloadParsingTest` ship in the same PR.
+- **Handler pattern**: `httpButtonHealth` follows pure-core + thin-wrapper convention.
+- **Database refactor pattern**: `ButtonHealthDatabase` follows the per-collection module pattern.
+- **Config authority**: no new server config keys; reuses existing button config.
+- **ADR-008**: `NetworkButtonHealthRepository` (descriptive prefix).
+- **ADR-015**: subscription lifecycle in `ButtonHealthFcmSubscriptionManager`.
+- **ADR-019**: all repository state mutations dispatched onto `externalScope`.
+- **ADR-021/022**: no passthrough VM — derivation lives in `ComputeButtonHealthDisplayUseCase`.
+- **ADR-026**: `RemoteButtonContent` (sub-component) takes no new VM dependency; pill placed in `HomeContent`'s `HomeSection` trailing slot.
+- **`DI_SINGLETON_REQUIREMENTS`**: every new `@Singleton` provider has a matching `abstract val` entry point.

--- a/docs/BUTTON_HEALTH_ARCHITECTURE.md
+++ b/docs/BUTTON_HEALTH_ARCHITECTURE.md
@@ -9,7 +9,7 @@ Design for a server-detected, mobile-displayed health indicator for the remote-b
 
 ## Goal
 
-Show the user a small "Button offline" pill next to the Remote-control section title when the remote-button device hasn't checked in recently. Three states (server-side): `ONLINE`, `OFFLINE`, `UNKNOWN`. Only `OFFLINE` is visible to the user; the other two states render identically to today's UI.
+Show the user a small "Remote offline" pill next to the Remote-control section title when the remote-button device hasn't checked in recently. Three states (server-side): `ONLINE`, `OFFLINE`, `UNKNOWN`. Only `OFFLINE` is visible to the user; the other two states render identically to today's UI.
 
 ## Hard constraints
 
@@ -19,19 +19,27 @@ Show the user a small "Button offline" pill next to the Remote-control section t
 4. **Data-only FCM.** Never send a system-tray notification for this feature.
 5. **Door and button concepts stay separate on Android.** No shared interfaces between the door event flow and the button health flow — every layer gets its own button-side type.
 
+## Architectural goal note (out of scope, for future work)
+
+The ideal architecture for any screen is **one ViewModel per navigation destination, with all data and actions injected as UseCases.** This design intentionally does **not** refactor toward that ideal — the existing `RemoteButtonViewModel` is already consumed by `HomeContent` (a sub-component aggregator screen exempt from ADR-026), and pulling that apart belongs in its own PR. This design adds new state to the existing `RemoteButtonViewModel` via a new injected UseCase. Future cleanup: collapse the per-sub-component VMs into one screen-level VM that aggregates the same UseCases.
+
 ## State machine
 
-States: `UNKNOWN`, `ONLINE`, `OFFLINE`. Persisted server-side in `buttonHealthCurrent/{buildTimestamp}`. Each transition emits one data-only FCM.
+States: `UNKNOWN`, `ONLINE`, `OFFLINE`. Persisted server-side in `buttonHealthCurrent/{buildTimestamp}`. Each *transition* emits one data-only FCM. **No-op writes (state unchanged) MUST NOT bump `stateChangedAtSeconds`** — the UI's "Offline since X" label depends on `stateChangedAtSeconds` being the moment the state was *entered*, not the most recent observation.
 
-| Transition | Detected by | Latency |
-|---|---|---|
-| `UNKNOWN → ONLINE` | Firestore trigger (first poll seen for this `buildTimestamp`) | < 1 sec |
-| `OFFLINE → ONLINE` | Firestore trigger (device polls again after being marked offline) | < 1 sec |
-| `ONLINE → OFFLINE` | Pubsub (every 10 min, 60-sec freshness threshold) | up to 10 min |
-| `UNKNOWN → OFFLINE` | Same pubsub (no record exists, no recent poll) | up to 10 min |
-| `OFFLINE → ONLINE` (fallback) | Same pubsub (defense-in-depth in case the trigger missed it) | up to 10 min |
+| Event | Detected by | New state | Fires FCM | Latency |
+|---|---|---|---|---|
+| Poll arrives, prior state was `UNKNOWN` | Trigger | `ONLINE` | yes | < 1 sec |
+| Poll arrives, prior state was `OFFLINE` | Trigger | `ONLINE` | yes | < 1 sec |
+| Poll arrives, prior state was `ONLINE` | Trigger | `ONLINE` (no-op, no write) | no | n/a |
+| Pubsub finds last-poll > 60 sec ago, prior `ONLINE` | Pubsub | `OFFLINE` | yes | up to 10 min |
+| Pubsub finds NO record + last-poll > 2 min ago, prior `UNKNOWN` | Pubsub | `OFFLINE` | yes | up to 10 min |
+| Pubsub finds last-poll < 60 sec ago, prior `OFFLINE` for >10 min (fallback) | Pubsub | `ONLINE` | yes | up to 10 min |
+| Pubsub finds last-poll < 60 sec ago, prior `OFFLINE` for <10 min | Pubsub | (no action — trigger should have already handled) | no | n/a |
+| Pubsub finds last-poll fresh, prior `ONLINE` | Pubsub | `ONLINE` (no-op, no write) | no | n/a |
+| Pubsub finds last-poll fresh, prior `OFFLINE` for >10 min | Pubsub | `ONLINE` | yes | (this is the fallback row above) |
 
-ONLINE threshold: most recent poll within `60 sec`. Worst-case OFFLINE-detection latency: ~10 min (acknowledged tradeoff).
+ONLINE threshold: most recent poll within `60 sec` (steady state). Bootstrap grace: `UNKNOWN → OFFLINE` requires last-poll older than `120 sec` (or no record), guarding against Firestore replication lag where the pubsub reads `RemoteButtonRequestDatabase` before a fresh first-deploy poll has propagated. Pubsub fallback grace: `OFFLINE → ONLINE` from pubsub only fires if state has been `OFFLINE` for more than 10 min (i.e., the trigger had ample time to recover and didn't), avoiding duplicate FCMs when trigger and pubsub race on the same fresh poll. Worst-case `OFFLINE`-detection latency: ~10 min (acknowledged tradeoff).
 
 ## Why a Firestore trigger, not an HTTP-handler modification
 
@@ -46,9 +54,10 @@ Switching to a Firestore `onWrite` trigger on `remoteButtonRequestAll/{docId}` (
 Device → httpRemoteButton (UNCHANGED, byte-identical to today)
                 ↓
        writes to remoteButtonRequestAll
-                ↓ (Firestore onWrite trigger)
+                ↓ (Firestore onWrite trigger; default no-retry policy)
        firestoreCheckButtonHealth (NEW)
                 ↓
+       re-reads RemoteButtonRequestDatabase.getCurrent() (NOT the event payload — see below)
        reads buttonHealthCurrent
        computes transition
        conditionally writes + sends FCM
@@ -56,7 +65,11 @@ Device → httpRemoteButton (UNCHANGED, byte-identical to today)
 
 The trigger fires asynchronously after the device's response is already on the wire. Trigger failures, Firestore failures, and FCM failures all have **zero effect** on the response the device receives. This mirrors the existing door-event pattern (`firestoreUpdateEvents` triggers on `updateAll/{docId}` writes).
 
-Cost: ~17,000 trigger invocations/day at the button's polling cadence. Cloud Functions invocations + Firestore reads ≈ $0.50/month. Negligible.
+**Critical: trigger must re-read `RemoteButtonRequestDatabase.getCurrent()` rather than trust `change.after.data()`.** Cloud Functions retry triggers with the *original* event payload, which can become stale by the time the retry runs. A retry of an old poll could otherwise incorrectly compute `OFFLINE` despite the device having polled successfully many times since.
+
+**Critical: trigger MUST NOT enable `runWith({failurePolicy: true})`.** Default is no-retry, matching `firestoreUpdateEvents`. Retried instances on a buggy trigger could pile up; cost spike, no device impact.
+
+Cost: ~17,000 trigger invocations/day at the button's polling cadence. Cloud Functions invocations + Firestore reads ≈ $0.50/month *marginal* (verify total Firestore-read budget across all features before declaring negligible at the org level).
 
 ## Server design
 
@@ -70,7 +83,7 @@ buttonHealthAll/{auto-id}        // history; daily retention pubsub sweeps it
 
 Document shape:
   state: 'ONLINE' | 'OFFLINE' | 'UNKNOWN'
-  stateChangedAtSeconds: number          // when this state was entered (transition timestamp)
+  stateChangedAtSeconds: number          // when this state was ENTERED (NOT bumped on no-op)
   lastObservedPollAtSeconds: number | null
 ```
 
@@ -81,12 +94,12 @@ All NEW files; no modification to any existing function file the device calls.
 | File | Purpose |
 |---|---|
 | `database/ButtonHealthDatabase.ts` | Firestore CRUD; `setImpl`/`resetImpl` for tests. Same shape as `RemoteButtonRequestDatabase`. |
-| `controller/ButtonHealthInterpreter.ts` | Pure functions: `computeHealthFromLastPoll(lastPollSec, nowSec)` + `detectTransition(prior, computed, nowSec)`. |
-| `controller/ButtonHealthUpdates.ts` | `handleButtonHealthFromPollWrite(data)` — called by the Firestore trigger. |
-| `controller/fcm/ButtonHealthFCM.ts` | `sendForTransition(buildTimestamp, record)`. Pattern matches `EventFCM.ts`. |
-| `model/ButtonHealthFcmTopic.ts` | `buildTimestampToButtonHealthFcmTopic(buildTimestamp)` — distinct from door's topic builder; handles the URL-encoded button `buildTimestamp`. |
-| `functions/firestore/ButtonHealth.ts` | `firestoreCheckButtonHealth` — `onWrite` trigger on `remoteButtonRequestAll/{docId}`. Thin wrapper around `handleButtonHealthFromPollWrite`. |
-| `functions/pubsub/ButtonHealth.ts` | `pubsubCheckButtonHealth` — every 10 min. Detects `ONLINE → OFFLINE` (and fallback `OFFLINE → ONLINE`). |
+| `controller/ButtonHealthInterpreter.ts` | Pure functions: `computeHealthFromLastPoll(lastPollSec, nowSec)` (clamped: returns `ONLINE` if `lastPollSec > nowSec` to handle clock skew) + `detectTransition(prior, computed, nowSec)` — never bumps `stateChangedAtSeconds` on no-op. |
+| `controller/ButtonHealthUpdates.ts` | `handleButtonHealthFromPollWrite(buildTimestamp)` — called by the Firestore trigger. Re-reads `RemoteButtonRequestDatabase` (does NOT trust the event payload). |
+| `controller/fcm/ButtonHealthFCM.ts` | `sendForTransition(buildTimestamp, record)`. Pattern matches `EventFCM.ts` (`SERVICE` exported object indirection, module-level `let _instance`, `setImpl`/`resetImpl`). |
+| `model/ButtonHealthFcmTopic.ts` | `buildTimestampToButtonHealthFcmTopic(buildTimestamp)` — distinct from door's topic builder; handles the URL-encoded button `buildTimestamp` with try/catch. |
+| `functions/firestore/ButtonHealth.ts` | `firestoreCheckButtonHealth` — `onWrite` trigger on `remoteButtonRequestAll/{docId}`. Thin wrapper around `handleButtonHealthFromPollWrite`. **No `failurePolicy`.** |
+| `functions/pubsub/ButtonHealth.ts` | `pubsubCheckButtonHealth` — every 10 min. Detects `ONLINE → OFFLINE`, `UNKNOWN → OFFLINE` (with 120-sec grace), and fallback `OFFLINE → ONLINE` (only when state has been OFFLINE for >10 min). |
 | `functions/http/ButtonHealth.ts` | `httpButtonHealth` — mobile cold-start endpoint. Same auth chain as `handleAddRemoteButtonCommand` (push key + Google ID token + email allowlist). |
 
 ### Modified files (all changes are isolated from the device path)
@@ -95,6 +108,18 @@ All NEW files; no modification to any existing function file the device calls.
 |---|---|
 | `controller/DatabaseCleaner.ts` | One-line addition to sweep `buttonHealthAll` in the existing daily-midnight retention pubsub. |
 | `index.ts` | Three new exports: `firestoreCheckButtonHealth`, `pubsubCheckButtonHealth`, `httpButtonHealth`. |
+
+### Race-condition mitigation
+
+Trigger and pubsub can race; both can read `buttonHealthCurrent`, compute, and write concurrently. Mitigations:
+
+- **Last-write-wins on `buttonHealthCurrent`** is acceptable for the doc itself — the state it records will converge to truth on the next event.
+- **Duplicate FCM avoidance** comes from three places combined:
+  1. The `OFFLINE → ONLINE` pubsub fallback only fires when state has been `OFFLINE` for >10 min (so a fresh trigger-write of `ONLINE` won't be undone by a concurrent pubsub).
+  2. The trigger always re-reads `RemoteButtonRequestDatabase.getCurrent()` so a Cloud-Functions retry sees the latest poll, not a stale event.
+  3. The bootstrap grace window (120 sec) prevents a first-deploy pubsub from racing the first-poll trigger.
+- **Mobile must be idempotent on receive.** `applyFcmUpdate(update)` overwrites with the full state. If the same FCM lands twice, the result is the same. The display does not blink.
+- A small race window remains where flapping is possible (trigger writes ONLINE, pubsub *just before its fallback grace window* writes nothing — fine; trigger writes ONLINE, slow pubsub still finishes its OFFLINE write — possible. Mobile sees pill flash on, then off within seconds. Acceptable: the underlying state did flap; the display reflects reality.
 
 ### Wire contract
 
@@ -132,19 +157,32 @@ Both server tests and Android Ktor tests load these in strict mode. Production d
 
 ### Topic builder
 
-The button `buildTimestamp` is stored URL-encoded in server config (since April 2021 — see `CLAUDE.md` "Dormant config readers"). The door's topic builder doesn't handle this, so the button needs its own:
+The button `buildTimestamp` is stored URL-encoded in server config (since April 2021 — see `CLAUDE.md` "Dormant config readers"). The door's topic builder doesn't handle this, so the button needs its own. The character set and replacement char must match the door's builder so a future agent reading both sees one rule:
 
 ```typescript
 const TOPIC_PREFIX = 'buttonHealth-';
 
 export function buildTimestampToButtonHealthFcmTopic(buildTimestamp: string): string {
-  const decoded = decodeURIComponent(buildTimestamp);  // idempotent for plain ASCII
-  const sanitized = decoded.replace(/[^a-zA-Z0-9_\-\.~]/g, '_');
+  // Match Firebase's allowed topic char set [a-zA-Z0-9-_.~%].
+  // Replacement char `.` matches the door builder; do NOT diverge.
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(buildTimestamp);  // throws on malformed input
+  } catch (_err) {
+    decoded = buildTimestamp;  // fall back to raw string; sanitization below makes it safe
+  }
+  if (decoded.length === 0) {
+    throw new Error('buildTimestampToButtonHealthFcmTopic: empty buildTimestamp');
+  }
+  const sanitized = decoded.replace(/[^a-zA-Z0-9\-_.~%]/g, '.');
   return `${TOPIC_PREFIX}${sanitized}`;
 }
 ```
 
-`ButtonHealthFcmTopicTest` pins the format on both sides per the FCM safety rule in `CLAUDE.md`.
+`ButtonHealthFcmTopicTest` pins the format on both sides per the FCM safety rule in `CLAUDE.md`. The test must include:
+- `decodeURIComponent`-throws case (e.g., `"100%25"` re-decoded → `"100%"` then attempted re-decode throws; verify fallback path).
+- Empty-input case (must throw).
+- A "two different inputs that would collide" check (must produce different topics for inputs that differ in non-sanitized chars).
 
 ## Android design
 
@@ -176,42 +214,92 @@ interface ButtonHealthRepository {
 ### Data (`data/.../buttonhealth/`)
 
 - `NetworkButtonHealthDataSource` (interface) + `KtorNetworkButtonHealthDataSource` (impl) — its own data source, returns `NetworkResult<ButtonHealth>`.
-- `DefaultButtonHealthRepository` — owns `MutableStateFlow<LoadingResult<ButtonHealth>>`. `fetchButtonHealth()` always force-refreshes. FCM updates dispatch through `applyFcmUpdate`.
-- `ButtonHealthFcmRepository` — separate from `DoorFcmRepository`. Different topic prefix, different lifecycle (subscribe gated by allowlist; door isn't).
+- `NetworkButtonHealthRepository` — owns `MutableStateFlow<LoadingResult<ButtonHealth>>`. Implements `ButtonHealthRepository`. Name uses the "Network" prefix per ADR-008 (not `Default`, since the strategy is clearly network-backed). All state mutations dispatch onto the injected `externalScope` per ADR-019 — `fetchButtonHealth()` and `applyFcmUpdate()` both `externalScope.launch { _state.value = ... }` so caller cancellation can never strand the singleton.
+- **FCM-vs-fetch ordering rule:** `applyFcmUpdate(update)` AND the `fetchButtonHealth()` success path BOTH check `update.stateChangedAtSeconds >= current.stateChangedAtSeconds` before writing. A stale fetch result that lands after a fresher FCM is discarded. (`UNKNOWN` is treated as oldest — any non-UNKNOWN result wins over a current UNKNOWN regardless of timestamp.)
+- `ButtonHealthFcmRepository` — separate from `DoorFcmRepository`. Different topic prefix, different lifecycle (subscribe gated by allowlist; door isn't). Methods: `subscribe(buildTimestamp)`, `unsubscribe(buildTimestamp)`. Subscription is idempotent (FCM SDK handles).
 - `ButtonHealthFcmPayloadParser` — parses `buttonHealth-*` data payloads. Contract test mirrors `FcmPayloadParsingTest`.
 
 ### UseCase (`usecase/.../buttonhealth/`)
 
-- `FetchButtonHealthUseCase`, `ObserveButtonHealthUseCase`
-- `ButtonHealthViewModel` — combines `AuthState + AllowlistAccess + ButtonHealth` → exposes a sealed display:
+- `FetchButtonHealthUseCase`, `ObserveButtonHealthUseCase` — thin wrappers around the repository.
+- `ComputeButtonHealthDisplayUseCase` — returns `StateFlow<ButtonHealthDisplay>` derived from `combine(authState, allowlistAccess, buttonHealthLoadingResult)`. **No new ViewModel.** This UseCase is the derivation; consumed by the existing `RemoteButtonViewModel`.
+- `ButtonHealthFcmSubscriptionManager` (ADR-015 Manager) — observes `combine(authState, allowlistAccess)` with `collectLatest` semantics so a sign-out in flight cancels an in-progress subscribe. Owns the `subscribe` / `unsubscribe` calls plus retry. App-scoped singleton, started from `AppStartup`.
+
+### ViewModel (modify the existing `RemoteButtonViewModel`)
+
+Add a new property to the existing `RemoteButtonViewModel`, fed by `ComputeButtonHealthDisplayUseCase`:
+
+```kotlin
+class RemoteButtonViewModel(
+    // ...existing constructor params...
+    computeButtonHealthDisplayUseCase: ComputeButtonHealthDisplayUseCase,
+    fetchButtonHealthUseCase: FetchButtonHealthUseCase,
+) : ViewModel() {
+
+    // ...existing remote-button state...
+
+    val buttonHealthDisplay: StateFlow<ButtonHealthDisplay> =
+        computeButtonHealthDisplayUseCase()  // already a StateFlow from the UseCase
+
+    fun fetchButtonHealth() {
+        viewModelScope.launch {
+            // Loading is set by the repository when fetchButtonHealth is called
+            // (it sets _state.value = LoadingResult.Loading inside externalScope.launch)
+            fetchButtonHealthUseCase()  // result lands in repository state
+        }
+    }
+}
+```
+
+The `fetchButtonHealth` action follows the user's stated pattern: VM calls the suspend UseCase; the repository sets `Loading` at the start of the call and writes the result on completion. `Loading` and `Unknown` are *different concepts* — `Loading` = the suspend fun is in flight; `Unknown` = the suspend fun returned `UNKNOWN`. Both render no pill but mean different things.
+
+### Display sealed type
 
 ```kotlin
 sealed interface ButtonHealthDisplay {
-    data object Unauthorized : ButtonHealthDisplay   // user not allowlisted — no pill
-    data object Online : ButtonHealthDisplay         // healthy / known good — no pill
-    data object Loading : ButtonHealthDisplay        // unknown / no data yet — no pill
-    data class Offline(val sinceLabel: String) : ButtonHealthDisplay   // pill shown
+    data object Unauthorized : ButtonHealthDisplay              // user not allowlisted — no pill
+    data object Loading      : ButtonHealthDisplay              // suspend fun in flight, no result yet — no pill
+    data object Unknown      : ButtonHealthDisplay              // server returned UNKNOWN (no data) — no pill
+    data object Online       : ButtonHealthDisplay              // server returned ONLINE, fresh — no pill
+    data class  Offline(val durationLabel: String) : ButtonHealthDisplay   // ONLY state that renders the pill
 }
 ```
 
-The four-arm sealed type preserves *why* the pill is hidden — debuggable, and resilient to future UX iterations on the non-Offline states.
+The five-arm sealed type preserves *why* the pill is hidden — `Loading` and `Unknown` look identical to the user but tell a future debugger which path led there.
+
+### `durationLabel` format
+
+`durationLabel` is computed by a pure function (`ButtonOfflineDuration.format(stateChangedAtSeconds, nowSeconds)`) ticked by the existing app-scoped `LiveClock` at 1-second cadence — same pattern as `DeviceCheckIn.format` driving `TitleBarCheckInPill`. Format mirrors the existing pill: `"5 min ago"`, `"11 min ago"`. Keeps both pills speaking the same grammar.
 
 ### UI
 
-- NEW `androidApp/.../ui/buttonhealth/ButtonOfflinePill.kt` — stateless Composable. `errorContainer` background, `Icons.Outlined.SignalWifiOff`, "Button offline" text. Mirrors the structure of `TitleBarCheckInPill` (the device check-in pill shipped in 2.9.4) but is a separate file — no shared base.
-- Modify `RemoteButtonContent.kt`:
+- NEW `androidApp/.../ui/buttonhealth/RemoteOfflinePill.kt` — stateless Composable taking `display: ButtonHealthDisplay.Offline` (already includes the `durationLabel`). `errorContainer` background, `Icons.Outlined.SignalWifiOff`, text format `"Remote offline · <durationLabel>"` (e.g., `"Remote offline · 11 min ago"`). TalkBack `contentDescription = "Remote offline, last checked in <durationLabel>"`.
+- Modify `RemoteButtonContent.kt` — takes a new `buttonHealthDisplay: ButtonHealthDisplay` parameter (NO ViewModel import; complies with ADR-026 sub-component rule):
 
 ```kotlin
-val display = viewModel { component.buttonHealthViewModel }.display.collectAsState()
-// In the section header row, right-aligned next to the title:
-when (val d = display.value) {
-    is ButtonHealthDisplay.Offline -> ButtonOfflinePill()
-    ButtonHealthDisplay.Unauthorized,
-    ButtonHealthDisplay.Online,
-    ButtonHealthDisplay.Loading -> Unit  // Render nothing — same as today.
+@Composable
+fun RemoteButtonContent(
+    state: RemoteButtonState,
+    buttonHealthDisplay: ButtonHealthDisplay,  // NEW required parameter
+    onTap: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    HomeSection(
+        title = "Remote control",
+        trailing = {
+            when (val d = buttonHealthDisplay) {
+                is ButtonHealthDisplay.Offline -> RemoteOfflinePill(display = d)
+                ButtonHealthDisplay.Unauthorized,
+                ButtonHealthDisplay.Loading,
+                ButtonHealthDisplay.Unknown,
+                ButtonHealthDisplay.Online -> Unit  // Render nothing — same as today.
+            }
+        },
+    ) { /* ...existing button... */ }
 }
 ```
 
+- Modify `HomeContent.kt` — collect `RemoteButtonViewModel.buttonHealthDisplay` and pass to `RemoteButtonContent`.
 - Modify `androidApp/.../fcm/FCMService.kt` — dispatch by topic prefix:
 
 ```kotlin
@@ -222,22 +310,29 @@ when {
 }
 ```
 
-- Modify `AppStartup.kt` — new task observes (auth state + allowlist) and calls `buttonHealthFcmRepository.subscribe(buildTimestamp)` when both are true, `.unsubscribe(buildTimestamp)` when either flips false. Cold-start `fetchButtonHealth()` fires once when the user first becomes allowlisted in this app session.
-- Modify `AppComponent.kt` — wire `ButtonHealthRepository`, `ButtonHealthFcmRepository`, `ButtonHealthViewModel`.
+- Modify `AppStartup.kt` — start `ButtonHealthFcmSubscriptionManager`. The Manager handles all subscription lifecycle internally with `combine(authState, allowlistAccess) + collectLatest`.
+- Modify `AppComponent.kt` — wire as `@Singleton` providers with matching `abstract val` entry points (per `DI_SINGLETON_REQUIREMENTS.md`):
+  - `abstract val buttonHealthRepository: ButtonHealthRepository`
+  - `abstract val buttonHealthFcmRepository: ButtonHealthFcmRepository`
+  - `abstract val buttonHealthFcmSubscriptionManager: ButtonHealthFcmSubscriptionManager`
+  - `provideComputeButtonHealthDisplayUseCase`, `provideFetchButtonHealthUseCase` — non-`@Singleton` factories.
+  - `RemoteButtonViewModel` provider gains the two new UseCase parameters.
 
-### Subscription lifecycle
+### Subscription lifecycle (encapsulated in `ButtonHealthFcmSubscriptionManager`)
 
 | Event | Action |
 |---|---|
-| User signs in AND allowlist returns `true` | Subscribe to `buttonHealth-<buttonBuildTimestamp>`; cold-start fetch |
-| User signs out | Unsubscribe; clear state |
-| Allowlist flips to `false` mid-session | Unsubscribe; flip display to `Unauthorized` |
+| `combine(authState, allowlistAccess)` emits `(SignedIn, Allowed)` | Subscribe to `buttonHealth-<buttonBuildTimestamp>`; trigger one-shot `fetchButtonHealth()` |
+| `combine(...)` emits anything else (signed-out, allowlist false) | Unsubscribe; `applyFcmUpdate` becomes a no-op until re-allowed |
+| In-flight subscribe + sign-out fires before subscribe completes | `collectLatest` cancels the in-progress subscribe; unsubscribe wins |
+| In-flight `fetchButtonHealth()` + sign-out fires before fetch completes | `collectLatest` cancels the fetch; late HTTP response (if any) is discarded by the timestamp gate (UNKNOWN is treated as oldest) and by the auth-check inside `applyFcmUpdate` (no-op when not authorized) |
+| `httpButtonHealth` returns 403 (allowlist removed) | Repository surfaces `ButtonHealthError.Forbidden`; ViewModel maps to `Unauthorized` display; Manager unsubscribes |
 
 ## Naming convention summary
 
 | Concept | Name |
 |---|---|
-| State enum | `ONLINE`, `OFFLINE`, `UNKNOWN` |
+| State enum (server + Android) | `ONLINE`, `OFFLINE`, `UNKNOWN` |
 | Timestamp field (wire + Android) | `stateChangedAtSeconds` |
 | FCM payload field for state | `buttonState` |
 | Topic prefix | `buttonHealth-` |
@@ -248,9 +343,12 @@ when {
 | Firestore trigger | `firestoreCheckButtonHealth` / `handleButtonHealthFromPollWrite` |
 | FCM collapse key | `button_health_update` |
 | Domain types | `ButtonHealth`, `ButtonHealthState`, `ButtonHealthError`, `ButtonHealthRepository` |
-| Display sealed type | `ButtonHealthDisplay.Unauthorized` / `.Online` / `.Loading` / `.Offline(sinceLabel)` |
-| Pill Composable | `ButtonOfflinePill` |
-| User-visible text | "Button offline" |
+| Repository impl | `NetworkButtonHealthRepository` (ADR-008 — "Network" prefix denotes strategy) |
+| Display sealed type | `ButtonHealthDisplay.Unauthorized` / `.Loading` / `.Unknown` / `.Online` / `.Offline(durationLabel)` |
+| UseCases | `FetchButtonHealthUseCase`, `ObserveButtonHealthUseCase`, `ComputeButtonHealthDisplayUseCase` |
+| Subscription manager | `ButtonHealthFcmSubscriptionManager` (ADR-015 Manager pattern) |
+| Pill Composable | `RemoteOfflinePill` |
+| User-visible text | "Remote offline" + `" · <durationLabel>"` (matches "Remote control" section title) |
 
 The states are connectivity-shaped (`ONLINE`/`OFFLINE`) but the feature noun is "health" (`ButtonHealth*`, `buttonHealth-` topic). This deliberately leaves room for future health signals (battery, sensor errors) without renaming the present feature, while keeping current state names matching the user-visible "offline" string.
 
@@ -262,7 +360,7 @@ Every server change is in a function file the device does not touch:
 |---|---|---|
 | `httpRemoteButton` (existing) | YES | Unchanged — same response shape, same Firestore ops, same latency |
 | `httpAddRemoteButtonCommand` (existing) | NO | Mobile only |
-| `firestoreCheckButtonHealth` (NEW) | NO | Fires asynchronously after the device's response is sent |
+| `firestoreCheckButtonHealth` (NEW) | NO | Fires asynchronously after the device's response is sent. No `failurePolicy`. |
 | `pubsubCheckButtonHealth` (NEW) | NO | Runs on schedule |
 | `httpButtonHealth` (NEW) | NO | Mobile only |
 | `pubsubDataRetentionPolicy` (existing, modified one line) | NO | Doesn't touch device-written collections |
@@ -271,24 +369,36 @@ Every server change is in a function file the device does not touch:
 
 ## Acceptable failure modes
 
-- A `OFFLINE` state that recovers within 10 min may never reach mobile (pubsub didn't fire while it was OFFLINE). User stated this is acceptable.
+- An `OFFLINE` state that recovers within 10 min may never reach mobile (pubsub didn't fire while it was OFFLINE). User stated this is acceptable.
 - FCM delivery failures are not retried — mobile re-fetches on next cold start. Eventually consistent.
 - A pubsub run that crashes mid-flight may leave state stale until the next run — bounded by 10-min cadence.
+- A brand-new install with a device that has never polled stays in `Loading → Unknown` (no pill) indefinitely. Acceptable per requirements; user has no way to distinguish "Unknown" from "Online" but this is the same as today (today there's no indicator at all).
+- During a network failure, `AllowlistAccess` returning the last-known-good value is preferred over flipping to `false` (which would unsubscribe + show `Unauthorized`); the Manager treats network failures as transient and retains the last successful allowlist verdict.
+- During a WiFi outage the device-check-in pill (existing, in Status section) AND the remote-offline pill (new) may both render. They reflect independent devices and represent the truth: two devices are unreachable. No coordination needed.
 
 ## Failure modes designed out
 
-- **Unauthorized user seeing the pill** — eliminated by the four-arm sealed display: `Unauthorized` and `Online` and `Loading` all render no pill, and the rendering site has no way to express "show pill to non-`Offline`" state.
+- **Unauthorized user seeing the pill** — eliminated by the five-arm sealed display: only `Offline` ever renders the pill, and `applyFcmUpdate` is a no-op when display is `Unauthorized` so a late FCM (or stale fetch) cannot leak through.
+- **Stale fetch clobbering fresher FCM update** — eliminated by the `stateChangedAtSeconds` timestamp gate in the repository (both `applyFcmUpdate` and `fetchButtonHealth` success path check it).
+- **Late fetch landing for signed-out user** — eliminated by `collectLatest` in `ButtonHealthFcmSubscriptionManager` (cancels in-flight fetch on sign-out) plus the auth check in `applyFcmUpdate`.
 - **Topic format drift between server and Android** — pinned by `ButtonHealthFcmTopicTest` running on both sides.
 - **Payload key drift** — pinned by `wire-contracts/buttonHealth/` fixtures consumed by tests in strict mode on both sides.
+- **`stateChangedAtSeconds` drifting forward on no-op writes** — `detectTransition` returns "no change" when state matches; trigger and pubsub do nothing on no-op (no write, no FCM, `stateChangedAtSeconds` preserved).
+- **Trigger retry on stale event** — trigger re-reads `RemoteButtonRequestDatabase.getCurrent()` rather than trust `change.after.data()`.
+- **Bootstrap race between pubsub and first-poll trigger** — pubsub `UNKNOWN → OFFLINE` requires last-poll older than 120 sec (or no record), giving Firestore replication time to settle.
+- **Duplicate `OFFLINE → ONLINE` FCMs from trigger + pubsub fallback** — pubsub fallback only fires when state has been `OFFLINE` for >10 min, so the trigger's recovery path is never duplicated by a contemporaneous pubsub.
+- **Topic-builder throw on malformed `buildTimestamp`** — `decodeURIComponent` wrapped in try/catch; falls back to raw string + sanitization.
 
 ## Out of scope
 
 - ESP32 firmware changes.
 - Modifications to existing door event flow, existing button command flow, or existing pubsubs.
+- Refactoring `RemoteButtonViewModel` into a one-VM-per-screen structure (see "Architectural goal note" — that's a future PR).
 - Room caching of button health (state is short-lived; FCM keeps it fresh; cold-start endpoint reseeds in <1s).
 - New server config keys.
 - History view or "uptime" metric — `buttonHealthAll` is for diagnostics if ever needed.
 - Visible system-tray notifications.
+- Transactional `buttonHealthCurrent` writes — last-write-wins is acceptable (race-condition mitigation lives in the FCM-duplication rules, not in document-write atomicity).
 
 ## Versioning impact
 
@@ -298,6 +408,12 @@ Every server change is in a function file the device does not touch:
 ## CLAUDE.md compliance
 
 - **FCM safety rule**: this feature *adds* a new topic format and new payload keys; existing `FcmTopicTest` and `FcmPayloadParsingTest` stay green. New contract tests (`ButtonHealthFcmTopicTest`, `ButtonHealthFcmPayloadParsingTest`) ship in the same PR as the topic builder and parser.
-- **Handler pattern**: new HTTP handler follows the pure `handle<Action>(input)` core + thin wrapper convention from `docs/FIREBASE_HANDLER_PATTERN.md`.
-- **Database refactor pattern**: new `ButtonHealthDatabase` follows the per-collection module pattern from `docs/FIREBASE_DATABASE_REFACTOR.md` (interface + Firestore impl + `setImpl`/`resetImpl`).
-- **Config authority**: no new server config keys; reuses existing button config (`remoteButtonBuildTimestamp`, `remoteButtonPushKey`, `remoteButtonAuthorizedEmails`).
+- **Handler pattern** (`docs/FIREBASE_HANDLER_PATTERN.md`): new HTTP handler follows the pure `handle<Action>(input)` core + thin wrapper convention.
+- **Database refactor pattern** (`docs/FIREBASE_DATABASE_REFACTOR.md`): new `ButtonHealthDatabase` follows the per-collection module pattern (interface + Firestore impl + `setImpl`/`resetImpl`).
+- **Config authority** (`docs/FIREBASE_CONFIG_AUTHORITY.md`): no new server config keys; reuses existing button config (`remoteButtonBuildTimestamp`, `remoteButtonPushKey`, `remoteButtonAuthorizedEmails`); pubsub uses `requireBuildTimestamp` to throw on missing config.
+- **ADR-008** (no `*Impl` suffix): repository named `NetworkButtonHealthRepository`, not `DefaultButtonHealthRepository`.
+- **ADR-015** (app-scoped Managers): subscription lifecycle wrapped in `ButtonHealthFcmSubscriptionManager`, started from `AppStartup`.
+- **ADR-019** (repository `externalScope`): all `MutableStateFlow` writes in `NetworkButtonHealthRepository` dispatch onto the injected `externalScope`.
+- **ADR-021/022** (no passthrough VMs): no new ViewModel; derivation lives in `ComputeButtonHealthDisplayUseCase` consumed by the existing `RemoteButtonViewModel`.
+- **ADR-026** (one VM per screen + sub-components have no VMs): `RemoteButtonContent` takes `buttonHealthDisplay` as a parameter; `HomeContent` collects from `RemoteButtonViewModel` and passes down.
+- **DI_SINGLETON_REQUIREMENTS**: every new `@Singleton` provider has a matching `abstract val` entry point in `AppComponent.kt`.

--- a/docs/BUTTON_HEALTH_ARCHITECTURE.md
+++ b/docs/BUTTON_HEALTH_ARCHITECTURE.md
@@ -416,6 +416,69 @@ The device cannot observe whether this feature is deployed. A failure in any new
 - New server config keys.
 - History / uptime metrics.
 
+## Release plan
+
+### Order of operations
+1. **Server first** (`server/N+1`). Deploy trigger + pubsub + HTTP endpoint + FCM service in one Firebase release. Verify in production via Cloud Logs that pubsub fires and computes the expected state for the live `buttonBuildTimestamp`. **No mobile users see anything change** — old clients don't subscribe to the new FCM topic and don't call the new HTTP endpoint.
+2. **Android second** (`android/N+1`, minor bump per CHANGELOG semver — adds a user-visible capability). Ships through Play Store internal track first per `scripts/release-android.sh`, then production.
+
+Server-first is mandatory because Android cold-start expects the HTTP endpoint to exist. The reverse order causes new Android installs to sit in `Loading` indefinitely (the cold-start fetch returns 404), but with no UI regression — the pill never renders. So even if order is flipped accidentally, no user sees anything wrong.
+
+### Kill switch (no new config key)
+
+Every new server function (`firestoreCheckButtonHealth`, `pubsubCheckButtonHealth`, `httpButtonHealth`) MUST short-circuit when `isRemoteButtonEnabled(config) == false`. This reuses the existing button-feature kill switch — one toggle disables everything button-related. Mobile clients see the same state as "server before deploy": no FCMs, HTTP returns 400 `Disabled`, display stays `Loading`/`Unknown` (no pill).
+
+### Forward compat (new Android, server not yet deployed OR rolled back)
+
+- HTTP cold-start endpoint returns 404 (or 400 `Disabled`) → repository surfaces `Network`/`Forbidden` error → display stays `Loading` → no pill.
+- FCM topic has no publisher → no updates arrive → display unchanged.
+- **UI identical to today.** No spinner, no error message, no broken affordance.
+
+### Backward compat (old Android, server fully deployed)
+
+- Old Android doesn't subscribe to `buttonHealth-*` topic → receives no FCMs.
+- Old Android doesn't call `httpButtonHealth` → no 404s.
+- Old Android doesn't import `ButtonHealthFcmPayloadParser` → topic-prefix dispatch (when shipped later) is the new-side concern only.
+- **No regression.**
+
+### Schema evolution forward compat (future-proofing)
+
+- **`buttonState` is `String` on the wire**, mapped to Android `ButtonHealthState` enum at the data layer. Unrecognized strings default to `UNKNOWN`. Future server-added states (e.g., `MAINTENANCE`) won't crash old Android — they'll just see `Unknown`.
+- **`ignoreUnknownKeys = true`** in production decode → server can add new fields to the response without breaking old clients.
+- **Strict-mode tests** (`ignoreUnknownKeys = false`) consume `wire-contracts/buttonHealth/` fixtures → catch breaking renames or removals at PR time, not in production.
+- **Topic format MUST NOT change post-launch** (CLAUDE.md FCM safety rule). `ButtonHealthFcmTopicTest` pins it on both sides. If a future change is genuinely needed, follow the door-topic dance: add the new topic alongside, migrate, then retire the old.
+- **`stateChangedAtSeconds` is nullable** on the wire (null only when wire `state == UNKNOWN`). Future Android versions can rely on it being non-null when state is ONLINE/OFFLINE.
+
+### Rollback
+
+**Server rollback is two-tier:**
+1. **Soft kill** (instant, no deploy): set `isRemoteButtonEnabled = false` in `httpServerConfigUpdate`. All button + button-health functions short-circuit. Mobile sees the "no pill ever" state.
+2. **Hard rollback** (full deploy): `./scripts/release-firebase.sh --check` prints the rollback command (per existing convention). Reverts to `server/N` (pre-feature). The `buttonHealthCurrent` collection persists harmlessly; can be deleted manually if desired (no other code references it after rollback).
+
+**Android rollback** is standard Play Store: roll back to `android/N`. The previous version doesn't subscribe to the new topic or call the new endpoint, so there's no stale-subscription cleanup needed (Firebase tolerates orphan topic subscriptions indefinitely).
+
+### Risks during rollout
+
+- **First production pubsub run after deploy** writes `OFFLINE` if no doc exists and no fresh poll is recorded. Cloud Logs should show `OFFLINE` then `ONLINE` within ~10 sec as the next device poll arrives. If it stays `OFFLINE`, the device is genuinely offline OR the trigger isn't firing — investigate via the existing `firestoreUpdateEvents` runbook.
+- **Cost**: trigger fires ~17K/day. Within Cloud Functions free tier. Verify the org-level Firestore-read budget hasn't drifted since last estimate.
+- **FCMService dispatcher modification** is the highest-risk Android change — a bug here could break the existing door FCM path for all users. Mitigation: door dispatch stays as the `else` branch (default-preserving); `FcmTopicDispatcherTest` pins both branches; manual smoke-test on internal track with a real door event before promoting to production.
+
+### Per-PR rollout split (recommended order)
+
+Following the PR-shape review:
+
+1. `wire(contracts): button health response fixtures` — JSON only, ~30 lines, no consumers yet. Unblocks server + Android tests.
+2. `feat(firebase): button health database + interpreter + FCM topic + FCM service` — pure modules + tests. No `index.ts` change. Dead code, harmless.
+3. `feat(firebase): firestoreCheckButtonHealth trigger` — adds `index.ts` export. Live trigger; passive OFFLINE detection only (no FCM yet because no subscribers).
+4. `feat(firebase): pubsubCheckButtonHealth (10-min sweep)` — adds `index.ts` export. Sequence after PR 3 (same file).
+5. `feat(firebase): httpButtonHealth cold-start endpoint` — adds `index.ts` export. Sequence after PR 4. **End of server-side; ship `server/N+1` after this lands.**
+6. `feat(android-domain+data): button health types + repo + datasource + parser + topic test` — dead code on Android side until DI wiring lands.
+7. `feat(android-usecase): button health UseCases + FCM subscription manager` — still dead code.
+8. `ui(android): RemoteOfflinePill + previews + screenshot test` — UI-only, satisfies preview-coverage check, can't regress production.
+9. `feat(android): wire button health into AppComponent + AppStartup + HomeContent + FCMService` — **highest-risk PR**. Manual smoke-test on internal track; do not auto-merge to production.
+
+PRs 1, 2, 6 can land in parallel (no shared files). PRs 3/4/5 must serialize on `index.ts`. PRs 7/8 can land in parallel. PR 9 is the user-visible flip and the only one that can affect existing FCM behavior.
+
 ## ADR / convention compliance
 
 - **FCM safety**: adds new topic + payload keys; existing `FcmTopicTest` and `FcmPayloadParsingTest` stay green; new `ButtonHealthFcmTopicTest` + `ButtonHealthFcmPayloadParsingTest` ship in the same PR as the topic builder + parser.

--- a/docs/BUTTON_HEALTH_ARCHITECTURE.md
+++ b/docs/BUTTON_HEALTH_ARCHITECTURE.md
@@ -479,6 +479,75 @@ Following the PR-shape review:
 
 PRs 1, 2, 6 can land in parallel (no shared files). PRs 3/4/5 must serialize on `index.ts`. PRs 7/8 can land in parallel. PR 9 is the user-visible flip and the only one that can affect existing FCM behavior.
 
+## Test plan
+
+Every new module ships with tests in the same PR. Each test layer has a precedent file in the codebase — implementer should mirror the existing pattern.
+
+### Server tests (Mocha + Chai, fakes via `setImpl`/`resetImpl`)
+
+| Test file | What it covers | Convention |
+|---|---|---|
+| `test/controller/ButtonHealthInterpreterTest.ts` | Pure functions: `computeHealthFromLastPoll` (4 cases: null poll, fresh ≤60s, boundary at 60s, stale >60s) + `detectTransition` (2 priors × 2 computed = 4 cases; verify `stateChangedAtSeconds` not bumped on no-op) | Pattern: `EventInterpreterTest.ts` |
+| `test/controller/ButtonHealthUpdatesTest.ts` | `handleButtonHealthFromPollWrite` with fakes for `ButtonHealthDatabase`, `RemoteButtonRequestDatabase`, `ButtonHealthFCMService`. Verifies trigger re-reads `getCurrent()` (test the stale-event-payload case explicitly: pass an old payload, expect logic to use the fresh re-read) | Pattern: `EventUpdatesFakeTest.ts` |
+| `test/controller/fcm/ButtonHealthFCMTest.ts` | `sendForTransition` payload shape: data-only, correct topic via builder, `collapse_key`, no `notification` block | Pattern: `EventFCMTest.ts` |
+| `test/model/ButtonHealthFcmTopicTest.ts` | Topic format pinning. Cases: empty input throws; `"100%25"` re-decode throws → fallback to raw; known-good buildTimestamp produces known-good topic; sanitization replaces forbidden chars with `.` | Pattern: `FcmTopicTest.ts` |
+| `test/database/ButtonHealthDatabaseTest.ts` | CRUD round-trip via fake. Verifies `getCurrent` returns null when no doc, `save` then `getCurrent` round-trips. | Pattern: `RemoteButtonRequestDatabaseTest.ts` |
+| `test/functions/firestore/ButtonHealthTest.ts` | Trigger handler integration: fakes wired end-to-end. Asserts on `database.writeCount` and `fcm.sendCount` per scenario. | Pattern: `EventsTriggerTest.ts` (door equivalent) |
+| `test/functions/pubsub/ButtonHealthTest.ts` | **MUST enumerate the state-machine table rows 1:1 by name.** Three tests, named `"row 1: pubsub fresh poll → ONLINE no-op"`, `"row 2: pubsub fresh poll, prior OFFLINE → ONLINE + FCM"`, `"row 3: pubsub stale poll OR no record → OFFLINE + FCM (only on transition)"`. Reading test file alongside doc table verifies completeness. | New convention; doc is the spec |
+| `test/functions/http/ButtonHealthTest.ts` | Auth chain mirrors `handleAddRemoteButtonCommand`: missing push key → 401; wrong push key → 403; missing token → 401; bad token → 500; non-allowlisted email → 403; missing buildTimestamp → 400. Plus: success cases deep-equal against `wire-contracts/buttonHealth/response_*.json` fixtures (loaded in strict mode). | Pattern: existing handler tests |
+
+### Android tests (Kotlin, JUnit, fakes only — no Mockito per ADR-003)
+
+| Test file | What it covers | Convention |
+|---|---|---|
+| `domain/src/commonTest/.../buttonhealth/ButtonHealthDisplayLogicTest.kt` | Pure `compute()`. Truth table: 5 display states × all relevant input combos. ~12 cases minimum: not-SignedIn → Unauthorized (3 sub-cases); allowlist null → Unauthorized; allowlist false → Unauthorized; Loading → Loading; Error → Loading; Complete×ONLINE → Online; Complete×OFFLINE → Offline(label); Complete×UNKNOWN → Unknown | Pure-function tests, no fakes |
+| `domain/src/commonTest/.../buttonhealth/ButtonHealthDurationFormatterTest.kt` | Format strings: just-now, minutes, hours, days, negative (clock skew). Pin exact strings. | Pure |
+| `data/src/commonTest/.../buttonhealth/KtorButtonHealthDataSourceTest.kt` | Loads `wire-contracts/buttonHealth/*.json` in strict mode (`ignoreUnknownKeys = false`). Each variant decodes to the expected `ButtonHealth`. Unknown `buttonState` string maps to `ButtonHealthState.UNKNOWN` (not a throw). 401 + 403 surface as `Forbidden`/`Network` errors. | Pattern: existing wire-contract test |
+| `data/src/commonTest/.../buttonhealth/ButtonHealthFcmPayloadParserTest.kt` | Parses data-only FCM payloads. Tests: known-good payload → `ButtonHealth`; missing field → null (or `Unknown` mapping per design); unknown `buttonState` string → `ButtonHealthState.UNKNOWN`. | Pattern: `FcmPayloadParsingTest.kt` |
+| `data/src/commonTest/.../buttonhealth/ButtonHealthFcmTopicTest.kt` | **MUST pin format identically to server `ButtonHealthFcmTopicTest.ts`** — same input/output pairs. Catches drift between server topic builder and Android topic-string assumption. | Pattern: `FcmTopicTest.kt` |
+| `data/src/commonTest/.../buttonhealth/NetworkButtonHealthRepositoryTest.kt` | Fake `NetworkButtonHealthDataSource` returns canned `NetworkResult`. Asserts `repository.buttonHealth.value` after `fetchButtonHealth()` and `applyFcmUpdate()`. Uses `runTest` with `backgroundScope` as `externalScope` (matches `NetworkSnoozeRepositoryTest`). | Pattern: `NetworkSnoozeRepositoryTest.kt` |
+| `data/src/commonTest/.../fcm/FcmTopicDispatcherTest.kt` | Pure dispatcher: `isButtonHealth("buttonHealth-X") == true`, `isButtonHealth("door-X") == false`, `isButtonHealth("") == false`, `isButtonHealth("buttonHealth") == false` (no trailing `-`). | Pure |
+| `usecase/src/commonTest/.../buttonhealth/ComputeButtonHealthDisplayUseCaseTest.kt` | Wires fake `AuthRepository`, `FeatureAccessRepository`, `ButtonHealthRepository`, `LiveClock`. Emits on `MutableStateFlow`s, asserts on collected display values. Verifies `combine` re-emits on every input change. | Pattern: `ObserveAuthStateUseCaseTest.kt` |
+| `usecase/src/commonTest/.../buttonhealth/ButtonHealthFcmSubscriptionManagerTest.kt` | Fake `ButtonHealthFcmRepository` (records `subscribe`/`unsubscribe`/`unsubscribeAll` calls + counts) + fake `FetchButtonHealthUseCase` (records invocation count). Scenarios: signed-out → only `unsubscribeAll`; signed-in + allowed + bt → `unsubscribeAll` then `subscribe(bt)` then `fetch`; buildTimestamp rotates → `unsubscribeAll` then `subscribe(new)` (the always-unsubscribe-first pattern); allowlist flip → unsubscribe. Uses `runTest` + `backgroundScope`. | Pattern: `FcmRegistrationManagerTest.kt` |
+| `androidApp/src/screenshotTest/.../buttonhealth/RemoteOfflinePillPreviewTest.kt` | Imports `RemoteOfflinePillFreshPreview`, `RemoteOfflinePillAgingPreview` (light + dark variants). Required by `checkPreviewCoverage` (build fails otherwise). | Pattern: `TitleBarCheckInPillPreviewTest.kt` |
+| `androidApp/src/test/.../ComponentGraphTest.kt` | Add identity-`assertSame` checks for `buttonHealthRepository`, `buttonHealthFcmRepository`, `buttonHealthFcmSubscriptionManager` — verifies `@Singleton` providers are properly cached per `DI_SINGLETON_REQUIREMENTS.md`. | Existing test file, just append |
+| `androidApp/src/androidTest/.../AppStartupInstrumentedTest.kt` | If touched: verify Manager starts after FCM token registration. Per CLAUDE.md, instrumented tests required when AppComponent/AppStartup change. | Pattern: existing instrumented tests |
+
+### What CANNOT be tested without running the app
+
+- **Real FCM delivery** to a device. Mitigation: cold-start fetch on next launch.
+- **FCM topic subscription persistence** across app restarts. Mitigation: Manager re-subscribes on every state-change cycle (idempotent).
+- **Layoutlib pill rendering** in screenshot tests can fail silently with custom 960-viewport vectors (CLAUDE.md gotcha). Mitigation: use Material `Icons.Outlined.SignalWifiOff` (24-viewport, known-good).
+- **Real Firestore trigger firing** under production load. Mitigation: pattern matches `firestoreUpdateEvents` which already runs in production.
+
+### Manual verification (per release)
+
+**Internal-track (`android/N+1`) smoke test before promoting to production:**
+
+1. **Allowlisted user, device online**: open app → no pill. Verify in Cloud Logs that cold-start `httpButtonHealth` returned `ONLINE` and FCM topic subscription succeeded.
+2. **Force OFFLINE**: unplug ESP32 button device. Wait ~10 min for pubsub to fire. Verify pill appears with realistic duration label.
+3. **Recovery**: plug ESP32 back in. Within 1 sec of next poll, the trigger should fire → FCM → pill disappears.
+4. **Sign out**: pill clears immediately (Manager unsubscribes; display flips to `Unauthorized`).
+5. **Sign back in**: cold-start fetch → display returns to correct state within seconds.
+6. **Non-allowlisted user**: sign in with non-allowlisted account. Verify no pill ever; verify FCM topic NOT subscribed (Cloud Logs); verify `httpButtonHealth` returns 403.
+7. **Door FCM regression check** (highest-risk PR #9 only): trigger a door state change and verify the door UI still updates via FCM. Confirms the dispatcher's `else` branch is intact.
+
+**Pre-deploy gates:**
+- `./scripts/validate.sh` — full pre-submit (includes `checkPreviewCoverage`, `checkSingletonCaching`, `checkNoBareTopLevelFunctions`, `checkNoImplSuffix`, `checkScreenViewModelCardinality`).
+- `./scripts/validate-firebase.sh` — Firebase tests + lint.
+- `./scripts/run-instrumented-tests.sh` — required when AppComponent / AppStartup / Activity lifecycle code changes (PR #9 triggers this).
+
+**Post-deploy verification (production server):**
+- Cloud Logs: `firestoreCheckButtonHealth` fires on every poll (cadence ~5 sec).
+- Cloud Logs: `pubsubCheckButtonHealth` fires every 10 min.
+- Firestore Console: `buttonHealthCurrent/{buildTimestamp}` doc exists with current state.
+- No ERROR-level logs from new functions in the first 24 hours.
+
+**Coverage targets:**
+- Pure functions (`computeHealthFromLastPoll`, `detectTransition`, `compute`, `formatAgo`, topic builder, dispatcher): 100% line + branch.
+- Repositories + Manager: 100% public surface; covers all sealed-class arms.
+- Wire-contract tests cover all 5 fixture variants.
+
 ## ADR / convention compliance
 
 - **FCM safety**: adds new topic + payload keys; existing `FcmTopicTest` and `FcmPayloadParsingTest` stay green; new `ButtonHealthFcmTopicTest` + `ButtonHealthFcmPayloadParsingTest` ship in the same PR as the topic builder + parser.

--- a/docs/BUTTON_HEALTH_ARCHITECTURE.md
+++ b/docs/BUTTON_HEALTH_ARCHITECTURE.md
@@ -1,0 +1,303 @@
+---
+category: plan
+status: active
+---
+
+# Button Health Architecture
+
+Design for a server-detected, mobile-displayed health indicator for the remote-button ESP32 device. **Not yet implemented.** This doc is the canonical design; implementation PRs should reference it.
+
+## Goal
+
+Show the user a small "Button offline" pill next to the Remote-control section title when the remote-button device hasn't checked in recently. Three states (server-side): `ONLINE`, `OFFLINE`, `UNKNOWN`. Only `OFFLINE` is visible to the user; the other two states render identically to today's UI.
+
+## Hard constraints
+
+1. **Zero ESP32 firmware changes.** The button device's HTTP behavior must be byte-identical to today.
+2. **Device contract preserved.** No change to request shape, response shape, response timing, or failure semantics for any endpoint the device calls. Specifically, `httpRemoteButton` must remain unmodified.
+3. **Allowlist-gated end-to-end.** Same `remoteButtonAuthorizedEmails` allowlist that already gates the button feature itself. Non-allowlisted users see no UI change vs. today.
+4. **Data-only FCM.** Never send a system-tray notification for this feature.
+5. **Door and button concepts stay separate on Android.** No shared interfaces between the door event flow and the button health flow — every layer gets its own button-side type.
+
+## State machine
+
+States: `UNKNOWN`, `ONLINE`, `OFFLINE`. Persisted server-side in `buttonHealthCurrent/{buildTimestamp}`. Each transition emits one data-only FCM.
+
+| Transition | Detected by | Latency |
+|---|---|---|
+| `UNKNOWN → ONLINE` | Firestore trigger (first poll seen for this `buildTimestamp`) | < 1 sec |
+| `OFFLINE → ONLINE` | Firestore trigger (device polls again after being marked offline) | < 1 sec |
+| `ONLINE → OFFLINE` | Pubsub (every 10 min, 60-sec freshness threshold) | up to 10 min |
+| `UNKNOWN → OFFLINE` | Same pubsub (no record exists, no recent poll) | up to 10 min |
+| `OFFLINE → ONLINE` (fallback) | Same pubsub (defense-in-depth in case the trigger missed it) | up to 10 min |
+
+ONLINE threshold: most recent poll within `60 sec`. Worst-case OFFLINE-detection latency: ~10 min (acknowledged tradeoff).
+
+## Why a Firestore trigger, not an HTTP-handler modification
+
+The naive design appends health-detection code to `handleRemoteButtonPoll`. That was rejected because it puts new Firestore reads, new writes, and new FCM sends on the device's request path:
+
+- A throw in any new code becomes a `500` response to the device.
+- Each added Firestore op (~50–100ms) eats into the device's HTTP timeout budget — a budget defined in firmware we can't change and haven't measured.
+
+Switching to a Firestore `onWrite` trigger on `remoteButtonRequestAll/{docId}` (the collection the existing handler writes to on every poll) achieves the same detection without touching the device path:
+
+```
+Device → httpRemoteButton (UNCHANGED, byte-identical to today)
+                ↓
+       writes to remoteButtonRequestAll
+                ↓ (Firestore onWrite trigger)
+       firestoreCheckButtonHealth (NEW)
+                ↓
+       reads buttonHealthCurrent
+       computes transition
+       conditionally writes + sends FCM
+```
+
+The trigger fires asynchronously after the device's response is already on the wire. Trigger failures, Firestore failures, and FCM failures all have **zero effect** on the response the device receives. This mirrors the existing door-event pattern (`firestoreUpdateEvents` triggers on `updateAll/{docId}` writes).
+
+Cost: ~17,000 trigger invocations/day at the button's polling cadence. Cloud Functions invocations + Firestore reads ≈ $0.50/month. Negligible.
+
+## Server design
+
+### Data model
+
+NEW collection, single doc per button device:
+
+```
+buttonHealthCurrent/{buildTimestamp}
+buttonHealthAll/{auto-id}        // history; daily retention pubsub sweeps it
+
+Document shape:
+  state: 'ONLINE' | 'OFFLINE' | 'UNKNOWN'
+  stateChangedAtSeconds: number          // when this state was entered (transition timestamp)
+  lastObservedPollAtSeconds: number | null
+```
+
+### New files
+
+All NEW files; no modification to any existing function file the device calls.
+
+| File | Purpose |
+|---|---|
+| `database/ButtonHealthDatabase.ts` | Firestore CRUD; `setImpl`/`resetImpl` for tests. Same shape as `RemoteButtonRequestDatabase`. |
+| `controller/ButtonHealthInterpreter.ts` | Pure functions: `computeHealthFromLastPoll(lastPollSec, nowSec)` + `detectTransition(prior, computed, nowSec)`. |
+| `controller/ButtonHealthUpdates.ts` | `handleButtonHealthFromPollWrite(data)` — called by the Firestore trigger. |
+| `controller/fcm/ButtonHealthFCM.ts` | `sendForTransition(buildTimestamp, record)`. Pattern matches `EventFCM.ts`. |
+| `model/ButtonHealthFcmTopic.ts` | `buildTimestampToButtonHealthFcmTopic(buildTimestamp)` — distinct from door's topic builder; handles the URL-encoded button `buildTimestamp`. |
+| `functions/firestore/ButtonHealth.ts` | `firestoreCheckButtonHealth` — `onWrite` trigger on `remoteButtonRequestAll/{docId}`. Thin wrapper around `handleButtonHealthFromPollWrite`. |
+| `functions/pubsub/ButtonHealth.ts` | `pubsubCheckButtonHealth` — every 10 min. Detects `ONLINE → OFFLINE` (and fallback `OFFLINE → ONLINE`). |
+| `functions/http/ButtonHealth.ts` | `httpButtonHealth` — mobile cold-start endpoint. Same auth chain as `handleAddRemoteButtonCommand` (push key + Google ID token + email allowlist). |
+
+### Modified files (all changes are isolated from the device path)
+
+| File | Change |
+|---|---|
+| `controller/DatabaseCleaner.ts` | One-line addition to sweep `buttonHealthAll` in the existing daily-midnight retention pubsub. |
+| `index.ts` | Three new exports: `firestoreCheckButtonHealth`, `pubsubCheckButtonHealth`, `httpButtonHealth`. |
+
+### Wire contract
+
+NEW directory `wire-contracts/buttonHealth/`:
+
+```
+response_online.json        { buttonState: "ONLINE",  stateChangedAtSeconds: 1730000000, buildTimestamp: "..." }
+response_offline.json       { buttonState: "OFFLINE", stateChangedAtSeconds: 1730000000, buildTimestamp: "..." }
+response_unknown.json       { buttonState: "UNKNOWN", stateChangedAtSeconds: null,        buildTimestamp: "..." }
+response_unauthorized.json  { error: "Unauthorized (token)." }                    // 401
+response_forbidden_user.json { error: "Forbidden (user)." }                       // 403
+```
+
+Both server tests and Android Ktor tests load these in strict mode. Production decoding stays `ignoreUnknownKeys = true` for forward-compat.
+
+### FCM payload
+
+```json
+{
+  "topic": "buttonHealth-<sanitized-buttonBuildTimestamp>",
+  "data": {
+    "buttonState": "ONLINE" | "OFFLINE",
+    "stateChangedAtSeconds": "1730000000",
+    "buildTimestamp": "<original-buttonBuildTimestamp>"
+  },
+  "android": {
+    "priority": "HIGH",
+    "collapse_key": "button_health_update"
+  }
+  // No `notification` block — data-only by design.
+}
+```
+
+`UNKNOWN` is never sent over FCM; it's a server-side bootstrap state only. Mobile sees ONLINE or OFFLINE via FCM, and may see UNKNOWN only as the cold-start HTTP response when no record exists yet.
+
+### Topic builder
+
+The button `buildTimestamp` is stored URL-encoded in server config (since April 2021 — see `CLAUDE.md` "Dormant config readers"). The door's topic builder doesn't handle this, so the button needs its own:
+
+```typescript
+const TOPIC_PREFIX = 'buttonHealth-';
+
+export function buildTimestampToButtonHealthFcmTopic(buildTimestamp: string): string {
+  const decoded = decodeURIComponent(buildTimestamp);  // idempotent for plain ASCII
+  const sanitized = decoded.replace(/[^a-zA-Z0-9_\-\.~]/g, '_');
+  return `${TOPIC_PREFIX}${sanitized}`;
+}
+```
+
+`ButtonHealthFcmTopicTest` pins the format on both sides per the FCM safety rule in `CLAUDE.md`.
+
+## Android design
+
+Every layer gets its own button-health type. No reuse of door interfaces.
+
+### Domain (`domain/.../buttonhealth/`)
+
+```kotlin
+enum class ButtonHealthState { UNKNOWN, ONLINE, OFFLINE }
+
+data class ButtonHealth(
+    val state: ButtonHealthState,
+    val stateChangedAtSeconds: Long?,
+)
+
+sealed interface ButtonHealthError {
+    data object Network : ButtonHealthError
+    data object Forbidden : ButtonHealthError
+    data class Unknown(val cause: String) : ButtonHealthError
+}
+
+interface ButtonHealthRepository {
+    val buttonHealth: StateFlow<LoadingResult<ButtonHealth>>
+    suspend fun fetchButtonHealth(): AppResult<ButtonHealth, ButtonHealthError>
+    fun applyFcmUpdate(update: ButtonHealth)
+}
+```
+
+### Data (`data/.../buttonhealth/`)
+
+- `NetworkButtonHealthDataSource` (interface) + `KtorNetworkButtonHealthDataSource` (impl) — its own data source, returns `NetworkResult<ButtonHealth>`.
+- `DefaultButtonHealthRepository` — owns `MutableStateFlow<LoadingResult<ButtonHealth>>`. `fetchButtonHealth()` always force-refreshes. FCM updates dispatch through `applyFcmUpdate`.
+- `ButtonHealthFcmRepository` — separate from `DoorFcmRepository`. Different topic prefix, different lifecycle (subscribe gated by allowlist; door isn't).
+- `ButtonHealthFcmPayloadParser` — parses `buttonHealth-*` data payloads. Contract test mirrors `FcmPayloadParsingTest`.
+
+### UseCase (`usecase/.../buttonhealth/`)
+
+- `FetchButtonHealthUseCase`, `ObserveButtonHealthUseCase`
+- `ButtonHealthViewModel` — combines `AuthState + AllowlistAccess + ButtonHealth` → exposes a sealed display:
+
+```kotlin
+sealed interface ButtonHealthDisplay {
+    data object Unauthorized : ButtonHealthDisplay   // user not allowlisted — no pill
+    data object Online : ButtonHealthDisplay         // healthy / known good — no pill
+    data object Loading : ButtonHealthDisplay        // unknown / no data yet — no pill
+    data class Offline(val sinceLabel: String) : ButtonHealthDisplay   // pill shown
+}
+```
+
+The four-arm sealed type preserves *why* the pill is hidden — debuggable, and resilient to future UX iterations on the non-Offline states.
+
+### UI
+
+- NEW `androidApp/.../ui/buttonhealth/ButtonOfflinePill.kt` — stateless Composable. `errorContainer` background, `Icons.Outlined.SignalWifiOff`, "Button offline" text. Mirrors the structure of `TitleBarCheckInPill` (the device check-in pill shipped in 2.9.4) but is a separate file — no shared base.
+- Modify `RemoteButtonContent.kt`:
+
+```kotlin
+val display = viewModel { component.buttonHealthViewModel }.display.collectAsState()
+// In the section header row, right-aligned next to the title:
+when (val d = display.value) {
+    is ButtonHealthDisplay.Offline -> ButtonOfflinePill()
+    ButtonHealthDisplay.Unauthorized,
+    ButtonHealthDisplay.Online,
+    ButtonHealthDisplay.Loading -> Unit  // Render nothing — same as today.
+}
+```
+
+- Modify `androidApp/.../fcm/FCMService.kt` — dispatch by topic prefix:
+
+```kotlin
+when {
+    topic.startsWith("buttonHealth-") ->
+        ButtonHealthFcmPayloadParser.parse(data)?.let { buttonHealthRepository.applyFcmUpdate(it) }
+    else -> existingDoorPayloadParser(data)
+}
+```
+
+- Modify `AppStartup.kt` — new task observes (auth state + allowlist) and calls `buttonHealthFcmRepository.subscribe(buildTimestamp)` when both are true, `.unsubscribe(buildTimestamp)` when either flips false. Cold-start `fetchButtonHealth()` fires once when the user first becomes allowlisted in this app session.
+- Modify `AppComponent.kt` — wire `ButtonHealthRepository`, `ButtonHealthFcmRepository`, `ButtonHealthViewModel`.
+
+### Subscription lifecycle
+
+| Event | Action |
+|---|---|
+| User signs in AND allowlist returns `true` | Subscribe to `buttonHealth-<buttonBuildTimestamp>`; cold-start fetch |
+| User signs out | Unsubscribe; clear state |
+| Allowlist flips to `false` mid-session | Unsubscribe; flip display to `Unauthorized` |
+
+## Naming convention summary
+
+| Concept | Name |
+|---|---|
+| State enum | `ONLINE`, `OFFLINE`, `UNKNOWN` |
+| Timestamp field (wire + Android) | `stateChangedAtSeconds` |
+| FCM payload field for state | `buttonState` |
+| Topic prefix | `buttonHealth-` |
+| Topic builder | `buildTimestampToButtonHealthFcmTopic` |
+| Collection | `buttonHealthCurrent` / `buttonHealthAll` |
+| HTTP endpoint | `httpButtonHealth` / `handleButtonHealth` |
+| Pubsub | `pubsubCheckButtonHealth` / `handleCheckButtonHealth` |
+| Firestore trigger | `firestoreCheckButtonHealth` / `handleButtonHealthFromPollWrite` |
+| FCM collapse key | `button_health_update` |
+| Domain types | `ButtonHealth`, `ButtonHealthState`, `ButtonHealthError`, `ButtonHealthRepository` |
+| Display sealed type | `ButtonHealthDisplay.Unauthorized` / `.Online` / `.Loading` / `.Offline(sinceLabel)` |
+| Pill Composable | `ButtonOfflinePill` |
+| User-visible text | "Button offline" |
+
+The states are connectivity-shaped (`ONLINE`/`OFFLINE`) but the feature noun is "health" (`ButtonHealth*`, `buttonHealth-` topic). This deliberately leaves room for future health signals (battery, sensor errors) without renaming the present feature, while keeping current state names matching the user-visible "offline" string.
+
+## Safety property
+
+Every server change is in a function file the device does not touch:
+
+| Function | Device path? | Notes |
+|---|---|---|
+| `httpRemoteButton` (existing) | YES | Unchanged — same response shape, same Firestore ops, same latency |
+| `httpAddRemoteButtonCommand` (existing) | NO | Mobile only |
+| `firestoreCheckButtonHealth` (NEW) | NO | Fires asynchronously after the device's response is sent |
+| `pubsubCheckButtonHealth` (NEW) | NO | Runs on schedule |
+| `httpButtonHealth` (NEW) | NO | Mobile only |
+| `pubsubDataRetentionPolicy` (existing, modified one line) | NO | Doesn't touch device-written collections |
+
+**The device cannot observe whether this feature is deployed.** A failure in any new code path — Firestore trigger crash, Firestore read failure, FCM send failure, malformed health record — has zero effect on the response the device receives from `httpRemoteButton`. Worst case: the indicator stays stale until the next pubsub run; the button itself works exactly as today.
+
+## Acceptable failure modes
+
+- A `OFFLINE` state that recovers within 10 min may never reach mobile (pubsub didn't fire while it was OFFLINE). User stated this is acceptable.
+- FCM delivery failures are not retried — mobile re-fetches on next cold start. Eventually consistent.
+- A pubsub run that crashes mid-flight may leave state stale until the next run — bounded by 10-min cadence.
+
+## Failure modes designed out
+
+- **Unauthorized user seeing the pill** — eliminated by the four-arm sealed display: `Unauthorized` and `Online` and `Loading` all render no pill, and the rendering site has no way to express "show pill to non-`Offline`" state.
+- **Topic format drift between server and Android** — pinned by `ButtonHealthFcmTopicTest` running on both sides.
+- **Payload key drift** — pinned by `wire-contracts/buttonHealth/` fixtures consumed by tests in strict mode on both sides.
+
+## Out of scope
+
+- ESP32 firmware changes.
+- Modifications to existing door event flow, existing button command flow, or existing pubsubs.
+- Room caching of button health (state is short-lived; FCM keeps it fresh; cold-start endpoint reseeds in <1s).
+- New server config keys.
+- History view or "uptime" metric — `buttonHealthAll` is for diagnostics if ever needed.
+- Visible system-tray notifications.
+
+## Versioning impact
+
+- **Android**: minor bump (new user-visible capability — offline indicator). Add `distribution/whatsnew/` line and `CHANGELOG.md` entry.
+- **Firebase server**: minor entry in `FirebaseServer/CHANGELOG.md` covering the new Firestore trigger, pubsub, HTTP endpoint, and collection.
+
+## CLAUDE.md compliance
+
+- **FCM safety rule**: this feature *adds* a new topic format and new payload keys; existing `FcmTopicTest` and `FcmPayloadParsingTest` stay green. New contract tests (`ButtonHealthFcmTopicTest`, `ButtonHealthFcmPayloadParsingTest`) ship in the same PR as the topic builder and parser.
+- **Handler pattern**: new HTTP handler follows the pure `handle<Action>(input)` core + thin wrapper convention from `docs/FIREBASE_HANDLER_PATTERN.md`.
+- **Database refactor pattern**: new `ButtonHealthDatabase` follows the per-collection module pattern from `docs/FIREBASE_DATABASE_REFACTOR.md` (interface + Firestore impl + `setImpl`/`resetImpl`).
+- **Config authority**: no new server config keys; reuses existing button config (`remoteButtonBuildTimestamp`, `remoteButtonPushKey`, `remoteButtonAuthorizedEmails`).


### PR DESCRIPTION
## Summary
- Captures the agreed-upon design for a server-detected, mobile-displayed "Button offline" indicator next to the Remote-control section title on the Home tab.
- **Design only — no code changes yet.** Implementation is a separate effort that should reference this doc.
- Critical safety property: the device contract for `httpRemoteButton` is preserved byte-for-byte. Detection runs in a Firestore `onWrite` trigger fired *after* the device's response is on the wire, not as a modification to the device-facing handler.

## Key design decisions
- **States**: \`ONLINE\` / \`OFFLINE\` / \`UNKNOWN\` (server-side). Only \`OFFLINE\` is visible to the user.
- **Detection split**: Firestore trigger on every poll → ONLINE detection (sub-second). Pubsub every 10 min → OFFLINE detection (up to 10-min latency, acknowledged).
- **Auth**: same allowlist as the button feature itself. Non-allowlisted users see no UI change vs. today.
- **FCM**: data-only, separate topic prefix \`buttonHealth-\`, distinct topic builder (handles URL-encoded button \`buildTimestamp\`).
- **Android**: every layer gets its own button-health type. No reuse of door interfaces.
- **Naming**: state names align with user-visible "offline" string; feature noun stays "health" for future-proofing.

## Test plan
- [ ] Doc front-matter passes \`scripts/check-doc-frontmatter.sh\` (passes locally)
- [ ] Read by user before any implementation PR is opened
- [ ] When implementing, link each implementation PR back to this doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)