### PR TITLE
refactor(android): Add DoorHistoryViewModel; one VM per History screen (ADR-026)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/MainActivity.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/MainActivity.kt
@@ -28,8 +28,6 @@ import com.chriscartland.garage.ui.GarageApp
 class MainActivity : ComponentActivity() {
     private val component by lazy { (application as GarageApplication).component }
     private val authViewModel by lazy { activityViewModel(this) { component.authViewModel } }
-    private val doorViewModel by lazy { activityViewModel(this) { component.doorViewModel } }
-    private val appLoggerViewModel by lazy { activityViewModel(this) { component.appLoggerViewModel } }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -38,8 +36,6 @@ class MainActivity : ComponentActivity() {
             setContent {
                 GarageApp(
                     authViewModel = authViewModel,
-                    doorViewModel = doorViewModel,
-                    appLoggerViewModel = appLoggerViewModel,
                 )
             }
         }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -80,6 +80,7 @@ import com.chriscartland.garage.usecase.ComputeButtonHealthDisplayUseCase
 import com.chriscartland.garage.usecase.DefaultAppLoggerViewModel
 import com.chriscartland.garage.usecase.DefaultAppSettingsViewModel
 import com.chriscartland.garage.usecase.DefaultAuthViewModel
+import com.chriscartland.garage.usecase.DefaultDoorHistoryViewModel
 import com.chriscartland.garage.usecase.DefaultDoorViewModel
 import com.chriscartland.garage.usecase.DefaultFunctionListViewModel
 import com.chriscartland.garage.usecase.DefaultHomeViewModel
@@ -154,6 +155,7 @@ abstract class AppComponent(
     abstract val remoteButtonViewModel: DefaultRemoteButtonViewModel
     abstract val functionListViewModel: DefaultFunctionListViewModel
     abstract val homeViewModel: DefaultHomeViewModel
+    abstract val doorHistoryViewModel: DefaultDoorHistoryViewModel
 
     // --- Entry points: @Singleton providers (testable via assertSame) ---
     abstract val appConfig: AppConfig
@@ -354,6 +356,26 @@ abstract class AppComponent(
             liveClock = liveClock,
             buttonHealthDisplay = computeButtonHealthDisplay(),
             appVersion = appVersion,
+        )
+
+    @Provides
+    fun provideDoorHistoryViewModel(
+        observeDoorEvents: ObserveDoorEventsUseCase,
+        logAppEvent: LogAppEventUseCase,
+        dispatchers: DispatcherProvider,
+        fetchRecentDoorEvents: FetchRecentDoorEventsUseCase,
+        deregisterFcm: DeregisterFcmUseCase,
+        checkInStalenessManager: CheckInStalenessManager,
+        liveClock: LiveClock,
+    ): DefaultDoorHistoryViewModel =
+        DefaultDoorHistoryViewModel(
+            observeDoorEvents = observeDoorEvents,
+            logAppEvent = logAppEvent,
+            dispatchers = dispatchers,
+            fetchRecentDoorEventsUseCase = fetchRecentDoorEvents,
+            deregisterFcmUseCase = deregisterFcm,
+            checkInStalenessManager = checkInStalenessManager,
+            liveClock = liveClock,
         )
 
     // --- UseCases (constructors are single-dep or small, kept concise) ---

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
@@ -39,26 +39,23 @@ import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.presentation.demoDoorEvents
 import com.chriscartland.garage.ui.history.HistoryContent
 import com.chriscartland.garage.ui.history.HistoryMapper
-import com.chriscartland.garage.usecase.AppLoggerViewModel
-import com.chriscartland.garage.usecase.DoorViewModel
+import com.chriscartland.garage.usecase.DoorHistoryViewModel
 import java.time.Instant
 import java.time.ZoneId
 
 @Composable
 fun DoorHistoryContent(
     modifier: Modifier = Modifier,
-    doorViewModel: DoorViewModel? = null,
-    appLoggerViewModel: AppLoggerViewModel? = null,
+    doorHistoryViewModel: DoorHistoryViewModel? = null,
 ) {
     val component = rememberAppComponent()
-    val resolvedDoorViewModel = doorViewModel ?: viewModel { component.doorViewModel }
-    val resolvedAppLoggerViewModel = appLoggerViewModel ?: viewModel { component.appLoggerViewModel }
-    val recentDoorEvents by resolvedDoorViewModel.recentDoorEvents.collectAsState()
-    val isCheckInStale by resolvedDoorViewModel.isCheckInStale.collectAsState()
+    val resolved = doorHistoryViewModel ?: viewModel { component.doorHistoryViewModel }
+    val recentDoorEvents by resolved.recentDoorEvents.collectAsState()
+    val isCheckInStale by resolved.isCheckInStale.collectAsState()
     // `now` is driven by the VM's LiveClock-backed StateFlow (1s tick) —
     // `rememberLiveNow()` no longer exists; the ticker is owned by the
     // UseCase layer and lives across the app, not per-Composable.
-    val nowEpochSeconds by resolvedDoorViewModel.nowEpochSeconds.collectAsState()
+    val nowEpochSeconds by resolved.nowEpochSeconds.collectAsState()
     val now = remember(nowEpochSeconds) { Instant.ofEpochSecond(nowEpochSeconds) }
     DoorHistoryContent(
         recentDoorEvents = recentDoorEvents,
@@ -67,11 +64,11 @@ fun DoorHistoryContent(
         zone = ZoneId.systemDefault(),
         modifier = modifier,
         onFetchRecentDoorEvents = {
-            resolvedAppLoggerViewModel.log(AppLoggerKeys.USER_FETCH_RECENT_DOOR)
-            resolvedDoorViewModel.fetchRecentDoorEvents()
+            resolved.log(AppLoggerKeys.USER_FETCH_RECENT_DOOR)
+            resolved.fetchRecentDoorEvents()
         },
         onResetFcm = {
-            resolvedDoorViewModel.deregisterFcm()
+            resolved.deregisterFcm()
         },
     )
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -49,17 +49,11 @@ import androidx.navigation3.ui.NavDisplay
 import com.chriscartland.garage.ui.settings.DiagnosticsScreen
 import com.chriscartland.garage.ui.theme.AppTheme
 import com.chriscartland.garage.ui.theme.Spacing
-import com.chriscartland.garage.usecase.AppLoggerViewModel
 import com.chriscartland.garage.usecase.AuthViewModel
-import com.chriscartland.garage.usecase.DoorViewModel
 import kotlinx.serialization.Serializable
 
 @Composable
-fun GarageApp(
-    authViewModel: AuthViewModel,
-    doorViewModel: DoorViewModel,
-    appLoggerViewModel: AppLoggerViewModel,
-) {
+fun GarageApp(authViewModel: AuthViewModel) {
     // ProvideAppWindowSizeClass installs `LocalAppWindowSizeClass` for the
     // whole app. Adaptive layout decisions (current screen-width cap; future
     // single-pane vs. two-pane branching) read from that local — never from
@@ -70,8 +64,6 @@ fun GarageApp(
         AppTheme {
             AppNavigation(
                 authViewModel = authViewModel,
-                doorViewModel = doorViewModel,
-                appLoggerViewModel = appLoggerViewModel,
             )
         }
     }
@@ -123,11 +115,7 @@ enum class Tab(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AppNavigation(
-    authViewModel: AuthViewModel,
-    doorViewModel: DoorViewModel,
-    appLoggerViewModel: AppLoggerViewModel,
-) {
+fun AppNavigation(authViewModel: AuthViewModel) {
     // Nav3: `rememberNavBackStack` is the saveable back stack. Survives
     // configuration changes (rotation, window size, dark mode, locale,
     // font scale) AND process death. The serialized form rides through
@@ -222,8 +210,6 @@ fun AppNavigation(
                         screen = screen,
                         mode = mode,
                         authViewModel = authViewModel,
-                        doorViewModel = doorViewModel,
-                        appLoggerViewModel = appLoggerViewModel,
                         onNavigateToFunctionList = { backStack.add(Screen.FunctionList) },
                         onNavigateToDiagnostics = { backStack.add(Screen.Diagnostics) },
                         onBack = { onPopBack() },
@@ -295,8 +281,6 @@ private fun RouteEntryFor(
     screen: Screen,
     mode: AppLayoutMode,
     authViewModel: AuthViewModel,
-    doorViewModel: DoorViewModel,
-    appLoggerViewModel: AppLoggerViewModel,
     onNavigateToFunctionList: () -> Unit,
     onNavigateToDiagnostics: () -> Unit,
     onBack: () -> Unit,
@@ -319,8 +303,6 @@ private fun RouteEntryFor(
                         },
                         historyPane = { paneModifier ->
                             DoorHistoryContent(
-                                doorViewModel = doorViewModel,
-                                appLoggerViewModel = appLoggerViewModel,
                                 modifier = paneModifier,
                             )
                         },
@@ -338,8 +320,6 @@ private fun RouteEntryFor(
             // Reached only on Compact (Wide.mergedRoutes redirects to Home).
             RouteContent { routeModifier ->
                 DoorHistoryContent(
-                    doorViewModel = doorViewModel,
-                    appLoggerViewModel = appLoggerViewModel,
                     modifier = routeModifier.padding(horizontal = Spacing.Screen),
                 )
             }

--- a/AndroidGarage/screen-viewmodel-exemptions.txt
+++ b/AndroidGarage/screen-viewmodel-exemptions.txt
@@ -13,8 +13,5 @@
 # build a screen-specific ViewModel that aggregates the UseCases that screen
 # needs (see `FunctionListViewModel` for the canonical example).
 
-# Aggregates DoorViewModel + AppLoggerViewModel.
-DoorHistoryContent.kt
-
 # Aggregates AuthViewModel + RemoteButtonViewModel + AppSettingsViewModel.
 ProfileContent.kt

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorHistoryViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorHistoryViewModel.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
+import com.chriscartland.garage.domain.coroutines.DispatcherProvider
+import com.chriscartland.garage.domain.model.AppLoggerKeys
+import com.chriscartland.garage.domain.model.AppResult
+import com.chriscartland.garage.domain.model.DoorEvent
+import com.chriscartland.garage.domain.model.FetchError
+import com.chriscartland.garage.domain.model.LoadingResult
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Drives the History screen — one VM per screen (ADR-026). Aggregates the
+ * UseCases that the legacy `DoorViewModel` + `AppLoggerViewModel` pair
+ * exposed to `DoorHistoryContent.kt`. Phase 43 — depends on UseCases only.
+ *
+ * The Wide-screen Home dashboard renders this VM in its right pane. On
+ * phones it backs the History tab. The legacy VMs remain for callers that
+ * haven't been refactored yet (`ProfileContent`).
+ */
+interface DoorHistoryViewModel {
+    val recentDoorEvents: StateFlow<LoadingResult<List<DoorEvent>>>
+
+    /** True when the last check-in is older than the staleness threshold (11 min). */
+    val isCheckInStale: StateFlow<Boolean>
+
+    /**
+     * Wall-clock time as epoch seconds, ticking on the [LiveClock] cadence.
+     * Pass-through of [LiveClock.nowEpochSeconds] (ADR-022).
+     */
+    val nowEpochSeconds: StateFlow<Long>
+
+    fun fetchRecentDoorEvents()
+
+    fun deregisterFcm()
+
+    fun log(key: String)
+}
+
+class DefaultDoorHistoryViewModel(
+    observeDoorEvents: ObserveDoorEventsUseCase,
+    private val logAppEvent: LogAppEventUseCase,
+    private val dispatchers: DispatcherProvider,
+    private val fetchRecentDoorEventsUseCase: FetchRecentDoorEventsUseCase,
+    private val deregisterFcmUseCase: DeregisterFcmUseCase,
+    private val checkInStalenessManager: CheckInStalenessManager,
+    private val liveClock: LiveClock,
+    private val fetchOnInit: Boolean = true,
+) : ViewModel(),
+    DoorHistoryViewModel {
+    // ADR-022: pass through LiveClock's StateFlow — no mirror.
+    override val nowEpochSeconds: StateFlow<Long> = liveClock.nowEpochSeconds
+
+    private val _recentDoorEvents =
+        MutableStateFlow<LoadingResult<List<DoorEvent>>>(LoadingResult.Loading(listOf()))
+    override val recentDoorEvents: StateFlow<LoadingResult<List<DoorEvent>>> = _recentDoorEvents
+
+    private val _isCheckInStale = MutableStateFlow(false)
+    override val isCheckInStale: StateFlow<Boolean> = _isCheckInStale
+
+    init {
+        Logger.d { "init" }
+        viewModelScope.launch(dispatchers.io) {
+            checkInStalenessManager.isCheckInStale.collect {
+                _isCheckInStale.value = it
+            }
+        }
+        viewModelScope.launch(dispatchers.io) {
+            observeDoorEvents.recent().collect {
+                Logger.d { "recentDoorEvents collect: $it" }
+                _recentDoorEvents.value = LoadingResult.Complete(it)
+            }
+        }
+        if (fetchOnInit) {
+            viewModelScope.launch(dispatchers.io) {
+                logAppEvent(AppLoggerKeys.INIT_RECENT_DOOR)
+            }
+            fetchRecentDoorEvents()
+        }
+    }
+
+    override fun fetchRecentDoorEvents() {
+        Logger.d { "fetchRecentDoorEvents" }
+        viewModelScope.launch(dispatchers.io) {
+            // ADR-023: explicit `Complete(...)` write on success — relying on
+            // the repo StateFlow to fire is unsafe because MutableStateFlow
+            // dedups by equality.
+            _recentDoorEvents.value = LoadingResult.Loading(_recentDoorEvents.value.data)
+            when (val result = fetchRecentDoorEventsUseCase()) {
+                is AppResult.Success -> {
+                    _recentDoorEvents.value = LoadingResult.Complete(result.data)
+                }
+                is AppResult.Error -> {
+                    // Restore previous data so UI exits Loading state.
+                    _recentDoorEvents.value = LoadingResult.Complete(_recentDoorEvents.value.data)
+                    when (result.error) {
+                        FetchError.NotReady -> Logger.w { "Server config not ready" }
+                        FetchError.NetworkFailed -> Logger.w { "Network request failed" }
+                    }
+                }
+            }
+        }
+    }
+
+    override fun deregisterFcm() {
+        Logger.d { "deregisterFcm" }
+        viewModelScope.launch(dispatchers.io) {
+            deregisterFcmUseCase()
+        }
+    }
+
+    override fun log(key: String) {
+        viewModelScope.launch(dispatchers.io) {
+            logAppEvent(key)
+        }
+    }
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DoorHistoryViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DoorHistoryViewModelTest.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.coroutines.AppClock
+import com.chriscartland.garage.domain.model.AppLoggerKeys
+import com.chriscartland.garage.domain.model.DoorEvent
+import com.chriscartland.garage.domain.model.DoorPosition
+import com.chriscartland.garage.domain.model.LoadingResult
+import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
+import com.chriscartland.garage.testcommon.FakeDiagnosticsCountersRepository
+import com.chriscartland.garage.testcommon.FakeDoorFcmRepository
+import com.chriscartland.garage.testcommon.FakeDoorRepository
+import com.chriscartland.garage.testcommon.TestDispatcherProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DoorHistoryViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var doorRepository: FakeDoorRepository
+    private lateinit var appLoggerRepository: FakeAppLoggerRepository
+    private lateinit var doorFcmRepository: FakeDoorFcmRepository
+
+    private val testDoorEvent =
+        DoorEvent(
+            doorPosition = DoorPosition.CLOSED,
+            message = "The door is closed.",
+            lastCheckInTimeSeconds = 1000L,
+            lastChangeTimeSeconds = 900L,
+        )
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        doorRepository = FakeDoorRepository()
+        appLoggerRepository = FakeAppLoggerRepository()
+        doorFcmRepository = FakeDoorFcmRepository()
+        doorRepository.setRecentDoorEvents(listOf(testDoorEvent))
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    /**
+     * [scope] is used for the CheckInStalenessManager (infinite loop) and
+     * LiveClock (10s ticker). Tests pass `backgroundScope` from `runTest`
+     * so those loops are cancelled when the test completes.
+     */
+    private fun createViewModel(
+        scope: CoroutineScope,
+        fetchOnInit: Boolean = true,
+    ): DefaultDoorHistoryViewModel {
+        val stalenessManager = CheckInStalenessManager(
+            observeDoorEvents = ObserveDoorEventsUseCase(doorRepository),
+            logAppEvent = LogAppEventUseCase(appLoggerRepository, FakeDiagnosticsCountersRepository()),
+            scope = scope,
+            dispatcher = testDispatcher,
+            clock = AppClock { 0L },
+        )
+        val liveClock = DefaultLiveClock(
+            clock = AppClock { 0L },
+            scope = scope,
+            dispatcher = testDispatcher,
+        )
+        val vm = DefaultDoorHistoryViewModel(
+            observeDoorEvents = ObserveDoorEventsUseCase(doorRepository),
+            logAppEvent = LogAppEventUseCase(
+                appLoggerRepository,
+                FakeDiagnosticsCountersRepository(),
+            ),
+            dispatchers = TestDispatcherProvider(testDispatcher),
+            fetchRecentDoorEventsUseCase = FetchRecentDoorEventsUseCase(doorRepository),
+            deregisterFcmUseCase = DeregisterFcmUseCase(doorFcmRepository),
+            checkInStalenessManager = stalenessManager,
+            liveClock = liveClock,
+            fetchOnInit = fetchOnInit,
+        )
+        testDispatcher.scheduler.runCurrent()
+        return vm
+    }
+
+    @Test
+    fun collectsRecentDoorEventsFromRepository() =
+        runTest {
+            val viewModel = createViewModel(scope = backgroundScope)
+
+            val events = listOf(
+                testDoorEvent,
+                DoorEvent(doorPosition = DoorPosition.OPEN, lastChangeTimeSeconds = 800L),
+            )
+            doorRepository.setRecentDoorEvents(events)
+            testDispatcher.scheduler.runCurrent()
+
+            val result = viewModel.recentDoorEvents.value
+            assertTrue(result is LoadingResult.Complete, "Should be Complete after collection")
+            assertEquals(2, result.data?.size)
+        }
+
+    @Test
+    fun fetchRecentDoorEventsCallsRepository() =
+        runTest {
+            val viewModel = createViewModel(scope = backgroundScope, fetchOnInit = false)
+
+            viewModel.fetchRecentDoorEvents()
+            advanceUntilIdle()
+
+            assertEquals(1, doorRepository.fetchRecentDoorEventsCount)
+        }
+
+    @Test
+    fun fetchOnInitFalseSkipsInitialFetch() =
+        runTest {
+            createViewModel(scope = backgroundScope, fetchOnInit = false)
+
+            assertEquals(0, doorRepository.fetchRecentDoorEventsCount)
+        }
+
+    @Test
+    fun fetchOnInitTrueTriggersInitialFetch() =
+        runTest {
+            createViewModel(scope = backgroundScope, fetchOnInit = true)
+            advanceUntilIdle()
+
+            assertEquals(1, doorRepository.fetchRecentDoorEventsCount)
+        }
+
+    @Test
+    fun fetchOnInitTrueLogsInitRecentDoor() =
+        runTest {
+            createViewModel(scope = backgroundScope, fetchOnInit = true)
+            advanceUntilIdle()
+
+            assertTrue(
+                appLoggerRepository.loggedKeys.any { it == AppLoggerKeys.INIT_RECENT_DOOR },
+                "INIT_RECENT_DOOR should be logged on init when fetchOnInit=true",
+            )
+        }
+
+    @Test
+    fun logForwardsToAppLogger() =
+        runTest {
+            val viewModel = createViewModel(scope = backgroundScope, fetchOnInit = false)
+
+            viewModel.log("custom_key")
+            advanceUntilIdle()
+
+            assertTrue(appLoggerRepository.loggedKeys.any { it == "custom_key" })
+        }
+
+    @Test
+    fun nowEpochSecondsIsLiveClockReference() =
+        runTest {
+            val viewModel = createViewModel(scope = backgroundScope, fetchOnInit = false)
+
+            assertEquals(0L, viewModel.nowEpochSeconds.value)
+        }
+}


### PR DESCRIPTION
## Summary
- Adds `DoorHistoryViewModel` (interface + `DefaultDoorHistoryViewModel`) in `usecase/commonMain`.
- Updates `DoorHistoryContent.kt` to resolve a single VM via `viewModel { component.doorHistoryViewModel }`.
- Drops `DoorHistoryContent.kt` from the exemption file.
- Drops `doorViewModel` + `appLoggerViewModel` threading from `MainActivity` → `GarageApp` → `AppNavigation` → `RouteEntryFor` (no longer needed for screens; `AuthViewModel` stays for `ProfileContent`).
- Adds `DoorHistoryViewModelTest` (7 tests).

## Merge order
This is PR 2 of 3 in the screen-VM stack.
⚠️ Merge AFTER #711. Stacked on `refactor/home-viewmodel`.
Full stack: #711 → this PR → ProfileViewModel PR

## Why
Continues ADR-026 cleanup — `DoorHistoryContent.kt` was the second of three exempted screens. After this PR, only `ProfileContent.kt` remains exempt.

## Behavior
Pure refactor. No UI changes. `INIT_RECENT_DOOR` log fires from `DoorHistoryViewModel.init` for the History tab and the Wide dashboard's right pane (instead of from `DoorViewModel.init`); behavior identical.

## Test plan
- [x] `./scripts/validate.sh` green
- [x] `DoorHistoryViewModelTest` (7 tests) passes
- [x] `checkScreenViewModelCardinality` accepts the dropped exemption
- [ ] Manual smoke: History tab on phone, Wide dashboard on tablet

🤖 Generated with [Claude Code](https://claude.com/claude-code)