### PR TITLE
docs(skill/repo-check): surface failing CI checks per open PR

### DIFF
--- a/.claude/skills/repo-check/SKILL.md
+++ b/.claude/skills/repo-check/SKILL.md
@@ -17,7 +17,43 @@ gh pr list --state open --json number,title,mergeStateStatus,autoMergeRequest \
   --jq '.[] | {number, title, status: .mergeStateStatus, autoMerge: (.autoMergeRequest != null)}'
 ```
 
-Report: count, any with conflicts (DIRTY), any without auto-merge.
+Then check **failing CI checks per PR** — `BLOCKED` is GitHub's catch-all
+status that covers everything from "waiting on a reviewer" to "CI red";
+the rollup is what tells you if the PR has actual failures versus is
+just queued:
+
+```bash
+# Lists only PRs that have at least one failing check, with the names.
+gh pr list --state open --json number,title,statusCheckRollup --jq '
+  .[] | {
+    number,
+    title,
+    failed: [.statusCheckRollup[]?
+      | select(.conclusion == "FAILURE"
+            or .conclusion == "CANCELLED"
+            or .conclusion == "TIMED_OUT")
+      | .name]
+  } | select(.failed | length > 0)'
+```
+
+If a PR has failing checks, **drill in and identify the cause**:
+
+```bash
+# Replace <RUN_ID> with the run ID from the failed check's URL.
+gh run view <RUN_ID> --log-failed 2>&1 | grep -E "FAILED|Error:|Exception|##\[error\]" | head -25
+```
+
+Common patterns to recognize:
+- **`HTTP 502 ... gradle-distributions`** — transient infra failure, not
+  a real test failure. Re-run with `gh run rerun <RUN_ID> --failed`.
+- **`Test FAILED` / `AssertionError`** — real test failure; investigate
+  the test name and assertion.
+- **`Kotlin compile failed` / `e: file://...`** — compile error; check
+  the file/line.
+
+Report: count, any with conflicts (DIRTY), any without auto-merge,
+**any with failing checks (name them)**, and for transient infra
+failures note "re-runnable".
 
 ### 2. CI Health
 
@@ -102,7 +138,9 @@ Report: current branch, clean/dirty, any uncommitted changes.
 Summarize as a compact status report:
 
 ```
-PRs:        N open (N conflicts, N auto-merge)
+PRs:        N open (N conflicts, N auto-merge, N failing checks)
+            [for each PR with failing checks, name them on its own line:
+             "  #705 fail: Android Checks / Unit Tests (transient HTTP 502, re-runnable)"]
 CI:         passing/failing (last run: date) [if failing, name the failed sub-job]
 Issues:     N open [if any are CI failures, name source PR per issue: "#701 ← PR #700"]
 Releases:   android/N, server/N


### PR DESCRIPTION
## Summary

Complements #706 (source-PR-for-failure-issues). When an open PR has red checks, the bare PR list (just title + `mergeStateStatus`) doesn't say what's red. `BLOCKED` covers everything from "waiting on a reviewer" to "CI failed" — only the check rollup distinguishes them.

## Motivating incident

During this session, #705 (instrumented-test fix) sat with a red gate check for several minutes before the human asked why. The previous `/repo-check` output had reported "1 PR open, BLOCKED" — accurate but unactionable. Cause turned out to be a transient HTTP 502 fetching the Gradle distribution, fixed by `gh run rerun <RUN_ID> --failed`.

## What changes

- **Step 1 (Open PRs):** new snippet filters open PRs by failing checks (FAILURE / CANCELLED / TIMED_OUT) and names which checks failed.
- **Step 1 (continued):** small recognition cheatsheet for common failure patterns (transient HTTP 502 → re-runnable; real test failure; compile error).
- **Output format:** PR line now includes failing-check count, with per-PR detail on indented sub-lines:

```
PRs:        1 open (0 conflicts, 1 auto-merge, 1 failing checks)
              #705 fail: Android Checks / Unit Tests (transient HTTP 502, re-runnable)
```

## Test plan

- [x] Snippet smoke-tested against the live `#705` failing build during this session
- [x] Doesn't double-count: a PR with no failing checks doesn't appear in the per-PR detail list

🤖 Generated with [Claude Code](https://claude.com/claude-code)