### PR TITLE
fix(android-test): retarget rotation-survival test to always-visible Settings row

### DIFF
--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/ConfigurationChangeTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/ConfigurationChangeTest.kt
@@ -43,27 +43,31 @@ class ConfigurationChangeTest {
     }
 
     /**
-     * A sub-screen reached via two clicks (Settings → Diagnostics) must
-     * still be the active screen after recreation.
+     * A non-Home tab must still be the active screen after recreation.
      *
-     * "Diagnostics" is the topbar title for that sub-screen and appears
-     * nowhere else, so its presence post-recreate proves the back stack
-     * was restored to depth-2 (`[Home, Diagnostics]`).
+     * Depth-1 to a non-Home destination is the load-bearing assertion:
+     * pre-PR-A this would always reset to Home regardless of where the
+     * user was. Asserting that "Privacy Policy" (a Settings-only row)
+     * is still displayed post-recreate proves the back stack survived.
+     *
+     * Why not navigate to a sub-screen? Diagnostics and FunctionList
+     * are gated by the developer allowlist (`functionListAccess`), so
+     * they're not reachable from a fresh install in test conditions.
+     * "Privacy Policy" is in the always-visible "About" section of
+     * Settings — independent of auth state, allowlist, or feature flags.
      */
     @Test
-    fun subScreenSurvivesRecreation() {
-        // Navigate Settings tab → Diagnostics row.
+    fun nonHomeTabSurvivesRecreation() {
+        // Navigate to Settings tab.
         composeTestRule.onNodeWithText("Settings").performClick()
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Diagnostics").performClick()
-        composeTestRule.waitForIdle()
-        // "Diagnostics" topbar title is unique to this screen.
-        composeTestRule.onNodeWithText("Diagnostics").assertIsDisplayed()
+        // "Privacy Policy" row is unique to Settings and always visible.
+        composeTestRule.onNodeWithText("Privacy Policy").assertIsDisplayed()
 
         composeTestRule.activityRule.scenario.recreate()
 
-        // Back stack survived: still on Diagnostics.
-        composeTestRule.onNodeWithText("Diagnostics").assertIsDisplayed()
+        // Back stack survived: still on Settings.
+        composeTestRule.onNodeWithText("Privacy Policy").assertIsDisplayed()
     }
 
     /**


### PR DESCRIPTION
## Summary

The `subScreenSurvivesRecreation` test (added in #699) navigated Settings → Diagnostics, which fails on a fresh emulator install: Diagnostics is gated by the developer allowlist (`functionListAccess`) and a test fixture has no signed-in user with allowlist access.

Renamed to `nonHomeTabSurvivesRecreation` and retargeted to depth-1 — Settings tab → "Privacy Policy" row, which sits in the always-visible "About" section regardless of auth or feature flags.

## Why depth-1 is sufficient

The load-bearing assertion is unchanged: **pre-PR-A every Activity recreate reset the back stack to `[Home]`**. Asserting any non-Home destination is still visible post-recreate proves the back stack survived. Depth-2 testing would need an emulator with a seeded allowlist — out of scope for this fix.

## Verification

- 56/56 instrumented tests pass on `Medium_Phone_API_36` emulator
- Run via `AndroidGarage/gradlew -PVERSION_CODE=99999 :androidApp:connectedDebugAndroidTest` (the `VERSION_CODE` override sidesteps the downgrade conflict with the previously installed app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)