### PR TITLE
feat(firebase): pubsubCheckButtonHealth (10-min sweep)

### DIFF
--- a/FirebaseServer/src/functions/pubsub/ButtonHealth.ts
+++ b/FirebaseServer/src/functions/pubsub/ButtonHealth.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import * as firebase from 'firebase-admin';
+import * as functions from 'firebase-functions/v1';
+
+import { DATABASE as BUTTON_HEALTH_DATABASE } from '../../database/ButtonHealthDatabase';
+import { DATABASE as REMOTE_BUTTON_REQUEST_DATABASE } from '../../database/RemoteButtonRequestDatabase';
+import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
+import { computeHealthFromLastPoll, detectTransition } from '../../controller/ButtonHealthInterpreter';
+import { SERVICE as ButtonHealthFCMService } from '../../controller/fcm/ButtonHealthFCM';
+import { isRemoteButtonEnabled, getRemoteButtonBuildTimestamp, requireBuildTimestamp } from '../../controller/config/ConfigAccessors';
+
+const DATABASE_TIMESTAMP_SECONDS_KEY = 'FIRESTORE_databaseTimestampSeconds';
+
+/**
+ * Pure handler core for the every-10-min sweep.
+ *
+ * Reads the latest poll record + the prior persisted health state,
+ * computes the new state via the same pure function the trigger uses,
+ * and persists + sends FCM only on transitions. No-op writes (state
+ * unchanged) preserve stateChangedAtSeconds.
+ *
+ * Drives the OFFLINE-side detection (the trigger handles ONLINE
+ * recovery sub-second on every poll).
+ *
+ * Kill switch: short-circuits when isRemoteButtonEnabled(config) ==
+ * false.
+ */
+export async function handleCheckButtonHealth(): Promise<void> {
+  const config = await ServerConfigDatabase.get();
+  if (!isRemoteButtonEnabled(config)) {
+    console.log('handleCheckButtonHealth: button feature disabled; no-op');
+    return;
+  }
+  const buildTimestamp = requireBuildTimestamp(
+    getRemoteButtonBuildTimestamp(config),
+    'pubsubCheckButtonHealth',
+  );
+  const latestRequest = await REMOTE_BUTTON_REQUEST_DATABASE.getCurrent(buildTimestamp);
+  const lastPollSeconds: number | null = latestRequest?.[DATABASE_TIMESTAMP_SECONDS_KEY] ?? null;
+  const nowSeconds = firebase.firestore.Timestamp.now().seconds;
+  const computed = computeHealthFromLastPoll(lastPollSeconds, nowSeconds);
+  const prior = await BUTTON_HEALTH_DATABASE.getCurrent(buildTimestamp);
+  const { didTransition, newRecord } = detectTransition(prior, computed, nowSeconds);
+  if (didTransition) {
+    await BUTTON_HEALTH_DATABASE.save(buildTimestamp, newRecord);
+    await ButtonHealthFCMService.sendForTransition(buildTimestamp, newRecord);
+  }
+}
+
+export const pubsubCheckButtonHealth = functions.pubsub
+  .schedule('every 10 minutes').timeZone('America/Los_Angeles')
+  .onRun(async (_context) => {
+    await handleCheckButtonHealth();
+    return null;
+  });

--- a/FirebaseServer/src/index.ts
+++ b/FirebaseServer/src/index.ts
@@ -32,6 +32,7 @@ import { httpFunctionListAccess } from './functions/http/FunctionListAccess'
 import { pubsubCheckForDoorErrors } from './functions/pubsub/DoorErrors'
 import { pubsubCheckForOpenDoorsJob } from './functions/pubsub/OpenDoor'
 import { pubsubCheckForRemoteButtonErrors } from './functions/pubsub/RemoteButton'
+import { pubsubCheckButtonHealth } from './functions/pubsub/ButtonHealth'
 import { pubsubDataRetentionPolicy } from './functions/pubsub/DataRetentionPolicy'
 
 // Firestore Functions.
@@ -93,6 +94,23 @@ if (!process.env.FUNCTION_NAME || process.env.FUNCTION_NAME === 'updateEvents') 
  */
 if (!process.env.FUNCTION_NAME || process.env.FUNCTION_NAME === 'firestoreCheckButtonHealth') {
   exports.firestoreCheckButtonHealth = firestoreCheckButtonHealth;
+}
+
+/**
+ * Detect remote-button device OFFLINE state on a 10-min schedule.
+ *
+ * Trigger Type: PubSub Job
+ *
+ * Drives the OFFLINE side of the state machine — the trigger handles
+ * sub-second ONLINE recovery on every poll. Worst-case OFFLINE
+ * detection latency is ~10 min (acknowledged tradeoff). Sends data-
+ * only FCM only on transitions; preserves stateChangedAtSeconds on
+ * no-op writes.
+ *
+ * See docs/BUTTON_HEALTH_ARCHITECTURE.md.
+ */
+if (!process.env.FUNCTION_NAME || process.env.FUNCTION_NAME === 'pubsubCheckButtonHealth') {
+  exports.pubsubCheckButtonHealth = pubsubCheckButtonHealth;
 }
 
 /**

--- a/FirebaseServer/test/functions/pubsub/ButtonHealthTest.ts
+++ b/FirebaseServer/test/functions/pubsub/ButtonHealthTest.ts
@@ -1,0 +1,166 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * Tests for handleCheckButtonHealth — the 10-min pubsub.
+ *
+ * Per the doc convention (BUTTON_HEALTH_ARCHITECTURE.md > Test plan):
+ * the test class MUST enumerate the state-machine table rows 1:1 by
+ * name. Reading this file alongside the doc table verifies completeness
+ * in seconds.
+ */
+
+import { expect } from 'chai';
+
+import { handleCheckButtonHealth } from '../../../src/functions/pubsub/ButtonHealth';
+import {
+  setImpl as setButtonHealthDBImpl,
+  resetImpl as resetButtonHealthDBImpl,
+} from '../../../src/database/ButtonHealthDatabase';
+import {
+  setImpl as setRemoteButtonRequestDBImpl,
+  resetImpl as resetRemoteButtonRequestDBImpl,
+} from '../../../src/database/RemoteButtonRequestDatabase';
+import {
+  setImpl as setServerConfigDBImpl,
+  resetImpl as resetServerConfigDBImpl,
+} from '../../../src/database/ServerConfigDatabase';
+import {
+  setImpl as setButtonHealthFCMImpl,
+  resetImpl as resetButtonHealthFCMImpl,
+} from '../../../src/controller/fcm/ButtonHealthFCM';
+import { FakeButtonHealthDatabase } from '../../fakes/FakeButtonHealthDatabase';
+import { FakeRemoteButtonRequestDatabase } from '../../fakes/FakeRemoteButtonRequestDatabase';
+import { FakeServerConfigDatabase } from '../../fakes/FakeServerConfigDatabase';
+import { FakeButtonHealthFCMService } from '../../fakes/FakeButtonHealthFCMService';
+
+const DATABASE_TIMESTAMP_SECONDS_KEY = 'FIRESTORE_databaseTimestampSeconds';
+
+const BUILD_TIMESTAMP = 'Sat Apr 10 23:57:32 2021';
+
+function configEnabled() {
+  return {
+    body: {
+      remoteButtonEnabled: true,
+      remoteButtonBuildTimestamp: 'Sat%20Apr%2010%2023%3A57%3A32%202021',
+    },
+  };
+}
+
+describe('handleCheckButtonHealth (pubsub state-machine rows 1:1)', () => {
+  let healthDB: FakeButtonHealthDatabase;
+  let requestDB: FakeRemoteButtonRequestDatabase;
+  let configDB: FakeServerConfigDatabase;
+  let fcm: FakeButtonHealthFCMService;
+
+  beforeEach(() => {
+    healthDB = new FakeButtonHealthDatabase();
+    requestDB = new FakeRemoteButtonRequestDatabase();
+    configDB = new FakeServerConfigDatabase();
+    fcm = new FakeButtonHealthFCMService();
+    setButtonHealthDBImpl(healthDB);
+    setRemoteButtonRequestDBImpl(requestDB);
+    setServerConfigDBImpl(configDB);
+    setButtonHealthFCMImpl(fcm);
+    configDB.seed(configEnabled());
+  });
+
+  afterEach(() => {
+    resetButtonHealthDBImpl();
+    resetRemoteButtonRequestDBImpl();
+    resetServerConfigDBImpl();
+    resetButtonHealthFCMImpl();
+  });
+
+  it('row 1: pubsub fresh poll (<= 60s ago) + prior ONLINE -> ONLINE no-op (no write, no FCM)', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    requestDB.seed(BUILD_TIMESTAMP, { [DATABASE_TIMESTAMP_SECONDS_KEY]: now - 30 });
+    healthDB.seed(BUILD_TIMESTAMP, { state: 'ONLINE', stateChangedAtSeconds: now - 600 });
+
+    await handleCheckButtonHealth();
+
+    expect(healthDB.saved).to.be.empty;
+    expect(fcm.sends).to.be.empty;
+  });
+
+  it('row 2: pubsub stale poll (> 60s ago) + prior ONLINE -> OFFLINE + FCM', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    requestDB.seed(BUILD_TIMESTAMP, { [DATABASE_TIMESTAMP_SECONDS_KEY]: now - 120 });
+    healthDB.seed(BUILD_TIMESTAMP, { state: 'ONLINE', stateChangedAtSeconds: now - 600 });
+
+    await handleCheckButtonHealth();
+
+    expect(healthDB.saved).to.have.length(1);
+    expect(healthDB.saved[0][1].state).to.equal('OFFLINE');
+    expect(fcm.sends).to.have.length(1);
+    expect(fcm.sends[0].record.state).to.equal('OFFLINE');
+  });
+
+  it('row 3: pubsub no poll record + no prior buttonHealth doc -> OFFLINE + FCM', async () => {
+    // Bootstrap case: device never polled, no prior health state.
+    await handleCheckButtonHealth();
+
+    expect(healthDB.saved).to.have.length(1);
+    expect(healthDB.saved[0][1].state).to.equal('OFFLINE');
+    expect(fcm.sends).to.have.length(1);
+    expect(fcm.sends[0].record.state).to.equal('OFFLINE');
+  });
+
+  // Additional coverage beyond the table — kill switch and bootstrap edges.
+
+  it('kill switch: no-op when remoteButtonEnabled is false', async () => {
+    configDB.seed({ body: { remoteButtonEnabled: false } });
+    const now = Math.floor(Date.now() / 1000);
+    requestDB.seed(BUILD_TIMESTAMP, { [DATABASE_TIMESTAMP_SECONDS_KEY]: now });
+
+    await handleCheckButtonHealth();
+
+    expect(healthDB.saved).to.be.empty;
+    expect(fcm.sends).to.be.empty;
+  });
+
+  it('bootstrap: pubsub fresh poll + no prior health doc -> ONLINE + FCM', async () => {
+    // Recovery case: a poll arrived between trigger failure and pubsub run.
+    const now = Math.floor(Date.now() / 1000);
+    requestDB.seed(BUILD_TIMESTAMP, { [DATABASE_TIMESTAMP_SECONDS_KEY]: now - 10 });
+
+    await handleCheckButtonHealth();
+
+    expect(healthDB.saved).to.have.length(1);
+    expect(healthDB.saved[0][1].state).to.equal('ONLINE');
+    expect(fcm.sends).to.have.length(1);
+    expect(fcm.sends[0].record.state).to.equal('ONLINE');
+  });
+
+  it('OFFLINE -> ONLINE recovery (the pubsub-side fallback for missed trigger)', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    requestDB.seed(BUILD_TIMESTAMP, { [DATABASE_TIMESTAMP_SECONDS_KEY]: now - 10 });
+    healthDB.seed(BUILD_TIMESTAMP, { state: 'OFFLINE', stateChangedAtSeconds: now - 1200 });
+
+    await handleCheckButtonHealth();
+
+    expect(healthDB.saved).to.have.length(1);
+    expect(healthDB.saved[0][1].state).to.equal('ONLINE');
+    expect(fcm.sends).to.have.length(1);
+    expect(fcm.sends[0].record.state).to.equal('ONLINE');
+  });
+
+  it('preserves stateChangedAtSeconds on no-op writes (OFFLINE -> OFFLINE)', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    requestDB.seed(BUILD_TIMESTAMP, { [DATABASE_TIMESTAMP_SECONDS_KEY]: now - 600 });
+    healthDB.seed(BUILD_TIMESTAMP, { state: 'OFFLINE', stateChangedAtSeconds: now - 1800 });
+
+    await handleCheckButtonHealth();
+
+    // No save, no FCM — and the prior stateChangedAtSeconds is preserved.
+    expect(healthDB.saved).to.be.empty;
+    expect(fcm.sends).to.be.empty;
+  });
+});


### PR DESCRIPTION
## Summary
- PR 4 of 9 in the button health rollout per [docs/BUTTON_HEALTH_ARCHITECTURE.md](https://github.com/cartland/SmartGarageDoor/blob/main/docs/BUTTON_HEALTH_ARCHITECTURE.md).
- Drives OFFLINE-side detection (the trigger from PR #636 handles ONLINE recovery sub-second).
- 7 new tests; the first 3 enumerate the state-machine table rows 1:1 by name per the doc's test convention.

## Test convention
Each test name maps directly to a state-machine row, e.g.:
- \`row 1: pubsub fresh poll (<= 60s ago) + prior ONLINE -> ONLINE no-op (no write, no FCM)\`
- \`row 2: pubsub stale poll (> 60s ago) + prior ONLINE -> OFFLINE + FCM\`
- \`row 3: pubsub no poll record + no prior buttonHealth doc -> OFFLINE + FCM\`

Reading the test file alongside the doc table verifies completeness in seconds.

## Test plan
- [x] \`./scripts/validate-firebase.sh\` passes (287 tests, +7 new)
- [x] State-table rows 1:1 enumeration
- [x] Kill switch covered
- [x] Bootstrap + OFFLINE → ONLINE recovery covered
- [x] No-op preservation of stateChangedAtSeconds covered
- [ ] CI green
- [ ] **Cloud Logs verification post-deploy**: \`pubsubCheckButtonHealth\` fires every 10 min, computes correctly per state-machine table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)