### PR TITLE
docs: Fix misleading Room migration guidance; document migration-test gap

### DIFF
--- a/AndroidGarage/docs/TESTING.md
+++ b/AndroidGarage/docs/TESTING.md
@@ -233,8 +233,12 @@ Verify the database can be created and basic DAO operations work. Catches R8 str
 - Insert and read a `DoorEvent`
 - Insert and read an `AppEvent`
 - Verify all DAOs are accessible from `AppDatabase`
+- AppLogger per-key cap behavior (`insertAndPruneKey`, `pruneAllKeys`, `deleteAllAppEvents`)
+- `RoomAppLoggerRepository.log()` end-to-end with cap
 
 **Files:** `src/androidTest/.../db/DatabaseSanityTest.kt`
+
+**Gap:** these tests use `inMemoryDatabaseBuilder`, which always opens at the latest schema version. **They do not exercise migration code paths.** A regression in an `@AutoMigration` or `Migration` class would pass every test in this suite and only surface on a real device with pre-existing user data — i.e., on the Play Store internal track at the earliest. Until we wire up Room's `MigrationTestHelper` (which can replay an exported schema and run the migration against real SQLite), schema changes should be smoke-tested by installing the upgrade build over the previous one on a test device before promoting from the internal track to production. PR #660 (AppLogger v11→v12) shipped under this gap; the migration was reviewed by inspecting the KSP-generated `AppDatabase_AutoMigration_11_12_Impl.kt`.
 
 ### 7.3 kotlin-inject Component Test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,11 @@ Run `./scripts/run-instrumented-tests.sh` when changing Room entities/DAOs, DI w
 
 ### Room Database Safety
 
-When modifying Room entities or DAOs: (1) increment the `version` in `@Database` (`AppDatabase.kt`); (2) run `./gradlew :androidApp:assembleDebug` to regenerate the schema; (3) commit the new schema JSON alongside the code change. `fallbackToDestructiveMigration` handles upgrades. Full safeguard list (schema drift check in `validate.sh`, guardrails hook, `RoomSchemaTest` contract tests, exported schema files): see `AndroidGarage/docs/ARCHITECTURE.md` § Database.
+When modifying Room entities or DAOs: (1) increment the `version` in `@Database` (`AppDatabase.kt`); (2) run `./gradlew :androidApp:assembleDebug` to regenerate the schema; (3) commit the new schema JSON alongside the code change; (4) **declare a `Migration` or `@AutoMigration(from = N, to = N+1)` to preserve data.** Full safeguard list (schema drift check in `validate.sh`, guardrails hook, `RoomSchemaTest` contract tests, exported schema files): see `AndroidGarage/docs/ARCHITECTURE.md` § Database.
+
+**Step 4 is load-bearing — do not skip.** The codebase uses `fallbackToDestructiveMigration(false)` (in `DatabaseFactory.android.kt`) which **drops every Room-managed table** on any version mismatch with no declared migration — not just the changed one. So a single-column index addition on `appEvent` would also wipe the user's `doorEvent` history. For data-preserving changes (adding columns with defaults, adding/removing indexes, adding tables), Room's auto-migration handles them with no spec class — declare `autoMigrations = [AutoMigration(from = 11, to = 12)]` in the `@Database` annotation, build, and inspect the generated `AppDatabase_AutoMigration_*_Impl.kt` to confirm it preserves your data. For non-trivial changes (column renames, type changes), write an explicit `Migration` class and register it on the database builder. This trap was hit in PR #660 — caught pre-release on review.
+
+**Migration transitions are NOT empirically tested by the existing instrumented suite.** `DatabaseSanityTest` uses `inMemoryDatabaseBuilder`, which always starts at the latest version and so never runs migration code. To test a v(N)→v(N+1) transition with real data, use Room's `MigrationTestHelper` against an exported schema, or smoke-test the upgrade on the internal Play Store track (which is what we do today; the production-promotion gate is the actual test).
 
 ### AppComponent / kotlin-inject Safety
 


### PR DESCRIPTION
## Summary

Two doc fixes prompted by PR #660 (which would have wiped door history if not caught in review):

1. **CLAUDE.md Room safety section** — replace the misleading line `fallbackToDestructiveMigration handles upgrades` with the real rule. The configured mode drops *every* Room-managed table on version mismatch when no Migration is declared, not just the changed one. Doc now says: declare `@AutoMigration(from = N, to = N+1)` (or an explicit `Migration`) as step 4 of the schema-bump checklist; the existing wording would have led a future agent into shipping a destructive change.

2. **TESTING.md § 7.2** — note that migration code paths are NOT exercised by `DatabaseSanityTest` (it uses `inMemoryDatabaseBuilder` which always opens at the latest version). Until `MigrationTestHelper` is wired up, schema changes need a real-device install-over-previous smoke test on the internal Play Store track.

Memory updates (machine-local, not in this PR):
- `project_applogger_pr2_pending.md` — DataStore monotonic counters + Reset Diagnostics action are the agreed PR 2 follow-up to the row-cap shipped in `android/198`. Diagnostics counts currently plateau at 1000/key; PR 2 fixes the UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)