### PR TITLE
feat(android): Stage 3a — list screens consume spacing tokens

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/FunctionListContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/FunctionListContent.kt
@@ -37,6 +37,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.chriscartland.garage.auth.rememberGoogleSignIn
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.ui.theme.PreviewScreenSurface
+import com.chriscartland.garage.ui.theme.Spacing
 import com.chriscartland.garage.usecase.FunctionListViewModel
 
 @Composable
@@ -89,7 +90,7 @@ fun FunctionListContent(
     if (accessGranted == true) {
         LazyColumn(
             modifier = modifier,
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(Spacing.BetweenItems),
         ) {
             item { FunctionListWarning() }
             item { FunctionButton("Open or close garage door", onOpenOrCloseDoor) }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryContent.kt
@@ -50,8 +50,10 @@ import androidx.compose.ui.unit.dp
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.ui.GarageIcon
+import com.chriscartland.garage.ui.theme.DividerInset
 import com.chriscartland.garage.ui.theme.DoorColorState
 import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
+import com.chriscartland.garage.ui.theme.ParagraphSpacing
 import com.chriscartland.garage.ui.theme.Spacing
 import com.chriscartland.garage.ui.theme.doorColorSet
 import com.chriscartland.garage.ui.theme.doorColorState
@@ -148,8 +150,8 @@ fun HistoryContent(
     ) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(vertical = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(vertical = Spacing.ListVertical),
+            verticalArrangement = Arrangement.spacedBy(Spacing.BetweenItems),
         ) {
             if (days.isEmpty()) {
                 item { HistoryEmptyState() }
@@ -188,7 +190,7 @@ private fun HistoryDaySection(day: HistoryDay) {
             Column {
                 day.entries.forEachIndexed { index, entry ->
                     if (index > 0) {
-                        HorizontalDivider(modifier = Modifier.padding(start = 72.dp))
+                        HorizontalDivider(modifier = Modifier.padding(start = DividerInset.LargeLeading))
                     }
                     HistoryEntryRow(entry = entry)
                 }
@@ -277,7 +279,7 @@ private fun HistoryStateRow(
                             tint = MaterialTheme.colorScheme.tertiary,
                             modifier = Modifier.size(14.dp),
                         )
-                        Spacer(Modifier.width(4.dp))
+                        Spacer(Modifier.width(Spacing.Tight))
                         Text(
                             text = warning,
                             style = MaterialTheme.typography.bodySmall,
@@ -312,7 +314,7 @@ private fun HistoryEmptyState() {
             text = "No events yet",
             style = MaterialTheme.typography.titleMedium,
         )
-        Spacer(Modifier.height(4.dp))
+        Spacer(Modifier.height(ParagraphSpacing.TitleToBody))
         Text(
             text = "Open or close the garage and check back here.",
             style = MaterialTheme.typography.bodyMedium,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/DiagnosticsContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/DiagnosticsContent.kt
@@ -58,7 +58,11 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.chriscartland.garage.GarageApplication
 import com.chriscartland.garage.applogger.exportAppLogCsvToUri
 import com.chriscartland.garage.di.rememberAppComponent
+import com.chriscartland.garage.ui.theme.ButtonSpacing
+import com.chriscartland.garage.ui.theme.CardPadding
+import com.chriscartland.garage.ui.theme.DividerInset
 import com.chriscartland.garage.ui.theme.PreviewScreenSurface
+import com.chriscartland.garage.ui.theme.Spacing
 import com.chriscartland.garage.usecase.AppLoggerViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -162,8 +166,11 @@ fun DiagnosticsContent(
     ) {
         LazyColumn(
             modifier = Modifier.weight(1f).fillMaxWidth(),
-            contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(
+                horizontal = Spacing.Screen,
+                vertical = Spacing.ListVertical,
+            ),
+            verticalArrangement = Arrangement.spacedBy(Spacing.BetweenItems),
         ) {
             item {
                 Surface(
@@ -175,7 +182,7 @@ fun DiagnosticsContent(
                         counters.forEachIndexed { index, c ->
                             CounterRow(c.label, c.value)
                             if (index < counters.lastIndex) {
-                                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                                HorizontalDivider(modifier = Modifier.padding(horizontal = DividerInset.FullWidth))
                             }
                         }
                     }
@@ -194,7 +201,7 @@ fun DiagnosticsContent(
             )
             Text(
                 text = "Export CSV",
-                modifier = Modifier.padding(start = 8.dp),
+                modifier = Modifier.padding(start = ButtonSpacing.IconText),
             )
         }
         OutlinedButton(
@@ -218,7 +225,7 @@ fun DiagnosticsContent(
                 )
                 Text(
                     text = "Clearing…",
-                    modifier = Modifier.padding(start = 8.dp),
+                    modifier = Modifier.padding(start = ButtonSpacing.IconText),
                 )
             } else {
                 Icon(
@@ -227,7 +234,7 @@ fun DiagnosticsContent(
                 )
                 Text(
                     text = "Clear all diagnostics",
-                    modifier = Modifier.padding(start = 8.dp),
+                    modifier = Modifier.padding(start = ButtonSpacing.IconText),
                 )
             }
         }
@@ -293,7 +300,7 @@ private fun CounterRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            .padding(CardPadding.Compact),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.chriscartland.garage.ui.theme.DividerInset
 import com.chriscartland.garage.ui.theme.PreviewScreenSurface
 import com.chriscartland.garage.ui.theme.Spacing
 
@@ -118,8 +119,8 @@ fun SettingsContent(
 ) {
     LazyColumn(
         modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(vertical = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        contentPadding = PaddingValues(vertical = Spacing.ListVertical),
+        verticalArrangement = Arrangement.spacedBy(Spacing.BetweenItems),
     ) {
         item {
             SettingsSection(label = "Account") {
@@ -174,7 +175,7 @@ fun SettingsContent(
                     showChevron = true,
                     onClick = onVersionTap,
                 )
-                HorizontalDivider(modifier = Modifier.padding(start = 56.dp))
+                HorizontalDivider(modifier = Modifier.padding(start = DividerInset.ListItem))
                 SettingsRow(
                     icon = Icons.Outlined.Storefront,
                     title = "Play Store",
@@ -183,7 +184,7 @@ fun SettingsContent(
                     showChevron = false,
                     onClick = onPlayStoreTap,
                 )
-                HorizontalDivider(modifier = Modifier.padding(start = 56.dp))
+                HorizontalDivider(modifier = Modifier.padding(start = DividerInset.ListItem))
                 SettingsRow(
                     icon = Icons.Outlined.Description,
                     title = "Privacy Policy",
@@ -205,7 +206,7 @@ fun SettingsContent(
                         showChevron = true,
                         onClick = onDiagnosticsTap,
                     )
-                    HorizontalDivider(modifier = Modifier.padding(start = 56.dp))
+                    HorizontalDivider(modifier = Modifier.padding(start = DividerInset.ListItem))
                     SettingsRow(
                         icon = Icons.AutoMirrored.Outlined.List,
                         title = "Function list",


### PR DESCRIPTION
## Summary

Stage 3a of the spacing-consistency plan ([SPACING_PLAN.md](https://github.com/cartland/SmartGarageDoor/blob/main/AndroidGarage/docs/SPACING_PLAN.md)).

Migrates four list-screen files to consume spacing tokens:
- \`SettingsContent.kt\` — \`Spacing.ListVertical\`, \`Spacing.BetweenItems\`, \`DividerInset.ListItem\` (56dp)
- \`HistoryContent.kt\` — same plus \`DividerInset.LargeLeading\` (72dp), \`Spacing.Tight\`, \`ParagraphSpacing.TitleToBody\`
- \`DiagnosticsContent.kt\` — same plus \`DividerInset.FullWidth\`, \`CardPadding.Compact\`, \`ButtonSpacing.IconText\`, \`Spacing.Screen\` (since Diagnostics is the one screen NOT inside Main.kt's 16dp horizontal wrapper)
- \`FunctionListContent.kt\` — \`Spacing.BetweenItems\`

**Pure rename, zero pixel diff** (verified by screenshot regeneration on Settings, History, Screens tests).

## Two design issues spotted (deferred to Stage 4)

\`DiagnosticsContent.kt:189,208\` — Export and Clear buttons each apply their own outer padding (\`top = 16.dp\`, \`padding(16.dp)\`) rather than the parent Column owning the gap via \`Arrangement.spacedBy(...)\`. This violates the parent-vs-child spacing rule (a composable should not claim ownership of its own outer gap). Stage 4 will pick the correct \`ButtonSpacing.Stacked\` pattern.

## Merge order

Stacked on #679 (Stage 2 — section headers).
⚠️ Merge AFTER #679. Do not merge before #679 lands on main.
Stack: #677 (doc) → #678 (Stage 1) → #679 (Stage 2) → **#680 (Stage 3a)** → Stage 3b → Stage 0 → Stage 4.

## Test plan

- [x] \`./scripts/validate.sh\` passes
- [x] Screenshot regeneration produced zero PNG diffs
- [x] No screenshot updates required — pure rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)