### PR TITLE
docs: Dump session context — list new hooks in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,6 +403,8 @@ Do not just tell the user to run it — the next Stop hook fires before they can
 - **check-pr-backlog.sh** — Warns at 5+ open PRs, blocks at 10+
 - **dev-mode.sh** — Keeps Claude working when `.claude/.dev-mode` exists
 - **warn-shell-loops.sh** — Warns on `for`/`while` loops (prefer separate Bash calls)
+- **warn-command-substitution.sh** — Warns on `$(...)` command substitution (harder to review)
+- **block-large-image-read.sh** — Blocks Read on images whose long edge exceeds 2000px (many-image conversations reject these with InputValidationError). Only Read; Write/Edit/Bash unaffected so scripts can still generate and commit oversized PNGs (e.g. 1294×2744 framed screenshots). Resize and Read the smaller copy: `sips -Z 2000 path/to/image.png --out /tmp/preview.png`. Added in PR #649.
 
 ### Testing Philosophy
 - Tests must add value — no coverage for coverage's sake


### PR DESCRIPTION
## Summary

Adds two missing entries to the Claude Hooks list in CLAUDE.md:

- **block-large-image-read.sh** — added in PR #649 this session, blocks Read on images >2000px on the long edge (resize-and-Read workaround included in the description)
- **warn-command-substitution.sh** — long-standing hook that wasn't listed

Memory updates (machine-local, not in this PR):
- `project_developer_allowlist_pending.md` — pointer that the dedicated Developer allowlist flag is the next follow-up to PR #648
- `project_home_permission_banner_copy.md` — production permission-banner copy is wordy; visible since PR #656 made the preview honest
- `project_button_health_shipped.md` updated with `android/196` (2.10.2) entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)