### PR TITLE
refactor(android): Add ProfileViewModel; finish ADR-026 1:1 cardinality

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/MainActivity.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/MainActivity.kt
@@ -22,21 +22,17 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.ui.util.trace
-import com.chriscartland.garage.di.activityViewModel
 import com.chriscartland.garage.ui.GarageApp
 
 class MainActivity : ComponentActivity() {
     private val component by lazy { (application as GarageApplication).component }
-    private val authViewModel by lazy { activityViewModel(this) { component.authViewModel } }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge() // Edge-to-edge required on Android 15+ (target SDK 35).
         trace("MainActivity.setContent") {
             setContent {
-                GarageApp(
-                    authViewModel = authViewModel,
-                )
+                GarageApp()
             }
         }
         component.appStartup.run()

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -85,6 +85,7 @@ import com.chriscartland.garage.usecase.DefaultDoorViewModel
 import com.chriscartland.garage.usecase.DefaultFunctionListViewModel
 import com.chriscartland.garage.usecase.DefaultHomeViewModel
 import com.chriscartland.garage.usecase.DefaultLiveClock
+import com.chriscartland.garage.usecase.DefaultProfileViewModel
 import com.chriscartland.garage.usecase.DefaultReceiveFcmDoorEventUseCase
 import com.chriscartland.garage.usecase.DefaultRegisterFcmUseCase
 import com.chriscartland.garage.usecase.DefaultRemoteButtonViewModel
@@ -156,6 +157,7 @@ abstract class AppComponent(
     abstract val functionListViewModel: DefaultFunctionListViewModel
     abstract val homeViewModel: DefaultHomeViewModel
     abstract val doorHistoryViewModel: DefaultDoorHistoryViewModel
+    abstract val profileViewModel: DefaultProfileViewModel
 
     // --- Entry points: @Singleton providers (testable via assertSame) ---
     abstract val appConfig: AppConfig
@@ -356,6 +358,32 @@ abstract class AppComponent(
             liveClock = liveClock,
             buttonHealthDisplay = computeButtonHealthDisplay(),
             appVersion = appVersion,
+        )
+
+    @Provides
+    fun provideProfileViewModel(
+        observeAuthState: ObserveAuthStateUseCase,
+        observeSnoozeState: ObserveSnoozeStateUseCase,
+        observeDoorEvents: ObserveDoorEventsUseCase,
+        observeFeatureAccess: ObserveFeatureAccessUseCase,
+        signInWithGoogle: SignInWithGoogleUseCase,
+        signOut: SignOutUseCase,
+        fetchSnoozeStatus: FetchSnoozeStatusUseCase,
+        snoozeNotifications: SnoozeNotificationsUseCase,
+        logAppEvent: LogAppEventUseCase,
+        dispatchers: DispatcherProvider,
+    ): DefaultProfileViewModel =
+        DefaultProfileViewModel(
+            observeAuthState = observeAuthState,
+            observeSnoozeState = observeSnoozeState,
+            observeDoorEvents = observeDoorEvents,
+            observeFeatureAccessUseCase = observeFeatureAccess,
+            signInWithGoogleUseCase = signInWithGoogle,
+            signOutUseCase = signOut,
+            fetchSnoozeStatusUseCase = fetchSnoozeStatus,
+            snoozeNotificationsUseCase = snoozeNotifications,
+            logAppEvent = logAppEvent,
+            dispatchers = dispatchers,
         )
 
     @Provides

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -49,11 +49,10 @@ import androidx.navigation3.ui.NavDisplay
 import com.chriscartland.garage.ui.settings.DiagnosticsScreen
 import com.chriscartland.garage.ui.theme.AppTheme
 import com.chriscartland.garage.ui.theme.Spacing
-import com.chriscartland.garage.usecase.AuthViewModel
 import kotlinx.serialization.Serializable
 
 @Composable
-fun GarageApp(authViewModel: AuthViewModel) {
+fun GarageApp() {
     // ProvideAppWindowSizeClass installs `LocalAppWindowSizeClass` for the
     // whole app. Adaptive layout decisions (current screen-width cap; future
     // single-pane vs. two-pane branching) read from that local — never from
@@ -62,9 +61,7 @@ fun GarageApp(authViewModel: AuthViewModel) {
     // (`checkNoLocalConfigurationDimensionReads`).
     ProvideAppWindowSizeClass {
         AppTheme {
-            AppNavigation(
-                authViewModel = authViewModel,
-            )
+            AppNavigation()
         }
     }
 }
@@ -115,7 +112,7 @@ enum class Tab(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AppNavigation(authViewModel: AuthViewModel) {
+fun AppNavigation() {
     // Nav3: `rememberNavBackStack` is the saveable back stack. Survives
     // configuration changes (rotation, window size, dark mode, locale,
     // font scale) AND process death. The serialized form rides through
@@ -209,7 +206,6 @@ fun AppNavigation(authViewModel: AuthViewModel) {
                     RouteEntryFor(
                         screen = screen,
                         mode = mode,
-                        authViewModel = authViewModel,
                         onNavigateToFunctionList = { backStack.add(Screen.FunctionList) },
                         onNavigateToDiagnostics = { backStack.add(Screen.Diagnostics) },
                         onBack = { onPopBack() },
@@ -280,7 +276,6 @@ fun BottomNavigationBar(
 private fun RouteEntryFor(
     screen: Screen,
     mode: AppLayoutMode,
-    authViewModel: AuthViewModel,
     onNavigateToFunctionList: () -> Unit,
     onNavigateToDiagnostics: () -> Unit,
     onBack: () -> Unit,
@@ -327,7 +322,6 @@ private fun RouteEntryFor(
         Screen.Profile -> {
             RouteContent { routeModifier ->
                 ProfileContent(
-                    authViewModel = authViewModel,
                     onNavigateToFunctionList = onNavigateToFunctionList,
                     onNavigateToDiagnostics = onNavigateToDiagnostics,
                     modifier = routeModifier.padding(horizontal = Spacing.Screen),

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
@@ -43,9 +43,7 @@ import com.chriscartland.garage.ui.settings.SettingsContent
 import com.chriscartland.garage.ui.settings.SnoozeBottomSheet
 import com.chriscartland.garage.ui.settings.SnoozeRowState
 import com.chriscartland.garage.ui.settings.VersionDialog
-import com.chriscartland.garage.usecase.AppSettingsViewModel
-import com.chriscartland.garage.usecase.AuthViewModel
-import com.chriscartland.garage.usecase.RemoteButtonViewModel
+import com.chriscartland.garage.usecase.ProfileViewModel
 import com.chriscartland.garage.version.AppVersion
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
@@ -57,10 +55,8 @@ import java.time.format.DateTimeFormatter
 
 /**
  * Settings screen — bottom-nav destination. Sectioned-list redesign
- * shipped in PR after the legacy expandable-cards layout. Aggregates
- * AuthViewModel + RemoteButtonViewModel + AppSettingsViewModel
- * (legacy multi-VM exemption per ADR-026; the screen-level VM split
- * is deferred — see screen-viewmodel-exemptions.txt).
+ * shipped in PR after the legacy expandable-cards layout. Uses a single
+ * screen-scoped [ProfileViewModel] (ADR-026 — one VM per screen).
  *
  * The function name is preserved (`ProfileContent`) to avoid touching
  * `Screen.Profile` and the bottom-nav definition; the user-facing tab
@@ -70,23 +66,21 @@ import java.time.format.DateTimeFormatter
 @Composable
 fun ProfileContent(
     modifier: Modifier = Modifier,
-    authViewModel: AuthViewModel? = null,
+    profileViewModel: ProfileViewModel? = null,
     onNavigateToDiagnostics: () -> Unit = {},
     onNavigateToFunctionList: () -> Unit = {},
 ) {
     val component = rememberAppComponent()
-    val resolvedAuthViewModel = authViewModel ?: viewModel { component.authViewModel }
-    val buttonViewModel: RemoteButtonViewModel = viewModel { component.remoteButtonViewModel }
-    val settingsViewModel: AppSettingsViewModel = viewModel { component.appSettingsViewModel }
+    val resolved = profileViewModel ?: viewModel { component.profileViewModel }
     val notificationPermissionState = rememberNotificationPermissionState()
     val googleSignIn = rememberGoogleSignIn(
-        onTokenReceived = { token -> resolvedAuthViewModel.signInWithGoogle(token) },
+        onTokenReceived = { token -> resolved.signInWithGoogle(token) },
     )
 
-    val authState by resolvedAuthViewModel.authState.collectAsState()
-    val snoozeState by buttonViewModel.snoozeState.collectAsState()
-    val snoozeAction by buttonViewModel.snoozeAction.collectAsState()
-    val functionListAccess by settingsViewModel.functionListAccess.collectAsState()
+    val authState by resolved.authState.collectAsState()
+    val snoozeState by resolved.snoozeState.collectAsState()
+    val snoozeAction by resolved.snoozeAction.collectAsState()
+    val functionListAccess by resolved.functionListAccess.collectAsState()
     val appConfig = component.appConfig
     val context = LocalContext.current
     val appVersion = context.AppVersion()
@@ -105,7 +99,7 @@ fun ProfileContent(
     // covers both the row-secondary-text and the sheet's pre-selection.
     LaunchedEffect(Unit) {
         while (true) {
-            buttonViewModel.fetchSnoozeStatus()
+            resolved.fetchSnoozeStatus()
             delay(Duration.ofMinutes(1).toMillis())
         }
     }
@@ -160,7 +154,7 @@ fun ProfileContent(
         SnoozeBottomSheet(
             initialSelection = SnoozeDurationUIOption.None,
             onSave = { duration ->
-                buttonViewModel.snoozeOpenDoorsNotifications(duration)
+                resolved.snoozeOpenDoorsNotifications(duration)
             },
             onDismiss = { snoozeSheetOpen = false },
         )
@@ -172,7 +166,7 @@ fun ProfileContent(
             AccountBottomSheet(
                 displayName = signedIn.displayName,
                 email = signedIn.email,
-                onSignOut = { resolvedAuthViewModel.signOut() },
+                onSignOut = { resolved.signOut() },
                 onDismiss = { accountSheetOpen = false },
             )
         }

--- a/AndroidGarage/screen-viewmodel-exemptions.txt
+++ b/AndroidGarage/screen-viewmodel-exemptions.txt
@@ -13,5 +13,5 @@
 # build a screen-specific ViewModel that aggregates the UseCases that screen
 # needs (see `FunctionListViewModel` for the canonical example).
 
-# Aggregates AuthViewModel + RemoteButtonViewModel + AppSettingsViewModel.
-ProfileContent.kt
+# (Currently no exempt screens — keep this file as the on-ramp if a future
+# refactor temporarily needs to defer 1:1 compliance.)

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ProfileViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ProfileViewModel.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
+import com.chriscartland.garage.domain.coroutines.DispatcherProvider
+import com.chriscartland.garage.domain.model.ActionError
+import com.chriscartland.garage.domain.model.AppLoggerKeys
+import com.chriscartland.garage.domain.model.AppResult
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.DoorEvent
+import com.chriscartland.garage.domain.model.GoogleIdToken
+import com.chriscartland.garage.domain.model.SnoozeAction
+import com.chriscartland.garage.domain.model.SnoozeDurationUIOption
+import com.chriscartland.garage.domain.model.SnoozeState
+import com.chriscartland.garage.domain.model.toServer
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+private const val SNOOZE_ACTION_RESET_DELAY_MS = 10_000L
+
+/**
+ * Drives the Settings screen — one VM per screen (ADR-026). Aggregates the
+ * UseCases that the legacy `AuthViewModel` + `RemoteButtonViewModel` +
+ * `AppSettingsViewModel` trio exposed to `ProfileContent.kt`. Phase 43 —
+ * depends on UseCases only.
+ *
+ * The user-facing tab label is "Settings"; the function name `ProfileContent`
+ * (and `Screen.Profile` route) is preserved for backwards compatibility with
+ * the bottom-nav definition.
+ */
+interface ProfileViewModel {
+    val authState: StateFlow<AuthState>
+
+    val snoozeState: StateFlow<SnoozeState>
+
+    val snoozeAction: StateFlow<SnoozeAction>
+
+    /**
+     * Per-user access for the Function List feature, used to gate the
+     * Settings-screen developer entry. Tri-state: `null` (loading or denied),
+     * `false` (server says denied), `true` (allowed). Full convention in
+     * `docs/FEATURE_FLAGS.md`.
+     */
+    val functionListAccess: StateFlow<Boolean?>
+
+    fun signInWithGoogle(idToken: GoogleIdToken)
+
+    fun signOut()
+
+    fun fetchSnoozeStatus()
+
+    fun snoozeOpenDoorsNotifications(snoozeDuration: SnoozeDurationUIOption)
+}
+
+class DefaultProfileViewModel(
+    observeAuthState: ObserveAuthStateUseCase,
+    observeSnoozeState: ObserveSnoozeStateUseCase,
+    private val observeDoorEvents: ObserveDoorEventsUseCase,
+    private val observeFeatureAccessUseCase: ObserveFeatureAccessUseCase,
+    private val signInWithGoogleUseCase: SignInWithGoogleUseCase,
+    private val signOutUseCase: SignOutUseCase,
+    private val fetchSnoozeStatusUseCase: FetchSnoozeStatusUseCase,
+    private val snoozeNotificationsUseCase: SnoozeNotificationsUseCase,
+    private val logAppEvent: LogAppEventUseCase,
+    private val dispatchers: DispatcherProvider,
+) : ViewModel(),
+    ProfileViewModel {
+    // ADR-022: pass through the repository's StateFlow by reference — no mirror.
+    override val authState: StateFlow<AuthState> = observeAuthState()
+    override val snoozeState: StateFlow<SnoozeState> = observeSnoozeState()
+
+    private val _snoozeAction = MutableStateFlow<SnoozeAction>(SnoozeAction.Idle)
+    override val snoozeAction: StateFlow<SnoozeAction> = _snoozeAction
+
+    private val _functionListAccess = MutableStateFlow<Boolean?>(null)
+    override val functionListAccess: StateFlow<Boolean?> = _functionListAccess
+
+    // Cached so the snooze action can attach the latest door change time
+    // without the UI having to thread it through.
+    private val currentDoorEvent = MutableStateFlow<DoorEvent?>(null)
+
+    init {
+        viewModelScope.launch(dispatchers.io) {
+            observeDoorEvents.current().collect { currentDoorEvent.value = it }
+        }
+        viewModelScope.launch(dispatchers.io) {
+            observeFeatureAccessUseCase.functionList().collect { _functionListAccess.value = it }
+        }
+    }
+
+    override fun signInWithGoogle(idToken: GoogleIdToken) {
+        viewModelScope.launch(dispatchers.io) {
+            logAppEvent(AppLoggerKeys.BEGIN_GOOGLE_SIGN_IN)
+            Logger.d { "signInWithGoogle" }
+            signInWithGoogleUseCase(idToken)
+        }
+    }
+
+    override fun signOut() {
+        viewModelScope.launch(dispatchers.io) {
+            signOutUseCase()
+        }
+    }
+
+    override fun fetchSnoozeStatus() {
+        viewModelScope.launch(dispatchers.io) {
+            fetchSnoozeStatusUseCase()
+        }
+    }
+
+    override fun snoozeOpenDoorsNotifications(snoozeDuration: SnoozeDurationUIOption) {
+        Logger.d { "snoozeOpenDoorsNotifications" }
+        _snoozeAction.value = SnoozeAction.Sending
+        viewModelScope.launch(dispatchers.io) {
+            when (
+                val result = snoozeNotificationsUseCase(
+                    snoozeDurationHours = snoozeDuration.toServer().duration,
+                    lastChangeTimeSeconds = currentDoorEvent.value?.lastChangeTimeSeconds,
+                )
+            ) {
+                is AppResult.Success -> {
+                    val newState = result.data
+                    _snoozeAction.value = when (newState) {
+                        is SnoozeState.Snoozing -> SnoozeAction.Succeeded.Set(newState.untilEpochSeconds)
+                        SnoozeState.NotSnoozing -> SnoozeAction.Succeeded.Cleared
+                        SnoozeState.Loading -> SnoozeAction.Succeeded.Cleared
+                    }
+                    scheduleActionReset()
+                }
+                is AppResult.Error -> {
+                    _snoozeAction.value = when (result.error) {
+                        ActionError.NotAuthenticated -> SnoozeAction.Failed.NotAuthenticated
+                        ActionError.MissingData -> SnoozeAction.Failed.MissingData
+                        ActionError.NetworkFailed -> SnoozeAction.Failed.NetworkError
+                    }
+                    scheduleActionReset()
+                }
+            }
+        }
+    }
+
+    private fun scheduleActionReset() {
+        viewModelScope.launch {
+            delay(SNOOZE_ACTION_RESET_DELAY_MS)
+            _snoozeAction.value = SnoozeAction.Idle
+        }
+    }
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ProfileViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ProfileViewModelTest.kt
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.AppLoggerKeys
+import com.chriscartland.garage.domain.model.AppResult
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.DisplayName
+import com.chriscartland.garage.domain.model.DoorEvent
+import com.chriscartland.garage.domain.model.DoorPosition
+import com.chriscartland.garage.domain.model.Email
+import com.chriscartland.garage.domain.model.FeatureAllowlist
+import com.chriscartland.garage.domain.model.GoogleIdToken
+import com.chriscartland.garage.domain.model.SnoozeAction
+import com.chriscartland.garage.domain.model.SnoozeDurationUIOption
+import com.chriscartland.garage.domain.model.SnoozeState
+import com.chriscartland.garage.domain.model.User
+import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
+import com.chriscartland.garage.testcommon.FakeAuthRepository
+import com.chriscartland.garage.testcommon.FakeDiagnosticsCountersRepository
+import com.chriscartland.garage.testcommon.FakeDoorRepository
+import com.chriscartland.garage.testcommon.FakeFeatureAllowlistRepository
+import com.chriscartland.garage.testcommon.FakeSnoozeRepository
+import com.chriscartland.garage.testcommon.TestDispatcherProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProfileViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    private lateinit var authRepository: FakeAuthRepository
+    private lateinit var doorRepository: FakeDoorRepository
+    private lateinit var snoozeRepository: FakeSnoozeRepository
+    private lateinit var featureAllowlistRepository: FakeFeatureAllowlistRepository
+    private lateinit var appLoggerRepository: FakeAppLoggerRepository
+
+    private val testUser = User(
+        name = DisplayName("User"),
+        email = Email("user@example.com"),
+    )
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        authRepository = FakeAuthRepository()
+        doorRepository = FakeDoorRepository()
+        snoozeRepository = FakeSnoozeRepository()
+        featureAllowlistRepository = FakeFeatureAllowlistRepository()
+        appLoggerRepository = FakeAppLoggerRepository()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel(authState: AuthState = AuthState.Unauthenticated): DefaultProfileViewModel {
+        authRepository.setAuthState(authState)
+        return DefaultProfileViewModel(
+            observeAuthState = ObserveAuthStateUseCase(authRepository),
+            observeSnoozeState = ObserveSnoozeStateUseCase(snoozeRepository),
+            observeDoorEvents = ObserveDoorEventsUseCase(doorRepository),
+            observeFeatureAccessUseCase = ObserveFeatureAccessUseCase(featureAllowlistRepository),
+            signInWithGoogleUseCase = SignInWithGoogleUseCase(authRepository),
+            signOutUseCase = SignOutUseCase(authRepository),
+            fetchSnoozeStatusUseCase = FetchSnoozeStatusUseCase(snoozeRepository),
+            snoozeNotificationsUseCase = SnoozeNotificationsUseCase(
+                authRepository,
+                snoozeRepository,
+            ),
+            logAppEvent = LogAppEventUseCase(
+                appLoggerRepository,
+                FakeDiagnosticsCountersRepository(),
+            ),
+            dispatchers = TestDispatcherProvider(testDispatcher),
+        ).also {
+            testDispatcher.scheduler.runCurrent()
+        }
+    }
+
+    @Test
+    fun authStatePassesThroughFromRepository() =
+        runTest {
+            val viewModel = createViewModel(authState = AuthState.Authenticated(testUser))
+            assertTrue(viewModel.authState.value is AuthState.Authenticated)
+        }
+
+    @Test
+    fun snoozeStatePassesThroughFromRepository() =
+        runTest {
+            val viewModel = createViewModel()
+            snoozeRepository.setSnoozeState(SnoozeState.NotSnoozing)
+            advanceUntilIdle()
+
+            assertEquals(SnoozeState.NotSnoozing, viewModel.snoozeState.value)
+        }
+
+    @Test
+    fun fetchSnoozeStatusCallsRepository() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.fetchSnoozeStatus()
+            advanceUntilIdle()
+
+            assertEquals(1, snoozeRepository.fetchCount)
+        }
+
+    @Test
+    fun signInForwardsToUseCase() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.signInWithGoogle(GoogleIdToken("test"))
+            advanceUntilIdle()
+
+            assertTrue(
+                appLoggerRepository.loggedKeys.any {
+                    it == AppLoggerKeys.BEGIN_GOOGLE_SIGN_IN
+                },
+                "BEGIN_GOOGLE_SIGN_IN should be logged on sign-in",
+            )
+        }
+
+    @Test
+    fun signOutForwardsToUseCase() =
+        runTest {
+            val viewModel = createViewModel(authState = AuthState.Authenticated(testUser))
+
+            viewModel.signOut()
+            advanceUntilIdle()
+
+            // After signOut the fake should report Unauthenticated.
+            assertEquals(AuthState.Unauthenticated, authRepository.authState.value)
+        }
+
+    @Test
+    fun functionListAccessReflectsAllowlist() =
+        runTest {
+            featureAllowlistRepository.setAllowlist(
+                FeatureAllowlist(functionList = true),
+            )
+            val viewModel = createViewModel(
+                authState = AuthState.Authenticated(testUser),
+            )
+            advanceUntilIdle()
+
+            assertEquals(true, viewModel.functionListAccess.value)
+        }
+
+    @Test
+    fun functionListAccessNullWhenAllowlistMissing() =
+        runTest {
+            val viewModel = createViewModel(
+                authState = AuthState.Authenticated(testUser),
+            )
+            featureAllowlistRepository.setAllowlist(null)
+            advanceUntilIdle()
+
+            assertNull(viewModel.functionListAccess.value)
+        }
+
+    @Test
+    fun snoozeOpenDoorsTransitionsThroughSendingThenSucceeded() =
+        runTest {
+            val viewModel = createViewModel(
+                authState = AuthState.Authenticated(testUser),
+            )
+            snoozeRepository.setSnoozeResult(AppResult.Success(SnoozeState.NotSnoozing))
+            doorRepository.setCurrentDoorEvent(
+                DoorEvent(
+                    doorPosition = DoorPosition.OPEN,
+                    lastChangeTimeSeconds = 900L,
+                ),
+            )
+            advanceUntilIdle()
+
+            viewModel.snoozeOpenDoorsNotifications(SnoozeDurationUIOption.OneHour)
+            // Don't `advanceUntilIdle` — that fires the 10s reset delay too.
+            testDispatcher.scheduler.runCurrent()
+
+            assertTrue(
+                viewModel.snoozeAction.value is SnoozeAction.Succeeded,
+                "Expected Succeeded after the snooze call returns; got " +
+                    "${viewModel.snoozeAction.value}",
+            )
+        }
+}


### PR DESCRIPTION
## Summary
- Adds `ProfileViewModel` (interface + `DefaultProfileViewModel`) in `usecase/commonMain`.
- Updates `ProfileContent.kt` to resolve a single VM via `viewModel { component.profileViewModel }` — drops the 3-way multi-VM resolution.
- Drops `ProfileContent.kt` from the exemption file. **Exemption file is now empty.**
- Drops `authViewModel` threading from `MainActivity` → `GarageApp` → `AppNavigation` → `RouteEntryFor`. `MainActivity` no longer resolves any VMs at the Activity level.
- Adds `ProfileViewModelTest` (8 tests).

## Merge order
This is PR 3 of 3 in the screen-VM stack.
⚠️ Merge AFTER #712. Stacked on `refactor/door-history-viewmodel` (which is stacked on `refactor/home-viewmodel` / #711).
Full stack: #711 → #712 → this PR

## Why
Final ADR-026 cleanup. After this PR, every `*Content.kt` screen imports exactly one ViewModel and `screen-viewmodel-exemptions.txt` has no entries. The `checkScreenViewModelCardinality` lint is now load-bearing — any new screen must follow the 1:1 rule from day one.

## Behavior
Pure refactor. No UI changes. Same UseCases drive the same actions. The `BEGIN_GOOGLE_SIGN_IN` log fires from `ProfileViewModel.signInWithGoogle` instead of `AuthViewModel.signInWithGoogle`; behavior identical.

## Future cleanup (not in this PR)
The legacy multi-purpose VMs (`AuthViewModel`, `DoorViewModel`, `AppLoggerViewModel`, `RemoteButtonViewModel`, `AppSettingsViewModel`) remain as DI providers — non-screen code (FCM service, app startup) still consumes them. Removing them can happen after auditing those callers.

## Test plan
- [x] `./scripts/validate.sh` green
- [x] `ProfileViewModelTest` (8 tests) passes
- [x] `checkScreenViewModelCardinality` accepts the empty exemption file
- [ ] Manual smoke: Settings tab on phone (account row, sign-in/out, snooze flow, navigate to Function List, navigate to Diagnostics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)