### PR TITLE
docs(skill/repo-check): surface source PR for open CI failure issues

### DIFF
--- a/.claude/skills/repo-check/SKILL.md
+++ b/.claude/skills/repo-check/SKILL.md
@@ -32,12 +32,41 @@ gh run list --branch main --workflow "Firebase Post-Merge CI" --limit 1 \
   --json conclusion,headSha,createdAt \
   --jq '.[0] | {conclusion, sha: .headSha[:7], date: .createdAt[:10]}'
 
-# Any open CI failure issues (both labels)
+# Any open CI failure issues (both labels) — title includes which sub-job
+# failed in the form `(checks: <status>, instrumented: <status>)`.
 gh issue list --label "ci-failure/post-merge" --state open --json number,title --jq '.[]'
 gh issue list --label "ci-failure/firebase-post-merge" --state open --json number,title --jq '.[]'
 ```
 
-Report: last post-merge result for each, any open failure issues. The exact workflow names matter — `gh run list --workflow "Post-Merge CI"` (without the platform prefix) returns nothing.
+If any CI failure issue is open, **also fetch its body to identify the
+source PR and commit** — the auto-created issue lists them under fixed
+fields:
+
+```bash
+# For each open failure issue, surface "Source: PR #N" + commit SHA.
+# The auto-issue body has fixed `- **Run:**`, `- **Commit:**`, `- **Source:**`
+# bullets — match by the colon-suffixed field name (BSD grep's ERE parser
+# refuses `\*\*(...)\*\*` directly; the colon-anchored form works).
+for n in $(gh issue list --label "ci-failure/post-merge" --state open --json number --jq '.[].number'; gh issue list --label "ci-failure/firebase-post-merge" --state open --json number --jq '.[].number'); do
+  echo "Issue #$n:"
+  gh issue view "$n" --json body --jq '.body' \
+    | grep -E '^- \*\*(Source|Commit|Run):' \
+    | sed 's/^- \*\*//; s/\*\*//'
+  echo
+done
+```
+
+Why this matters: the bare issue title only says "checks: X, instrumented:
+Y" — useful for which sub-job failed but not which PR introduced it. The
+body always carries `**Source:** PR #N (<title>)` and `**Commit:** SHA`,
+which is what you need to decide if the failure already has a fix in
+flight (e.g. a follow-up PR fixing the same test). Always pull these for
+open failure issues.
+
+Report: last post-merge result for each, any open failure issues, and
+the source PR + commit for each open failure. The exact workflow names
+matter — `gh run list --workflow "Post-Merge CI"` (without the platform
+prefix) returns nothing.
 
 ### 3. Recent Releases
 
@@ -74,11 +103,18 @@ Summarize as a compact status report:
 
 ```
 PRs:        N open (N conflicts, N auto-merge)
-CI:         passing/failing (last run: date)
-Issues:     N open
+CI:         passing/failing (last run: date) [if failing, name the failed sub-job]
+Issues:     N open [if any are CI failures, name source PR per issue: "#701 ← PR #700"]
 Releases:   android/N, server/N
 Migration:  Phases 1-4,6,7 complete. Next: Phase 5 (KMP)
 Local:      main, clean | main, dirty (list changed files)
 ```
 
-Expand on anything that needs attention (conflicts, failures, stale PRs, uncommitted changes). A dirty working tree is NOT clean — always report it as needing attention.
+Expand on anything that needs attention (conflicts, failures, stale PRs,
+uncommitted changes). A dirty working tree is NOT clean — always report
+it as needing attention.
+
+For open CI failure issues, **always state the source PR**. A user reading
+"1 issue open" learns nothing actionable; "issue #701 ← PR #700 (instrumented test)"
+tells them whether the failure already has a fix in flight (look for an
+open PR touching the same test or area) or needs a new investigation.


### PR DESCRIPTION
## Summary

When `/repo-check` reports an open CI failure issue, it currently shows only the issue title ("CI: Android Post-Merge CI (checks: success, instrumented: failure) failing"). That tells you which sub-job failed but not which PR introduced it.

The auto-created failure-issue body has fixed `**Run:**`, `**Commit:**`, `**Source:**` bullets. This PR adds a snippet under Step 2 that iterates open failure issues and prints those three fields per issue.

## Output format change

Old:
```
Issues:     1 open
```
New:
```
Issues:     1 open — issue #701 ← PR #700 (instrumented test)
```

The lesson surfaced inline in the skill: "1 issue open" tells the reader nothing actionable; "issue #N ← PR #M" tells them whether to look for a fix already in flight (open PR touching the same area) or open a new investigation.

## Snippet detail (BSD grep gotcha)

The intuitive ERE pattern `^- \*\*(Source|Commit|Run)\*\*` is rejected by BSD grep's ERE parser. The colon-anchored form `^- \*\*(Source|Commit|Run):` works on macOS and Linux. Documented inline in the snippet so a future maintainer who tries to "simplify" it doesn't break it.

## Test plan

- [x] Verified the snippet against the live `#701` issue — produces `Run:`, `Commit:`, `Source: PR #700` lines as expected
- [x] Skill runs cleanly under `/repo-check` invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)