### PR TITLE
refactor(android): Add HomeViewModel; one VM per Home screen (ADR-026)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -82,6 +82,7 @@ import com.chriscartland.garage.usecase.DefaultAppSettingsViewModel
 import com.chriscartland.garage.usecase.DefaultAuthViewModel
 import com.chriscartland.garage.usecase.DefaultDoorViewModel
 import com.chriscartland.garage.usecase.DefaultFunctionListViewModel
+import com.chriscartland.garage.usecase.DefaultHomeViewModel
 import com.chriscartland.garage.usecase.DefaultLiveClock
 import com.chriscartland.garage.usecase.DefaultReceiveFcmDoorEventUseCase
 import com.chriscartland.garage.usecase.DefaultRegisterFcmUseCase
@@ -152,6 +153,7 @@ abstract class AppComponent(
     abstract val doorViewModel: DefaultDoorViewModel
     abstract val remoteButtonViewModel: DefaultRemoteButtonViewModel
     abstract val functionListViewModel: DefaultFunctionListViewModel
+    abstract val homeViewModel: DefaultHomeViewModel
 
     // --- Entry points: @Singleton providers (testable via assertSame) ---
     abstract val appConfig: AppConfig
@@ -321,6 +323,36 @@ abstract class AppComponent(
             registerFcmUseCase = registerFcm,
             deregisterFcmUseCase = deregisterFcm,
             dispatchers = dispatchers,
+            appVersion = appVersion,
+        )
+
+    @Provides
+    fun provideHomeViewModel(
+        observeDoorEvents: ObserveDoorEventsUseCase,
+        observeAuthState: ObserveAuthStateUseCase,
+        logAppEvent: LogAppEventUseCase,
+        dispatchers: DispatcherProvider,
+        fetchCurrentDoorEvent: FetchCurrentDoorEventUseCase,
+        deregisterFcm: DeregisterFcmUseCase,
+        signInWithGoogle: SignInWithGoogleUseCase,
+        pushRemoteButton: PushRemoteButtonUseCase,
+        checkInStalenessManager: CheckInStalenessManager,
+        liveClock: LiveClock,
+        computeButtonHealthDisplay: ComputeButtonHealthDisplayUseCase,
+        appVersion: String,
+    ): DefaultHomeViewModel =
+        DefaultHomeViewModel(
+            observeDoorEvents = observeDoorEvents,
+            observeAuthState = observeAuthState,
+            logAppEvent = logAppEvent,
+            dispatchers = dispatchers,
+            fetchCurrentDoorEventUseCase = fetchCurrentDoorEvent,
+            deregisterFcmUseCase = deregisterFcm,
+            signInWithGoogleUseCase = signInWithGoogle,
+            pushRemoteButtonUseCase = pushRemoteButton,
+            checkInStalenessManager = checkInStalenessManager,
+            liveClock = liveClock,
+            buttonHealthDisplay = computeButtonHealthDisplay(),
             appVersion = appVersion,
         )
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -38,11 +38,8 @@ import com.chriscartland.garage.permissions.rememberNotificationPermissionState
 import com.chriscartland.garage.ui.home.DeviceCheckIn
 import com.chriscartland.garage.ui.home.HomeAlert
 import com.chriscartland.garage.ui.home.HomeMapper
-import com.chriscartland.garage.usecase.AppLoggerViewModel
-import com.chriscartland.garage.usecase.AuthViewModel
 import com.chriscartland.garage.usecase.ButtonHealthDisplay
-import com.chriscartland.garage.usecase.DoorViewModel
-import com.chriscartland.garage.usecase.RemoteButtonViewModel
+import com.chriscartland.garage.usecase.HomeViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import java.time.Instant
@@ -53,32 +50,28 @@ import com.chriscartland.garage.ui.home.HomeContent as HomeContentInternal
  * Stateful Home tab — thin bridge between Main.kt and the stateless
  * [HomeContentInternal] in [com.chriscartland.garage.ui.home].
  *
- * Resolves ViewModels, collects flows, runs [HomeMapper], renders. All
- * mapping logic is in [HomeMapper] (unit-tested); all layout is in
- * [HomeContentInternal] (screenshot-tested).
+ * Resolves the screen-scoped [HomeViewModel] (ADR-026 — one VM per screen),
+ * collects flows, runs [HomeMapper], renders. All mapping logic is in
+ * [HomeMapper] (unit-tested); all layout is in [HomeContentInternal]
+ * (screenshot-tested).
  */
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun HomeContent(
     modifier: Modifier = Modifier,
-    authViewModel: AuthViewModel? = null,
-    doorViewModel: DoorViewModel? = null,
-    appLoggerViewModel: AppLoggerViewModel? = null,
+    homeViewModel: HomeViewModel? = null,
 ) {
     val component = rememberAppComponent()
-    val resolvedAuthViewModel = authViewModel ?: viewModel { component.authViewModel }
-    val resolvedDoorViewModel = doorViewModel ?: viewModel { component.doorViewModel }
-    val buttonViewModel: RemoteButtonViewModel = viewModel { component.remoteButtonViewModel }
-    val resolvedAppLoggerViewModel = appLoggerViewModel ?: viewModel { component.appLoggerViewModel }
+    val resolved = homeViewModel ?: viewModel { component.homeViewModel }
 
     val googleSignIn = rememberGoogleSignIn(
-        onTokenReceived = { token -> resolvedAuthViewModel.signInWithGoogle(token) },
+        onTokenReceived = { token -> resolved.signInWithGoogle(token) },
     )
-    val currentDoorEvent by resolvedDoorViewModel.currentDoorEvent.collectAsState()
-    val buttonState by buttonViewModel.buttonState.collectAsState()
-    val authState by resolvedAuthViewModel.authState.collectAsState()
-    val isCheckInStale by resolvedDoorViewModel.isCheckInStale.collectAsState()
-    val buttonHealthDisplay: ButtonHealthDisplay by buttonViewModel.buttonHealthDisplay
+    val currentDoorEvent by resolved.currentDoorEvent.collectAsState()
+    val buttonState by resolved.buttonState.collectAsState()
+    val authState by resolved.authState.collectAsState()
+    val isCheckInStale by resolved.isCheckInStale.collectAsState()
+    val buttonHealthDisplay: ButtonHealthDisplay by resolved.buttonHealthDisplay
         .collectAsStateWithLifecycle(initialValue = ButtonHealthDisplay.Loading)
 
     val notificationPermissionState = rememberNotificationPermissionState()
@@ -89,7 +82,7 @@ fun HomeContent(
     // `now` is driven by the VM's LiveClock-backed StateFlow (10s tick) —
     // `rememberLiveNow()` no longer exists; the ticker is owned by the
     // UseCase layer and lives across the app, not per-Composable.
-    val nowEpochSeconds by resolvedDoorViewModel.nowEpochSeconds.collectAsState()
+    val nowEpochSeconds by resolved.nowEpochSeconds.collectAsState()
     val now = remember(nowEpochSeconds) { Instant.ofEpochSecond(nowEpochSeconds) }
     val zone = remember { ZoneId.systemDefault() }
 
@@ -116,23 +109,23 @@ fun HomeContent(
         buttonHealthDisplay = buttonHealthDisplay,
         isRefreshing = currentDoorEvent is LoadingResult.Loading,
         onRefresh = {
-            resolvedAppLoggerViewModel.log(AppLoggerKeys.USER_FETCH_CURRENT_DOOR)
-            resolvedDoorViewModel.fetchCurrentDoorEvent()
+            resolved.log(AppLoggerKeys.USER_FETCH_CURRENT_DOOR)
+            resolved.fetchCurrentDoorEvent()
         },
         onAlertAction = { alert ->
             when (alert) {
                 is HomeAlert.Stale -> {
                     Logger.e { "Trying to fix outdated info. Resetting FCM, and fetching data." }
-                    resolvedDoorViewModel.deregisterFcm()
-                    resolvedDoorViewModel.fetchCurrentDoorEvent()
+                    resolved.deregisterFcm()
+                    resolved.fetchCurrentDoorEvent()
                 }
                 is HomeAlert.PermissionMissing -> {
                     permissionRequestCount++
                     notificationPermissionState.launchPermissionRequest()
-                    resolvedAppLoggerViewModel.log(AppLoggerKeys.USER_REQUESTED_NOTIFICATION_PERMISSION)
+                    resolved.log(AppLoggerKeys.USER_REQUESTED_NOTIFICATION_PERMISSION)
                 }
                 is HomeAlert.FetchError -> {
-                    resolvedDoorViewModel.fetchCurrentDoorEvent()
+                    resolved.fetchCurrentDoorEvent()
                 }
             }
         },
@@ -140,7 +133,7 @@ fun HomeContent(
             when (authState) {
                 is AuthState.Authenticated -> {
                     Logger.d { "Remote button tapped. AuthViewModel authState $authState" }
-                    buttonViewModel.onButtonTap()
+                    resolved.onButtonTap()
                 }
                 AuthState.Unauthenticated, AuthState.Unknown -> {
                     googleSignIn.launchSignIn()

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -314,9 +314,6 @@ private fun RouteEntryFor(
                         modifier = routeModifier.padding(horizontal = Spacing.Screen),
                         homePane = { paneModifier ->
                             HomeContent(
-                                authViewModel = authViewModel,
-                                doorViewModel = doorViewModel,
-                                appLoggerViewModel = appLoggerViewModel,
                                 modifier = paneModifier,
                             )
                         },
@@ -332,9 +329,6 @@ private fun RouteEntryFor(
             } else {
                 RouteContent { routeModifier ->
                     HomeContent(
-                        authViewModel = authViewModel,
-                        doorViewModel = doorViewModel,
-                        appLoggerViewModel = appLoggerViewModel,
                         modifier = routeModifier.padding(horizontal = Spacing.Screen),
                     )
                 }

--- a/AndroidGarage/screen-viewmodel-exemptions.txt
+++ b/AndroidGarage/screen-viewmodel-exemptions.txt
@@ -13,9 +13,6 @@
 # build a screen-specific ViewModel that aggregates the UseCases that screen
 # needs (see `FunctionListViewModel` for the canonical example).
 
-# Aggregates DoorViewModel + AuthViewModel + AppLoggerViewModel + RemoteButtonViewModel.
-HomeContent.kt
-
 # Aggregates DoorViewModel + AppLoggerViewModel.
 DoorHistoryContent.kt
 

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/HomeViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/HomeViewModel.kt
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
+import com.chriscartland.garage.domain.coroutines.DispatcherProvider
+import com.chriscartland.garage.domain.model.ActionError
+import com.chriscartland.garage.domain.model.AppLoggerKeys
+import com.chriscartland.garage.domain.model.AppResult
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.DoorEvent
+import com.chriscartland.garage.domain.model.FetchError
+import com.chriscartland.garage.domain.model.GoogleIdToken
+import com.chriscartland.garage.domain.model.LoadingResult
+import com.chriscartland.garage.domain.model.RemoteButtonState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Drives the Home screen — the canonical example for ADR-026
+ * (one ViewModel per screen). Aggregates everything `HomeContent.kt`
+ * needs from below, depending on UseCases only (Phase 43 rule).
+ *
+ * Replaces the previous direct use of `DoorViewModel` + `AuthViewModel` +
+ * `RemoteButtonViewModel` + `AppLoggerViewModel` from `HomeContent.kt`.
+ * Those VMs still exist and back the legacy multi-VM screens that haven't
+ * yet been refactored to one-VM-per-screen (`DoorHistoryContent`,
+ * `ProfileContent`).
+ */
+interface HomeViewModel {
+    val authState: StateFlow<AuthState>
+
+    val currentDoorEvent: StateFlow<LoadingResult<DoorEvent?>>
+
+    /** True when the last check-in is older than the staleness threshold (11 min). */
+    val isCheckInStale: StateFlow<Boolean>
+
+    /**
+     * Wall-clock time as epoch seconds, ticking on the [LiveClock] cadence
+     * (10s by default). Pass-through of [LiveClock.nowEpochSeconds] (ADR-022).
+     */
+    val nowEpochSeconds: StateFlow<Long>
+
+    val buttonState: StateFlow<RemoteButtonState>
+
+    /**
+     * Display state for the remote-button device's online/offline pill.
+     * Per ADR-022, derived [Flow]; the Composable consumer collects via
+     * [androidx.compose.runtime.collectAsState] with an initial value.
+     */
+    val buttonHealthDisplay: Flow<ButtonHealthDisplay>
+
+    fun signInWithGoogle(idToken: GoogleIdToken)
+
+    fun fetchCurrentDoorEvent()
+
+    fun deregisterFcm()
+
+    fun onButtonTap()
+
+    fun log(key: String)
+}
+
+class DefaultHomeViewModel(
+    observeDoorEvents: ObserveDoorEventsUseCase,
+    observeAuthState: ObserveAuthStateUseCase,
+    private val logAppEvent: LogAppEventUseCase,
+    private val dispatchers: DispatcherProvider,
+    private val fetchCurrentDoorEventUseCase: FetchCurrentDoorEventUseCase,
+    private val deregisterFcmUseCase: DeregisterFcmUseCase,
+    private val signInWithGoogleUseCase: SignInWithGoogleUseCase,
+    private val pushRemoteButtonUseCase: PushRemoteButtonUseCase,
+    private val checkInStalenessManager: CheckInStalenessManager,
+    private val liveClock: LiveClock,
+    override val buttonHealthDisplay: Flow<ButtonHealthDisplay>,
+    private val appVersion: String,
+    private val fetchOnInit: Boolean = true,
+) : ViewModel(),
+    HomeViewModel {
+    // ADR-022: pass through the repository's StateFlow by reference — no mirror.
+    override val authState: StateFlow<AuthState> = observeAuthState()
+
+    // ADR-022: pass through LiveClock's StateFlow — no mirror.
+    override val nowEpochSeconds: StateFlow<Long> = liveClock.nowEpochSeconds
+
+    private val _currentDoorEvent =
+        MutableStateFlow<LoadingResult<DoorEvent?>>(LoadingResult.Loading(null))
+    override val currentDoorEvent: StateFlow<LoadingResult<DoorEvent?>> = _currentDoorEvent
+
+    private val _isCheckInStale = MutableStateFlow(false)
+    override val isCheckInStale: StateFlow<Boolean> = _isCheckInStale
+
+    private val stateMachine = ButtonStateMachine(
+        doorPosition = observeDoorEvents.position(),
+        onSubmit = ::submitButtonPress,
+        scope = viewModelScope,
+        dispatcher = dispatchers.io,
+    )
+    override val buttonState: StateFlow<RemoteButtonState> = stateMachine.state
+
+    init {
+        Logger.d { "init" }
+        viewModelScope.launch(dispatchers.io) {
+            checkInStalenessManager.isCheckInStale.collect {
+                _isCheckInStale.value = it
+            }
+        }
+        viewModelScope.launch(dispatchers.io) {
+            observeDoorEvents.current().collect {
+                Logger.d { "currentDoorEvent collect: $it" }
+                _currentDoorEvent.value = LoadingResult.Complete(it)
+            }
+        }
+        if (fetchOnInit) {
+            viewModelScope.launch(dispatchers.io) {
+                logAppEvent(AppLoggerKeys.INIT_CURRENT_DOOR)
+            }
+            fetchCurrentDoorEvent()
+        }
+    }
+
+    override fun signInWithGoogle(idToken: GoogleIdToken) {
+        viewModelScope.launch(dispatchers.io) {
+            logAppEvent(AppLoggerKeys.BEGIN_GOOGLE_SIGN_IN)
+            Logger.d { "signInWithGoogle" }
+            signInWithGoogleUseCase(idToken)
+        }
+    }
+
+    override fun fetchCurrentDoorEvent() {
+        Logger.d { "fetchCurrentDoorEvent" }
+        viewModelScope.launch(dispatchers.io) {
+            // ADR-023: explicit `Complete(...)` write on success — relying on
+            // the repo StateFlow to fire is unsafe because MutableStateFlow
+            // dedups by equality.
+            _currentDoorEvent.value = LoadingResult.Loading(_currentDoorEvent.value.data)
+            when (val result = fetchCurrentDoorEventUseCase()) {
+                is AppResult.Success -> {
+                    _currentDoorEvent.value = LoadingResult.Complete(result.data)
+                }
+                is AppResult.Error -> {
+                    // Restore previous data so UI exits Loading state.
+                    _currentDoorEvent.value = LoadingResult.Complete(_currentDoorEvent.value.data)
+                    when (result.error) {
+                        FetchError.NotReady -> Logger.w { "Server config not ready" }
+                        FetchError.NetworkFailed -> Logger.w { "Network request failed" }
+                    }
+                }
+            }
+        }
+    }
+
+    override fun deregisterFcm() {
+        Logger.d { "deregisterFcm" }
+        viewModelScope.launch(dispatchers.io) {
+            deregisterFcmUseCase()
+        }
+    }
+
+    override fun onButtonTap() {
+        stateMachine.onTap()
+    }
+
+    override fun log(key: String) {
+        viewModelScope.launch(dispatchers.io) {
+            logAppEvent(key)
+        }
+    }
+
+    private fun submitButtonPress() {
+        Logger.d { "submitButtonPress" }
+        stateMachine.onNetworkStarted()
+        viewModelScope.launch(dispatchers.io) {
+            when (
+                val result = pushRemoteButtonUseCase(
+                    buttonAckToken = ButtonAckToken.create(
+                        currentTimeMillis = System.currentTimeMillis(),
+                        appVersion = appVersion,
+                    ),
+                )
+            ) {
+                is AppResult.Success -> stateMachine.onNetworkCompleted()
+                is AppResult.Error -> when (result.error) {
+                    ActionError.NotAuthenticated -> {
+                        Logger.w { "Push failed — not authenticated" }
+                        stateMachine.reset()
+                    }
+                    ActionError.MissingData -> {
+                        Logger.w { "Push failed — missing data" }
+                        stateMachine.reset()
+                    }
+                    ActionError.NetworkFailed -> {
+                        Logger.w { "Push failed — network error" }
+                        stateMachine.onNetworkFailed()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/HomeViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/HomeViewModelTest.kt
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.coroutines.AppClock
+import com.chriscartland.garage.domain.model.AppLoggerKeys
+import com.chriscartland.garage.domain.model.AppResult
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.ButtonHealth
+import com.chriscartland.garage.domain.model.ButtonHealthError
+import com.chriscartland.garage.domain.model.ButtonHealthState
+import com.chriscartland.garage.domain.model.DisplayName
+import com.chriscartland.garage.domain.model.DoorEvent
+import com.chriscartland.garage.domain.model.DoorPosition
+import com.chriscartland.garage.domain.model.Email
+import com.chriscartland.garage.domain.model.LoadingResult
+import com.chriscartland.garage.domain.model.User
+import com.chriscartland.garage.domain.repository.ButtonHealthRepository
+import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
+import com.chriscartland.garage.testcommon.FakeAuthRepository
+import com.chriscartland.garage.testcommon.FakeDiagnosticsCountersRepository
+import com.chriscartland.garage.testcommon.FakeDoorFcmRepository
+import com.chriscartland.garage.testcommon.FakeDoorRepository
+import com.chriscartland.garage.testcommon.FakeRemoteButtonRepository
+import com.chriscartland.garage.testcommon.TestDispatcherProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var doorRepository: FakeDoorRepository
+    private lateinit var authRepository: FakeAuthRepository
+    private lateinit var appLoggerRepository: FakeAppLoggerRepository
+    private lateinit var doorFcmRepository: FakeDoorFcmRepository
+    private lateinit var remoteButtonRepository: FakeRemoteButtonRepository
+
+    private val testDoorEvent =
+        DoorEvent(
+            doorPosition = DoorPosition.CLOSED,
+            message = "The door is closed.",
+            lastCheckInTimeSeconds = 1000L,
+            lastChangeTimeSeconds = 900L,
+        )
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        doorRepository = FakeDoorRepository()
+        authRepository = FakeAuthRepository()
+        appLoggerRepository = FakeAppLoggerRepository()
+        doorFcmRepository = FakeDoorFcmRepository()
+        remoteButtonRepository = FakeRemoteButtonRepository()
+        doorRepository.setCurrentDoorEvent(testDoorEvent)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    /**
+     * [scope] is used for the CheckInStalenessManager (infinite loop) and
+     * LiveClock (10s ticker). Tests pass `backgroundScope` from `runTest`
+     * so those loops are cancelled when the test completes.
+     */
+    private fun createViewModel(
+        scope: CoroutineScope,
+        authState: AuthState = AuthState.Unauthenticated,
+        fetchOnInit: Boolean = true,
+    ): DefaultHomeViewModel {
+        authRepository.setAuthState(authState)
+        val stalenessManager = CheckInStalenessManager(
+            observeDoorEvents = ObserveDoorEventsUseCase(doorRepository),
+            logAppEvent = LogAppEventUseCase(appLoggerRepository, FakeDiagnosticsCountersRepository()),
+            scope = scope,
+            dispatcher = testDispatcher,
+            clock = AppClock { 0L },
+        )
+        val liveClock = DefaultLiveClock(
+            clock = AppClock { 0L },
+            scope = scope,
+            dispatcher = testDispatcher,
+        )
+        val computeButtonHealth = ComputeButtonHealthDisplayUseCase(
+            authRepository = authRepository,
+            buttonHealthRepository = HomeTestNoopButtonHealthRepository(),
+            liveClock = liveClock,
+        )
+        val vm = DefaultHomeViewModel(
+            observeDoorEvents = ObserveDoorEventsUseCase(doorRepository),
+            observeAuthState = ObserveAuthStateUseCase(authRepository),
+            logAppEvent = LogAppEventUseCase(
+                appLoggerRepository,
+                FakeDiagnosticsCountersRepository(),
+            ),
+            dispatchers = TestDispatcherProvider(testDispatcher),
+            fetchCurrentDoorEventUseCase = FetchCurrentDoorEventUseCase(doorRepository),
+            deregisterFcmUseCase = DeregisterFcmUseCase(doorFcmRepository),
+            signInWithGoogleUseCase = SignInWithGoogleUseCase(authRepository),
+            pushRemoteButtonUseCase = PushRemoteButtonUseCase(
+                authRepository,
+                remoteButtonRepository,
+            ),
+            checkInStalenessManager = stalenessManager,
+            liveClock = liveClock,
+            buttonHealthDisplay = computeButtonHealth(),
+            appVersion = "test",
+            fetchOnInit = fetchOnInit,
+        )
+        testDispatcher.scheduler.runCurrent()
+        return vm
+    }
+
+    @Test
+    fun authStatePassesThroughFromRepository() =
+        runTest {
+            val authedUser = User(
+                name = DisplayName("User"),
+                email = Email("user@example.com"),
+            )
+            val viewModel = createViewModel(
+                scope = backgroundScope,
+                authState = AuthState.Authenticated(authedUser),
+            )
+            assertTrue(viewModel.authState.value is AuthState.Authenticated)
+        }
+
+    @Test
+    fun collectsCurrentDoorEventFromRepository() =
+        runTest {
+            val viewModel = createViewModel(scope = backgroundScope)
+
+            val updatedEvent =
+                DoorEvent(
+                    doorPosition = DoorPosition.OPEN,
+                    message = "The door is open.",
+                    lastCheckInTimeSeconds = 2000L,
+                    lastChangeTimeSeconds = 1900L,
+                )
+            doorRepository.setCurrentDoorEvent(updatedEvent)
+            testDispatcher.scheduler.runCurrent()
+
+            val result = viewModel.currentDoorEvent.value
+            assertTrue(result is LoadingResult.Complete, "Should be Complete after collection")
+            assertEquals(updatedEvent, result.data)
+        }
+
+    @Test
+    fun fetchCurrentDoorEventCallsRepository() =
+        runTest {
+            val viewModel = createViewModel(scope = backgroundScope, fetchOnInit = false)
+
+            viewModel.fetchCurrentDoorEvent()
+            advanceUntilIdle()
+
+            assertEquals(1, doorRepository.fetchCurrentDoorEventCount)
+        }
+
+    @Test
+    fun fetchOnInitFalseSkipsInitialFetch() =
+        runTest {
+            createViewModel(scope = backgroundScope, fetchOnInit = false)
+
+            assertEquals(0, doorRepository.fetchCurrentDoorEventCount)
+        }
+
+    @Test
+    fun fetchOnInitTrueTriggersInitialFetch() =
+        runTest {
+            createViewModel(scope = backgroundScope, fetchOnInit = true)
+            advanceUntilIdle()
+
+            assertEquals(1, doorRepository.fetchCurrentDoorEventCount)
+        }
+
+    @Test
+    fun logForwardsToAppLogger() =
+        runTest {
+            val viewModel = createViewModel(scope = backgroundScope, fetchOnInit = false)
+
+            viewModel.log("custom_key")
+            advanceUntilIdle()
+
+            assertTrue(appLoggerRepository.loggedKeys.any { it == "custom_key" })
+        }
+
+    @Test
+    fun fetchOnInitTrueLogsInitCurrentDoor() =
+        runTest {
+            createViewModel(scope = backgroundScope, fetchOnInit = true)
+            advanceUntilIdle()
+
+            assertTrue(
+                appLoggerRepository.loggedKeys.any { it == AppLoggerKeys.INIT_CURRENT_DOOR },
+                "INIT_CURRENT_DOOR should be logged on init when fetchOnInit=true",
+            )
+        }
+
+    @Test
+    fun nowEpochSecondsIsLiveClockReference() =
+        runTest {
+            val viewModel = createViewModel(scope = backgroundScope, fetchOnInit = false)
+
+            // LiveClock backed by AppClock { 0L }: initial value is 0.
+            assertEquals(0L, viewModel.nowEpochSeconds.value)
+        }
+}
+
+private class HomeTestNoopButtonHealthRepository : ButtonHealthRepository {
+    override val buttonHealth: StateFlow<LoadingResult<ButtonHealth>> =
+        MutableStateFlow(LoadingResult.Loading(null))
+
+    override suspend fun fetchButtonHealth(): AppResult<ButtonHealth, ButtonHealthError> =
+        AppResult.Success(ButtonHealth(ButtonHealthState.UNKNOWN, null))
+
+    override fun applyFcmUpdate(update: ButtonHealth) {
+        // no-op
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `HomeViewModel` (interface + `DefaultHomeViewModel`) in `usecase/commonMain`, aggregating the same UseCases the old multi-VM setup used.
- Updates `HomeContent.kt` to resolve a single VM via `viewModel { component.homeViewModel }` — drops 3 VM parameters.
- Drops `HomeContent.kt` from `AndroidGarage/screen-viewmodel-exemptions.txt` (the cardinality lint will now hold the line).
- Adds `HomeViewModelTest` (8 tests) following `DoorViewModelTest` + `DefaultFunctionListViewModelTest` pattern.

## Why
ADR-026 — one ViewModel per screen — is enforced by `checkScreenViewModelCardinality`. `HomeContent` was on the exemption list because it imported four VMs directly (`DoorViewModel`, `AuthViewModel`, `RemoteButtonViewModel`, `AppLoggerViewModel`). The exemptions doc says the list is meant to shrink. This is the first reduction; `DoorHistoryViewModel` + `ProfileViewModel` are intended follow-ups.

## Architecture choices (confirmed via session discussion)
- Pattern: interface + `Default*` impl in `usecase/commonMain`, matching `FunctionListViewModel`.
- Dependencies: UseCases only, never other VMs (Phase 43 rule).
- State exposure: ADR-022 pass-throughs preserved (`authState`, `nowEpochSeconds`, `buttonHealthDisplay` Flow).
- ADR-023: explicit `LoadingResult.Complete(...)` write on fetch success kept.
- Legacy multi-purpose VMs stay — still consumed by `DoorHistoryContent` and `ProfileContent`.

## Behavior
Pure refactor. No UI changes. No screenshot changes. The `INIT_CURRENT_DOOR` log fires from `HomeViewModel.init` instead of `DoorViewModel.init` for the Home tab; behavior identical.

## Test plan
- [x] `./scripts/validate.sh` green
- [x] `HomeViewModelTest` (8 tests) passes
- [x] `checkScreenViewModelCardinality` accepts the dropped exemption
- [ ] Manual smoke on phone (Home tab — door state, refresh, button tap, sign-in flow)
- [ ] Manual smoke on tablet/foldable (wide dashboard left pane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)