### PR TITLE
wire(contracts): button health response fixtures

### DIFF
--- a/wire-contracts/buttonHealth/response_forbidden_user.json
+++ b/wire-contracts/buttonHealth/response_forbidden_user.json
@@ -1,0 +1,1 @@
+{"error":"Forbidden (user)."}

--- a/wire-contracts/buttonHealth/response_offline.json
+++ b/wire-contracts/buttonHealth/response_offline.json
@@ -1,0 +1,1 @@
+{"buildTimestamp":"Sat Apr 10 23:57:32 2021","buttonState":"OFFLINE","stateChangedAtSeconds":1730000000}

--- a/wire-contracts/buttonHealth/response_online.json
+++ b/wire-contracts/buttonHealth/response_online.json
@@ -1,0 +1,1 @@
+{"buildTimestamp":"Sat Apr 10 23:57:32 2021","buttonState":"ONLINE","stateChangedAtSeconds":1730000000}

--- a/wire-contracts/buttonHealth/response_unauthorized.json
+++ b/wire-contracts/buttonHealth/response_unauthorized.json
@@ -1,0 +1,1 @@
+{"error":"Unauthorized (token)."}

--- a/wire-contracts/buttonHealth/response_unknown.json
+++ b/wire-contracts/buttonHealth/response_unknown.json
@@ -1,0 +1,1 @@
+{"buildTimestamp":"Sat Apr 10 23:57:32 2021","buttonState":"UNKNOWN","stateChangedAtSeconds":null}


### PR DESCRIPTION
## Summary
- PR 1 of 9 in the button health rollout per [docs/BUTTON_HEALTH_ARCHITECTURE.md](https://github.com/cartland/SmartGarageDoor/blob/main/docs/BUTTON_HEALTH_ARCHITECTURE.md).
- Adds 5 JSON fixtures under \`wire-contracts/buttonHealth/\`. No code consumes them yet — they'll be loaded in strict mode by both server (Mocha) and Android (commonTest) in the implementation PRs that follow.
- One fixture per response shape worth pinning: ONLINE, OFFLINE, UNKNOWN, 401, 403.

## Why JSON-only first
Per \`wire-contracts/README.md\` convention: drop the fixture file alongside its tests on day one. This lets both server and Android tests reference the same canonical bytes; a unilateral rename or shape change fails the test on at least one side.

## Test plan
- [x] All 5 files parse as valid JSON
- [x] Keys sorted (per \`wire-contracts/README.md\`)
- [x] Body bytes only (status codes asserted in per-side tests, not in fixtures)
- [ ] CI green (no consumers yet, so just lint passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)