### PR TITLE
fix(android): Developer section animates vertical-only (was 2D expand/shrink)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
@@ -18,6 +18,10 @@
 package com.chriscartland.garage.ui.settings
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -194,7 +198,16 @@ fun SettingsContent(
         }
 
         item {
-            AnimatedVisibility(visible = showDeveloperSection) {
+            AnimatedVisibility(
+                visible = showDeveloperSection,
+                // Compose's default `expandIn`/`shrinkOut` animate in both
+                // dimensions; for a section that fills the row width and only
+                // changes its height, we want vertical-only — `expandVertically`/
+                // `shrinkVertically` keep width constant and animate height.
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut(),
+                label = "Developer section",
+            ) {
                 SettingsSection(label = "Developer") {
                     SettingsRow(
                         icon = Icons.Outlined.Analytics,


### PR DESCRIPTION
## Summary

The Developer section (Settings → Diagnostics + Function list) was animating in **both dimensions** on show/hide because the \`AnimatedVisibility\` call site used Compose's defaults (\`fadeIn() + expandIn()\` and \`shrinkOut() + fadeOut()\`). The section is full-row-width and only its height changes; the horizontal expand/shrink looked like an unintentional zoom.

## Fix

\`\`\`kotlin
AnimatedVisibility(
    visible = showDeveloperSection,
    enter = expandVertically() + fadeIn(),
    exit = shrinkVertically() + fadeOut(),
    label = "Developer section",
)
\`\`\`

\`expandVertically\` / \`shrinkVertically\` keep width constant and only animate height. Also adds a \`label\` for Layout Inspector / Compose tooling (closes the loop on the recommendation from the prior \`AnimatedVisibility\` audit).

## Test plan

- [x] Compiles + spotless clean
- [x] \`./scripts/validate.sh\` passes
- [x] Settings screenshot regeneration produced zero PNG diffs (screenshot tests pin end-states only; mid-transition frames are not captured, so the animation change isn't visible in PNG diffs)
- [ ] Smoke test on device after release: sign in → Settings tab → toggle Developer-allowlist visibility (sign in/out) → confirm section slides in/out vertically without horizontal zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)