### PR TITLE
docs: Add stat-cache hint to release-script section in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,13 @@ The script computes the next tag as `android/<highest + 1>`. The `--confirm-tag`
 
 The changelog and the Play Store whatsnew are different files: `CHANGELOG.md` is the permanent internal history (every version, patches included); `distribution/whatsnew/` is rolling and only covers the current minor/major. Missing changelog entries silently went unnoticed through 2.5.0 (added in #548) — the gate closes that gap.
 
+**Stat-cache stale after `validate.sh`** (recurring — observed in `android/193`, `android/194`, and `server/24` releases). When the release script reports `Working tree has uncommitted changes` but `git status --short` is empty, it's git's stat-cache holding stale `lstat` info from files validate.sh touched (Gradle build outputs, marker file write). The release script's quick check uses timestamps; when they look new but content is identical, it falsely flags dirty. Fix:
+```bash
+git update-index --refresh > /dev/null 2>&1   # forces git to re-stat everything
+./scripts/release-android.sh --confirm-tag android/N    # then retry
+```
+Same pattern works for `release-firebase.sh`. The stat-cache refresh is harmless either way; safe to run before every release-script retry. (Both Android and Firebase release scripts share the same `git diff-index --quiet HEAD --` check pattern.)
+
 **Rollback requires two steps** (intentionally hard to do accidentally):
 ```bash
 git checkout android/M                 # 1. move HEAD to the commit you want to re-release


### PR DESCRIPTION
## Summary
Captures a recurring operational gotcha: the release scripts report \`Working tree has uncommitted changes\` but \`git status --short\` is empty — git's stat-cache is stale because validate.sh just touched files. \`git update-index --refresh\` fixes it; re-run the release command.

This recurred 3 times in the 2026-05-05 button-health release session (\`android/193\`, \`android/194\`, \`server/24\`). Was previously noted as "document if it recurs"; now documented.

## Test plan
- [x] CLAUDE.md frontmatter check passes (no docs that need YAML changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)