### PR TITLE
fix(android): scope dashboard pull-to-refresh per-pane (2.15.1)

### DIFF
--- a/AndroidGarage/CHANGELOG.md
+++ b/AndroidGarage/CHANGELOG.md
@@ -15,6 +15,9 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
 
+## 2.15.1
+- **Pull-to-refresh on the wide Home dashboard is now per-pane.** Pulling on the Home column refreshes the door status only; pulling on the History column refreshes recent events only. Pre-2.15.1 either pull fired both fetches as a "single-screen" model. Per-pane scoping matches the behavior each screen has on phone — a smaller, more predictable surface (and fewer redundant network round-trips when the user only wanted to refresh one half). Independent scroll behavior is unchanged. Implementation: dropped the `onRefreshExtra` parameter wired into `HomeContent` / `DoorHistoryContent` for the dashboard route; each screen's existing refresh callback runs unmodified.
+
 ## 2.15.0
 - **Wide-screen Home dashboard.** On tablets, foldables in landscape, ChromeOS, and any window ≥600dp wide, the Home and History tabs merge into a single side-by-side dashboard with Home on the left and History on the right. The bottom navigation collapses to two items (Home, Settings); History is no longer its own tab — it's the right column of the Home destination. Phones (<600dp) keep the existing 3-tab single-pane behavior unchanged. Each pane caps at 640dp wide; on very wide windows the dashboard centers in the available space rather than stretching.
 - **Independent scroll, synced refresh.** Each pane scrolls independently — scroll History without affecting the Home column, and vice versa. Pull-to-refresh on either pane refreshes both: a pull on Home triggers `fetchCurrentDoorEvent` AND `fetchRecentDoorEvents`, and a pull on History does the same. Behaves like one screen for refresh, two screens for scroll.

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
@@ -49,11 +49,6 @@ fun DoorHistoryContent(
     modifier: Modifier = Modifier,
     doorViewModel: DoorViewModel? = null,
     appLoggerViewModel: AppLoggerViewModel? = null,
-    // Additional refresh action invoked alongside this screen's normal
-    // pull-to-refresh fetch. Used by the wide-screen Home dashboard so a
-    // pull on either pane refreshes both. Empty default keeps the
-    // single-pane phone behavior unchanged.
-    onRefreshExtra: () -> Unit = {},
 ) {
     val component = rememberAppComponent()
     val resolvedDoorViewModel = doorViewModel ?: viewModel { component.doorViewModel }
@@ -74,7 +69,6 @@ fun DoorHistoryContent(
         onFetchRecentDoorEvents = {
             resolvedAppLoggerViewModel.log(AppLoggerKeys.USER_FETCH_RECENT_DOOR)
             resolvedDoorViewModel.fetchRecentDoorEvents()
-            onRefreshExtra()
         },
         onResetFcm = {
             resolvedDoorViewModel.deregisterFcm()

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -64,11 +64,6 @@ fun HomeContent(
     authViewModel: AuthViewModel? = null,
     doorViewModel: DoorViewModel? = null,
     appLoggerViewModel: AppLoggerViewModel? = null,
-    // Additional refresh action invoked alongside this screen's normal
-    // pull-to-refresh fetch. Used by the wide-screen Home dashboard so a
-    // pull on either pane refreshes both. Empty default keeps the
-    // single-pane phone behavior unchanged.
-    onRefreshExtra: () -> Unit = {},
 ) {
     val component = rememberAppComponent()
     val resolvedAuthViewModel = authViewModel ?: viewModel { component.authViewModel }
@@ -123,7 +118,6 @@ fun HomeContent(
         onRefresh = {
             resolvedAppLoggerViewModel.log(AppLoggerKeys.USER_FETCH_CURRENT_DOOR)
             resolvedDoorViewModel.fetchCurrentDoorEvent()
-            onRefreshExtra()
         },
         onAlertAction = { alert ->
             when (alert) {

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -305,6 +305,10 @@ private fun RouteEntryFor(
     when (canonicalScreen) {
         Screen.Home -> {
             if (mode is AppLayoutMode.Wide) {
+                // Pull-to-refresh is per-pane: pulling Home refreshes door
+                // status only; pulling History refreshes recent events only.
+                // Each pane behaves like its own screen for refresh,
+                // matching what the user experiences on phone.
                 DashboardRouteContent { routeModifier ->
                     HomeDashboardContent(
                         modifier = routeModifier.padding(horizontal = Spacing.Screen),
@@ -314,7 +318,6 @@ private fun RouteEntryFor(
                                 doorViewModel = doorViewModel,
                                 appLoggerViewModel = appLoggerViewModel,
                                 modifier = paneModifier,
-                                onRefreshExtra = { doorViewModel.fetchRecentDoorEvents() },
                             )
                         },
                         historyPane = { paneModifier ->
@@ -322,7 +325,6 @@ private fun RouteEntryFor(
                                 doorViewModel = doorViewModel,
                                 appLoggerViewModel = appLoggerViewModel,
                                 modifier = paneModifier,
-                                onRefreshExtra = { doorViewModel.fetchCurrentDoorEvent() },
                             )
                         },
                     )

--- a/AndroidGarage/distribution/whatsnew/whatsnew-en-US
+++ b/AndroidGarage/distribution/whatsnew/whatsnew-en-US
@@ -1,1 +1,1 @@
-2.15: Wide-screen Home dashboard. On tablets, foldables in landscape, and any window 600dp+ wide, Home and History now display side-by-side. The bottom nav collapses to two tabs (Home, Settings); History becomes the right column of Home. Pull-to-refresh on either pane refreshes both. Phones unchanged.
+2.15: Wide-screen Home dashboard. On tablets, foldables in landscape, and any window 600dp+ wide, Home and History now display side-by-side. The bottom nav collapses to two tabs (Home, Settings); History becomes the right column of Home. Phones unchanged.

--- a/AndroidGarage/version.properties
+++ b/AndroidGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.15.0
+versionName=2.15.1


### PR DESCRIPTION
## Summary

Pre-2.15.1 dashboard pulls were cross-pane: pulling Home fired both `fetchCurrentDoorEvent` AND `fetchRecentDoorEvents`; pulling History did the same. **Per-pane scoping** is the simpler model — pulling Home refreshes door status only; pulling History refreshes recent events only. Independent scroll behavior is unchanged.

## Why

- Matches what each screen does on phone today — no novel behavior on the dashboard.
- Half the round-trips when the user only meant to refresh one column.
- Smaller, more predictable surface area.

## Implementation

Drops the `onRefreshExtra: () -> Unit = {}` parameter that #704 added to `HomeContent` and `DoorHistoryContent`. The parameter existed solely to wire the cross-pane action from `WideHomeDashboard` in `Main.kt`; nothing else called it. Removed the parameter, removed the body call, removed the wiring in Main.kt.

| File | Change |
|---|---|
| `HomeContent.kt` | Drop `onRefreshExtra` param + body call |
| `DoorHistoryContent.kt` | Same |
| `Main.kt` (`RouteEntryFor` Home arm) | Drop `onRefreshExtra =` slots; add comment explaining per-pane scoping |
| `version.properties` | `2.15.0` → `2.15.1` (patch — UI polish, no new capability) |
| `CHANGELOG.md` | New 2.15.1 entry. 2.15.0 entry kept historically accurate |
| `whatsnew-en-US` | Drop the now-inaccurate "Pull-to-refresh on either pane refreshes both" sentence |

## Test plan

- [x] `./scripts/validate.sh` PASSES
- [x] **56/56 instrumented tests** pass on `Medium_Phone_API_36` emulator
- [ ] Auto-merge → `release-android.sh` → Play Store internal track as `android/211`
- [ ] Tablet smoke test: pulling Home only refreshes Home; pulling History only refreshes History; both still scroll independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)