### PR TITLE
feat(android): Stage 4 — Diagnostics buttons follow parent-vs-child spacing rule [REVIEW]

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/DiagnosticsContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/DiagnosticsContent.kt
@@ -189,53 +189,63 @@ fun DiagnosticsContent(
                 }
             }
         }
-        Button(
-            onClick = onExportCsv,
+        // Action buttons sit in a sub-Column whose Arrangement.spacedBy
+        // owns the gap between buttons (parent-vs-child spacing rule:
+        // children don't claim ownership of their outer gap). Horizontal
+        // and bottom screen padding move from per-button modifiers to the
+        // Column wrapper so the rule "single source of horizontal layout"
+        // holds inside this section too.
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 16.dp, end = 16.dp, top = 16.dp),
+                .padding(horizontal = Spacing.Screen)
+                .padding(vertical = Spacing.ListVertical),
+            verticalArrangement = Arrangement.spacedBy(ButtonSpacing.Stacked),
         ) {
-            Icon(
-                imageVector = Icons.Filled.Download,
-                contentDescription = null,
-            )
-            Text(
-                text = "Export CSV",
-                modifier = Modifier.padding(start = ButtonSpacing.IconText),
-            )
-        }
-        OutlinedButton(
-            onClick = { confirmClearOpen = true },
-            enabled = !clearInFlight,
-            colors = ButtonDefaults.outlinedButtonColors(
-                contentColor = MaterialTheme.colorScheme.error,
-            ),
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-        ) {
-            // While the clear is in flight, swap the trash icon for a small
-            // spinner and the label for "Clearing…". Button is disabled so
-            // a second tap can't queue another clear during the wait.
-            if (clearInFlight) {
-                CircularProgressIndicator(
-                    strokeWidth = 2.dp,
-                    color = MaterialTheme.colorScheme.error,
-                    modifier = Modifier.size(20.dp),
-                )
-                Text(
-                    text = "Clearing…",
-                    modifier = Modifier.padding(start = ButtonSpacing.IconText),
-                )
-            } else {
+            Button(
+                onClick = onExportCsv,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
                 Icon(
-                    imageVector = Icons.Outlined.DeleteForever,
+                    imageVector = Icons.Filled.Download,
                     contentDescription = null,
                 )
                 Text(
-                    text = "Clear all diagnostics",
+                    text = "Export CSV",
                     modifier = Modifier.padding(start = ButtonSpacing.IconText),
                 )
+            }
+            OutlinedButton(
+                onClick = { confirmClearOpen = true },
+                enabled = !clearInFlight,
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = MaterialTheme.colorScheme.error,
+                ),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                // While the clear is in flight, swap the trash icon for a small
+                // spinner and the label for "Clearing…". Button is disabled so
+                // a second tap can't queue another clear during the wait.
+                if (clearInFlight) {
+                    CircularProgressIndicator(
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.size(20.dp),
+                    )
+                    Text(
+                        text = "Clearing…",
+                        modifier = Modifier.padding(start = ButtonSpacing.IconText),
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Outlined.DeleteForever,
+                        contentDescription = null,
+                    )
+                    Text(
+                        text = "Clear all diagnostics",
+                        modifier = Modifier.padding(start = ButtonSpacing.IconText),
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Stage 4 of the spacing-consistency plan ([SPACING_PLAN.md](https://github.com/cartland/SmartGarageDoor/blob/main/AndroidGarage/docs/SPACING_PLAN.md)).

Refactors \`DiagnosticsContent\`'s Export and Clear action buttons to use a parent Column that owns the gap between them, instead of each button claiming its own outer padding via \`Modifier.padding(top = 16.dp)\` etc.

This fixes the parent-vs-child spacing rule violation flagged during Stage 3a — a composable should describe its interior, not its surrounding gap. The cleanest form has the parent owning gaps via \`Arrangement.spacedBy(...)\`; the children just say \`Modifier.fillMaxWidth()\`.

**Visual: byte-identical.** The new \`Arrangement.spacedBy(ButtonSpacing.Stacked = 16dp)\` produces the exact same 16dp gap as the old per-button \`padding(top = 16.dp)\`. Verified via screenshot regeneration on the Settings tests — zero PNG diffs.

## What about the other Stage 4 sub-decisions?

The plan flagged three sub-decisions:
1. ✅ **Button inter-spacing** (this PR) — adopt \`ButtonSpacing.Stacked\` via parent \`Arrangement.spacedBy\`
2. ⏸️ **Paragraph-spacing rule** — deferred. \`FunctionListWarning\`'s \`vertical = 8.dp\` already doubles up with the LazyColumn's \`Arrangement.spacedBy(BetweenItems = 8dp)\`, so removing the warning's own padding would cut the visual gap in half. That's a design call, not a mechanical migration.
3. ⏸️ **Bottom-sheet vertical padding** — deferred. AccountBottomSheet (24dp) vs SnoozeBottomSheet (16dp) is content-density dependent; both feel correct for what's inside.

Both deferred items remain open questions in SPACING_PLAN.md and can land in follow-up PRs once you pick a direction. This PR closes the most concrete sub-decision.

## Merge order

Stacked on #682 (Stage 0).
⚠️ Merge AFTER #682. Auto-merge intentionally NOT enabled — even though the visual is byte-identical, this is design-call territory and benefits from review.
Stack: #677 → #678 → #679 → #680 → #681 → #682 → **#683 (Stage 4)**.

## Test plan

- [x] \`./scripts/validate.sh\` passes
- [x] Settings screenshot regeneration produced zero PNG diffs
- [x] Code compiles, lints, ktlint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)