### PR TITLE
feat(android): Cap AppLogger Room rows per-key (1000); fix deleteAll bug

### DIFF
--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/db/DatabaseSanityTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/db/DatabaseSanityTest.kt
@@ -103,6 +103,75 @@ class DatabaseSanityTest {
     }
 
     @Test
+    fun insertAndPruneKey_keepsMostRecentRowsUpToLimit() {
+        // Insert 5 rows; cap to 3. Oldest 2 should be evicted; newest 3 retained.
+        for (i in 1..5) {
+            db.appLoggerDao().insertAndPruneKey(
+                appEvent = AppEvent(eventKey = "k", timestamp = i.toLong()),
+                limit = 3,
+            )
+        }
+
+        val rows = runBlocking { db.appLoggerDao().getAll().first() }
+        assertEquals("Should keep at most 3 rows for the key", 3, rows.size)
+        assertEquals(
+            "Most recent timestamps retained",
+            listOf(3L, 4L, 5L),
+            rows.map { it.timestamp }.sorted(),
+        )
+    }
+
+    @Test
+    fun insertAndPruneKey_doesNotAffectOtherKeys() {
+        // High-volume key + a single low-volume key. Cap each to 2.
+        for (i in 1..5) {
+            db.appLoggerDao().insertAndPruneKey(
+                appEvent = AppEvent(eventKey = "noisy", timestamp = i.toLong()),
+                limit = 2,
+            )
+        }
+        db.appLoggerDao().insertAndPruneKey(
+            appEvent = AppEvent(eventKey = "quiet", timestamp = 100L),
+            limit = 2,
+        )
+
+        val all = runBlocking { db.appLoggerDao().getAll().first() }
+        val noisy = all.filter { it.eventKey == "noisy" }
+        val quiet = all.filter { it.eventKey == "quiet" }
+        assertEquals("Noisy key capped at 2", 2, noisy.size)
+        assertEquals("Quiet key untouched", 1, quiet.size)
+    }
+
+    @Test
+    fun pruneAllKeys_trimsLegacyRowsForEveryKey() {
+        // Simulate the migration case: many existing rows pre-cap.
+        for (i in 1..10) {
+            db.appLoggerDao().insert(AppEvent(eventKey = "a", timestamp = i.toLong()))
+        }
+        for (i in 1..7) {
+            db.appLoggerDao().insert(AppEvent(eventKey = "b", timestamp = i.toLong()))
+        }
+
+        db.appLoggerDao().pruneAllKeys(limit = 4)
+
+        val all = runBlocking { db.appLoggerDao().getAll().first() }
+        assertEquals("Both keys trimmed to limit", 8, all.size)
+        assertEquals(4, all.count { it.eventKey == "a" })
+        assertEquals(4, all.count { it.eventKey == "b" })
+    }
+
+    @Test
+    fun deleteAllAppEvents_clearsTheTable() {
+        db.appLoggerDao().insert(AppEvent(eventKey = "k", timestamp = 1L))
+        db.appLoggerDao().insert(AppEvent(eventKey = "k", timestamp = 2L))
+
+        db.appLoggerDao().deleteAllAppEvents()
+
+        val rows = runBlocking { db.appLoggerDao().getAll().first() }
+        assertEquals("Table should be empty", 0, rows.size)
+    }
+
+    @Test
     fun doorEventReplaceAll() {
         val events = listOf(
             DoorEventEntity(

--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/db/DatabaseSanityTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/db/DatabaseSanityTest.kt
@@ -23,6 +23,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.chriscartland.garage.datalocal.AppDatabase
 import com.chriscartland.garage.datalocal.AppEvent
 import com.chriscartland.garage.datalocal.DoorEventEntity
+import com.chriscartland.garage.datalocal.RoomAppLoggerRepository
 import com.chriscartland.garage.domain.model.DoorPosition
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -169,6 +170,31 @@ class DatabaseSanityTest {
 
         val rows = runBlocking { db.appLoggerDao().getAll().first() }
         assertEquals("Table should be empty", 0, rows.size)
+    }
+
+    /**
+     * Wires through the actual [RoomAppLoggerRepository.log] (not the DAO
+     * directly) to prove `log()` honors the per-write cap. Without this
+     * test, a future regression that swapped `insertAndPruneKey` back to
+     * `insert` inside the repository would pass every other test.
+     */
+    @Test
+    fun roomAppLoggerRepositoryLog_capsAtPerKeyLimit() {
+        val repo = RoomAppLoggerRepository(
+            appDatabase = db,
+            appVersion = "test",
+            perKeyLimit = 3,
+        )
+
+        runBlocking {
+            // Log 5 events for the same key.
+            for (i in 1..5) {
+                repo.log("repo_key")
+            }
+        }
+
+        val rows = runBlocking { db.appLoggerDao().getAll().first() }
+        assertEquals("Repo log() should cap at perKeyLimit", 3, rows.size)
     }
 
     @Test

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/AppStartup.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/AppStartup.kt
@@ -65,6 +65,14 @@ class AppStartup(
         appLoggerViewModel.log(AppLoggerKeys.ON_CREATE_FCM_SUBSCRIBE_TOPIC)
         actions.add("logFcmSubscribe")
 
+        // One-shot trim of any keys that grew past the per-key cap before
+        // the cap was added (existing installs may have ~50K rows). The
+        // per-write cap inside log() keeps it bounded going forward, so
+        // this only matters for the migration case.
+        Logger.d { "AppStartup: Pruning old AppLogger entries" }
+        appLoggerViewModel.pruneOldEntries()
+        actions.add("pruneAppLogger")
+
         return actions
     }
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -97,6 +97,7 @@ import com.chriscartland.garage.usecase.ObserveAuthStateUseCase
 import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
 import com.chriscartland.garage.usecase.ObserveFeatureAccessUseCase
 import com.chriscartland.garage.usecase.ObserveSnoozeStateUseCase
+import com.chriscartland.garage.usecase.PruneAppLogUseCase
 import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
 import com.chriscartland.garage.usecase.ReceiveFcmDoorEventUseCase
 import com.chriscartland.garage.usecase.RegisterFcmUseCase
@@ -197,8 +198,12 @@ abstract class AppComponent(
     fun provideAppLoggerViewModel(
         logAppEvent: LogAppEventUseCase,
         observeAppLogCount: ObserveAppLogCountUseCase,
+        pruneAppLog: PruneAppLogUseCase,
         dispatchers: DispatcherProvider,
-    ): DefaultAppLoggerViewModel = DefaultAppLoggerViewModel(logAppEvent, observeAppLogCount, dispatchers)
+    ): DefaultAppLoggerViewModel = DefaultAppLoggerViewModel(logAppEvent, observeAppLogCount, pruneAppLog, dispatchers)
+
+    @Provides
+    fun providePruneAppLogUseCase(appLoggerRepository: AppLoggerRepository): PruneAppLogUseCase = PruneAppLogUseCase(appLoggerRepository)
 
     @Provides
     fun provideAppSettingsViewModel(

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/AppStartupTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/AppStartupTest.kt
@@ -123,9 +123,14 @@ class AppStartupTest {
 
     private class FakeAppLoggerViewModel : AppLoggerViewModel {
         val loggedKeys = mutableListOf<String>()
+        val pruneCalls = mutableListOf<Int>()
 
         override fun log(key: String) {
             loggedKeys.add(key)
+        }
+
+        override fun pruneOldEntries(perKeyLimit: Int) {
+            pruneCalls.add(perKeyLimit)
         }
 
         override val initCurrentDoorCount = MutableStateFlow(0L)
@@ -175,8 +180,27 @@ class AppStartupTest {
                 "startLiveClock",
                 "startButtonHealthFcmSubscription",
                 "logFcmSubscribe",
+                "pruneAppLogger",
             ),
             result,
+        )
+    }
+
+    @Test
+    fun onActivityCreated_prunesAppLoggerWithDefaultLimit() {
+        val scope = TestScope(testDispatcher)
+        val fcmManager = createFcmManager(scope)
+        val stalenessManager = createStalenessManager(scope)
+        val appLoggerViewModel = FakeAppLoggerViewModel()
+        val liveClock = createLiveClock(scope)
+        val buttonHealthMgr = createButtonHealthFcmSubscriptionManager(scope)
+        val actions = AppStartup(fcmManager, stalenessManager, liveClock, appLoggerViewModel, buttonHealthMgr)
+
+        actions.run()
+
+        assertEquals(
+            listOf(AppLoggerViewModel.DEFAULT_PER_KEY_LIMIT),
+            appLoggerViewModel.pruneCalls,
         )
     }
 }

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/AppStartupTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/AppStartupTest.kt
@@ -20,6 +20,7 @@ package com.chriscartland.garage
 import com.chriscartland.garage.domain.coroutines.AppClock
 import com.chriscartland.garage.domain.model.ActionError
 import com.chriscartland.garage.domain.model.AppLoggerKeys
+import com.chriscartland.garage.domain.model.AppLoggerLimits
 import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.ButtonHealth
 import com.chriscartland.garage.domain.model.ButtonHealthError
@@ -199,7 +200,7 @@ class AppStartupTest {
         actions.run()
 
         assertEquals(
-            listOf(AppLoggerViewModel.DEFAULT_PER_KEY_LIMIT),
+            listOf(AppLoggerLimits.DEFAULT_PER_KEY_LIMIT),
             appLoggerViewModel.pruneCalls,
         )
     }

--- a/AndroidGarage/data-local/schemas/com.chriscartland.garage.datalocal.AppDatabase/12.json
+++ b/AndroidGarage/data-local/schemas/com.chriscartland.garage.datalocal.AppDatabase/12.json
@@ -1,0 +1,98 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "ba9474ea2e0e285b81561284560962a3",
+    "entities": [
+      {
+        "tableName": "DoorEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`doorPosition` TEXT, `message` TEXT, `lastCheckInTimeSeconds` INTEGER, `lastChangeTimeSeconds` INTEGER, `id` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "doorPosition",
+            "columnName": "doorPosition",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastCheckInTimeSeconds",
+            "columnName": "lastCheckInTimeSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastChangeTimeSeconds",
+            "columnName": "lastChangeTimeSeconds",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "AppEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventKey` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestamp` INTEGER NOT NULL, `appVersion` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "eventKey",
+            "columnName": "eventKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appVersion",
+            "columnName": "appVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AppEvent_eventKey",
+            "unique": false,
+            "columnNames": [
+              "eventKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AppEvent_eventKey` ON `${TABLE_NAME}` (`eventKey`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ba9474ea2e0e285b81561284560962a3')"
+    ]
+  }
+}

--- a/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/AppDatabase.kt
+++ b/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/AppDatabase.kt
@@ -27,7 +27,7 @@ import androidx.room.RoomDatabaseConstructor
         DoorEventEntity::class,
         AppEvent::class,
     ],
-    version = 11,
+    version = 12,
     exportSchema = true,
 )
 @ConstructedBy(AppDatabaseConstructor::class)

--- a/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/AppDatabase.kt
+++ b/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/AppDatabase.kt
@@ -17,6 +17,7 @@
 
 package com.chriscartland.garage.datalocal
 
+import androidx.room.AutoMigration
 import androidx.room.ConstructedBy
 import androidx.room.Database
 import androidx.room.RoomDatabase
@@ -29,6 +30,17 @@ import androidx.room.RoomDatabaseConstructor
     ],
     version = 12,
     exportSchema = true,
+    // v11 → v12: adds @Index(value = ["eventKey"]) on AppEvent.
+    // Index-only change; Room's auto-migration generates the
+    // CREATE INDEX without dropping any rows. Without this annotation
+    // the configured fallbackToDestructiveMigration would wipe both
+    // appEvent (50K rows) AND doorEvent (door history). Auto-migration
+    // preserves both; the existing 50K appEvent rows are then trimmed
+    // on first launch by AppLoggerDao.pruneAllKeys() called from
+    // AppStartup.run().
+    autoMigrations = [
+        AutoMigration(from = 11, to = 12),
+    ],
 )
 @ConstructedBy(AppDatabaseConstructor::class)
 abstract class AppDatabase : RoomDatabase() {

--- a/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/AppEvent.kt
+++ b/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/AppEvent.kt
@@ -1,9 +1,10 @@
 package com.chriscartland.garage.datalocal
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity
+@Entity(indices = [Index(value = ["eventKey"])])
 data class AppEvent(
     val eventKey: String,
     @PrimaryKey(autoGenerate = true) val id: Int = 0,

--- a/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/AppLoggerDao.kt
+++ b/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/AppLoggerDao.kt
@@ -21,6 +21,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -34,6 +35,35 @@ interface AppLoggerDao {
     @Query("SELECT count(*) from appEvent WHERE eventKey = :key")
     fun countKey(key: String): Flow<Long>
 
-    @Query("DELETE FROM doorEvent")
-    fun deleteAll()
+    @Query("SELECT DISTINCT eventKey FROM appEvent")
+    fun distinctKeys(): List<String>
+
+    @Query(
+        "DELETE FROM appEvent WHERE eventKey = :key " +
+            "AND id NOT IN (SELECT id FROM appEvent WHERE eventKey = :key " +
+            "ORDER BY timestamp DESC, id DESC LIMIT :limit)",
+    )
+    fun pruneKey(
+        key: String,
+        limit: Int,
+    )
+
+    @Transaction
+    fun insertAndPruneKey(
+        appEvent: AppEvent,
+        limit: Int,
+    ) {
+        insert(appEvent)
+        pruneKey(appEvent.eventKey, limit)
+    }
+
+    @Transaction
+    fun pruneAllKeys(limit: Int) {
+        for (key in distinctKeys()) {
+            pruneKey(key, limit)
+        }
+    }
+
+    @Query("DELETE FROM appEvent")
+    fun deleteAllAppEvents()
 }

--- a/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/AppLoggerDao.kt
+++ b/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/AppLoggerDao.kt
@@ -53,12 +53,21 @@ interface AppLoggerDao {
         appEvent: AppEvent,
         limit: Int,
     ) {
+        require(limit > 0) { "limit must be > 0; got $limit" }
         insert(appEvent)
         pruneKey(appEvent.eventKey, limit)
     }
 
-    @Transaction
+    /**
+     * Trim every existing `eventKey` to at most [limit] rows. Each key
+     * is pruned in its own transaction (no `@Transaction` on this
+     * wrapper) so concurrent `insertAndPruneKey` calls do not block on
+     * the entire loop — important on first-launch upgrade where the
+     * legacy table may have ~50K rows across many keys, and FCM /
+     * staleness / auth code paths may be firing log() simultaneously.
+     */
     fun pruneAllKeys(limit: Int) {
+        require(limit > 0) { "limit must be > 0; got $limit" }
         for (key in distinctKeys()) {
             pruneKey(key, limit)
         }

--- a/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/RoomAppLoggerRepository.kt
+++ b/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/RoomAppLoggerRepository.kt
@@ -2,6 +2,7 @@ package com.chriscartland.garage.datalocal
 
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.domain.model.AppLogEvent
+import com.chriscartland.garage.domain.model.AppLoggerLimits
 import com.chriscartland.garage.domain.repository.AppLoggerRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -21,7 +22,7 @@ import kotlinx.coroutines.flow.map
 class RoomAppLoggerRepository(
     private val appDatabase: AppDatabase,
     private val appVersion: String,
-    private val perKeyLimit: Int = DEFAULT_PER_KEY_LIMIT,
+    private val perKeyLimit: Int = AppLoggerLimits.DEFAULT_PER_KEY_LIMIT,
 ) : AppLoggerRepository {
     override suspend fun log(key: String) {
         Logger.d { "Logging key: $key" }
@@ -42,11 +43,8 @@ class RoomAppLoggerRepository(
         }
 
     override suspend fun pruneToLimit(perKeyLimit: Int) {
+        require(perKeyLimit > 0) { "perKeyLimit must be > 0; got $perKeyLimit" }
         appDatabase.appLoggerDao().pruneAllKeys(perKeyLimit)
-    }
-
-    companion object {
-        const val DEFAULT_PER_KEY_LIMIT: Int = 1000
     }
 }
 

--- a/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/RoomAppLoggerRepository.kt
+++ b/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/RoomAppLoggerRepository.kt
@@ -9,20 +9,28 @@ import kotlinx.coroutines.flow.map
 /**
  * KMP-compatible [AppLoggerRepository] backed by Room.
  *
- * Platform-specific concerns (CSV export, Android Context) stay in androidApp.
- * This class handles only storage: log, count, and getAll.
+ * Platform-specific concerns (CSV export, Android Context) stay in
+ * androidApp. This class handles only storage: log, count, getAll, and
+ * the per-write retention cap.
+ *
+ * Each [log] call inserts a row and immediately prunes the per-key
+ * row set to at most [perKeyLimit] entries (single Room transaction),
+ * so the table stays bounded in steady state. To clean up databases
+ * that pre-date the cap, call [pruneToLimit] once on app startup.
  */
 class RoomAppLoggerRepository(
     private val appDatabase: AppDatabase,
     private val appVersion: String,
+    private val perKeyLimit: Int = DEFAULT_PER_KEY_LIMIT,
 ) : AppLoggerRepository {
     override suspend fun log(key: String) {
         Logger.d { "Logging key: $key" }
-        appDatabase.appLoggerDao().insert(
-            AppEvent(
+        appDatabase.appLoggerDao().insertAndPruneKey(
+            appEvent = AppEvent(
                 eventKey = key,
                 appVersion = appVersion,
             ),
+            limit = perKeyLimit,
         )
     }
 
@@ -32,6 +40,14 @@ class RoomAppLoggerRepository(
         appDatabase.appLoggerDao().getAll().map { events ->
             events.map { it.toAppLogEvent() }
         }
+
+    override suspend fun pruneToLimit(perKeyLimit: Int) {
+        appDatabase.appLoggerDao().pruneAllKeys(perKeyLimit)
+    }
+
+    companion object {
+        const val DEFAULT_PER_KEY_LIMIT: Int = 1000
+    }
 }
 
 private fun AppEvent.toAppLogEvent() =

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/AppLoggerLimits.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/AppLoggerLimits.kt
@@ -1,0 +1,18 @@
+package com.chriscartland.garage.domain.model
+
+/**
+ * Tunables for the AppLogger retention policy.
+ *
+ * Lives in `domain.model` (not `domain.repository`) so ViewModels can
+ * reference the default without crossing the layer-import check that
+ * forbids ViewModels from importing repository interfaces.
+ */
+object AppLoggerLimits {
+    /**
+     * Default per-key row cap. Single source of truth so the
+     * per-write cap (in `RoomAppLoggerRepository.log`) and the
+     * startup-prune cap (in `RoomAppLoggerRepository.pruneToLimit`)
+     * cannot drift.
+     */
+    const val DEFAULT_PER_KEY_LIMIT: Int = 1000
+}

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/AppLoggerRepository.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/AppLoggerRepository.kt
@@ -15,4 +15,13 @@ interface AppLoggerRepository {
 
     /** All logged events, ordered by timestamp ascending. Used for CSV export. */
     fun getAll(): Flow<List<AppLogEvent>>
+
+    /**
+     * Trim the log so that no individual `eventKey` retains more than
+     * [perKeyLimit] rows. Keeps the most recent rows per key. Intended
+     * for one-shot startup cleanup of databases that grew past the cap
+     * before the per-write cap was added; the per-write cap (inside
+     * [log]) keeps steady-state size bounded going forward.
+     */
+    suspend fun pruneToLimit(perKeyLimit: Int)
 }

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/AppLoggerRepository.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/AppLoggerRepository.kt
@@ -22,6 +22,11 @@ interface AppLoggerRepository {
      * for one-shot startup cleanup of databases that grew past the cap
      * before the per-write cap was added; the per-write cap (inside
      * [log]) keeps steady-state size bounded going forward.
+     *
+     * Implementations must reject `perKeyLimit <= 0` — `0` would be an
+     * unbounded delete-everything (subquery matches no rows), which is
+     * never a valid retention policy. Use a dedicated clear/reset API
+     * for that.
      */
     suspend fun pruneToLimit(perKeyLimit: Int)
 }

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAppLoggerRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAppLoggerRepository.kt
@@ -15,6 +15,9 @@ class FakeAppLoggerRepository : AppLoggerRepository {
     private val _loggedKeys = mutableListOf<String>()
     val loggedKeys: List<String> get() = _loggedKeys
 
+    private val _pruneCalls = mutableListOf<Int>()
+    val pruneCalls: List<Int> get() = _pruneCalls
+
     private val counts = mutableMapOf<String, MutableStateFlow<Long>>()
 
     override suspend fun log(key: String) {
@@ -25,4 +28,8 @@ class FakeAppLoggerRepository : AppLoggerRepository {
     override fun countKey(key: String): Flow<Long> = counts.getOrPut(key) { MutableStateFlow(0L) }
 
     override fun getAll(): Flow<List<AppLogEvent>> = MutableStateFlow(emptyList())
+
+    override suspend fun pruneToLimit(perKeyLimit: Int) {
+        _pruneCalls.add(perKeyLimit)
+    }
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppLoggerViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppLoggerViewModel.kt
@@ -28,6 +28,13 @@ import kotlinx.coroutines.launch
 interface AppLoggerViewModel {
     fun log(key: String)
 
+    /**
+     * Trim the per-key row count for any [AppLoggerKeys] that exceed
+     * the cap. Fire once at app startup; ongoing writes are capped
+     * inline and don't need this.
+     */
+    fun pruneOldEntries(perKeyLimit: Int = DEFAULT_PER_KEY_LIMIT)
+
     val initCurrentDoorCount: StateFlow<Long>
     val initRecentDoorCount: StateFlow<Long>
     val userFetchCurrentDoorCount: StateFlow<Long>
@@ -36,11 +43,16 @@ interface AppLoggerViewModel {
     val fcmSubscribeTopicCount: StateFlow<Long>
     val exceededExpectedTimeWithoutFcmCount: StateFlow<Long>
     val timeWithoutFcmInExpectedRangeCount: StateFlow<Long>
+
+    companion object {
+        const val DEFAULT_PER_KEY_LIMIT: Int = 1000
+    }
 }
 
 class DefaultAppLoggerViewModel(
     private val logAppEvent: LogAppEventUseCase,
     private val observeAppLogCount: ObserveAppLogCountUseCase,
+    private val pruneAppLog: PruneAppLogUseCase,
     private val dispatchers: DispatcherProvider,
 ) : ViewModel(),
     AppLoggerViewModel {
@@ -91,6 +103,12 @@ class DefaultAppLoggerViewModel(
     override fun log(key: String) {
         viewModelScope.launch(dispatchers.io) {
             logAppEvent(key)
+        }
+    }
+
+    override fun pruneOldEntries(perKeyLimit: Int) {
+        viewModelScope.launch(dispatchers.io) {
+            pruneAppLog(perKeyLimit)
         }
     }
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppLoggerViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppLoggerViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.AppLoggerKeys
+import com.chriscartland.garage.domain.model.AppLoggerLimits
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -33,7 +34,7 @@ interface AppLoggerViewModel {
      * the cap. Fire once at app startup; ongoing writes are capped
      * inline and don't need this.
      */
-    fun pruneOldEntries(perKeyLimit: Int = DEFAULT_PER_KEY_LIMIT)
+    fun pruneOldEntries(perKeyLimit: Int = AppLoggerLimits.DEFAULT_PER_KEY_LIMIT)
 
     val initCurrentDoorCount: StateFlow<Long>
     val initRecentDoorCount: StateFlow<Long>
@@ -43,10 +44,6 @@ interface AppLoggerViewModel {
     val fcmSubscribeTopicCount: StateFlow<Long>
     val exceededExpectedTimeWithoutFcmCount: StateFlow<Long>
     val timeWithoutFcmInExpectedRangeCount: StateFlow<Long>
-
-    companion object {
-        const val DEFAULT_PER_KEY_LIMIT: Int = 1000
-    }
 }
 
 class DefaultAppLoggerViewModel(

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/PruneAppLogUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/PruneAppLogUseCase.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.repository.AppLoggerRepository
+
+/**
+ * Trims the app-log table so that no individual `eventKey` retains
+ * more than [perKeyLimit] rows. One-shot startup cleanup for databases
+ * that grew past the cap before the per-write cap was introduced. The
+ * per-write cap (in [LogAppEventUseCase]) keeps steady-state size
+ * bounded going forward.
+ */
+class PruneAppLogUseCase(
+    private val appLoggerRepository: AppLoggerRepository,
+) {
+    suspend operator fun invoke(perKeyLimit: Int) {
+        appLoggerRepository.pruneToLimit(perKeyLimit)
+    }
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAppLoggerViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAppLoggerViewModelTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.test.setMain
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -28,6 +29,7 @@ class DefaultAppLoggerViewModelTest {
         viewModel = DefaultAppLoggerViewModel(
             logAppEvent = LogAppEventUseCase(logger),
             observeAppLogCount = ObserveAppLogCountUseCase(logger),
+            pruneAppLog = PruneAppLogUseCase(logger),
             dispatchers = dispatchers,
         )
     }
@@ -69,5 +71,26 @@ class DefaultAppLoggerViewModelTest {
 
             // The init block collects countKey flows, so the StateFlow should update
             assertTrue(viewModel.userFetchCurrentDoorCount.value >= 1L)
+        }
+
+    @Test
+    fun pruneOldEntriesDelegatesToRepository() =
+        runTest(testDispatcher) {
+            viewModel.pruneOldEntries(perKeyLimit = 500)
+            advanceUntilIdle()
+
+            assertEquals(listOf(500), logger.pruneCalls)
+        }
+
+    @Test
+    fun pruneOldEntriesUsesDefaultLimit() =
+        runTest(testDispatcher) {
+            viewModel.pruneOldEntries()
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf(AppLoggerViewModel.DEFAULT_PER_KEY_LIMIT),
+                logger.pruneCalls,
+            )
         }
 }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAppLoggerViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultAppLoggerViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.chriscartland.garage.usecase
 
 import com.chriscartland.garage.domain.model.AppLoggerKeys
+import com.chriscartland.garage.domain.model.AppLoggerLimits
 import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
 import com.chriscartland.garage.testcommon.TestDispatcherProvider
 import kotlinx.coroutines.Dispatchers
@@ -89,7 +90,7 @@ class DefaultAppLoggerViewModelTest {
             advanceUntilIdle()
 
             assertEquals(
-                listOf(AppLoggerViewModel.DEFAULT_PER_KEY_LIMIT),
+                listOf(AppLoggerLimits.DEFAULT_PER_KEY_LIMIT),
                 logger.pruneCalls,
             )
         }


### PR DESCRIPTION
## Summary

Caps each `AppLogger.eventKey` to at most 1000 rows in Room, fixing the unbounded-growth path that lets the table accumulate ~50K rows over months of normal use. Two enforcement points:

1. **Per-write cap** — every `log(key)` now does `INSERT then DELETE oldest beyond limit` for that key in a single `@Transaction` (`AppLoggerDao.insertAndPruneKey`). Steady-state size is bounded going forward.
2. **Startup migration** — `AppStartup.run()` fires `appLoggerViewModel.pruneOldEntries()` once per launch (`AppLoggerDao.pruneAllKeys`). Handles existing 50K-row installs without a Room migration. Cheap no-op once the table is below the cap.

Per-key (not global) so a chatty key (`TIME_WITHOUT_FCM_*`) can't squeeze out a rare key (`USER_AUTHENTICATED`).

Adds `@Index(value = ["eventKey"])` on the `AppEvent` entity so `countKey()` and the new `pruneKey()` are indexed lookups, not full scans. Database version bumped 11→12; schema `12.json` committed.

The previously-broken `deleteAll()` (DAO query was `DELETE FROM doorEvent` not `appEvent`) is renamed to `deleteAllAppEvents()` with the correct query. Currently unused — a follow-up "Reset diagnostics" PR will wire it in.

## Out of scope

This PR is the bounded-storage fix only. **No UX change.** A future PR will introduce monotonic DataStore counters so the Diagnostics screen can show "lifetime totals" instead of current-rows-in-table (which now plateaus at 1000 per key). The user explicitly asked for this to be staged as PR 1.

## Tests

- `DatabaseSanityTest` (instrumented): 4 new — per-write cap, per-key isolation, startup `pruneAllKeys` migration, `deleteAllAppEvents`.
- `DefaultAppLoggerViewModelTest` (unit): 2 new — `pruneOldEntries` delegation with default + custom limit.
- `AppStartupTest` (unit): confirms prune fires on startup with the default limit, and the action is in the returned action list.
- `FakeAppLoggerRepository`: gains `pruneCalls` call-list (ADR-017 Rule 5 pattern).

## Test plan

- [x] `./scripts/validate.sh` passes (includes Room schema drift check)
- [ ] Instrumented tests pass on a connected device — `./scripts/run-instrumented-tests.sh` (CLAUDE.md says this is required for Room/DAO changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)