### PR TITLE
feat(firebase): firestoreCheckButtonHealth trigger + handler core

### DIFF
--- a/FirebaseServer/src/controller/ButtonHealthUpdates.ts
+++ b/FirebaseServer/src/controller/ButtonHealthUpdates.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import * as firebase from 'firebase-admin';
+
+import { DATABASE as BUTTON_HEALTH_DATABASE } from '../database/ButtonHealthDatabase';
+import { DATABASE as REMOTE_BUTTON_REQUEST_DATABASE } from '../database/RemoteButtonRequestDatabase';
+import { DATABASE as ServerConfigDatabase } from '../database/ServerConfigDatabase';
+import { computeHealthFromLastPoll, detectTransition } from './ButtonHealthInterpreter';
+import { SERVICE as ButtonHealthFCMService } from './fcm/ButtonHealthFCM';
+import { isRemoteButtonEnabled, getRemoteButtonBuildTimestamp, requireBuildTimestamp } from './config/ConfigAccessors';
+
+const DATABASE_TIMESTAMP_SECONDS_KEY = 'FIRESTORE_databaseTimestampSeconds';
+
+/**
+ * Pure handler core called by the Firestore trigger on every poll write.
+ *
+ * Critical: re-reads `RemoteButtonRequestDatabase.getCurrent()` rather
+ * than trusting the trigger's event payload. Cloud Functions retries
+ * triggers with the ORIGINAL event payload, which can become stale
+ * by the time the retry runs. The fresh re-read prevents a stale-event
+ * retry from incorrectly computing OFFLINE.
+ *
+ * Kill switch: short-circuits when `isRemoteButtonEnabled(config) ==
+ * false`. Reuses the existing button-feature kill switch — one toggle
+ * disables everything button-related.
+ *
+ * @param buildTimestamp Identifies which device's poll arrived. Stable
+ * across retries (it's the device identity, not a state value).
+ */
+export async function handleButtonHealthFromPollWrite(buildTimestamp: string): Promise<void> {
+  if (!buildTimestamp) {
+    console.warn('handleButtonHealthFromPollWrite: missing buildTimestamp; no-op');
+    return;
+  }
+  const config = await ServerConfigDatabase.get();
+  if (!isRemoteButtonEnabled(config)) {
+    console.log('handleButtonHealthFromPollWrite: button feature disabled; no-op');
+    return;
+  }
+  const expectedBuildTimestamp = requireBuildTimestamp(
+    getRemoteButtonBuildTimestamp(config),
+    'firestoreCheckButtonHealth',
+  );
+  if (buildTimestamp !== expectedBuildTimestamp) {
+    // Trigger fired for a doc whose buildTimestamp doesn't match server config.
+    // Could happen during a device-rotation transition; safer to no-op than
+    // to flap state for the OLD device.
+    console.log(
+      'handleButtonHealthFromPollWrite: buildTimestamp does not match config',
+      { eventBuildTimestamp: buildTimestamp, configBuildTimestamp: expectedBuildTimestamp },
+    );
+    return;
+  }
+  // Re-read for the freshest poll (defends against retry with stale event).
+  const latestRequest = await REMOTE_BUTTON_REQUEST_DATABASE.getCurrent(buildTimestamp);
+  const lastPollSeconds: number | null = latestRequest?.[DATABASE_TIMESTAMP_SECONDS_KEY] ?? null;
+  const nowSeconds = firebase.firestore.Timestamp.now().seconds;
+  const computed = computeHealthFromLastPoll(lastPollSeconds, nowSeconds);
+  const prior = await BUTTON_HEALTH_DATABASE.getCurrent(buildTimestamp);
+  const { didTransition, newRecord } = detectTransition(prior, computed, nowSeconds);
+  if (didTransition) {
+    await BUTTON_HEALTH_DATABASE.save(buildTimestamp, newRecord);
+    await ButtonHealthFCMService.sendForTransition(buildTimestamp, newRecord);
+  }
+}

--- a/FirebaseServer/src/functions/firestore/ButtonHealth.ts
+++ b/FirebaseServer/src/functions/firestore/ButtonHealth.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import * as functions from 'firebase-functions/v1';
+
+import { handleButtonHealthFromPollWrite } from '../../controller/ButtonHealthUpdates';
+
+/**
+ * Fires asynchronously after every button-poll write. The handler
+ * re-reads RemoteButtonRequestDatabase to get the freshest poll,
+ * computes the new health state, persists if different from prior,
+ * and sends an FCM on transition.
+ *
+ * MUST NOT use {failurePolicy: true}. Default no-retry mirrors
+ * firestoreUpdateEvents — Cloud Functions retries with the ORIGINAL
+ * event payload, which can become stale; instead the handler defends
+ * itself with a fresh re-read.
+ *
+ * Provably cannot affect the device path:
+ *  - The trigger fires AFTER the device's HTTP response is on the wire.
+ *  - The trigger reads/writes a separate collection (buttonHealthCurrent).
+ *  - Trigger crashes / Firestore failures / FCM failures are isolated.
+ */
+export const firestoreCheckButtonHealth = functions.firestore
+  .document('remoteButtonRequestAll/{docId}')
+  .onWrite(async (change, _context) => {
+    const data = change.after.data();
+    const buildTimestamp = data?.queryParams?.buildTimestamp ?? data?.buildTimestamp;
+    await handleButtonHealthFromPollWrite(buildTimestamp);
+    return null;
+  });

--- a/FirebaseServer/src/index.ts
+++ b/FirebaseServer/src/index.ts
@@ -36,6 +36,7 @@ import { pubsubDataRetentionPolicy } from './functions/pubsub/DataRetentionPolic
 
 // Firestore Functions.
 import { firestoreUpdateEvents } from './functions/firestore/Events'
+import { firestoreCheckButtonHealth } from './functions/firestore/ButtonHealth'
 
 /*
  * This file is the main entrace for Cloud Functions for Firebase.
@@ -76,6 +77,22 @@ if (!process.env.FUNCTION_NAME || process.env.FUNCTION_NAME === 'echo') {
  */
 if (!process.env.FUNCTION_NAME || process.env.FUNCTION_NAME === 'updateEvents') {
   exports.updateEvents = firestoreUpdateEvents;
+}
+
+/**
+ * Detect remote-button device online/offline state.
+ *
+ * Trigger Type: Firestore (onWrite on remoteButtonRequestAll/{docId})
+ *
+ * Fires after every device poll. Computes the new health state from
+ * the latest poll timestamp and persists + sends a data-only FCM only
+ * on transitions. Provably cannot affect the device path — runs
+ * asynchronously after the device's HTTP response is on the wire.
+ *
+ * See docs/BUTTON_HEALTH_ARCHITECTURE.md.
+ */
+if (!process.env.FUNCTION_NAME || process.env.FUNCTION_NAME === 'firestoreCheckButtonHealth') {
+  exports.firestoreCheckButtonHealth = firestoreCheckButtonHealth;
 }
 
 /**

--- a/FirebaseServer/test/controller/ButtonHealthUpdatesTest.ts
+++ b/FirebaseServer/test/controller/ButtonHealthUpdatesTest.ts
@@ -1,0 +1,191 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { expect } from 'chai';
+
+import { handleButtonHealthFromPollWrite } from '../../src/controller/ButtonHealthUpdates';
+import {
+  setImpl as setButtonHealthDBImpl,
+  resetImpl as resetButtonHealthDBImpl,
+} from '../../src/database/ButtonHealthDatabase';
+import {
+  setImpl as setRemoteButtonRequestDBImpl,
+  resetImpl as resetRemoteButtonRequestDBImpl,
+} from '../../src/database/RemoteButtonRequestDatabase';
+import {
+  setImpl as setServerConfigDBImpl,
+  resetImpl as resetServerConfigDBImpl,
+} from '../../src/database/ServerConfigDatabase';
+import {
+  setImpl as setButtonHealthFCMImpl,
+  resetImpl as resetButtonHealthFCMImpl,
+} from '../../src/controller/fcm/ButtonHealthFCM';
+import { FakeButtonHealthDatabase } from '../fakes/FakeButtonHealthDatabase';
+import { FakeRemoteButtonRequestDatabase } from '../fakes/FakeRemoteButtonRequestDatabase';
+import { FakeServerConfigDatabase } from '../fakes/FakeServerConfigDatabase';
+import { FakeButtonHealthFCMService } from '../fakes/FakeButtonHealthFCMService';
+
+const DATABASE_TIMESTAMP_SECONDS_KEY = 'FIRESTORE_databaseTimestampSeconds';
+
+const BUILD_TIMESTAMP = 'Sat Apr 10 23:57:32 2021';
+
+/**
+ * Server config that enables the button feature with the production
+ * remoteButtonBuildTimestamp shape (URL-encoded — matches the prod config
+ * since April 2021).
+ */
+function configEnabled() {
+  return {
+    body: {
+      remoteButtonEnabled: true,
+      // The accessor decodeURIComponents this on read; both encoded and decoded
+      // forms work for tests since we pass BUILD_TIMESTAMP (decoded) to the
+      // handler too.
+      remoteButtonBuildTimestamp: 'Sat%20Apr%2010%2023%3A57%3A32%202021',
+    },
+  };
+}
+
+function configDisabled() {
+  return {
+    body: {
+      remoteButtonEnabled: false,
+      remoteButtonBuildTimestamp: 'Sat%20Apr%2010%2023%3A57%3A32%202021',
+    },
+  };
+}
+
+describe('handleButtonHealthFromPollWrite', () => {
+  let healthDB: FakeButtonHealthDatabase;
+  let requestDB: FakeRemoteButtonRequestDatabase;
+  let configDB: FakeServerConfigDatabase;
+  let fcm: FakeButtonHealthFCMService;
+
+  beforeEach(() => {
+    healthDB = new FakeButtonHealthDatabase();
+    requestDB = new FakeRemoteButtonRequestDatabase();
+    configDB = new FakeServerConfigDatabase();
+    fcm = new FakeButtonHealthFCMService();
+    setButtonHealthDBImpl(healthDB);
+    setRemoteButtonRequestDBImpl(requestDB);
+    setServerConfigDBImpl(configDB);
+    setButtonHealthFCMImpl(fcm);
+    configDB.seed(configEnabled());
+  });
+
+  afterEach(() => {
+    resetButtonHealthDBImpl();
+    resetRemoteButtonRequestDBImpl();
+    resetServerConfigDBImpl();
+    resetButtonHealthFCMImpl();
+  });
+
+  it('no-ops when buildTimestamp is missing', async () => {
+    await handleButtonHealthFromPollWrite('');
+    expect(healthDB.saved).to.be.empty;
+    expect(fcm.sends).to.be.empty;
+  });
+
+  it('no-ops when remoteButtonEnabled is false (kill switch)', async () => {
+    configDB.seed(configDisabled());
+    requestDB.seed(BUILD_TIMESTAMP, {
+      [DATABASE_TIMESTAMP_SECONDS_KEY]: Math.floor(Date.now() / 1000),
+    });
+
+    await handleButtonHealthFromPollWrite(BUILD_TIMESTAMP);
+
+    expect(healthDB.saved).to.be.empty;
+    expect(fcm.sends).to.be.empty;
+  });
+
+  it('no-ops when buildTimestamp does not match server config', async () => {
+    requestDB.seed('OTHER_DEVICE', {
+      [DATABASE_TIMESTAMP_SECONDS_KEY]: Math.floor(Date.now() / 1000),
+    });
+
+    await handleButtonHealthFromPollWrite('OTHER_DEVICE');
+
+    expect(healthDB.saved).to.be.empty;
+    expect(fcm.sends).to.be.empty;
+  });
+
+  it('writes ONLINE + sends FCM on first poll for this buildTimestamp (UNKNOWN -> ONLINE)', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    requestDB.seed(BUILD_TIMESTAMP, { [DATABASE_TIMESTAMP_SECONDS_KEY]: nowSeconds });
+
+    await handleButtonHealthFromPollWrite(BUILD_TIMESTAMP);
+
+    expect(healthDB.saved).to.have.length(1);
+    expect(healthDB.saved[0][0]).to.equal(BUILD_TIMESTAMP);
+    expect(healthDB.saved[0][1].state).to.equal('ONLINE');
+    expect(fcm.sends).to.have.length(1);
+    expect(fcm.sends[0].record.state).to.equal('ONLINE');
+  });
+
+  it('writes ONLINE + sends FCM on OFFLINE -> ONLINE recovery', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    healthDB.seed(BUILD_TIMESTAMP, {
+      state: 'OFFLINE',
+      stateChangedAtSeconds: nowSeconds - 1200,
+    });
+    requestDB.seed(BUILD_TIMESTAMP, { [DATABASE_TIMESTAMP_SECONDS_KEY]: nowSeconds });
+
+    await handleButtonHealthFromPollWrite(BUILD_TIMESTAMP);
+
+    expect(healthDB.saved).to.have.length(1);
+    expect(healthDB.saved[0][1].state).to.equal('ONLINE');
+    expect(fcm.sends).to.have.length(1);
+    expect(fcm.sends[0].record.state).to.equal('ONLINE');
+  });
+
+  it('does NOT write or send FCM on ONLINE -> ONLINE no-op', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    healthDB.seed(BUILD_TIMESTAMP, {
+      state: 'ONLINE',
+      stateChangedAtSeconds: nowSeconds - 100,
+    });
+    requestDB.seed(BUILD_TIMESTAMP, { [DATABASE_TIMESTAMP_SECONDS_KEY]: nowSeconds });
+
+    await handleButtonHealthFromPollWrite(BUILD_TIMESTAMP);
+
+    expect(healthDB.saved).to.be.empty;
+    expect(fcm.sends).to.be.empty;
+  });
+
+  it('re-reads RemoteButtonRequestDatabase rather than trusting stale event payload', async () => {
+    // The trigger handler doesn't take the timestamp as a parameter — it always
+    // re-reads. So even if a Cloud Functions retry fires LONG after the original
+    // poll, the handler sees whatever the latest poll wrote (which is stored
+    // separately by the unrelated httpRemoteButton handler).
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    requestDB.seed(BUILD_TIMESTAMP, { [DATABASE_TIMESTAMP_SECONDS_KEY]: nowSeconds });
+    // No prior buttonHealth doc.
+
+    await handleButtonHealthFromPollWrite(BUILD_TIMESTAMP);
+
+    // Fresh poll → ONLINE.
+    expect(healthDB.saved[0][1].state).to.equal('ONLINE');
+
+    // Now imagine the handler fires again after the device went silent for
+    // an hour — the fresh re-read would see the OLD poll record (stale).
+    healthDB.clear();
+    fcm.clear();
+    requestDB.seed(BUILD_TIMESTAMP, {
+      [DATABASE_TIMESTAMP_SECONDS_KEY]: nowSeconds - 3600,  // an hour stale
+    });
+    healthDB.seed(BUILD_TIMESTAMP, { state: 'ONLINE', stateChangedAtSeconds: nowSeconds - 100 });
+
+    await handleButtonHealthFromPollWrite(BUILD_TIMESTAMP);
+
+    // Now the latest poll is stale → handler computes OFFLINE, writes the transition.
+    expect(healthDB.saved).to.have.length(1);
+    expect(healthDB.saved[0][1].state).to.equal('OFFLINE');
+  });
+});

--- a/FirebaseServer/test/fakes/FakeButtonHealthDatabase.ts
+++ b/FirebaseServer/test/fakes/FakeButtonHealthDatabase.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { ButtonHealthDatabase, ButtonHealthRecord } from '../../src/database/ButtonHealthDatabase';
+
+export class FakeButtonHealthDatabase implements ButtonHealthDatabase {
+  private readonly store = new Map<string, ButtonHealthRecord>();
+
+  /** Audit log of all save() calls. */
+  readonly saved: Array<[string, ButtonHealthRecord]> = [];
+
+  async save(buildTimestamp: string, record: ButtonHealthRecord): Promise<void> {
+    this.store.set(buildTimestamp, record);
+    this.saved.push([buildTimestamp, record]);
+  }
+
+  async getCurrent(buildTimestamp: string): Promise<ButtonHealthRecord | null> {
+    return this.store.get(buildTimestamp) ?? null;
+  }
+
+  /** Test-only helper: pre-populate storage without recording in saved[]. */
+  seed(buildTimestamp: string, record: ButtonHealthRecord): void {
+    this.store.set(buildTimestamp, record);
+  }
+
+  /** Test-only helper: wipe storage and audit logs. */
+  clear(): void {
+    this.store.clear();
+    this.saved.length = 0;
+  }
+}

--- a/FirebaseServer/test/fakes/FakeButtonHealthFCMService.ts
+++ b/FirebaseServer/test/fakes/FakeButtonHealthFCMService.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { ButtonHealthFCMService, buildTransitionPayload } from '../../src/controller/fcm/ButtonHealthFCM';
+import { ButtonHealthRecord } from '../../src/database/ButtonHealthDatabase';
+import { TopicMessage } from '../../src/model/FCM';
+
+export class FakeButtonHealthFCMService implements ButtonHealthFCMService {
+  /** Audit log of all sendForTransition() calls. */
+  readonly sends: Array<{ buildTimestamp: string; record: ButtonHealthRecord }> = [];
+
+  async sendForTransition(buildTimestamp: string, record: ButtonHealthRecord): Promise<TopicMessage> {
+    this.sends.push({ buildTimestamp, record });
+    // Return the same payload the production impl would build, so callers
+    // that inspect the return value see realistic data.
+    return buildTransitionPayload(buildTimestamp, record);
+  }
+
+  /** Test-only helper: wipe audit logs. */
+  clear(): void {
+    this.sends.length = 0;
+  }
+}


### PR DESCRIPTION
## Summary
- PR 3 of 9 in the button health rollout per [docs/BUTTON_HEALTH_ARCHITECTURE.md](https://github.com/cartland/SmartGarageDoor/blob/main/docs/BUTTON_HEALTH_ARCHITECTURE.md).
- Live trigger; passive ONLINE-side detection only (no FCM subscribers yet — they'll come in the Android wiring PR). Server-side, this is the first PR that produces observable behavior in production.

## What it does
Fires after every device poll. Re-reads \`RemoteButtonRequestDatabase\` (defends against retry with stale event payload), computes the new health state, persists if different from prior, sends data-only FCM on transition.

## Safety properties
- \`firestoreCheckButtonHealth\` runs **asynchronously** after the device's HTTP response is on the wire. Trigger crashes / Firestore failures / FCM failures **provably cannot affect** the device path.
- No \`failurePolicy: true\` (matches \`firestoreUpdateEvents\` — Cloud Functions default no-retry).
- Kill switch: short-circuits when \`isRemoteButtonEnabled(config) == false\` (reuses existing button-feature flag, no new config keys).
- buildTimestamp validated against server config — protects against firing for an old device after firmware reflash.

## Test plan
- [x] \`./scripts/validate-firebase.sh\` passes (280 tests, +7 new)
- [x] All transition + no-op state-machine rows covered
- [x] Stale-event-payload defense covered explicitly
- [x] Kill switch covered
- [ ] CI green
- [ ] **Cloud Logs verification post-deploy**: \`firestoreCheckButtonHealth\` fires on every poll; transitions write to \`buttonHealthCurrent\`; FCM sends succeed (topic has zero subscribers until Android ships, so sends will go nowhere — that's fine, just verify no crashes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)