### PR TITLE
ui(android): RemoteOfflinePill + previews + screenshot tests

### DIFF
--- a/AndroidGarage/android-screenshot-tests/PREVIEW_COVERAGE.md
+++ b/AndroidGarage/android-screenshot-tests/PREVIEW_COVERAGE.md
@@ -3,7 +3,7 @@
 
 # Preview Screenshot Coverage
 
-**70 / 70 (100%)**
+**74 / 74 (100%)**
 
 ## Covered
 
@@ -66,6 +66,10 @@
 - `RemoteButtonContentSendingToServerPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/RemoteButtonContent.kt`
 - `RemoteButtonContentServerFailedPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/RemoteButtonContent.kt`
 - `RemoteButtonContentSucceededPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/RemoteButtonContent.kt`
+- `RemoteOfflinePillAgingPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/RemoteOfflinePill.kt`
+- `RemoteOfflinePillFreshPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/RemoteOfflinePill.kt`
+- `RemoteOfflinePillStalePreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/RemoteOfflinePill.kt`
+- `RemoteOfflinePillVeryStalePreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/RemoteOfflinePill.kt`
 - `SettingsContentSignedInAllowlistedPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt`
 - `SettingsContentSignedInBasicPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt`
 - `SettingsContentSignedOutPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt`

--- a/AndroidGarage/android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/ComponentsScreenshotTest.kt
+++ b/AndroidGarage/android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/ComponentsScreenshotTest.kt
@@ -31,6 +31,10 @@ import com.chriscartland.garage.ui.RemoteButtonContentSendingToDoorPreview
 import com.chriscartland.garage.ui.RemoteButtonContentSendingToServerPreview
 import com.chriscartland.garage.ui.RemoteButtonContentServerFailedPreview
 import com.chriscartland.garage.ui.RemoteButtonContentSucceededPreview
+import com.chriscartland.garage.ui.RemoteOfflinePillAgingPreview
+import com.chriscartland.garage.ui.RemoteOfflinePillFreshPreview
+import com.chriscartland.garage.ui.RemoteOfflinePillStalePreview
+import com.chriscartland.garage.ui.RemoteOfflinePillVeryStalePreview
 import com.chriscartland.garage.ui.TitleBarCheckInPillAgingPreview
 import com.chriscartland.garage.ui.TitleBarCheckInPillFreshPreview
 import com.chriscartland.garage.ui.TitleBarCheckInPillNoDataPreview
@@ -425,4 +429,52 @@ fun TitleBarCheckInPillStalePreviewTest() {
 @Composable
 fun TitleBarCheckInPillNoDataPreviewTest() {
     AppTheme { TitleBarCheckInPillNoDataPreview() }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun RemoteOfflinePillFreshPreviewTest() {
+    AppTheme { RemoteOfflinePillFreshPreview() }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun RemoteOfflinePillAgingPreviewTest() {
+    AppTheme { RemoteOfflinePillAgingPreview() }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun RemoteOfflinePillStalePreviewTest() {
+    AppTheme { RemoteOfflinePillStalePreview() }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun RemoteOfflinePillVeryStalePreviewTest() {
+    AppTheme { RemoteOfflinePillVeryStalePreview() }
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/RemoteOfflinePill.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/RemoteOfflinePill.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.SignalWifiOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.chriscartland.garage.ui.theme.PreviewSurface
+import com.chriscartland.garage.usecase.ButtonHealthDisplay
+
+/**
+ * Compact rounded-pill indicator that the remote-button device is offline.
+ *
+ * Lives in the Home tab's "Remote control" section header (right-aligned,
+ * in-line with the section label). Mirrors [TitleBarCheckInPill]'s structure
+ * so both indicators speak the same visual grammar.
+ *
+ * Stateless: pass a pre-formatted [ButtonHealthDisplay.Offline]. The
+ * duration label comes from the LiveClock-driven flow in the caller
+ * (typically `RemoteButtonViewModel.buttonHealthDisplay`).
+ *
+ * Always renders in the error palette: `errorContainer` background +
+ * `onErrorContainer` content. The pill is only ever rendered when state
+ * is OFFLINE — the four other [ButtonHealthDisplay] arms render no pill,
+ * so this Composable doesn't carry a fresh/stale toggle.
+ *
+ * Uses Material 24-viewport `Icons.Outlined.SignalWifiOff`. Custom
+ * 960-viewport vectors inside section header rows have been observed to
+ * silently drop the section from screenshot capture (see CLAUDE.md
+ * "Layoutlib gotcha"); Material icons avoid the issue.
+ */
+@Composable
+fun RemoteOfflinePill(
+    display: ButtonHealthDisplay.Offline,
+    modifier: Modifier = Modifier,
+) {
+    val pillShape = RoundedCornerShape(50)
+    CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onErrorContainer) {
+        Box(
+            modifier = modifier
+                .background(color = MaterialTheme.colorScheme.errorContainer, shape = pillShape)
+                .padding(start = 8.dp, end = 4.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = "Remote offline · ${display.durationLabel}",
+                    style = MaterialTheme.typography.labelSmall,
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Icon(
+                    modifier = Modifier.size(17.dp),
+                    imageVector = Icons.Outlined.SignalWifiOff,
+                    tint = LocalContentColor.current,
+                    contentDescription = "Remote offline, last seen ${display.durationLabel}",
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun RemoteOfflinePillFreshPreview() {
+    PreviewSurface {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            RemoteOfflinePill(display = ButtonHealthDisplay.Offline(durationLabel = "1 min ago"))
+        }
+    }
+}
+
+@Preview
+@Composable
+fun RemoteOfflinePillAgingPreview() {
+    PreviewSurface {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            RemoteOfflinePill(display = ButtonHealthDisplay.Offline(durationLabel = "11 min ago"))
+        }
+    }
+}
+
+@Preview
+@Composable
+fun RemoteOfflinePillStalePreview() {
+    PreviewSurface {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            RemoteOfflinePill(display = ButtonHealthDisplay.Offline(durationLabel = "2 hr ago"))
+        }
+    }
+}
+
+@Preview
+@Composable
+fun RemoteOfflinePillVeryStalePreview() {
+    PreviewSurface {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            RemoteOfflinePill(display = ButtonHealthDisplay.Offline(durationLabel = "3 days ago"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- PR 8 of 9 in the button health rollout per [docs/BUTTON_HEALTH_ARCHITECTURE.md](https://github.com/cartland/SmartGarageDoor/blob/main/docs/BUTTON_HEALTH_ARCHITECTURE.md).
- UI-only. No production wiring yet (PR 9 adds HomeContent collection + pass-through). Pill is dead code on Android side until PR 9 lands; safe to merge with auto-merge.

## Visual design
Mirrors \`TitleBarCheckInPill\` (the 2.9.4+ device check-in pill):
- Same rounded-pill shape
- Same \`Icons.Outlined.SignalWifiOff\` icon (Material 24-viewport — avoids Layoutlib gotcha)
- Same M3 errorContainer palette when offline
- Result: one consistent visual vocabulary for "device problem" across both pills

## Preview coverage
4 previews: Fresh (1 min ago), Aging (11 min — just past OFFLINE threshold), Stale (2 hr), VeryStale (3 days). Each gets a \`@PreviewTest\` wrapper in \`ComponentsScreenshotTest.kt\` (Light + Dark variants). \`checkPreviewCoverage\` enforces this (build fails otherwise).

## Test plan
- [x] \`./scripts/validate.sh\` passes including \`checkPreviewCoverage\` (74/74 previews covered)
- [x] Stateless Composable — pure rendering, no state to test beyond the screenshot
- [ ] CI green
- [ ] Dead code; harmless to merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)