### PR TITLE
feat(android): Stage 3b — Home migration to spacing tokens

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/FunctionListContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/FunctionListContent.kt
@@ -37,6 +37,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.chriscartland.garage.auth.rememberGoogleSignIn
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.ui.theme.PreviewScreenSurface
+import com.chriscartland.garage.ui.theme.Spacing
 import com.chriscartland.garage.usecase.FunctionListViewModel
 
 @Composable
@@ -89,7 +90,7 @@ fun FunctionListContent(
     if (accessGranted == true) {
         LazyColumn(
             modifier = modifier,
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(Spacing.BetweenItems),
         ) {
             item { FunctionListWarning() }
             item { FunctionButton("Open or close garage door", onOpenOrCloseDoor) }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryContent.kt
@@ -50,8 +50,10 @@ import androidx.compose.ui.unit.dp
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.ui.GarageIcon
+import com.chriscartland.garage.ui.theme.DividerInset
 import com.chriscartland.garage.ui.theme.DoorColorState
 import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
+import com.chriscartland.garage.ui.theme.ParagraphSpacing
 import com.chriscartland.garage.ui.theme.Spacing
 import com.chriscartland.garage.ui.theme.doorColorSet
 import com.chriscartland.garage.ui.theme.doorColorState
@@ -148,8 +150,8 @@ fun HistoryContent(
     ) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(vertical = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(vertical = Spacing.ListVertical),
+            verticalArrangement = Arrangement.spacedBy(Spacing.BetweenItems),
         ) {
             if (days.isEmpty()) {
                 item { HistoryEmptyState() }
@@ -188,7 +190,7 @@ private fun HistoryDaySection(day: HistoryDay) {
             Column {
                 day.entries.forEachIndexed { index, entry ->
                     if (index > 0) {
-                        HorizontalDivider(modifier = Modifier.padding(start = 72.dp))
+                        HorizontalDivider(modifier = Modifier.padding(start = DividerInset.LargeLeading))
                     }
                     HistoryEntryRow(entry = entry)
                 }
@@ -277,7 +279,7 @@ private fun HistoryStateRow(
                             tint = MaterialTheme.colorScheme.tertiary,
                             modifier = Modifier.size(14.dp),
                         )
-                        Spacer(Modifier.width(4.dp))
+                        Spacer(Modifier.width(Spacing.Tight))
                         Text(
                             text = warning,
                             style = MaterialTheme.typography.bodySmall,
@@ -312,7 +314,7 @@ private fun HistoryEmptyState() {
             text = "No events yet",
             style = MaterialTheme.typography.titleMedium,
         )
-        Spacer(Modifier.height(4.dp))
+        Spacer(Modifier.height(ParagraphSpacing.TitleToBody))
         Text(
             text = "Open or close the garage and check back here.",
             style = MaterialTheme.typography.bodyMedium,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
@@ -61,8 +61,11 @@ import com.chriscartland.garage.ui.GarageIcon
 import com.chriscartland.garage.ui.RemoteButtonContent
 import com.chriscartland.garage.ui.RemoteButtonHealthPill
 import com.chriscartland.garage.ui.TitleBarCheckInPill
+import com.chriscartland.garage.ui.theme.ButtonSpacing
+import com.chriscartland.garage.ui.theme.CardPadding
 import com.chriscartland.garage.ui.theme.DoorColorState
 import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
+import com.chriscartland.garage.ui.theme.ParagraphSpacing
 import com.chriscartland.garage.ui.theme.PreviewScreenSurface
 import com.chriscartland.garage.ui.theme.Spacing
 import com.chriscartland.garage.ui.theme.doorColorSet
@@ -171,12 +174,12 @@ fun HomeContent(
     ) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(vertical = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(vertical = Spacing.ListVertical),
+            verticalArrangement = Arrangement.spacedBy(Spacing.BetweenItems),
         ) {
             if (alerts.isNotEmpty()) {
                 item(key = "alerts") {
-                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Column(verticalArrangement = Arrangement.spacedBy(Spacing.BetweenItems)) {
                         alerts.forEach { alert ->
                             HomeAlertCard(
                                 alert = alert,
@@ -281,7 +284,7 @@ private fun HomeStatusCardBody(status: HomeStatusDisplay) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 24.dp, horizontal = 16.dp),
+            .padding(CardPadding.Tall),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
@@ -303,7 +306,7 @@ private fun HomeStatusCardBody(status: HomeStatusDisplay) {
         }
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(4.dp),
+            verticalArrangement = Arrangement.spacedBy(Spacing.Tight),
         ) {
             Text(
                 text = status.stateLabel,
@@ -317,7 +320,7 @@ private fun HomeStatusCardBody(status: HomeStatusDisplay) {
                 textAlign = TextAlign.Center,
             )
             if (status.warning != null) {
-                Spacer(modifier = Modifier.height(4.dp))
+                Spacer(modifier = Modifier.height(Spacing.Tight))
                 Surface(
                     color = MaterialTheme.colorScheme.errorContainer,
                     contentColor = MaterialTheme.colorScheme.onErrorContainer,
@@ -350,7 +353,7 @@ private fun HomeRemoteButtonBody(
     state: RemoteButtonState,
     onTap: () -> Unit,
 ) {
-    Box(modifier = Modifier.padding(16.dp)) {
+    Box(modifier = Modifier.padding(CardPadding.Standard)) {
         RemoteButtonContent(
             state = state,
             onTap = onTap,
@@ -423,7 +426,7 @@ private fun HomeAlertCard(
             .clip(MaterialTheme.shapes.large),
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            modifier = Modifier.padding(CardPadding.Compact),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Icon(
@@ -432,13 +435,13 @@ private fun HomeAlertCard(
                 tint = MaterialTheme.colorScheme.onErrorContainer,
                 modifier = Modifier.size(24.dp),
             )
-            Spacer(modifier = Modifier.width(12.dp))
+            Spacer(modifier = Modifier.width(ParagraphSpacing.IconToText))
             Text(
                 text = message,
                 style = MaterialTheme.typography.bodyMedium,
                 modifier = Modifier.weight(1f),
             )
-            Spacer(modifier = Modifier.width(12.dp))
+            Spacer(modifier = Modifier.width(ButtonSpacing.Inline))
             Button(onClick = onAction) { Text(actionLabel) }
         }
     }
@@ -490,7 +493,7 @@ fun HomeContentOpenSignedInPreview() =
             remoteButtonState = RemoteButtonState.Ready,
             deviceCheckIn = HomePreviewData.freshCheckIn,
             buttonHealthDisplay = ButtonHealthDisplay.Loading,
-            modifier = Modifier.padding(horizontal = 16.dp),
+            modifier = Modifier.padding(horizontal = Spacing.Screen),
         )
     }
 
@@ -504,7 +507,7 @@ fun HomeContentClosedSignedInPreview() =
             remoteButtonState = RemoteButtonState.Ready,
             deviceCheckIn = HomePreviewData.freshCheckIn,
             buttonHealthDisplay = ButtonHealthDisplay.Loading,
-            modifier = Modifier.padding(horizontal = 16.dp),
+            modifier = Modifier.padding(horizontal = Spacing.Screen),
         )
     }
 
@@ -518,7 +521,7 @@ fun HomeContentAwaitingConfirmationPreview() =
             remoteButtonState = RemoteButtonState.AwaitingConfirmation,
             deviceCheckIn = HomePreviewData.freshCheckIn,
             buttonHealthDisplay = ButtonHealthDisplay.Loading,
-            modifier = Modifier.padding(horizontal = 16.dp),
+            modifier = Modifier.padding(horizontal = Spacing.Screen),
         )
     }
 
@@ -532,7 +535,7 @@ fun HomeContentSendingToDoorPreview() =
             remoteButtonState = RemoteButtonState.SendingToDoor,
             deviceCheckIn = HomePreviewData.freshCheckIn,
             buttonHealthDisplay = ButtonHealthDisplay.Loading,
-            modifier = Modifier.padding(horizontal = 16.dp),
+            modifier = Modifier.padding(horizontal = Spacing.Screen),
         )
     }
 
@@ -546,7 +549,7 @@ fun HomeContentOpeningTooLongPreview() =
             remoteButtonState = RemoteButtonState.Ready,
             deviceCheckIn = HomePreviewData.freshCheckIn,
             buttonHealthDisplay = ButtonHealthDisplay.Loading,
-            modifier = Modifier.padding(horizontal = 16.dp),
+            modifier = Modifier.padding(horizontal = Spacing.Screen),
         )
     }
 
@@ -561,7 +564,7 @@ fun HomeContentStaleBannerPreview() =
             alerts = listOf(HomePreviewData.staleAlert),
             deviceCheckIn = HomePreviewData.staleCheckIn,
             buttonHealthDisplay = ButtonHealthDisplay.Loading,
-            modifier = Modifier.padding(horizontal = 16.dp),
+            modifier = Modifier.padding(horizontal = Spacing.Screen),
         )
     }
 
@@ -576,7 +579,7 @@ fun HomeContentPermissionMissingPreview() =
             alerts = listOf(HomePreviewData.permissionAlert),
             deviceCheckIn = HomePreviewData.freshCheckIn,
             buttonHealthDisplay = ButtonHealthDisplay.Loading,
-            modifier = Modifier.padding(horizontal = 16.dp),
+            modifier = Modifier.padding(horizontal = Spacing.Screen),
         )
     }
 
@@ -589,7 +592,7 @@ fun HomeContentSignedOutPreview() =
             authState = HomeAuthState.SignedOut,
             deviceCheckIn = HomePreviewData.freshCheckIn,
             buttonHealthDisplay = ButtonHealthDisplay.Loading,
-            modifier = Modifier.padding(horizontal = 16.dp),
+            modifier = Modifier.padding(horizontal = Spacing.Screen),
         )
     }
 
@@ -608,7 +611,7 @@ fun HomeContentRemotePillUnauthorizedPreview() =
             remoteButtonState = RemoteButtonState.Ready,
             deviceCheckIn = HomePreviewData.freshCheckIn,
             buttonHealthDisplay = ButtonHealthDisplay.Unauthorized,
-            modifier = Modifier.padding(horizontal = 16.dp),
+            modifier = Modifier.padding(horizontal = Spacing.Screen),
         )
     }
 
@@ -622,7 +625,7 @@ fun HomeContentRemotePillLoadingPreview() =
             remoteButtonState = RemoteButtonState.Ready,
             deviceCheckIn = HomePreviewData.freshCheckIn,
             buttonHealthDisplay = ButtonHealthDisplay.Loading,
-            modifier = Modifier.padding(horizontal = 16.dp),
+            modifier = Modifier.padding(horizontal = Spacing.Screen),
         )
     }
 
@@ -636,7 +639,7 @@ fun HomeContentRemotePillUnknownPreview() =
             remoteButtonState = RemoteButtonState.Ready,
             deviceCheckIn = HomePreviewData.freshCheckIn,
             buttonHealthDisplay = ButtonHealthDisplay.Unknown,
-            modifier = Modifier.padding(horizontal = 16.dp),
+            modifier = Modifier.padding(horizontal = Spacing.Screen),
         )
     }
 
@@ -650,7 +653,7 @@ fun HomeContentRemotePillOnlinePreview() =
             remoteButtonState = RemoteButtonState.Ready,
             deviceCheckIn = HomePreviewData.freshCheckIn,
             buttonHealthDisplay = ButtonHealthDisplay.Online,
-            modifier = Modifier.padding(horizontal = 16.dp),
+            modifier = Modifier.padding(horizontal = Spacing.Screen),
         )
     }
 
@@ -664,7 +667,7 @@ fun HomeContentRemotePillOfflinePreview() =
             remoteButtonState = RemoteButtonState.Ready,
             deviceCheckIn = HomePreviewData.freshCheckIn,
             buttonHealthDisplay = ButtonHealthDisplay.Offline(durationLabel = "11 min ago"),
-            modifier = Modifier.padding(horizontal = 16.dp),
+            modifier = Modifier.padding(horizontal = Spacing.Screen),
         )
     }
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/DiagnosticsContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/DiagnosticsContent.kt
@@ -58,7 +58,11 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.chriscartland.garage.GarageApplication
 import com.chriscartland.garage.applogger.exportAppLogCsvToUri
 import com.chriscartland.garage.di.rememberAppComponent
+import com.chriscartland.garage.ui.theme.ButtonSpacing
+import com.chriscartland.garage.ui.theme.CardPadding
+import com.chriscartland.garage.ui.theme.DividerInset
 import com.chriscartland.garage.ui.theme.PreviewScreenSurface
+import com.chriscartland.garage.ui.theme.Spacing
 import com.chriscartland.garage.usecase.AppLoggerViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -162,8 +166,11 @@ fun DiagnosticsContent(
     ) {
         LazyColumn(
             modifier = Modifier.weight(1f).fillMaxWidth(),
-            contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(
+                horizontal = Spacing.Screen,
+                vertical = Spacing.ListVertical,
+            ),
+            verticalArrangement = Arrangement.spacedBy(Spacing.BetweenItems),
         ) {
             item {
                 Surface(
@@ -175,7 +182,7 @@ fun DiagnosticsContent(
                         counters.forEachIndexed { index, c ->
                             CounterRow(c.label, c.value)
                             if (index < counters.lastIndex) {
-                                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                                HorizontalDivider(modifier = Modifier.padding(horizontal = DividerInset.FullWidth))
                             }
                         }
                     }
@@ -194,7 +201,7 @@ fun DiagnosticsContent(
             )
             Text(
                 text = "Export CSV",
-                modifier = Modifier.padding(start = 8.dp),
+                modifier = Modifier.padding(start = ButtonSpacing.IconText),
             )
         }
         OutlinedButton(
@@ -218,7 +225,7 @@ fun DiagnosticsContent(
                 )
                 Text(
                     text = "Clearing…",
-                    modifier = Modifier.padding(start = 8.dp),
+                    modifier = Modifier.padding(start = ButtonSpacing.IconText),
                 )
             } else {
                 Icon(
@@ -227,7 +234,7 @@ fun DiagnosticsContent(
                 )
                 Text(
                     text = "Clear all diagnostics",
-                    modifier = Modifier.padding(start = 8.dp),
+                    modifier = Modifier.padding(start = ButtonSpacing.IconText),
                 )
             }
         }
@@ -293,7 +300,7 @@ private fun CounterRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            .padding(CardPadding.Compact),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.chriscartland.garage.ui.theme.DividerInset
 import com.chriscartland.garage.ui.theme.PreviewScreenSurface
 import com.chriscartland.garage.ui.theme.Spacing
 
@@ -118,8 +119,8 @@ fun SettingsContent(
 ) {
     LazyColumn(
         modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(vertical = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        contentPadding = PaddingValues(vertical = Spacing.ListVertical),
+        verticalArrangement = Arrangement.spacedBy(Spacing.BetweenItems),
     ) {
         item {
             SettingsSection(label = "Account") {
@@ -174,7 +175,7 @@ fun SettingsContent(
                     showChevron = true,
                     onClick = onVersionTap,
                 )
-                HorizontalDivider(modifier = Modifier.padding(start = 56.dp))
+                HorizontalDivider(modifier = Modifier.padding(start = DividerInset.ListItem))
                 SettingsRow(
                     icon = Icons.Outlined.Storefront,
                     title = "Play Store",
@@ -183,7 +184,7 @@ fun SettingsContent(
                     showChevron = false,
                     onClick = onPlayStoreTap,
                 )
-                HorizontalDivider(modifier = Modifier.padding(start = 56.dp))
+                HorizontalDivider(modifier = Modifier.padding(start = DividerInset.ListItem))
                 SettingsRow(
                     icon = Icons.Outlined.Description,
                     title = "Privacy Policy",
@@ -205,7 +206,7 @@ fun SettingsContent(
                         showChevron = true,
                         onClick = onDiagnosticsTap,
                     )
-                    HorizontalDivider(modifier = Modifier.padding(start = 56.dp))
+                    HorizontalDivider(modifier = Modifier.padding(start = DividerInset.ListItem))
                     SettingsRow(
                         icon = Icons.AutoMirrored.Outlined.List,
                         title = "Function list",


### PR DESCRIPTION
## Summary

Stage 3b of the spacing-consistency plan ([SPACING_PLAN.md](https://github.com/cartland/SmartGarageDoor/blob/main/AndroidGarage/docs/SPACING_PLAN.md)).

Migrates \`HomeContent.kt\` and its child Composables (HomeStatusCardBody, HomeRemoteButtonBody, HomeAlertCard, HomeAuthLoadingBody, HomeSignInBody, the alerts inner Column, and 13 preview wrappers) to consume spacing tokens.

Highlights:
- \`CardPadding.Tall\` for the hero status card (24v/16h)
- \`CardPadding.Standard\` for the remote-button card
- \`CardPadding.Compact\` for HomeAlertCard (banner)
- \`ParagraphSpacing.IconToText\` and \`ButtonSpacing.Inline\` for alert layout
- \`Spacing.Screen\` on all 13 preview wrappers (production gets it from Main.kt; previews need to mirror)
- \`Spacing.Tight\` for tight text-stack groupings inside the status card

Pure rename — Home screenshot regeneration produced zero PNG diffs.

After this lands, Stages 1/2/3 together complete the pure-rename phase of the plan. Stage 0 (large-screen wrapper) and Stage 4 (design decisions) remain.

## Merge order

Stacked on #680 (Stage 3a — list screens).
⚠️ Merge AFTER #680. Do not merge before #680 lands on main.
Stack: #677 → #678 → #679 → #680 → **#681 (Stage 3b)** → Stage 0 → Stage 4.

## Test plan

- [x] \`./scripts/validate.sh\` passes
- [x] Home screenshot regeneration on 13 fixtures produced zero PNG diffs
- [x] No screenshot updates required — pure rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)