### PR TITLE
chore(android): Replace 4.dp Spacer literals with Spacing.Tight in pills

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/RemoteButtonHealthPill.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/RemoteButtonHealthPill.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.chriscartland.garage.ui.theme.PreviewComponentSurface
+import com.chriscartland.garage.ui.theme.Spacing
 import com.chriscartland.garage.usecase.ButtonHealthDisplay
 
 /**
@@ -98,7 +99,7 @@ fun RemoteButtonHealthPill(
                     text = label,
                     style = MaterialTheme.typography.labelSmall,
                 )
-                Spacer(modifier = Modifier.width(4.dp))
+                Spacer(modifier = Modifier.width(Spacing.Tight))
                 Icon(
                     modifier = Modifier.size(17.dp),
                     imageVector = icon,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/RemoteOfflinePill.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/RemoteOfflinePill.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.chriscartland.garage.ui.theme.PreviewComponentSurface
+import com.chriscartland.garage.ui.theme.Spacing
 import com.chriscartland.garage.usecase.ButtonHealthDisplay
 
 /**
@@ -78,7 +79,7 @@ fun RemoteOfflinePill(
                     text = "Remote offline · ${display.durationLabel}",
                     style = MaterialTheme.typography.labelSmall,
                 )
-                Spacer(modifier = Modifier.width(4.dp))
+                Spacer(modifier = Modifier.width(Spacing.Tight))
                 Icon(
                     modifier = Modifier.size(17.dp),
                     imageVector = Icons.Outlined.SignalWifiOff,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/TitleBarCheckInPill.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/TitleBarCheckInPill.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import com.chriscartland.garage.R
 import com.chriscartland.garage.ui.home.DeviceCheckInDisplay
 import com.chriscartland.garage.ui.theme.PreviewComponentSurface
+import com.chriscartland.garage.ui.theme.Spacing
 
 /**
  * Compact rounded-pill device-heartbeat indicator. Antenna icon + duration
@@ -87,7 +88,7 @@ fun TitleBarCheckInPill(
                         text = display.durationLabel,
                         style = MaterialTheme.typography.labelSmall,
                     )
-                    Spacer(modifier = Modifier.width(4.dp))
+                    Spacer(modifier = Modifier.width(Spacing.Tight))
                 }
                 if (display.isStale) {
                     Icon(


### PR DESCRIPTION
## Summary
Item 3 from the post-release queue. Three pill Composables were using raw `4.dp` for icon↔text Spacer widths — exactly the case the `Spacing.Tight` token's KDoc explicitly names ("icon ↔ text inside a pill, supporting text ↔ headline, label ↔ control").

Files: `RemoteOfflinePill`, `RemoteButtonHealthPill`, `TitleBarCheckInPill`.

Other Spacer literals in the codebase are inside bottom-sheet header layouts (consistent within the sheet design pattern; not covered by an existing token; introducing a new token would have <2 reuses) or are very-tight one-off gaps (`2.dp`). Leaving those alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)