### PR TITLE
feat(android): structural guards for ADR-027 (no-token-in-UseCase + listener-loop purity)

### DIFF
--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -212,6 +212,12 @@ tasks.register<architecture.NoBareTopLevelFunctionsTask>("checkNoBareTopLevelFun
     )
 }
 
+tasks.register<architecture.NoTokenInUseCaseTask>("checkNoTokenInUseCase") {
+    sourceDirs = listOf(
+        "$rootDir/usecase/src/commonMain/kotlin",
+    )
+}
+
 tasks.register<architecture.NoImplSuffixTask>("checkNoImplSuffix") {
     sourceDirs = listOf(
         "$rootDir/androidApp/src/main/java",

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/NoTokenInUseCaseTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/NoTokenInUseCaseTask.kt
@@ -1,0 +1,106 @@
+package architecture
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Enforces ADR-027: ID token state is private to `AuthRepository` and the
+ * network repositories that legitimately need it. **UseCases never touch
+ * a token.**
+ *
+ * Detection: scans every `*UseCase.kt` file in the configured source dirs
+ * for parameter declarations of the form `idToken: String` or
+ * `idToken: FirebaseIdToken`. Any match is a violation — the UseCase is
+ * threading a token through its public API surface, which is exactly what
+ * Option C eliminated.
+ *
+ * The token-handling responsibility moved into `AuthRepository.getIdToken`
+ * and the per-repo `getIdToken(forceRefresh = true)` calls in
+ * `Network*Repository`. UseCases call `AuthRepository.authState` to gate
+ * on `is AuthState.Authenticated` and delegate to a repo method that takes
+ * no token argument.
+ *
+ * **Exemptions:** `SignInWithGoogleUseCase` (and any future UseCase that
+ * passes a *Google* sign-in token to begin the auth flow — distinct from
+ * the Firebase ID token) is exempt because the credential it carries is
+ * the *input* to authentication, not a token *issued by* it. The check
+ * scopes to `idToken: ` (Firebase ID token convention) and ignores
+ * `googleIdToken: ` and other inbound credentials.
+ */
+abstract class NoTokenInUseCaseTask : DefaultTask() {
+    @get:Input
+    var sourceDirs: List<String> = emptyList()
+
+    /**
+     * Token parameter shapes that indicate the ADR-027 violation. Matches
+     * the parameter name `idToken` followed by a type the repository
+     * boundary uses for Firebase ID tokens. Other token shapes (Google
+     * sign-in credential, FCM topic key, button-ack token) are not
+     * covered by ADR-027 and stay legal.
+     */
+    @get:Input
+    var bannedParameterPatterns: List<String> = listOf(
+        """\bidToken\s*:\s*String\b""",
+        """\bidToken\s*:\s*FirebaseIdToken\b""",
+    )
+
+    @TaskAction
+    fun check() {
+        val violations = mutableListOf<String>()
+        val patterns = bannedParameterPatterns.map { Regex(it) }
+
+        sourceDirs.forEach { dir ->
+            val rootFile = File(dir)
+            if (!rootFile.exists()) return@forEach
+
+            rootFile
+                .walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .filter { it.name.endsWith("UseCase.kt") }
+                .forEach { file ->
+                    val relativePath = file.relativeTo(rootFile).path
+                    val lines = file.readLines()
+                    lines.forEachIndexed { index, line ->
+                        patterns.forEach { pattern ->
+                            if (pattern.containsMatchIn(line)) {
+                                violations.add("$relativePath:${index + 1}: ${line.trim()}")
+                            }
+                        }
+                    }
+                }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    append("NoTokenInUseCase check FAILED: ")
+                    append(violations.size)
+                    append(" violation(s).\n\n")
+                    violations.forEach { append("  - $it\n") }
+                    append("\n")
+                    append("ADR-027: ID tokens must NOT appear in UseCase signatures.\n")
+                    append("Token state is private to AuthRepository and the network\n")
+                    append("repositories that need it. UseCases gate on is-authenticated\n")
+                    append("and delegate to a repo method that takes no token argument.\n\n")
+                    append("Fix:\n")
+                    append("  - Drop the `idToken: String` (or `idToken: FirebaseIdToken`)\n")
+                    append("    parameter from the UseCase's `invoke(...)` signature.\n")
+                    append("  - Move the token fetch into the repository implementation\n")
+                    append("    via `authRepository.getIdToken(forceRefresh = true)`.\n")
+                    append("  - The UseCase keeps its `is AuthState.Authenticated` gate.\n\n")
+                    append("Canonical examples (post-ADR-027):\n")
+                    append("  - FetchButtonHealthUseCase, PushRemoteButtonUseCase,\n")
+                    append("    SnoozeNotificationsUseCase\n")
+                    append("  - NetworkButtonHealthRepository, NetworkRemoteButtonRepository,\n")
+                    append("    NetworkSnoozeRepository, CachedFeatureAllowlistRepository\n\n")
+                    append("See AndroidGarage/docs/DECISIONS.md (ADR-027).\n")
+                },
+            )
+        }
+
+        logger.lifecycle("NoTokenInUseCase check passed: no UseCase exposes an idToken parameter.")
+    }
+}

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/FirebaseAuthRepositoryTest.kt
@@ -156,4 +156,39 @@ class FirebaseAuthRepositoryTest {
 
             assertNull(repo.getIdToken(forceRefresh = true))
         }
+
+    // --- ADR-027: listener-loop purity ---
+
+    @Test
+    fun listenerLoopDoesNotCallGetIdToken() =
+        runTest(UnconfinedTestDispatcher()) {
+            // Structural guard for ADR-027. The reactive listener loop in
+            // FirebaseAuthRepository.init must NOT call authBridge.getIdToken;
+            // its responsibility is identity mapping only. Token state is a
+            // private concern of AuthRepository and the network repos that
+            // need it.
+            //
+            // This test pins the rule by setting up an auth user *before* the
+            // repo is constructed, letting the listener fire, and then
+            // asserting the bridge's getIdToken call counter is still zero.
+            // If a future change adds `getIdToken` back into the listener
+            // collect block (the regression that introduced the 2.13.2
+            // sign-in failure), this test will fail with a non-zero count.
+            val bridge = FakeAuthBridge()
+            bridge.setAuthUser(AuthUserInfo(displayName = "Eve", email = "eve@test.com"))
+
+            val (repo, _) = createRepository(authBridge = bridge)
+            advanceUntilIdle()
+
+            // Identity propagated through the listener — proves it ran.
+            assertIs<AuthState.Authenticated>(repo.authState.value)
+            // …but did NOT pull a token. That's the invariant.
+            assertEquals(
+                0,
+                bridge.getIdTokenCount,
+                "Listener loop must not call getIdToken (ADR-027). If you " +
+                    "need a token, fetch it explicitly via AuthRepository.getIdToken " +
+                    "from the network repo that needs it.",
+            )
+        }
 }

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -55,6 +55,9 @@ $GRADLE checkNoBareTopLevelFunctions && pass "no bare top-level functions" || fa
 step "No *Impl suffix on class names (ADR-008 — use descriptive prefix)"
 $GRADLE checkNoImplSuffix && pass "no *Impl suffix" || fail "no *Impl suffix"
 
+step "No idToken parameter on UseCases (ADR-027 — token internal to repos)"
+$GRADLE checkNoTokenInUseCase && pass "no token in UseCase" || fail "no token in UseCase"
+
 step "No Mockito imports (ADR-003 — fakes over mocks)"
 $GRADLE checkNoMockitoImports && pass "no Mockito imports" || fail "no Mockito imports"
 


### PR DESCRIPTION
## Summary

Two mechanical guards so the ADR-027 intent stays enforced going forward:

### 1. \`checkNoTokenInUseCase\` Gradle task

Scans \`usecase/src/commonMain/kotlin/.../UseCase.kt\` for \`idToken: String\` or \`idToken: FirebaseIdToken\` parameter declarations. Fails the build if any UseCase exposes a token on its public surface — the exact shape ADR-027 eliminated. Wired into \`validate.sh\` alongside the other architecture checks.

Mirrors the existing \`checkNoBareTopLevelFunctions\` / \`checkNoImplSuffix\` pattern (see \`buildSrc/src/main/kotlin/architecture/\`).

### 2. \`listenerLoopDoesNotCallGetIdToken\` test

Pins that the reactive listener loop in \`FirebaseAuthRepository.init\` does NOT call \`authBridge.getIdToken\`. Constructs the repo with a pre-populated auth user, lets the listener fire, then asserts the bridge's \`getIdTokenCount\` is still zero. If a future change re-adds the side-effecting fetch (the regression that caused the 2.13.2 sign-in failure and 2.13.3 defensive patch), this test fails with a non-zero count.

## Why these two

ADR-027's contract has two halves:
- **"UseCases don't see tokens"** — was enforced only by *deleted code* (the deleted \`EnsureFreshIdTokenUseCase\`). A future agent could re-add a similar UseCase pattern. Now: mechanical lint catches it.
- **"Listener doesn't fetch tokens"** — was enforced only by the inline KDoc comment and ADR text. Now: runtime test catches it.

Both halves now have a mechanical guard that fires on regression — the type system continues to do the rest.

## Test plan

- [x] \`./scripts/validate.sh\` passes
- [x] \`checkNoTokenInUseCase\` runs clean on current code (the 3 migrated UseCases all dropped the param)
- [x] \`listenerLoopDoesNotCallGetIdToken\` passes (the listener is currently pure)
- [x] No production code changes — guards only

🤖 Generated with [Claude Code](https://claude.com/claude-code)