### PR TITLE
feat(firebase): httpButtonHealth cold-start endpoint

### DIFF
--- a/FirebaseServer/src/functions/http/ButtonHealth.ts
+++ b/FirebaseServer/src/functions/http/ButtonHealth.ts
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import * as functions from 'firebase-functions/v1';
+
+import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
+import { DATABASE as BUTTON_HEALTH_DATABASE } from '../../database/ButtonHealthDatabase';
+import {
+  isRemoteButtonEnabled,
+  getRemoteButtonPushKey,
+  getRemoteButtonAuthorizedEmails,
+} from '../../controller/config/ConfigAccessors';
+import { isEmailInAllowlist } from '../../controller/Auth';
+import { SERVICE as AuthService } from '../../controller/AuthService';
+import { HandlerResult, ok, err } from '../HandlerResult';
+
+const BUILD_TIMESTAMP_PARAM_KEY = 'buildTimestamp';
+
+/**
+ * Cold-start endpoint for mobile clients. Returns the current health
+ * snapshot for the button device's buildTimestamp, or
+ * `{ buttonState: "UNKNOWN", stateChangedAtSeconds: null, ... }`
+ * when no buttonHealthCurrent doc exists yet.
+ *
+ * Auth chain mirrors handleAddRemoteButtonCommand byte-for-byte:
+ *   config-enabled → push-key-header → push-key-match →
+ *   id-token-header → verifyIdToken → email-authorized
+ *
+ * Same caveat as handleAddRemoteButtonCommand: verifyIdToken is NOT
+ * wrapped in try/catch — malformed tokens propagate to the wrapper's
+ * outer catch and yield 500 (not 401). Consistency with the existing
+ * button auth handler is more important than the asymmetry with
+ * Snooze (which wraps and returns 401).
+ */
+export async function handleButtonHealth(input: {
+  query: any;
+  pushKeyHeader: string | undefined;
+  googleIdTokenHeader: string | undefined;
+}): Promise<HandlerResult<any>> {
+  const config = await ServerConfigDatabase.get();
+  if (!isRemoteButtonEnabled(config)) {
+    return err(400, { error: 'Disabled' });
+  }
+  if (!input.pushKeyHeader || input.pushKeyHeader.length <= 0) {
+    const result = { error: 'Unauthorized (key).' };
+    console.error(result);
+    return err(401, result);
+  }
+  if (getRemoteButtonPushKey(config) !== input.pushKeyHeader) {
+    const result = { error: 'Forbidden (key).' };
+    console.error(result);
+    return err(403, result);
+  }
+  if (!input.googleIdTokenHeader || input.googleIdTokenHeader.length <= 0) {
+    const result = { error: 'Unauthorized (token).' };
+    console.error(result);
+    return err(401, result);
+  }
+  // Deliberately no try/catch — see doc above.
+  const decodedToken = await AuthService.verifyIdToken(input.googleIdTokenHeader);
+  const email = decodedToken.email;
+  const authorizedEmails = getRemoteButtonAuthorizedEmails(config);
+  if (!isEmailInAllowlist(email, authorizedEmails)) {
+    const result = { error: 'Forbidden (user).' };
+    console.error(result);
+    return err(403, result);
+  }
+
+  const buildTimestamp: string | undefined = input.query?.[BUILD_TIMESTAMP_PARAM_KEY];
+  if (!buildTimestamp || typeof buildTimestamp !== 'string' || buildTimestamp.length === 0) {
+    return err(400, { error: 'Missing required parameter: ' + BUILD_TIMESTAMP_PARAM_KEY });
+  }
+
+  const record = await BUTTON_HEALTH_DATABASE.getCurrent(buildTimestamp);
+  if (!record) {
+    // No doc yet — wire returns UNKNOWN per the design's bootstrap behavior.
+    return ok({
+      buildTimestamp,
+      buttonState: 'UNKNOWN',
+      stateChangedAtSeconds: null,
+    });
+  }
+  return ok({
+    buildTimestamp,
+    buttonState: record.state,
+    stateChangedAtSeconds: record.stateChangedAtSeconds,
+  });
+}
+
+/**
+ * curl -H "X-RemoteButtonPushKey: <key>" -H "X-AuthTokenGoogle: <id-token>" \
+ *   "https://.../buttonHealth?buildTimestamp=<bt>"
+ */
+export const httpButtonHealth = functions.https.onRequest(async (request, response) => {
+  try {
+    const result = await handleButtonHealth({
+      query: request.query,
+      pushKeyHeader: request.get('X-RemoteButtonPushKey'),
+      googleIdTokenHeader: request.get('X-AuthTokenGoogle'),
+    });
+    if (result.kind === 'error') {
+      response.status(result.status).send(result.body);
+    } else {
+      response.status(200).send(result.data);
+    }
+  } catch (error) {
+    // Catches a propagated AuthService.verifyIdToken throw — yields 500,
+    // matching handleAddRemoteButtonCommand's behavior.
+    console.error(error);
+    response.status(500).send(error);
+  }
+});

--- a/FirebaseServer/src/index.ts
+++ b/FirebaseServer/src/index.ts
@@ -27,6 +27,7 @@ import { httpDeleteOldData } from './functions/http/DeleteData'
 import { httpServerConfig, httpServerConfigUpdate } from './functions/http/ServerConfig'
 import { httpSnoozeNotificationsRequest, httpSnoozeNotificationsLatest} from './functions/http/Snooze'
 import { httpFunctionListAccess } from './functions/http/FunctionListAccess'
+import { httpButtonHealth } from './functions/http/ButtonHealth'
 
 // Pubsub Functions.
 import { pubsubCheckForDoorErrors } from './functions/pubsub/DoorErrors'
@@ -274,4 +275,19 @@ if (!process.env.FUNCTION_NAME || process.env.FUNCTION_NAME === 'snoozeNotificat
  */
 if (!process.env.FUNCTION_NAME || process.env.FUNCTION_NAME === 'functionListAccess') {
   exports.functionListAccess = httpFunctionListAccess;
+}
+
+/**
+ * Mobile cold-start fetch for the remote-button device's online/offline state.
+ *
+ * Trigger Type: HTTP (allowlist-gated)
+ *
+ * Auth chain mirrors addRemoteButtonCommand: push key + Google ID token +
+ * email allowlist. Returns the current buttonHealthCurrent doc, or
+ * UNKNOWN/null when no doc exists yet.
+ *
+ * See docs/BUTTON_HEALTH_ARCHITECTURE.md.
+ */
+if (!process.env.FUNCTION_NAME || process.env.FUNCTION_NAME === 'buttonHealth') {
+  exports.buttonHealth = httpButtonHealth;
 }

--- a/FirebaseServer/test/functions/http/HttpButtonHealthTest.ts
+++ b/FirebaseServer/test/functions/http/HttpButtonHealthTest.ts
@@ -1,0 +1,180 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { handleButtonHealth } from '../../../src/functions/http/ButtonHealth';
+import {
+  setImpl as setServerConfigDBImpl,
+  resetImpl as resetServerConfigDBImpl,
+} from '../../../src/database/ServerConfigDatabase';
+import {
+  setImpl as setButtonHealthDBImpl,
+  resetImpl as resetButtonHealthDBImpl,
+} from '../../../src/database/ButtonHealthDatabase';
+import {
+  setImpl as setAuthServiceImpl,
+  resetImpl as resetAuthServiceImpl,
+} from '../../../src/controller/AuthService';
+import { FakeServerConfigDatabase } from '../../fakes/FakeServerConfigDatabase';
+import { FakeButtonHealthDatabase } from '../../fakes/FakeButtonHealthDatabase';
+import { FakeAuthService } from '../../fakes/FakeAuthService';
+
+const ALLOWED_EMAIL = 'allowed@example.com';
+const DENIED_EMAIL = 'denied@example.com';
+const PUSH_KEY = 'test-push-key';
+const OK_TOKEN = 'google-id-token-xyz';
+const BUILD_TIMESTAMP = 'Sat Apr 10 23:57:32 2021';
+
+// Wire-contract fixtures shared with Android's KtorButtonHealthDataSourceTest.
+const FIXTURE_DIR = path.join(__dirname, '..', '..', '..', '..', 'wire-contracts', 'buttonHealth');
+const ONLINE_FIXTURE = JSON.parse(
+  fs.readFileSync(path.join(FIXTURE_DIR, 'response_online.json'), 'utf8'),
+);
+const OFFLINE_FIXTURE = JSON.parse(
+  fs.readFileSync(path.join(FIXTURE_DIR, 'response_offline.json'), 'utf8'),
+);
+const UNKNOWN_FIXTURE = JSON.parse(
+  fs.readFileSync(path.join(FIXTURE_DIR, 'response_unknown.json'), 'utf8'),
+);
+const UNAUTHORIZED_FIXTURE = JSON.parse(
+  fs.readFileSync(path.join(FIXTURE_DIR, 'response_unauthorized.json'), 'utf8'),
+);
+const FORBIDDEN_USER_FIXTURE = JSON.parse(
+  fs.readFileSync(path.join(FIXTURE_DIR, 'response_forbidden_user.json'), 'utf8'),
+);
+
+describe('handleButtonHealth (pure handler core)', () => {
+  let fakeConfig: FakeServerConfigDatabase;
+  let fakeAuth: FakeAuthService;
+  let fakeHealthDB: FakeButtonHealthDatabase;
+
+  beforeEach(() => {
+    fakeConfig = new FakeServerConfigDatabase();
+    fakeAuth = new FakeAuthService();
+    fakeHealthDB = new FakeButtonHealthDatabase();
+    setServerConfigDBImpl(fakeConfig);
+    setAuthServiceImpl(fakeAuth);
+    setButtonHealthDBImpl(fakeHealthDB);
+    fakeConfig.seed({
+      body: {
+        remoteButtonEnabled: true,
+        remoteButtonPushKey: PUSH_KEY,
+        remoteButtonAuthorizedEmails: [ALLOWED_EMAIL],
+      },
+    });
+    fakeAuth.seedDecoded({ email: ALLOWED_EMAIL });
+  });
+
+  afterEach(() => {
+    resetServerConfigDBImpl();
+    resetAuthServiceImpl();
+    resetButtonHealthDBImpl();
+  });
+
+  const happyInput = (overrides: any = {}) => ({
+    query: { buildTimestamp: BUILD_TIMESTAMP },
+    pushKeyHeader: PUSH_KEY,
+    googleIdTokenHeader: OK_TOKEN,
+    ...overrides,
+  });
+
+  // ---- Auth chain (mirrors handleAddRemoteButtonCommand byte-for-byte) ----
+
+  it('returns 400 Disabled when remoteButtonEnabled is false', async () => {
+    fakeConfig.seed({ body: { remoteButtonEnabled: false } });
+    const result = await handleButtonHealth(happyInput());
+    expect(result).to.deep.equal({ kind: 'error', status: 400, body: { error: 'Disabled' } });
+  });
+
+  it('returns 401 Unauthorized (key) when push-key header is missing', async () => {
+    const result = await handleButtonHealth(happyInput({ pushKeyHeader: undefined }));
+    expect(result.kind).to.equal('error');
+    expect(result).to.deep.include({ status: 401 });
+  });
+
+  it('returns 403 Forbidden (key) when push-key header does not match', async () => {
+    const result = await handleButtonHealth(happyInput({ pushKeyHeader: 'wrong-key' }));
+    expect(result.kind).to.equal('error');
+    expect(result).to.deep.include({ status: 403 });
+  });
+
+  it('returns 401 Unauthorized (token) when googleIdToken header is missing', async () => {
+    const result = await handleButtonHealth(happyInput({ googleIdTokenHeader: undefined }));
+    expect(result.kind).to.equal('error');
+    expect(result).to.deep.equal(
+      { kind: 'error', status: 401, body: UNAUTHORIZED_FIXTURE },
+    );
+  });
+
+  it('returns 403 Forbidden (user) when email is not in allowlist', async () => {
+    fakeAuth.seedDecoded({ email: DENIED_EMAIL });
+    const result = await handleButtonHealth(happyInput());
+    expect(result).to.deep.equal(
+      { kind: 'error', status: 403, body: FORBIDDEN_USER_FIXTURE },
+    );
+  });
+
+  it('propagates verifyIdToken throw to the wrapper (matches handleAddRemoteButtonCommand)', async () => {
+    fakeAuth.failNextVerify(new Error('bad token'));
+    let threw = false;
+    try {
+      await handleButtonHealth(happyInput());
+    } catch (_e) {
+      threw = true;
+    }
+    expect(threw).to.equal(true);
+  });
+
+  // ---- Param validation ----
+
+  it('returns 400 when buildTimestamp is missing', async () => {
+    const result = await handleButtonHealth(happyInput({ query: {} }));
+    expect(result).to.deep.equal({
+      kind: 'error',
+      status: 400,
+      body: { error: 'Missing required parameter: buildTimestamp' },
+    });
+  });
+
+  it('returns 400 when buildTimestamp is empty', async () => {
+    const result = await handleButtonHealth(happyInput({ query: { buildTimestamp: '' } }));
+    expect(result.kind).to.equal('error');
+    expect(result).to.deep.include({ status: 400 });
+  });
+
+  // ---- Success cases (deep-equal against shared wire-contract fixtures) ----
+
+  it('returns the ONLINE fixture when buttonHealthCurrent has ONLINE', async () => {
+    fakeHealthDB.seed(BUILD_TIMESTAMP, {
+      state: 'ONLINE',
+      stateChangedAtSeconds: 1730000000,
+    });
+    const result = await handleButtonHealth(happyInput());
+    expect(result).to.deep.equal({ kind: 'ok', data: ONLINE_FIXTURE });
+  });
+
+  it('returns the OFFLINE fixture when buttonHealthCurrent has OFFLINE', async () => {
+    fakeHealthDB.seed(BUILD_TIMESTAMP, {
+      state: 'OFFLINE',
+      stateChangedAtSeconds: 1730000000,
+    });
+    const result = await handleButtonHealth(happyInput());
+    expect(result).to.deep.equal({ kind: 'ok', data: OFFLINE_FIXTURE });
+  });
+
+  it('returns the UNKNOWN fixture when no buttonHealthCurrent doc exists', async () => {
+    // No fakeHealthDB.seed call.
+    const result = await handleButtonHealth(happyInput());
+    expect(result).to.deep.equal({ kind: 'ok', data: UNKNOWN_FIXTURE });
+  });
+});


### PR DESCRIPTION
## Summary
- PR 5 of 9 in the button health rollout per [docs/BUTTON_HEALTH_ARCHITECTURE.md](https://github.com/cartland/SmartGarageDoor/blob/main/docs/BUTTON_HEALTH_ARCHITECTURE.md).
- **Completes the server-side work.** After this lands, server is ready to be released and the new collection + trigger + pubsub + endpoint are live in production. The Android side (PRs 7, 8, 9) brings the user-visible indicator.
- 11 new tests including 5 wire-contract round-trip tests against the shared \`wire-contracts/buttonHealth/\` fixtures.

## Auth chain mirrors handleAddRemoteButtonCommand
Same byte-for-byte: enabled → push-key → token → verify → allowlist. Same try/catch-around-verifyIdToken absence (yields 500 on malformed tokens — preserved deliberately for consistency with the existing button auth handler).

## Wire-contract round-trip
Test deep-equals against the canonical fixtures shared with Android's \`KtorButtonHealthDataSourceTest\`:
- \`response_online.json\`
- \`response_offline.json\`
- \`response_unknown.json\` (returned when no doc exists yet)
- \`response_unauthorized.json\` (401 body)
- \`response_forbidden_user.json\` (403 body)

## Test plan
- [x] \`./scripts/validate-firebase.sh\` passes (309 tests, +11 new)
- [x] Auth chain fully covered (5 tests, one per step)
- [x] Param validation covered
- [x] Wire-contract fixtures deep-equaled on success + 401/403
- [ ] CI green
- [ ] Server release \`server/N+1\` after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)