### PR TITLE
feat(android): saveable back stack + rememberSaveable sweep (PR A)

### DIFF
--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/ConfigurationChangeTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/ConfigurationChangeTest.kt
@@ -10,59 +10,72 @@ import org.junit.Rule
 import org.junit.Test
 
 /**
- * Tests that the app survives configuration changes (rotation, dark mode toggle, etc.)
- * without crashing.
+ * Configuration-change resilience.
  *
- * Uses [ActivityScenario.recreate] to simulate a configuration change, which destroys
- * and recreates the Activity. This catches:
- * - State that isn't properly saved/restored
- * - ViewModels that don't survive recreation
- * - Compose state that crashes on re-composition after recreation
+ * Uses [ActivityScenario.recreate] to simulate a configuration change
+ * (rotation, dark mode, locale, font scale, density, multi-window resize —
+ * they all reduce to the same Activity-recreate cycle).
+ *
+ * Pre-PR-A: only asserted "doesn't crash" and explicitly accepted "may reset
+ * to Home" — the back stack was a plain `remember { mutableStateListOf(...) }`
+ * that did not survive Activity recreation. The save-restore signal is now
+ * `rememberNavBackStack()` and `rememberSaveable` for in-screen UI state, so
+ * post-recreate the user lands on the **same** screen they were on. These
+ * tests pin that contract.
  */
 class ConfigurationChangeTest {
     @get:Rule
     val composeTestRule = createAndroidComposeRule<MainActivity>()
 
     /**
-     * The app must not crash when the Activity is recreated (e.g., rotation).
-     *
-     * This was the primary crash bug: rememberSaveable tried to Bundle-save
-     * Screen objects that aren't Parcelable, causing a crash on save.
+     * Activity must recreate without crashing. The original failure was
+     * `rememberSaveable` Bundling Nav3 Screen objects that weren't
+     * Parcelable; the test stays in place to catch a similar regression
+     * in any future saveable wiring.
      */
     @Test
     fun appSurvivesActivityRecreation() {
-        // Verify app is running
         composeTestRule.onNodeWithText("Garage").assertIsDisplayed()
 
-        // Simulate configuration change (rotation)
         composeTestRule.activityRule.scenario.recreate()
 
-        // App should still be running after recreation
         composeTestRule.onNodeWithText("Garage").assertIsDisplayed()
     }
 
     /**
-     * Navigation state should survive configuration change.
-     * After recreation, we should still see the app functioning.
+     * A sub-screen reached via two clicks (Settings → Diagnostics) must
+     * still be the active screen after recreation.
+     *
+     * "Diagnostics" is the topbar title for that sub-screen and appears
+     * nowhere else, so its presence post-recreate proves the back stack
+     * was restored to depth-2 (`[Home, Diagnostics]`).
      */
     @Test
-    fun navigationSurvivesRecreation() {
-        // Navigate to History
-        composeTestRule.onNodeWithText("History").performClick()
+    fun subScreenSurvivesRecreation() {
+        // Navigate Settings tab → Diagnostics row.
+        composeTestRule.onNodeWithText("Settings").performClick()
         composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Diagnostics").performClick()
+        composeTestRule.waitForIdle()
+        // "Diagnostics" topbar title is unique to this screen.
+        composeTestRule.onNodeWithText("Diagnostics").assertIsDisplayed()
 
-        // Recreate Activity
         composeTestRule.activityRule.scenario.recreate()
 
-        // App should still be functional (may reset to Home, that's OK)
-        composeTestRule.onNodeWithText("Garage").assertIsDisplayed()
+        // Back stack survived: still on Diagnostics.
+        composeTestRule.onNodeWithText("Diagnostics").assertIsDisplayed()
     }
 
     /**
-     * Navigate to each screen and recreate — none should crash.
+     * Navigate to each top-level tab and recreate — none should crash.
+     *
+     * The test does not assert which tab is selected post-recreate per
+     * iteration (that would require a per-tab unique text marker the
+     * default state doesn't always emit). The depth-2 case above is the
+     * load-bearing assertion that the back stack rides through recreation.
      */
     @Test
-    fun allScreensSurviveRecreation() {
+    fun allTabsSurviveRecreation() {
         for (tab in listOf("Home", "History", "Settings")) {
             composeTestRule.onNodeWithText(tab).performClick()
             composeTestRule.waitForIdle()

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -81,7 +82,9 @@ fun HomeContent(
         .collectAsStateWithLifecycle(initialValue = ButtonHealthDisplay.Loading)
 
     val notificationPermissionState = rememberNotificationPermissionState()
-    var permissionRequestCount by remember { mutableIntStateOf(0) }
+    // Survives rotation + process death so the alert flicker on rotation
+    // doesn't re-prompt for permission spuriously.
+    var permissionRequestCount by rememberSaveable { mutableIntStateOf(0) }
 
     // `now` is driven by the VM's LiveClock-backed StateFlow (10s tick) —
     // `rememberLiveNow()` no longer exists; the ticker is owned by the

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -37,12 +37,13 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import com.chriscartland.garage.ui.settings.DiagnosticsScreen
@@ -76,11 +77,13 @@ private inline fun <reified T> navTween() = tween<T>(NAV_ANIM_DURATION, easing =
 /**
  * Type-safe navigation routes.
  *
- * Each route is a @Serializable object — the compiler ensures route references
- * are valid and navigation arguments (if added later) are type-checked.
- * Used with Navigation 3's NavDisplay + entryProvider.
+ * Each route is a `@Serializable NavKey` object so it can ride through the
+ * `rememberNavBackStack()` save/restore cycle (process death, rotation,
+ * window-size class change, etc.). Both annotations are load-bearing:
+ * `@Serializable` for kotlinx-serialization, `NavKey` for Nav3 to identify it
+ * as a destination key.
  */
-sealed interface Screen {
+sealed interface Screen : NavKey {
     @Serializable
     data object Home : Screen
 
@@ -117,14 +120,27 @@ fun AppNavigation(
     doorViewModel: DoorViewModel,
     appLoggerViewModel: AppLoggerViewModel,
 ) {
-    // Nav3: back stack is a simple mutable list of Screen objects.
-    // Using remember (not rememberSaveable) because Screen objects aren't Bundle-saveable.
-    // For tab navigation this is fine — process death just restarts on Home tab.
-    val backStack = remember { mutableStateListOf<Screen>(Screen.Home) }
+    // Nav3: `rememberNavBackStack` is the saveable back stack. Survives
+    // configuration changes (rotation, window size, dark mode, locale,
+    // font scale) AND process death. The serialized form rides through
+    // `SavedStateHolder` via `NavKeySerializer`, which requires every
+    // `Screen` subtype to be both `@Serializable` and a `NavKey` (see
+    // `Screen` above).
+    //
+    // Pre-PR-A used `remember { mutableStateListOf(Screen.Home) }`, which
+    // reset to `[Home]` on every Activity recreate. The cost was deliberate:
+    // tab nav, no deep links, "starts on Home after rotation" was acceptable.
+    // Now that the multi-pane future requires a saveable back stack (panes
+    // need to query historical entries, and a Window-size-class transition
+    // triggers Activity recreation we can't lose state through), saveable
+    // is the new floor.
+    val backStack: NavBackStack<NavKey> = rememberNavBackStack(Screen.Home)
 
     Scaffold(
         topBar = {
-            val currentScreen = backStack.lastOrNull()
+            // Back stack is `List<NavKey>`; narrow to our app's `Screen` type
+            // for the title + back-icon decision.
+            val currentScreen = backStack.lastOrNull() as? Screen
             val isSubScreen = currentScreen is Screen.FunctionList ||
                 currentScreen is Screen.Diagnostics
             TopAppBar(
@@ -153,7 +169,7 @@ fun AppNavigation(
         },
         bottomBar = {
             BottomNavigationBar(
-                currentScreen = backStack.lastOrNull(),
+                currentScreen = backStack.lastOrNull() as? Screen,
                 onTabSelected = { screen -> TabNavigation.navigateToTab(backStack, screen) },
             )
         },
@@ -165,8 +181,8 @@ fun AppNavigation(
             popTransitionSpec = { fadeIn(navTween()) togetherWith fadeOut(navTween()) },
             predictivePopTransitionSpec = { fadeIn(navTween()) togetherWith fadeOut(navTween()) },
             entryDecorators = listOf(
-                rememberSaveableStateHolderNavEntryDecorator<Screen>(),
-                rememberViewModelStoreNavEntryDecorator<Screen>(),
+                rememberSaveableStateHolderNavEntryDecorator<NavKey>(),
+                rememberViewModelStoreNavEntryDecorator<NavKey>(),
             ),
             modifier = Modifier.padding(innerPadding),
             // Screen-layout convention (single source of truth):
@@ -280,7 +296,7 @@ fun BottomNavigationBar(
  */
 object TabNavigation {
     fun navigateToTab(
-        backStack: MutableList<Screen>,
+        backStack: MutableList<NavKey>,
         screen: Screen,
     ) {
         when {

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -91,12 +91,14 @@ fun ProfileContent(
     val context = LocalContext.current
     val appVersion = context.AppVersion()
 
-    // Surface-level state: which sheet/dialog is currently open. Local to
-    // the screen — not persisted across process death (recreating the
-    // sheet/dialog after a crash would surprise the user).
-    var snoozeSheetOpen by remember { mutableStateOf(false) }
-    var accountSheetOpen by remember { mutableStateOf(false) }
-    var versionDialogOpen by remember { mutableStateOf(false) }
+    // Surface-level state: which sheet/dialog is currently open. Saveable
+    // so the user's mid-selection (snooze duration, account view) survives
+    // rotation, window resize, and process death. Auto-reopening a sheet
+    // after a process restart is mild and acceptable; closing one out from
+    // under the user on rotation is not.
+    var snoozeSheetOpen by rememberSaveable { mutableStateOf(false) }
+    var accountSheetOpen by rememberSaveable { mutableStateOf(false) }
+    var versionDialogOpen by rememberSaveable { mutableStateOf(false) }
 
     // Refresh snooze status every minute while this screen is mounted.
     // Mirrors the legacy ProfileContent behavior; the polling cadence

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/DiagnosticsContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/DiagnosticsContent.kt
@@ -47,7 +47,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -159,7 +159,7 @@ fun DiagnosticsContent(
     modifier: Modifier = Modifier,
     clearInFlight: Boolean = false,
 ) {
-    var confirmClearOpen by remember { mutableStateOf(false) }
+    var confirmClearOpen by rememberSaveable { mutableStateOf(false) }
 
     Column(
         modifier = modifier.fillMaxSize(),

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SnoozeBottomSheet.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SnoozeBottomSheet.kt
@@ -38,7 +38,8 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.autoSaver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -63,7 +64,9 @@ fun SnoozeBottomSheet(
     modifier: Modifier = Modifier,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    var selected by remember { mutableStateOf(initialSelection) }
+    // Saveable so the user's pending duration choice survives rotation /
+    // window resize while the sheet is open. `autoSaver` handles the enum.
+    var selected by rememberSaveable(stateSaver = autoSaver()) { mutableStateOf(initialSelection) }
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/NavigateToTabTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/NavigateToTabTest.kt
@@ -1,5 +1,6 @@
 package com.chriscartland.garage.ui
 
+import androidx.navigation3.runtime.NavKey
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -10,7 +11,7 @@ import org.junit.Test
  * each other on top. Stack is always [Home] or [Home, <tab>]. Max depth 2.
  */
 class NavigateToTabTest {
-    private fun backStack(vararg screens: Screen): MutableList<Screen> = mutableListOf(*screens)
+    private fun backStack(vararg screens: Screen): MutableList<NavKey> = mutableListOf<NavKey>(*screens)
 
     @Test
     fun initialStateIsHome() {

--- a/AndroidGarage/buildSrc/src/main/kotlin/codestyle/RememberSaveableGuardTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/codestyle/RememberSaveableGuardTask.kt
@@ -9,19 +9,49 @@ import java.io.File
 /**
  * Detects unsafe `rememberSaveable` usage with types that aren't Bundle-saveable.
  *
- * `rememberSaveable` serializes state to a Bundle on process death. If the state
- * contains types that aren't Parcelable, java.io.Serializable, or a primitive,
- * the app crashes on save or restore. This happened with Nav3's Screen objects
- * (kotlinx @Serializable ≠ java.io.Serializable).
+ * `rememberSaveable` serializes state to a Bundle on process death. If the
+ * state contains types that aren't Parcelable, java.io.Serializable, or a
+ * primitive, the app crashes on save or restore. This happened with Nav3's
+ * Screen objects (kotlinx `@Serializable` ≠ `java.io.Serializable`).
  *
- * This task scans for `rememberSaveable` calls and flags any that don't use a
- * known-safe type (String, Int, Boolean, etc.) or an explicit `saver` parameter.
+ * The check has three pass conditions for a `rememberSaveable` call line:
+ *   1. The line contains the substring `saver` — caller has supplied
+ *      `saver = ...` or `stateSaver = ...` explicitly.
+ *   2. The line uses a Compose-built-in primitive state factory whose Saver
+ *      is provided by Compose itself (`mutableIntStateOf`, `mutableLongStateOf`,
+ *      `mutableFloatStateOf`, `mutableDoubleStateOf`).
+ *   3. The line passes a primitive literal to `mutableStateOf(...)`
+ *      (`true`, `false`, an integer literal, a string literal, or a
+ *      hex/float literal) — `autoSaver()` handles these safely.
+ *
+ * Anything else fails the build. The motivating bug was Nav3 Screen objects
+ * being passed to `rememberSaveable` with no explicit Saver: `@Serializable`
+ * is `kotlinx.serialization`, not `java.io.Serializable`, and the Bundle
+ * write blew up at runtime. The check makes that class of mistake impossible
+ * to add silently.
  *
  * Use `remember` instead for types that don't need to survive process death.
  */
 abstract class RememberSaveableGuardTask : DefaultTask() {
     @get:Input
     var sourceDirs: List<String> = emptyList()
+
+    /**
+     * Patterns recognized as safe initializers without an explicit `saver`.
+     * Each is a Compose primitive whose serialization is built in.
+     */
+    private val safeInitializerPatterns: List<Regex> = listOf(
+        // Compose primitive state factories with built-in savers.
+        Regex("""mutableIntStateOf\s*\("""),
+        Regex("""mutableLongStateOf\s*\("""),
+        Regex("""mutableFloatStateOf\s*\("""),
+        Regex("""mutableDoubleStateOf\s*\("""),
+        // mutableStateOf(<primitive literal>) — autoSaver() handles these.
+        Regex("""mutableStateOf\s*\(\s*(true|false)\s*\)"""),
+        Regex("""mutableStateOf\s*\(\s*-?\d+(\.\d+)?[fFLd]?\s*\)"""),
+        Regex("""mutableStateOf\s*\(\s*0[xX][0-9a-fA-F]+[Ll]?\s*\)"""),
+        Regex("""mutableStateOf\s*\(\s*"[^"]*"\s*\)"""),
+    )
 
     @TaskAction
     fun check() {
@@ -43,22 +73,33 @@ abstract class RememberSaveableGuardTask : DefaultTask() {
 
                     lines.forEachIndexed { index, line ->
                         val trimmed = line.trim()
-                        // Match actual rememberSaveable function calls, not functions
-                        // that contain "rememberSaveable" as a substring (e.g.,
-                        // rememberSaveableStateHolderNavEntryDecorator).
+                        // Match actual rememberSaveable function calls, not
+                        // functions that contain "rememberSaveable" as a
+                        // substring (e.g., rememberSaveableStateHolderNavEntryDecorator).
                         val hasCall = Regex("""\brememberSaveable\s*[\({]""").containsMatchIn(trimmed)
-                        if (hasCall &&
-                            "saver" !in trimmed &&
-                            !trimmed.startsWith("//") &&
-                            !trimmed.startsWith("*") &&
-                            !trimmed.startsWith("import ")
+                        if (!hasCall ||
+                            trimmed.startsWith("//") ||
+                            trimmed.startsWith("*") ||
+                            trimmed.startsWith("import ")
                         ) {
-                            violations.add(
-                                "$relativePath:${index + 1}: $trimmed\n" +
-                                    "    rememberSaveable without an explicit `saver` parameter is unsafe\n" +
-                                    "    for custom types. Use `remember` or provide a Saver.",
-                            )
+                            return@forEachIndexed
                         }
+                        // Match both `saver = ...` and `stateSaver = ...`,
+                        // and bare `autoSaver()` calls (capital S in
+                        // `Saver`).
+                        if (trimmed.contains("saver", ignoreCase = true)) {
+                            return@forEachIndexed
+                        }
+                        if (safeInitializerPatterns.any { it.containsMatchIn(trimmed) }) {
+                            return@forEachIndexed
+                        }
+                        violations.add(
+                            "$relativePath:${index + 1}: $trimmed\n" +
+                                "    rememberSaveable without an explicit `saver` parameter is unsafe\n" +
+                                "    for custom types. Use `remember` or provide a Saver, or use a\n" +
+                                "    primitive initializer (mutable{Int,Long,Float,Double}StateOf, or\n" +
+                                "    mutableStateOf with a primitive literal).",
+                        )
                     }
                 }
         }


### PR DESCRIPTION
## Summary

PR A of a 4-PR rotation-resilience plan. Switches the Nav3 back stack from `remember { mutableStateListOf(Screen.Home) }` to `rememberNavBackStack(Screen.Home)`, plus a tightly-scoped `remember`→`rememberSaveable` sweep on the in-screen UI state that was silently lost on rotation.

After this PR:
- **Rotation, dark mode toggle, locale change, font scale, multi-window resize, foldable unfold, and process death** all preserve the user's navigation position. Pre-PR-A every Activity recreate reset the stack to `[Home]`.
- **Sheet/dialog open state, snooze pending selection, permission request count, clear-all-confirmation flag** all survive the same lifecycle events.
- The `SaveableStateHolderNavEntryDecorator` already wired in `Main.kt` finally has work to do — `LazyColumn` scroll positions in History, FunctionList, and Diagnostics are now retained via Compose's built-in `rememberLazyListState()` saver, because the entry that owns them now survives.

## Mechanism

| Change | File | Why |
|---|---|---|
| `Screen` extends `NavKey` | `Main.kt:84-100` | Required for `rememberNavBackStack()` and `NavKeySerializer` |
| `rememberNavBackStack(Screen.Home)` | `Main.kt:137` | Replaces unsaveable `mutableStateListOf` |
| Decorators typed `<NavKey>` | `Main.kt:181-183` | Matches inferred `NavDisplay<NavKey>` |
| `currentScreen as? Screen` | `Main.kt:143, 170` | Narrow at the topbar/bottom-nav boundary |
| `TabNavigation.navigateToTab(MutableList<NavKey>, ...)` | `Main.kt` | Accept the new back-stack type |
| `permissionRequestCount` saveable | `HomeContent.kt:84` | Avoid spurious re-prompt on rotation |
| `confirmClearOpen` saveable | `DiagnosticsContent.kt:162` | Confirmation dialog must survive rotation |
| `snoozeSheetOpen` / `accountSheetOpen` / `versionDialogOpen` saveable | `ProfileContent.kt:99-101` | User's mid-selection in a sheet shouldn't be lost on rotation |
| `selected` saveable | `SnoozeBottomSheet.kt:69` | Pending duration choice survives rotation while sheet is open |
| `RememberSaveableGuardTask` extended | `buildSrc/.../RememberSaveableGuardTask.kt` | Recognize Compose primitive factories + `mutableStateOf(<literal>)` + case-insensitive `saver` matching. Original Nav3-Screen-Bundling regression remains blocked |

## Test plan

- [x] `./scripts/validate.sh` — PASSES (spotless, all module unit tests, instrumented test compilation, all 25+ architecture checks)
- [x] `NavigateToTabTest` updated for `MutableList<NavKey>` signature, all 14 tests pass
- [x] `ConfigurationChangeTest.subScreenSurvivesRecreation` — new test asserts depth-2 back stack survives `ActivityScenario.recreate()`. Settings → Diagnostics → recreate → still on Diagnostics
- [ ] **Empirical rotation on device**: not run locally (no device attached). CI's `Android Post-Merge CI` instrumented-tests job covers this. If instrumented tests fail post-merge, the test name `subScreenSurvivesRecreation` is the canonical signal that the back-stack restoration regressed.
- [ ] Manual smoke (post-merge / next release): rotate device on Settings → Diagnostics, on a sheet/dialog, on a scrolled list

## Risk

Low. The change is mechanical and the lint widening is conservative (extends safe-pattern recognition, doesn't relax the unsafe path). Rollback is `git revert` of one commit.

## Follow-ups

- **PR B (next)**: WindowSizeClass plumbing — compute it once at `GarageApp` root, pass through `RouteContent`, add `checkNoLocalConfigurationDimensionReads` lint
- **PR C**: Lift in-flight state (`SnoozeAction.Sending`, button push) from VM to repository so multi-pane shows the same spinner everywhere
- **PR D**: Multi-pane scaffold — needs UX decisions first (no existing list-detail screen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)