### PR TITLE
feat(android): four more structural guards (RouteContent, ContentWidth, repo interfaces, AppAnimatedVisibility)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
@@ -17,11 +17,6 @@
 
 package com.chriscartland.garage.ui.settings
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -59,6 +54,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.chriscartland.garage.ui.theme.AppAnimatedVisibility
 import com.chriscartland.garage.ui.theme.DividerInset
 import com.chriscartland.garage.ui.theme.PreviewScreenSurface
 import com.chriscartland.garage.ui.theme.Spacing
@@ -198,14 +194,8 @@ fun SettingsContent(
         }
 
         item {
-            AnimatedVisibility(
+            AppAnimatedVisibility(
                 visible = showDeveloperSection,
-                // Compose's default `expandIn`/`shrinkOut` animate in both
-                // dimensions; for a section that fills the row width and only
-                // changes its height, we want vertical-only — `expandVertically`/
-                // `shrinkVertically` keep width constant and animate height.
-                enter = expandVertically() + fadeIn(),
-                exit = shrinkVertically() + fadeOut(),
                 label = "Developer section",
             ) {
                 SettingsSection(label = "Developer") {

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/theme/AppAnimatedVisibility.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/theme/AppAnimatedVisibility.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui.theme
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * Project-default visibility transition for sections / rows that change
+ * height but not width.
+ *
+ * Compose's stock `AnimatedVisibility(visible = ...)` defaults to
+ * `fadeIn() + expandIn()` and `shrinkOut() + fadeOut()` — both 2D
+ * (animates width AND height). For sections that fill the parent's
+ * width and only their height changes (the common case in this app),
+ * the horizontal expand/shrink reads as an unintentional zoom. 2.13.5
+ * fixed exactly that bug in the Developer section.
+ *
+ * This wrapper bakes in `expandVertically() + fadeIn()` /
+ * `shrinkVertically() + fadeOut()` so future call sites get the right
+ * default without re-discovering the trap. The `label` parameter is
+ * required (Compose tooling friendlier with labeled animations).
+ *
+ * If a future case genuinely needs 2D animation (a card growing in
+ * place, a popover, etc.), use the upstream `AnimatedVisibility`
+ * directly with explicit specs — that's a deliberate departure, not
+ * the default.
+ */
+@Composable
+fun AppAnimatedVisibility(
+    visible: Boolean,
+    label: String,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    AnimatedVisibility(
+        visible = visible,
+        modifier = modifier,
+        enter = expandVertically() + fadeIn(),
+        exit = shrinkVertically() + fadeOut(),
+        label = label,
+        content = { content() },
+    )
+}

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/theme/SpacingTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/theme/SpacingTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui.theme
+
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pin the asymmetry rule on `Spacing.ListContentPadding` (top vs bottom)
+ * so a future "tidy-up" doesn't silently make it symmetric.
+ *
+ * Rule documented in `AndroidGarage/docs/SPACING_PLAN.md` (Top vs.
+ * bottom asymmetry section). Top is below the TopAppBar (chrome already
+ * provides separation, minimal list padding needed). Bottom is above
+ * the NavigationBar (last item scrolls INTO that boundary; needs
+ * explicit clearance).
+ *
+ * If you intentionally change the values, update both this test and
+ * the doc — the asymmetry direction is the rule, not the specific dp
+ * values.
+ */
+class SpacingTest {
+    @Test
+    fun listContentPaddingTopIsTighterThanBottom() {
+        val pv = Spacing.ListContentPadding
+        val top = pv.calculateTopPadding()
+        val bottom = pv.calculateBottomPadding()
+
+        assertTrue(
+            "Spacing.ListContentPadding top ($top) must be < bottom ($bottom). " +
+                "Asymmetry rule: see AndroidGarage/docs/SPACING_PLAN.md.",
+            bottom > top,
+        )
+    }
+
+    @Test
+    fun listContentPaddingValues() {
+        // Pin the current values so an accidental rename / refactor that
+        // changes the dp literals also updates the doc and CHANGELOG.
+        val pv = Spacing.ListContentPadding
+        assertEquals(8.dp, pv.calculateTopPadding())
+        assertEquals(24.dp, pv.calculateBottomPadding())
+    }
+}

--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -218,6 +218,24 @@ tasks.register<architecture.NoTokenInUseCaseTask>("checkNoTokenInUseCase") {
     )
 }
 
+tasks.register<architecture.RepositoryInterfaceNoTokenCheckTask>("checkRepositoryInterfaceNoToken") {
+    // Scope deliberately narrow to repository interfaces — model classes
+    // (e.g., FirebaseIdToken) legitimately have an `idToken: String` field.
+    sourceDirs = listOf(
+        "$rootDir/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository",
+    )
+}
+
+tasks.register<architecture.RouteContentUsageCheckTask>("checkRouteContentUsage") {
+    mainKtPath = "$rootDir/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt"
+}
+
+tasks.register<architecture.ContentWidthCapCheckTask>("checkContentWidthCap") {
+    sourceDirs = listOf(
+        "$rootDir/androidApp/src/main/java",
+    )
+}
+
 tasks.register<architecture.NoImplSuffixTask>("checkNoImplSuffix") {
     sourceDirs = listOf(
         "$rootDir/androidApp/src/main/java",

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/ContentWidthCapCheckTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/ContentWidthCapCheckTask.kt
@@ -1,0 +1,98 @@
+package architecture
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Enforces that `Modifier.widthIn(max = ...)` for the route-level content
+ * cap is applied **only at `RouteContent.kt`** — the single source of
+ * horizontal layout per ADR / SPACING_PLAN.md.
+ *
+ * Why this matters: applying `widthIn(max = ...)` at a child Composable
+ * inside the route would either (a) double-cap (if narrower than the
+ * route cap) or (b) be a no-op (if wider) — both surface as silent
+ * tablet-only layout drift that phone screenshot tests miss.
+ *
+ * Detection: scans every `*.kt` file under [sourceDirs] for the literal
+ * string `widthIn(max`. Allows the configured exempt files; fails for
+ * any other use site.
+ *
+ * Note: `widthIn(min = ...)` is allowed everywhere — only the `max =`
+ * variant is the route-cap idiom we restrict.
+ */
+abstract class ContentWidthCapCheckTask : DefaultTask() {
+    @get:Input
+    var sourceDirs: List<String> = emptyList()
+
+    /**
+     * File names that are allowed to call `widthIn(max = ...)`.
+     *
+     * Default exempts:
+     * - `RouteContent.kt` — the canonical route-level wrapper.
+     * - `AnimatableGarageDoor.kt` — uses `widthIn(max)` to size a preview
+     *   icon, not for route-level layout. Sub-component dimension, not
+     *   the rule this check enforces.
+     */
+    @get:Input
+    var exemptFileNames: List<String> = listOf(
+        "RouteContent.kt",
+        "AnimatableGarageDoor.kt",
+    )
+
+    @TaskAction
+    fun check() {
+        val violations = mutableListOf<String>()
+        val widthInMaxPattern = Regex("""\bwidthIn\s*\(\s*max\s*=""")
+
+        sourceDirs.forEach { dir ->
+            val rootFile = File(dir)
+            if (!rootFile.exists()) return@forEach
+
+            rootFile
+                .walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .filter { it.name !in exemptFileNames }
+                .forEach { file ->
+                    val relativePath = file.relativeTo(rootFile).path
+                    file.readLines().forEachIndexed { index, line ->
+                        // Skip comment / KDoc lines so prose mentioning
+                        // `widthIn(max = ...)` isn't a false positive.
+                        val trimmed = line.trimStart()
+                        if (trimmed.startsWith("//") || trimmed.startsWith("*")) return@forEachIndexed
+                        if (widthInMaxPattern.containsMatchIn(line)) {
+                            violations.add("$relativePath:${index + 1}: ${line.trim()}")
+                        }
+                    }
+                }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    append("ContentWidthCap check FAILED: ")
+                    append(violations.size)
+                    append(" disallowed `widthIn(max = ...)` use(s).\n\n")
+                    violations.forEach { append("  - $it\n") }
+                    append("\n")
+                    append("`widthIn(max = ...)` for route-level content capping is the\n")
+                    append("single responsibility of RouteContent.kt. Children inside a\n")
+                    append("route must NOT re-apply the cap — they receive the capped\n")
+                    append("modifier from RouteContent's lambda.\n\n")
+                    append("Fix:\n")
+                    append("  - If the file is a screen Composable: receive the modifier\n")
+                    append("    from the route wrapper instead of declaring a cap inline.\n")
+                    append("  - If the file legitimately needs `widthIn(max)` for a\n")
+                    append("    sub-component (e.g. a centered confirmation card), add it\n")
+                    append("    to ContentWidthCapCheckTask.exemptFileNames in build.gradle.kts\n")
+                    append("    with a comment explaining why.\n\n")
+                    append("See AndroidGarage/docs/SPACING_PLAN.md (Large-screen extension).\n")
+                },
+            )
+        }
+
+        logger.lifecycle("ContentWidthCap check passed: only RouteContent.kt caps content width.")
+    }
+}

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/RepositoryInterfaceNoTokenCheckTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/RepositoryInterfaceNoTokenCheckTask.kt
@@ -1,0 +1,98 @@
+package architecture
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Enforces ADR-027 from the *repository interface* side: no domain
+ * repository interface may declare an `idToken: String` or
+ * `idToken: FirebaseIdToken` parameter on its public methods.
+ *
+ * Why this matters: ADR-027 puts the ID token entirely inside
+ * `AuthRepository`. The Network*Repository implementations call
+ * `authRepository.getIdToken(forceRefresh = true)` themselves before
+ * delegating to a data source. If a new repository interface threads
+ * `idToken` as a parameter, a downstream UseCase or ViewModel ends up
+ * pulling the token through the call chain — exactly the shape Option C
+ * eliminated.
+ *
+ * The complementary check, [NoTokenInUseCaseTask], catches the same
+ * regression at the UseCase layer. This one catches it earlier, at the
+ * interface declaration in `domain/`.
+ *
+ * Detection: scans every Kotlin file under `domain/.../repository/`
+ * for `idToken` parameters of type `String` or `FirebaseIdToken`. Exempts
+ * `AuthRepository.kt` (whose `getIdToken(forceRefresh)` doesn't have
+ * `idToken:` as a parameter — the param name is `forceRefresh` — but
+ * the file is exempted explicitly for clarity).
+ */
+abstract class RepositoryInterfaceNoTokenCheckTask : DefaultTask() {
+    @get:Input
+    var sourceDirs: List<String> = emptyList()
+
+    @get:Input
+    var exemptFileNames: List<String> = listOf("AuthRepository.kt")
+
+    @get:Input
+    var bannedParameterPatterns: List<String> = listOf(
+        """\bidToken\s*:\s*String\b""",
+        """\bidToken\s*:\s*FirebaseIdToken\b""",
+    )
+
+    @TaskAction
+    fun check() {
+        val violations = mutableListOf<String>()
+        val patterns = bannedParameterPatterns.map { Regex(it) }
+
+        sourceDirs.forEach { dir ->
+            val rootFile = File(dir)
+            if (!rootFile.exists()) return@forEach
+
+            rootFile
+                .walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .filter { it.name !in exemptFileNames }
+                .forEach { file ->
+                    val relativePath = file.relativeTo(rootFile).path
+                    file.readLines().forEachIndexed { index, line ->
+                        patterns.forEach { pattern ->
+                            if (pattern.containsMatchIn(line)) {
+                                violations.add("$relativePath:${index + 1}: ${line.trim()}")
+                            }
+                        }
+                    }
+                }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    append("RepositoryInterfaceNoToken check FAILED: ")
+                    append(violations.size)
+                    append(" violation(s).\n\n")
+                    violations.forEach { append("  - $it\n") }
+                    append("\n")
+                    append("ADR-027: domain repository interfaces must NOT declare an\n")
+                    append("`idToken: String` (or `idToken: FirebaseIdToken`) parameter.\n")
+                    append("Token state is private to AuthRepository; implementations\n")
+                    append("call `authRepository.getIdToken(forceRefresh = true)`\n")
+                    append("themselves before delegating to a data source.\n\n")
+                    append("Fix:\n")
+                    append("  - Drop the `idToken:` parameter from the interface method.\n")
+                    append("  - In the implementation, inject `AuthRepository` and\n")
+                    append("    fetch the token internally.\n\n")
+                    append("Canonical examples (post-ADR-027):\n")
+                    append("  - ButtonHealthRepository.fetchButtonHealth() — no params\n")
+                    append("  - RemoteButtonRepository.pushButton(buttonAckToken) — no token\n")
+                    append("  - SnoozeRepository.snoozeNotifications(...) — no token\n\n")
+                    append("See AndroidGarage/docs/DECISIONS.md (ADR-027).\n")
+                },
+            )
+        }
+
+        logger.lifecycle("RepositoryInterfaceNoToken check passed: no repo interface exposes an idToken parameter.")
+    }
+}

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/RouteContentUsageCheckTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/RouteContentUsageCheckTask.kt
@@ -1,0 +1,91 @@
+package architecture
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Enforces that every nav-graph entry in `Main.kt` wraps its content in
+ * `RouteContent { ... }` — the single source of horizontal layout
+ * (padding + max-width + centering) introduced in 2.13.0 (PR #682).
+ *
+ * Why this matters: `RouteContent` applies (a) `Modifier.widthIn(max =
+ * ContentWidth.Standard)` to cap content width on tablets/landscape and
+ * (b) horizontal centering via `Box(TopCenter)`. A new `entry<Screen.X>`
+ * block that skips the wrapper would silently break the cap on that
+ * route, and the regression would only be visible on tablets — easy to
+ * miss in phone-only screenshot tests.
+ *
+ * Detection (heuristic): scans `Main.kt` for `entry<Screen.X>` lines and
+ * verifies that within the next [lookAheadLines] lines, a `RouteContent {`
+ * call appears. The window is large enough to cover the entry's body
+ * without crossing into the next entry block.
+ */
+abstract class RouteContentUsageCheckTask : DefaultTask() {
+    @get:Input
+    var mainKtPath: String = ""
+
+    /**
+     * How many lines to scan after each `entry<...>` line for a
+     * `RouteContent {` call. 15 is comfortable for the current shape
+     * (~5 lines per entry block including the route's own param list).
+     */
+    @get:Input
+    var lookAheadLines: Int = 15
+
+    @TaskAction
+    fun check() {
+        val file = File(mainKtPath)
+        if (!file.exists()) {
+            throw GradleException("RouteContentUsage check: $mainKtPath not found.")
+        }
+
+        val lines = file.readLines()
+        val entryPattern = Regex("""\bentry<Screen\.[A-Za-z]+>\s*\{""")
+        val routeContentPattern = Regex("""\bRouteContent\s*\{""")
+
+        val violations = mutableListOf<String>()
+
+        lines.forEachIndexed { index, line ->
+            if (!entryPattern.containsMatchIn(line)) return@forEachIndexed
+            // Look ahead for RouteContent { within the window.
+            val window = lines.subList(
+                index + 1,
+                minOf(index + 1 + lookAheadLines, lines.size),
+            )
+            if (window.none { routeContentPattern.containsMatchIn(it) }) {
+                violations.add("${file.name}:${index + 1}: ${line.trim()}")
+            }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    append("RouteContentUsage check FAILED: ")
+                    append(violations.size)
+                    append(" entry block(s) without RouteContent.\n\n")
+                    violations.forEach { append("  - $it\n") }
+                    append("\n")
+                    append("Every NavDisplay entry in Main.kt must wrap its content in\n")
+                    append("RouteContent { routeModifier -> ... }. RouteContent is the\n")
+                    append("single source of horizontal layout — it applies the\n")
+                    append("ContentWidth.Standard cap and centers content on tablets/landscape.\n\n")
+                    append("Fix:\n")
+                    append("  entry<Screen.X> {\n")
+                    append("      RouteContent { routeModifier ->\n")
+                    append("          XContent(\n")
+                    append("              modifier = routeModifier.padding(horizontal = Spacing.Screen),\n")
+                    append("              ...\n")
+                    append("          )\n")
+                    append("      }\n")
+                    append("  }\n\n")
+                    append("See AndroidGarage/docs/SPACING_PLAN.md (Large-screen extension).\n")
+                },
+            )
+        }
+
+        logger.lifecycle("RouteContentUsage check passed: every entry uses RouteContent.")
+    }
+}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -58,6 +58,15 @@ $GRADLE checkNoImplSuffix && pass "no *Impl suffix" || fail "no *Impl suffix"
 step "No idToken parameter on UseCases (ADR-027 — token internal to repos)"
 $GRADLE checkNoTokenInUseCase && pass "no token in UseCase" || fail "no token in UseCase"
 
+step "No idToken parameter on domain repository interfaces (ADR-027)"
+$GRADLE checkRepositoryInterfaceNoToken && pass "no token in repo interface" || fail "no token in repo interface"
+
+step "Every NavDisplay entry uses RouteContent (single source of horizontal layout)"
+$GRADLE checkRouteContentUsage && pass "RouteContent usage" || fail "RouteContent usage"
+
+step "ContentWidth cap applied only at RouteContent (no per-screen widthIn(max))"
+$GRADLE checkContentWidthCap && pass "ContentWidth cap" || fail "ContentWidth cap"
+
 step "No Mockito imports (ADR-003 — fakes over mocks)"
 $GRADLE checkNoMockitoImports && pass "no Mockito imports" || fail "no Mockito imports"
 


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to PR #696 (auth-token guards). Adds four mechanical reinforcements + one wrapper composable + one small test.

### What's added

| Guard | Type | Reinforces |
|---|---|---|
| \`checkRouteContentUsage\` | Build task | Every NavDisplay entry in Main.kt wraps content in \`RouteContent { ... }\` |
| \`checkContentWidthCap\` | Build task | \`widthIn(max = ...)\` is only used in \`RouteContent.kt\` (sub-component preview-icon use in \`AnimatableGarageDoor.kt\` is exempted with comment) |
| \`checkRepositoryInterfaceNoToken\` | Build task | Domain repository interfaces don't expose \`idToken\` parameters (complements \`checkNoTokenInUseCase\` from #696) |
| \`AppAnimatedVisibility\` | Wrapper composable | Defaults to vertical-only enter/exit so future call sites avoid the 2D-vs-vertical bug fixed in 2.13.5 |
| \`SpacingTest.listContentPaddingTopIsTighterThanBottom\` | Unit test | Pins the asymmetry rule (top < bottom) on \`Spacing.ListContentPadding\` |

### Why now

The user asked to ship the helpful guards from the table without waiting for a regression. These five address conventions established during the recent rollouts (RouteContent/ContentWidth from 2.13.0, repo-interface clean-up from 2.13.4, AnimatedVisibility default from the 2.13.5 bug fix). All have either:
- A real bug history justifying the guard (AnimatedVisibility, ListContentPadding asymmetry), OR
- A load-bearing convention with no current enforcement (RouteContent, ContentWidth, repository interfaces)

Skipped from the table: \`checkNoRawDpInUi\` lint (too noisy without a careful allowlist; deferred per spacing plan Stage 5) and \`checkInFlightIndicatorContract\` (hard to define mechanically).

### One implementation choice worth flagging

\`AnimatableGarageDoor.kt:242\` uses \`Modifier.widthIn(max = PREVIEW_ICON_WIDTH_DP.dp)\` for legitimate preview-icon sizing, NOT route-level capping. Added to \`ContentWidthCapCheckTask.exemptFileNames\` with a comment explaining why. If a third file ever needs to be exempted, that's a smell worth investigating before adding it to the list.

### Test plan

- [x] All three new lint tasks run clean on current main
- [x] \`SpacingTest\` passes
- [x] Settings screenshot regen produced zero PNG diffs (\`AppAnimatedVisibility\` wrapper preserves the 2.13.5 vertical-only behavior)
- [x] \`./scripts/validate.sh\` passes (with the three new tasks wired in)
- [x] No production behavior change beyond the wrapper migration (which is byte-identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)