### PR TITLE
feat(android-usecase): button health UseCases + FCM subscription manager

### DIFF
--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ApplyButtonHealthFcmUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ApplyButtonHealthFcmUseCase.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.ButtonHealth
+import com.chriscartland.garage.domain.repository.ButtonHealthRepository
+
+/**
+ * Apply a server-pushed update from an FCM data message.
+ *
+ * Wrapper around [ButtonHealthRepository.applyFcmUpdate] so the
+ * FCMService dispatcher consumes a UseCase rather than calling the
+ * repository directly (consistent with the door FCM path's
+ * ReceiveFcmDoorEventUseCase).
+ */
+class ApplyButtonHealthFcmUseCase(
+    private val repository: ButtonHealthRepository,
+) {
+    operator fun invoke(update: ButtonHealth) = repository.applyFcmUpdate(update)
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ButtonHealthDisplay.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ButtonHealthDisplay.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+/**
+ * Display state for the remote-button health indicator.
+ *
+ * Five arms (only `Offline` ever renders the pill), preserving the
+ * *why* of "no pill" — useful for debugging and a future UX iteration
+ * that wants to distinguish steady-state Online from in-flight Loading
+ * from server-confirmed Unknown.
+ *
+ * Loading and Unknown are different concepts:
+ *  - [Loading]: the suspend cold-start fetch is in flight, no result yet.
+ *  - [Unknown]: the cold-start fetch returned UNKNOWN (server has no
+ *    record yet for the device's buildTimestamp).
+ *
+ * Both render no pill, but the distinction matters for diagnostic
+ * logs and for "stuck Loading > X sec" diagnostics.
+ */
+sealed interface ButtonHealthDisplay {
+    /** User is signed out. */
+    data object Unauthorized : ButtonHealthDisplay
+
+    /** Cold-start fetch is in flight or repository is in an error state pending retry. */
+    data object Loading : ButtonHealthDisplay
+
+    /** Server returned UNKNOWN (no buttonHealthCurrent doc yet). */
+    data object Unknown : ButtonHealthDisplay
+
+    /** Server confirmed ONLINE. */
+    data object Online : ButtonHealthDisplay
+
+    /** Server confirmed OFFLINE. The ONLY arm that renders the pill. */
+    data class Offline(
+        val durationLabel: String,
+    ) : ButtonHealthDisplay
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ButtonHealthDisplayLogic.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ButtonHealthDisplayLogic.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.ButtonHealth
+import com.chriscartland.garage.domain.model.ButtonHealthState
+import com.chriscartland.garage.domain.model.LoadingResult
+
+/**
+ * Pure derivation: combine the user's auth state and the current
+ * button-health snapshot into a single [ButtonHealthDisplay].
+ *
+ * Wrapped in a named `object` per ADR-009 (`checkNoBareTopLevelFunctions`).
+ *
+ * Auth pre-condition is a guard clause; the inner `when (health)` and
+ * nested `when (health.data.state)` are exhaustive over sealed types
+ * and enums respectively — the Kotlin compiler enforces completeness.
+ *
+ * TODO: when a server-side button-health allowlist is added to
+ * FeatureAllowlist, gate Unauthorized on that too. Currently any
+ * signed-in user reaches the Online/Offline/Unknown/Loading branches
+ * — a non-allowlisted user would see Loading-then-Loading from the
+ * cold-start 403, which renders as no pill (functionally correct,
+ * but doesn't tell the manager to stop subscribing).
+ */
+object ButtonHealthDisplayLogic {
+    fun compute(
+        auth: AuthState,
+        health: LoadingResult<ButtonHealth>,
+        nowSeconds: Long,
+    ): ButtonHealthDisplay {
+        // Pre-condition: signed-out users never see the indicator.
+        if (auth !is AuthState.Authenticated) return ButtonHealthDisplay.Unauthorized
+
+        // Sealed-type exhaustive when on LoadingResult — compiler-enforced.
+        return when (health) {
+            is LoadingResult.Loading -> ButtonHealthDisplay.Loading
+            is LoadingResult.Error -> ButtonHealthDisplay.Loading // transient; retry will fix
+            is LoadingResult.Complete -> {
+                val data = health.data
+                if (data == null) {
+                    ButtonHealthDisplay.Loading
+                } else {
+                    when (data.state) {
+                        ButtonHealthState.UNKNOWN -> ButtonHealthDisplay.Unknown
+                        ButtonHealthState.ONLINE -> ButtonHealthDisplay.Online
+                        ButtonHealthState.OFFLINE ->
+                            ButtonHealthDisplay.Offline(
+                                durationLabel = ButtonHealthDurationFormatter.formatAgo(
+                                    data.stateChangedAtSeconds,
+                                    nowSeconds,
+                                ),
+                            )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ButtonHealthDurationFormatter.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ButtonHealthDurationFormatter.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+/**
+ * Pure formatter for the duration shown alongside "Remote offline".
+ *
+ * Mirrors the buckets of [DeviceCheckIn.format] (the existing pill)
+ * so both indicators speak the same grammar.
+ */
+object ButtonHealthDurationFormatter {
+    /**
+     * Format the duration since [stateChangedAtSeconds] as a human
+     * label like `"5 min ago"`. Null input → `"unknown"` (defensive;
+     * production callers should not pass null).
+     */
+    fun formatAgo(
+        stateChangedAtSeconds: Long?,
+        nowSeconds: Long,
+    ): String {
+        if (stateChangedAtSeconds == null) return "unknown"
+        val deltaSec = nowSeconds - stateChangedAtSeconds
+        // Clock-skew clamp: future timestamps reported as just-now.
+        if (deltaSec <= 0) return "just now"
+        if (deltaSec < 60) return "$deltaSec sec ago"
+        val minutes = deltaSec / 60
+        if (minutes < 60) return "$minutes min ago"
+        val hours = minutes / 60
+        if (hours < 24) return "$hours hr ago"
+        val days = hours / 24
+        return "$days day${if (days == 1L) "" else "s"} ago"
+    }
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ButtonHealthFcmSubscriptionManager.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ButtonHealthFcmSubscriptionManager.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import co.touchlab.kermit.Logger
+import com.chriscartland.garage.domain.model.AppResult
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.ButtonHealthError
+import com.chriscartland.garage.domain.repository.AuthRepository
+import com.chriscartland.garage.domain.repository.ButtonHealthFcmRepository
+import com.chriscartland.garage.domain.repository.ServerConfigRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+/**
+ * App-scoped manager for the button-health FCM topic subscription
+ * (ADR-015 Manager pattern; mirrors [FcmRegistrationManager]).
+ *
+ * Subscription lifecycle:
+ *  - Always-unsubscribe-then-conditionally-subscribe on every state
+ *    change. This sidesteps the "did Firebase Task cancel?" question:
+ *    Firebase's subscribe Task is not cancellable via coroutine
+ *    cancellation, so we just always issue the unsubscribe.
+ *  - When (signed in AND server config has buttonBuildTimestamp) →
+ *    subscribe to the corresponding topic and trigger one-shot
+ *    cold-start fetch.
+ *  - On any other state → unsubscribe.
+ *
+ * Handles buttonBuildTimestamp rotation (firmware reflash): when
+ * server config changes, the combine emits and the always-unsubscribe-
+ * then-subscribe pattern updates the FCM topic.
+ *
+ * On cold-start fetch returning Forbidden (user not allowlisted):
+ * unsubscribe from the FCM topic so we don't keep receiving updates
+ * the user has no business seeing.
+ */
+class ButtonHealthFcmSubscriptionManager(
+    private val authRepository: AuthRepository,
+    private val serverConfigRepository: ServerConfigRepository,
+    private val fcmRepository: ButtonHealthFcmRepository,
+    private val fetchButtonHealthUseCase: FetchButtonHealthUseCase,
+    private val scope: CoroutineScope,
+    private val dispatcher: CoroutineDispatcher,
+) {
+    private var job: Job? = null
+
+    /** Idempotent — calling twice does not start a second collector. */
+    fun start() {
+        if (job?.isActive == true) {
+            Logger.d { "ButtonHealthFcmSubscriptionManager: already running" }
+            return
+        }
+        job = scope.launch(dispatcher) {
+            combine(
+                authRepository.authState,
+                serverConfigRepository.serverConfig.map { it?.remoteButtonBuildTimestamp },
+            ) { auth, buildTimestamp -> auth to buildTimestamp }
+                .distinctUntilChanged()
+                .collect { (auth, buildTimestamp) ->
+                    handleStateChange(auth, buildTimestamp)
+                }
+        }
+    }
+
+    private suspend fun handleStateChange(
+        auth: AuthState,
+        buildTimestamp: String?,
+    ) {
+        // Always unsubscribe first — idempotent. Cleans up prior topic if
+        // buildTimestamp rotated, or any prior subscription if signing out.
+        fcmRepository.unsubscribeAll()
+        if (auth !is AuthState.Authenticated) {
+            Logger.d { "ButtonHealthFcm: not signed in; staying unsubscribed" }
+            return
+        }
+        if (buildTimestamp.isNullOrEmpty()) {
+            Logger.d { "ButtonHealthFcm: no buttonBuildTimestamp in server config; staying unsubscribed" }
+            return
+        }
+        Logger.i { "ButtonHealthFcm: subscribing for buildTimestamp=$buildTimestamp" }
+        fcmRepository.subscribe(buildTimestamp)
+        // Cold-start fetch. If the server returns Forbidden (user not
+        // allowlisted), unsubscribe — we shouldn't keep receiving updates.
+        val idToken = auth.user.idToken.idToken
+        when (val result = fetchButtonHealthUseCase(idToken)) {
+            is AppResult.Success -> {
+                Logger.i { "ButtonHealthFcm: cold-start fetch succeeded" }
+            }
+            is AppResult.Error -> when (result.error) {
+                is ButtonHealthError.Forbidden -> {
+                    Logger.w { "ButtonHealthFcm: cold-start fetch forbidden; unsubscribing" }
+                    fcmRepository.unsubscribeAll()
+                }
+                is ButtonHealthError.Network -> {
+                    Logger.w { "ButtonHealthFcm: cold-start fetch failed (network); keeping subscription" }
+                }
+            }
+        }
+    }
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ComputeButtonHealthDisplayUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ComputeButtonHealthDisplayUseCase.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.repository.AuthRepository
+import com.chriscartland.garage.domain.repository.ButtonHealthRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+
+/**
+ * Combines auth state, the button-health snapshot, and the LiveClock
+ * tick into a single [ButtonHealthDisplay] flow.
+ *
+ * Returns [Flow] (not [kotlinx.coroutines.flow.StateFlow]) per ADR-022:
+ * the consumer (Composable) collects via `collectAsStateWithLifecycle`
+ * with an initial value, avoiding `stateIn(viewModelScope, ...)`.
+ *
+ * Pure derivation lives in [ButtonHealthDisplayLogic.compute]; this
+ * UseCase is the wiring + clock-tick combine.
+ */
+class ComputeButtonHealthDisplayUseCase(
+    private val authRepository: AuthRepository,
+    private val buttonHealthRepository: ButtonHealthRepository,
+    private val liveClock: LiveClock,
+) {
+    operator fun invoke(): Flow<ButtonHealthDisplay> =
+        combine(
+            authRepository.authState,
+            buttonHealthRepository.buttonHealth,
+            liveClock.nowEpochSeconds,
+        ) { auth, health, now ->
+            ButtonHealthDisplayLogic.compute(auth, health, now)
+        }
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/FetchButtonHealthUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/FetchButtonHealthUseCase.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.AppResult
+import com.chriscartland.garage.domain.model.ButtonHealth
+import com.chriscartland.garage.domain.model.ButtonHealthError
+import com.chriscartland.garage.domain.repository.ButtonHealthRepository
+
+/**
+ * Cold-start fetch for the remote-button device's online/offline state.
+ *
+ * Updates [ButtonHealthRepository.buttonHealth] on success. Returns
+ * the typed result so the caller (the Manager) can react to Forbidden
+ * by unsubscribing from the FCM topic.
+ */
+class FetchButtonHealthUseCase(
+    private val repository: ButtonHealthRepository,
+) {
+    suspend operator fun invoke(idToken: String): AppResult<ButtonHealth, ButtonHealthError> = repository.fetchButtonHealth(idToken)
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ButtonHealthDisplayLogicTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ButtonHealthDisplayLogicTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.ButtonHealth
+import com.chriscartland.garage.domain.model.ButtonHealthState
+import com.chriscartland.garage.domain.model.DisplayName
+import com.chriscartland.garage.domain.model.Email
+import com.chriscartland.garage.domain.model.FirebaseIdToken
+import com.chriscartland.garage.domain.model.LoadingResult
+import com.chriscartland.garage.domain.model.User
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class ButtonHealthDisplayLogicTest {
+    private val now = 1_700_000_000L
+
+    private val signedIn = AuthState.Authenticated(
+        user = User(
+            name = DisplayName("Test User"),
+            email = Email("test@example.com"),
+            idToken = FirebaseIdToken(idToken = "tok", exp = 0L),
+        ),
+    )
+
+    @Test
+    fun signedOut_isUnauthorized() {
+        val display = ButtonHealthDisplayLogic.compute(
+            auth = AuthState.Unauthenticated,
+            health = LoadingResult.Complete(ButtonHealth(ButtonHealthState.OFFLINE, now - 100)),
+            nowSeconds = now,
+        )
+        assertEquals(ButtonHealthDisplay.Unauthorized, display)
+    }
+
+    @Test
+    fun authUnknown_isUnauthorized() {
+        val display = ButtonHealthDisplayLogic.compute(
+            auth = AuthState.Unknown,
+            health = LoadingResult.Complete(ButtonHealth(ButtonHealthState.ONLINE, now - 100)),
+            nowSeconds = now,
+        )
+        assertEquals(ButtonHealthDisplay.Unauthorized, display)
+    }
+
+    @Test
+    fun signedIn_loading_isLoading() {
+        val display = ButtonHealthDisplayLogic.compute(
+            auth = signedIn,
+            health = LoadingResult.Loading(null),
+            nowSeconds = now,
+        )
+        assertEquals(ButtonHealthDisplay.Loading, display)
+    }
+
+    @Test
+    fun signedIn_error_isLoading() {
+        val display = ButtonHealthDisplayLogic.compute(
+            auth = signedIn,
+            health = LoadingResult.Error(IllegalStateException("network")),
+            nowSeconds = now,
+        )
+        assertEquals(ButtonHealthDisplay.Loading, display)
+    }
+
+    @Test
+    fun signedIn_completeNullData_isLoading() {
+        val display = ButtonHealthDisplayLogic.compute(
+            auth = signedIn,
+            health = LoadingResult.Complete(null),
+            nowSeconds = now,
+        )
+        assertEquals(ButtonHealthDisplay.Loading, display)
+    }
+
+    @Test
+    fun signedIn_completeUnknown_isUnknown() {
+        val display = ButtonHealthDisplayLogic.compute(
+            auth = signedIn,
+            health = LoadingResult.Complete(ButtonHealth(ButtonHealthState.UNKNOWN, null)),
+            nowSeconds = now,
+        )
+        assertEquals(ButtonHealthDisplay.Unknown, display)
+    }
+
+    @Test
+    fun signedIn_completeOnline_isOnline() {
+        val display = ButtonHealthDisplayLogic.compute(
+            auth = signedIn,
+            health = LoadingResult.Complete(ButtonHealth(ButtonHealthState.ONLINE, now - 30)),
+            nowSeconds = now,
+        )
+        assertEquals(ButtonHealthDisplay.Online, display)
+    }
+
+    @Test
+    fun signedIn_completeOffline_isOfflineWithDurationLabel() {
+        val display = ButtonHealthDisplayLogic.compute(
+            auth = signedIn,
+            health = LoadingResult.Complete(ButtonHealth(ButtonHealthState.OFFLINE, now - 11 * 60)),
+            nowSeconds = now,
+        )
+        val offline = assertIs<ButtonHealthDisplay.Offline>(display)
+        assertEquals("11 min ago", offline.durationLabel)
+    }
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ButtonHealthDurationFormatterTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ButtonHealthDurationFormatterTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ButtonHealthDurationFormatterTest {
+    private val now = 1_700_000_000L
+
+    @Test
+    fun nullStateChangedAtSeconds_isUnknown() {
+        assertEquals("unknown", ButtonHealthDurationFormatter.formatAgo(null, now))
+    }
+
+    @Test
+    fun futureTimestamp_isJustNow() {
+        assertEquals("just now", ButtonHealthDurationFormatter.formatAgo(now + 100, now))
+    }
+
+    @Test
+    fun sameTimestamp_isJustNow() {
+        assertEquals("just now", ButtonHealthDurationFormatter.formatAgo(now, now))
+    }
+
+    @Test
+    fun secondsBucket() {
+        assertEquals("30 sec ago", ButtonHealthDurationFormatter.formatAgo(now - 30, now))
+        assertEquals("59 sec ago", ButtonHealthDurationFormatter.formatAgo(now - 59, now))
+    }
+
+    @Test
+    fun minutesBucket() {
+        assertEquals("1 min ago", ButtonHealthDurationFormatter.formatAgo(now - 60, now))
+        assertEquals("11 min ago", ButtonHealthDurationFormatter.formatAgo(now - 11 * 60, now))
+        assertEquals("59 min ago", ButtonHealthDurationFormatter.formatAgo(now - 59 * 60, now))
+    }
+
+    @Test
+    fun hoursBucket() {
+        assertEquals("1 hr ago", ButtonHealthDurationFormatter.formatAgo(now - 60 * 60, now))
+        assertEquals("23 hr ago", ButtonHealthDurationFormatter.formatAgo(now - 23 * 60 * 60, now))
+    }
+
+    @Test
+    fun daysBucket_singular() {
+        assertEquals("1 day ago", ButtonHealthDurationFormatter.formatAgo(now - 24 * 60 * 60, now))
+    }
+
+    @Test
+    fun daysBucket_plural() {
+        assertEquals("3 days ago", ButtonHealthDurationFormatter.formatAgo(now - 3L * 24 * 60 * 60, now))
+    }
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ButtonHealthFcmSubscriptionManagerTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ButtonHealthFcmSubscriptionManagerTest.kt
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.AppResult
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.ButtonHealth
+import com.chriscartland.garage.domain.model.ButtonHealthError
+import com.chriscartland.garage.domain.model.ButtonHealthState
+import com.chriscartland.garage.domain.model.DisplayName
+import com.chriscartland.garage.domain.model.Email
+import com.chriscartland.garage.domain.model.FirebaseIdToken
+import com.chriscartland.garage.domain.model.LoadingResult
+import com.chriscartland.garage.domain.model.ServerConfig
+import com.chriscartland.garage.domain.model.User
+import com.chriscartland.garage.domain.repository.AuthRepository
+import com.chriscartland.garage.domain.repository.ButtonHealthFcmRepository
+import com.chriscartland.garage.domain.repository.ButtonHealthRepository
+import com.chriscartland.garage.domain.repository.ServerConfigRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ButtonHealthFcmSubscriptionManagerTest {
+    private val signedInUser = AuthState.Authenticated(
+        user = User(
+            name = DisplayName("Test"),
+            email = Email("test@example.com"),
+            idToken = FirebaseIdToken(idToken = "token-xyz", exp = 0L),
+        ),
+    )
+
+    private val configWithButton = ServerConfig(
+        buildTimestamp = "door",
+        remoteButtonBuildTimestamp = "Sat Apr 10 23:57:32 2021",
+        remoteButtonPushKey = "key",
+    )
+
+    @Test
+    fun signedOut_signedIn_signedOut_subscribesThenUnsubscribes() =
+        runTest {
+            val auth = FakeAuthRepository(_authState = MutableStateFlow(AuthState.Unauthenticated))
+            val config = FakeServerConfigRepository(MutableStateFlow(configWithButton))
+            val fcm = FakeButtonHealthFcmRepository()
+            val repo = FakeButtonHealthRepository().apply {
+                setFetchResult(AppResult.Success(ButtonHealth(ButtonHealthState.ONLINE, 100L)))
+            }
+            val manager = ButtonHealthFcmSubscriptionManager(
+                authRepository = auth,
+                serverConfigRepository = config,
+                fcmRepository = fcm,
+                fetchButtonHealthUseCase = FetchButtonHealthUseCase(repo),
+                scope = backgroundScope,
+                dispatcher = StandardTestDispatcher(testScheduler),
+            )
+
+            manager.start()
+            testScheduler.runCurrent()
+            testScheduler.advanceUntilIdle()
+            // First emission: signed-out + config — unsubscribeAll only.
+            assertEquals(0, fcm.subscribeCount)
+            assertEquals(1, fcm.unsubscribeAllCount)
+
+            auth.setAuthState(signedInUser)
+            testScheduler.runCurrent()
+            testScheduler.advanceUntilIdle()
+            // Now signed in: unsubscribeAll then subscribe + fetch.
+            assertEquals(1, fcm.subscribeCount)
+            assertEquals("Sat Apr 10 23:57:32 2021", fcm.lastSubscribeBuildTimestamp)
+            assertEquals(1, repo.fetchCount)
+            assertEquals("token-xyz", repo.lastFetchIdToken)
+
+            auth.setAuthState(AuthState.Unauthenticated)
+            testScheduler.runCurrent()
+            testScheduler.advanceUntilIdle()
+            // Sign out: another unsubscribeAll, no new subscribe.
+            assertEquals(1, fcm.subscribeCount)
+            assertEquals(3, fcm.unsubscribeAllCount) // initial + transition out
+        }
+
+    @Test
+    fun forbiddenColdStartFetch_unsubscribesAfterSubscribing() =
+        runTest {
+            val auth = FakeAuthRepository(_authState = MutableStateFlow(signedInUser))
+            val config = FakeServerConfigRepository(MutableStateFlow(configWithButton))
+            val fcm = FakeButtonHealthFcmRepository()
+            val repo = FakeButtonHealthRepository().apply {
+                setFetchResult(AppResult.Error(ButtonHealthError.Forbidden()))
+            }
+            val manager = ButtonHealthFcmSubscriptionManager(
+                authRepository = auth,
+                serverConfigRepository = config,
+                fcmRepository = fcm,
+                fetchButtonHealthUseCase = FetchButtonHealthUseCase(repo),
+                scope = backgroundScope,
+                dispatcher = StandardTestDispatcher(testScheduler),
+            )
+
+            manager.start()
+            testScheduler.runCurrent()
+            testScheduler.advanceUntilIdle()
+
+            assertEquals(1, fcm.subscribeCount)
+            assertEquals(1, repo.fetchCount)
+            // Fetch returned Forbidden → manager unsubscribes again.
+            assertEquals(2, fcm.unsubscribeAllCount)
+        }
+
+    @Test
+    fun networkErrorColdStartFetch_keepsSubscription() =
+        runTest {
+            val auth = FakeAuthRepository(_authState = MutableStateFlow(signedInUser))
+            val config = FakeServerConfigRepository(MutableStateFlow(configWithButton))
+            val fcm = FakeButtonHealthFcmRepository()
+            val repo = FakeButtonHealthRepository().apply {
+                setFetchResult(AppResult.Error(ButtonHealthError.Network()))
+            }
+            val manager = ButtonHealthFcmSubscriptionManager(
+                authRepository = auth,
+                serverConfigRepository = config,
+                fcmRepository = fcm,
+                fetchButtonHealthUseCase = FetchButtonHealthUseCase(repo),
+                scope = backgroundScope,
+                dispatcher = StandardTestDispatcher(testScheduler),
+            )
+
+            manager.start()
+            testScheduler.runCurrent()
+            testScheduler.advanceUntilIdle()
+
+            assertEquals(1, fcm.subscribeCount)
+            // Network error — keep subscription, only the initial unsubscribeAll fired.
+            assertEquals(1, fcm.unsubscribeAllCount)
+        }
+
+    @Test
+    fun buildTimestampRotation_unsubscribesOldThenSubscribesNew() =
+        runTest {
+            val auth = FakeAuthRepository(_authState = MutableStateFlow(signedInUser))
+            val configFlow = MutableStateFlow(configWithButton)
+            val config = FakeServerConfigRepository(configFlow)
+            val fcm = FakeButtonHealthFcmRepository()
+            val repo = FakeButtonHealthRepository().apply {
+                setFetchResult(AppResult.Success(ButtonHealth(ButtonHealthState.ONLINE, 100L)))
+            }
+            val manager = ButtonHealthFcmSubscriptionManager(
+                authRepository = auth,
+                serverConfigRepository = config,
+                fcmRepository = fcm,
+                fetchButtonHealthUseCase = FetchButtonHealthUseCase(repo),
+                scope = backgroundScope,
+                dispatcher = StandardTestDispatcher(testScheduler),
+            )
+
+            manager.start()
+            testScheduler.runCurrent()
+            testScheduler.advanceUntilIdle()
+            assertEquals(1, fcm.subscribeCount)
+            assertEquals("Sat Apr 10 23:57:32 2021", fcm.lastSubscribeBuildTimestamp)
+
+            // Rotate buildTimestamp (firmware reflash).
+            configFlow.value = configWithButton.copy(remoteButtonBuildTimestamp = "Mon Jan 01 00:00:00 2024")
+            testScheduler.runCurrent()
+            testScheduler.advanceUntilIdle()
+
+            assertEquals(2, fcm.subscribeCount)
+            assertEquals("Mon Jan 01 00:00:00 2024", fcm.lastSubscribeBuildTimestamp)
+        }
+
+    @Test
+    fun startIsIdempotent() =
+        runTest {
+            val auth = FakeAuthRepository(_authState = MutableStateFlow(signedInUser))
+            val config = FakeServerConfigRepository(MutableStateFlow(configWithButton))
+            val fcm = FakeButtonHealthFcmRepository()
+            val repo = FakeButtonHealthRepository().apply {
+                setFetchResult(AppResult.Success(ButtonHealth(ButtonHealthState.ONLINE, 100L)))
+            }
+            val manager = ButtonHealthFcmSubscriptionManager(
+                authRepository = auth,
+                serverConfigRepository = config,
+                fcmRepository = fcm,
+                fetchButtonHealthUseCase = FetchButtonHealthUseCase(repo),
+                scope = backgroundScope,
+                dispatcher = StandardTestDispatcher(testScheduler),
+            )
+
+            manager.start()
+            manager.start()
+            testScheduler.runCurrent()
+            testScheduler.advanceUntilIdle()
+
+            // Second start() did not start a second collector.
+            assertEquals(1, fcm.subscribeCount)
+            assertEquals(1, repo.fetchCount)
+        }
+}
+
+// ---- Inline fakes (only this test uses them; promote to test-common when re-used) ----
+
+private class FakeAuthRepository(
+    private val _authState: MutableStateFlow<AuthState>,
+) : AuthRepository {
+    override val authState: StateFlow<AuthState> = _authState
+
+    fun setAuthState(state: AuthState) {
+        _authState.value = state
+    }
+
+    override suspend fun signInWithGoogle(idToken: com.chriscartland.garage.domain.model.GoogleIdToken): AuthState = _authState.value
+
+    override suspend fun refreshIdToken(): FirebaseIdToken? = null
+
+    @Suppress("DEPRECATION")
+    @Deprecated("legacy")
+    override suspend fun refreshFirebaseAuthState(): AuthState = _authState.value
+
+    override suspend fun signOut() {
+        _authState.value = AuthState.Unauthenticated
+    }
+}
+
+private class FakeServerConfigRepository(
+    private val _flow: StateFlow<ServerConfig?>,
+) : ServerConfigRepository {
+    override val serverConfig: StateFlow<ServerConfig?> = _flow
+
+    override suspend fun fetchServerConfig(): ServerConfig? = _flow.value
+}
+
+private class FakeButtonHealthRepository : ButtonHealthRepository {
+    private val state = MutableStateFlow<LoadingResult<ButtonHealth>>(LoadingResult.Loading(null))
+    override val buttonHealth: StateFlow<LoadingResult<ButtonHealth>> = state
+
+    private var fetchResult: AppResult<ButtonHealth, ButtonHealthError> =
+        AppResult.Success(ButtonHealth(ButtonHealthState.UNKNOWN, null))
+
+    private val fetchTokens = mutableListOf<String>()
+    val fetchCount: Int get() = fetchTokens.size
+    val lastFetchIdToken: String? get() = fetchTokens.lastOrNull()
+
+    fun setFetchResult(value: AppResult<ButtonHealth, ButtonHealthError>) {
+        fetchResult = value
+    }
+
+    override suspend fun fetchButtonHealth(idToken: String): AppResult<ButtonHealth, ButtonHealthError> {
+        fetchTokens.add(idToken)
+        return fetchResult
+    }
+
+    override fun applyFcmUpdate(update: ButtonHealth) {
+        state.value = LoadingResult.Complete(update)
+    }
+}
+
+private class FakeButtonHealthFcmRepository : ButtonHealthFcmRepository {
+    private val subscribeCalls = mutableListOf<String>()
+    val subscribeCount: Int get() = subscribeCalls.size
+    val lastSubscribeBuildTimestamp: String? get() = subscribeCalls.lastOrNull()
+
+    var unsubscribeAllCount: Int = 0
+
+    override suspend fun subscribe(buildTimestamp: String) {
+        subscribeCalls.add(buildTimestamp)
+    }
+
+    override suspend fun unsubscribeAll() {
+        unsubscribeAllCount++
+    }
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ComputeButtonHealthDisplayUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ComputeButtonHealthDisplayUseCaseTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.AppResult
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.ButtonHealth
+import com.chriscartland.garage.domain.model.ButtonHealthError
+import com.chriscartland.garage.domain.model.ButtonHealthState
+import com.chriscartland.garage.domain.model.DisplayName
+import com.chriscartland.garage.domain.model.Email
+import com.chriscartland.garage.domain.model.FirebaseIdToken
+import com.chriscartland.garage.domain.model.LoadingResult
+import com.chriscartland.garage.domain.model.User
+import com.chriscartland.garage.domain.repository.AuthRepository
+import com.chriscartland.garage.domain.repository.ButtonHealthRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ComputeButtonHealthDisplayUseCaseTest {
+    private val signedIn = AuthState.Authenticated(
+        user = User(
+            name = DisplayName("Test"),
+            email = Email("test@example.com"),
+            idToken = FirebaseIdToken(idToken = "tok", exp = 0L),
+        ),
+    )
+
+    @Test
+    fun emitsUnauthorizedWhenSignedOut() =
+        runTest {
+            val auth = TestAuthRepository(MutableStateFlow(AuthState.Unauthenticated))
+            val repo = TestButtonHealthRepository()
+            val clock = TestLiveClock(MutableStateFlow(1_700_000_000L))
+
+            val display = ComputeButtonHealthDisplayUseCase(auth, repo, clock).invoke().first()
+
+            assertEquals(ButtonHealthDisplay.Unauthorized, display)
+        }
+
+    @Test
+    fun emitsOnlineWhenSignedInAndComplete() =
+        runTest {
+            val auth = TestAuthRepository(MutableStateFlow(signedIn))
+            val now = 1_700_000_000L
+            val repo = TestButtonHealthRepository(
+                MutableStateFlow(LoadingResult.Complete(ButtonHealth(ButtonHealthState.ONLINE, now - 30))),
+            )
+            val clock = TestLiveClock(MutableStateFlow(now))
+
+            val display = ComputeButtonHealthDisplayUseCase(auth, repo, clock).invoke().first()
+
+            assertEquals(ButtonHealthDisplay.Online, display)
+        }
+
+    @Test
+    fun emitsOfflineWhenSignedInAndCompleteOffline() =
+        runTest {
+            val auth = TestAuthRepository(MutableStateFlow(signedIn))
+            val now = 1_700_000_000L
+            val repo = TestButtonHealthRepository(
+                MutableStateFlow(
+                    LoadingResult.Complete(ButtonHealth(ButtonHealthState.OFFLINE, now - 660)),
+                ),
+            )
+            val clock = TestLiveClock(MutableStateFlow(now))
+
+            val display = ComputeButtonHealthDisplayUseCase(auth, repo, clock).invoke().first()
+
+            val offline = assertIs<ButtonHealthDisplay.Offline>(display)
+            assertEquals("11 min ago", offline.durationLabel)
+        }
+}
+
+// ---- Inline fakes ----
+
+private class TestAuthRepository(
+    private val flow: StateFlow<AuthState>,
+) : AuthRepository {
+    override val authState: StateFlow<AuthState> = flow
+
+    override suspend fun signInWithGoogle(idToken: com.chriscartland.garage.domain.model.GoogleIdToken): AuthState = flow.value
+
+    override suspend fun refreshIdToken(): FirebaseIdToken? = null
+
+    @Suppress("DEPRECATION")
+    @Deprecated("legacy")
+    override suspend fun refreshFirebaseAuthState(): AuthState = flow.value
+
+    override suspend fun signOut() {}
+}
+
+private class TestButtonHealthRepository(
+    private val flow: StateFlow<LoadingResult<ButtonHealth>> =
+        MutableStateFlow(LoadingResult.Loading(null)),
+) : ButtonHealthRepository {
+    override val buttonHealth: StateFlow<LoadingResult<ButtonHealth>> = flow
+
+    override suspend fun fetchButtonHealth(idToken: String): AppResult<ButtonHealth, ButtonHealthError> =
+        AppResult.Error(ButtonHealthError.Network())
+
+    override fun applyFcmUpdate(update: ButtonHealth) {}
+}
+
+private class TestLiveClock(
+    private val flow: StateFlow<Long>,
+) : LiveClock {
+    override val nowEpochSeconds: StateFlow<Long> = flow
+
+    override fun start() {}
+}


### PR DESCRIPTION
## Summary
- PR 7 of 9 in the button health rollout per [docs/BUTTON_HEALTH_ARCHITECTURE.md](https://github.com/cartland/SmartGarageDoor/blob/main/docs/BUTTON_HEALTH_ARCHITECTURE.md).
- 7 new UseCase/Manager files + 4 new test files (24 new test cases). Dead code on Android side until PR 9 wires into AppComponent.
- All \`./scripts/validate.sh\` checks pass locally.

## Architecture compliance
- **ADR-009**: pure derivation in named \`object\`s (\`ButtonHealthDisplayLogic\`, \`ButtonHealthDurationFormatter\`).
- **ADR-015**: \`ButtonHealthFcmSubscriptionManager\` follows the canonical pattern (constructor-injects scope + dispatcher, \`start()\` is idempotent, mirrors \`FcmRegistrationManager\` and \`CheckInStalenessManager\`).
- **ADR-021/022**: no passthrough VM; UseCase returns \`Flow\` not \`StateFlow\`; consumer collects via \`collectAsStateWithLifecycle\`.

## Display sealed type (5 arms)
\`Unauthorized / Loading / Unknown / Online / Offline\` — only \`Offline\` renders the pill. Compiler-enforced exhaustive \`when\` everywhere.

## Manager pattern
Always-unsubscribe-then-conditionally-subscribe on every state change. Sidesteps the "did Firebase Task cancel?" question entirely.

## Test plan
- [x] All 24 new tests pass
- [x] No regressions to existing tests
- [x] State-table-style coverage (each display arm + each manager state transition has a test)
- [ ] CI green
- [ ] Dead code (no DI wiring) — harmless to merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)