### PR TITLE
ui(android): 3-pane Expanded-width dashboard — Phase B (wire to production)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/AppLayoutMode.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/AppLayoutMode.kt
@@ -72,22 +72,77 @@ sealed interface AppLayoutMode {
 
     /**
      * Wide layout: 2 tabs (History merges into Home), Home renders the
-     * Home + History dashboard. Activation: `WindowWidthSizeClass.Medium`+
-     * (≥600dp).
+     * Home + History dashboard. Activation: `WindowWidthSizeClass.Medium`
+     * (600–839dp).
      */
     data object Wide : AppLayoutMode {
         override val visibleTabs: List<Tab> = Tab.entries.filter { it != Tab.History }
         override val mergedRoutes: Map<Screen, Screen> = mapOf(Screen.History to Screen.Home)
     }
 
+    /**
+     * Expanded layout: no tabs (bottom nav hidden), Home renders the
+     * Home + History + Settings 3-pane dashboard. Settings sub-screens
+     * (`FunctionList`, `Diagnostics`) overlay the Settings pane only —
+     * Home + History stay visible. Activation:
+     * `WindowWidthSizeClass.Expanded` (≥840dp).
+     *
+     * **Threshold note (M3 standard).** ≥840dp includes phones in
+     * landscape (~916dp on a Pixel 9 Pro), where each pane is ~280dp
+     * after gaps — narrower than ideal. If landscape phones look
+     * cramped in production, the fallback is to raise activation to a
+     * custom 1200dp threshold via a one-line change in
+     * [Companion.fromWidthSizeClass]. That keeps phones in landscape
+     * on the [Wide] 2-pane layout (~458dp/pane) while tablets in
+     * landscape (~1280dp+) and ChromeOS still get 3-pane (~415dp/pane).
+     *
+     * **Why Profile + FunctionList + Diagnostics all merge to Home.**
+     * In Expanded the Settings column is always visible, and sub-screens
+     * overlay only that column. The route for `Screen.Profile` therefore
+     * doesn't need its own destination — it canonicalizes to `Home` and
+     * renders the 3-pane with Profile in the Settings slot. Same for
+     * `Screen.FunctionList` and `Screen.Diagnostics` — they canonicalize
+     * to `Home` and render the 3-pane with their content as the Settings
+     * slot's body. The dispatch in `Main.kt` reads the original (non-
+     * canonicalized) screen to decide which body to drop into the slot.
+     */
+    data object Expanded : AppLayoutMode {
+        override val visibleTabs: List<Tab> = emptyList()
+        override val mergedRoutes: Map<Screen, Screen> = mapOf(
+            Screen.History to Screen.Home,
+            Screen.Profile to Screen.Home,
+            Screen.FunctionList to Screen.Home,
+            Screen.Diagnostics to Screen.Home,
+        )
+    }
+
     companion object {
         /**
          * Pure mapping from raw `WindowWidthSizeClass` to layout mode.
-         * Threshold lives here — change [Wide]'s activation by editing
-         * this single condition.
+         * Thresholds live here — change activation by editing this
+         * single function.
+         *
+         * **Custom threshold fallback for [Expanded].** If the
+         * M3-standard ≥840dp activation results in cramped 3-pane
+         * layouts on phones in landscape (~916dp / ~280dp per pane),
+         * raise the [Expanded] threshold to a custom width:
+         * ```kotlin
+         * widthSizeClass >= WindowWidthSizeClass.Expanded -> Expanded
+         * ```
+         * becomes (with `LocalConfiguration` access — adjust for the
+         * actual reading site):
+         * ```kotlin
+         * configuration.screenWidthDp >= 1200 -> Expanded
+         * ```
+         * That keeps phones-in-landscape on [Wide] 2-pane and only
+         * promotes to 3-pane on tablets in landscape and ChromeOS.
          */
         fun fromWidthSizeClass(widthSizeClass: WindowWidthSizeClass): AppLayoutMode =
-            if (widthSizeClass >= WindowWidthSizeClass.Medium) Wide else Compact
+            when {
+                widthSizeClass >= WindowWidthSizeClass.Expanded -> Expanded
+                widthSizeClass >= WindowWidthSizeClass.Medium -> Wide
+                else -> Compact
+            }
     }
 }
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -161,10 +161,16 @@ fun AppNavigation() {
             )
         },
         bottomBar = {
-            BottomNavigationBar(
-                currentScreen = backStack.lastOrNull() as? Screen,
-                onTabSelected = { screen -> TabNavigation.navigateToTab(backStack, screen) },
-            )
+            // Hide the bottom-nav chrome entirely on layouts with no
+            // visible tabs (Expanded). Empty NavigationBar still claims
+            // ~80dp of vertical space, which we want to recover for the
+            // 3-pane dashboard.
+            if (currentAppLayoutMode().visibleTabs.isNotEmpty()) {
+                BottomNavigationBar(
+                    currentScreen = backStack.lastOrNull() as? Screen,
+                    onTabSelected = { screen -> TabNavigation.navigateToTab(backStack, screen) },
+                )
+            }
         },
     ) { innerPadding ->
         NavDisplay(
@@ -283,36 +289,73 @@ private fun RouteEntryFor(
     val canonicalScreen = mode.canonicalScreen(screen) ?: screen
     when (canonicalScreen) {
         Screen.Home -> {
-            if (mode is AppLayoutMode.Wide) {
-                // Pull-to-refresh is per-pane: pulling Home refreshes door
-                // status only; pulling History refreshes recent events only.
-                // Each pane behaves like its own screen for refresh,
-                // matching what the user experiences on phone.
-                DashboardRouteContent { routeModifier ->
-                    HomeDashboardContent(
-                        modifier = routeModifier.padding(horizontal = Spacing.Screen),
-                        homePane = { paneModifier ->
-                            HomeContent(
-                                modifier = paneModifier,
-                            )
-                        },
-                        historyPane = { paneModifier ->
-                            DoorHistoryContent(
-                                modifier = paneModifier,
-                            )
-                        },
-                    )
+            when (mode) {
+                AppLayoutMode.Expanded -> {
+                    // 3-pane dashboard. The Settings slot's body depends on
+                    // the original (non-canonicalized) `screen`: Profile/Home
+                    // → ProfileContent, FunctionList → FunctionListContent,
+                    // Diagnostics → DiagnosticsScreen. Each back-stack entry
+                    // (Home, FunctionList, Diagnostics, Profile) renders its
+                    // own copy of the 3-pane; NavDisplay shows only the top
+                    // entry, so the cross-fade between entries visually
+                    // reads as the Settings pane swapping while Home and
+                    // History stay still.
+                    ThreePaneRouteContent { routeModifier ->
+                        ThreePaneDashboardContent(
+                            modifier = routeModifier.padding(horizontal = Spacing.Screen),
+                            homePane = { paneModifier ->
+                                HomeContent(modifier = paneModifier)
+                            },
+                            historyPane = { paneModifier ->
+                                DoorHistoryContent(modifier = paneModifier)
+                            },
+                            settingsPane = { paneModifier ->
+                                when (screen) {
+                                    Screen.FunctionList -> FunctionListContent(modifier = paneModifier)
+                                    Screen.Diagnostics ->
+                                        // DiagnosticsScreen owns its own
+                                        // horizontal padding (LazyColumn
+                                        // contentPadding) — pass paneModifier
+                                        // unmodified.
+                                        DiagnosticsScreen(onBack = onBack, modifier = paneModifier)
+                                    else -> ProfileContent(
+                                        onNavigateToFunctionList = onNavigateToFunctionList,
+                                        onNavigateToDiagnostics = onNavigateToDiagnostics,
+                                        modifier = paneModifier,
+                                    )
+                                }
+                            },
+                        )
+                    }
                 }
-            } else {
-                RouteContent { routeModifier ->
-                    HomeContent(
-                        modifier = routeModifier.padding(horizontal = Spacing.Screen),
-                    )
+                AppLayoutMode.Wide -> {
+                    // Pull-to-refresh is per-pane: pulling Home refreshes door
+                    // status only; pulling History refreshes recent events only.
+                    // Each pane behaves like its own screen for refresh,
+                    // matching what the user experiences on phone.
+                    DashboardRouteContent { routeModifier ->
+                        HomeDashboardContent(
+                            modifier = routeModifier.padding(horizontal = Spacing.Screen),
+                            homePane = { paneModifier ->
+                                HomeContent(modifier = paneModifier)
+                            },
+                            historyPane = { paneModifier ->
+                                DoorHistoryContent(modifier = paneModifier)
+                            },
+                        )
+                    }
+                }
+                AppLayoutMode.Compact -> {
+                    RouteContent { routeModifier ->
+                        HomeContent(
+                            modifier = routeModifier.padding(horizontal = Spacing.Screen),
+                        )
+                    }
                 }
             }
         }
         Screen.History -> {
-            // Reached only on Compact (Wide.mergedRoutes redirects to Home).
+            // Reached only on Compact (Wide + Expanded merge History to Home).
             RouteContent { routeModifier ->
                 DoorHistoryContent(
                     modifier = routeModifier.padding(horizontal = Spacing.Screen),
@@ -320,6 +363,7 @@ private fun RouteEntryFor(
             }
         }
         Screen.Profile -> {
+            // Reached on Compact and Wide (Expanded merges Profile to Home).
             RouteContent { routeModifier ->
                 ProfileContent(
                     onNavigateToFunctionList = onNavigateToFunctionList,
@@ -329,6 +373,7 @@ private fun RouteEntryFor(
             }
         }
         Screen.FunctionList -> {
+            // Reached on Compact and Wide (Expanded merges FunctionList to Home).
             RouteContent { routeModifier ->
                 FunctionListContent(
                     modifier = routeModifier.padding(horizontal = Spacing.Screen),
@@ -336,6 +381,7 @@ private fun RouteEntryFor(
             }
         }
         Screen.Diagnostics -> {
+            // Reached on Compact and Wide (Expanded merges Diagnostics to Home).
             RouteContent { routeModifier ->
                 // Diagnostics provides its own horizontal padding inside
                 // its LazyColumn (Spacing.Screen) — no padding here.

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ThreePaneRouteContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ThreePaneRouteContent.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chriscartland.garage.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.chriscartland.garage.ui.theme.ContentWidth
+import com.chriscartland.garage.ui.theme.Spacing
+
+/**
+ * Expanded-width sibling of [RouteContent] / [DashboardRouteContent].
+ * Caps the 3-pane dashboard width at `3 * ContentWidth.Standard +
+ * 2 * Spacing.Screen` (`1952dp`) and centers within the canvas.
+ *
+ * Use ONLY for the Expanded-width Home dashboard route.
+ *
+ * Modifier order matters here for the same reason as [RouteContent]:
+ * `widthIn(max = ...)` MUST come before `fillMaxSize`. Reversed, the
+ * cap would be a no-op because Compose's `SizeModifier` coerces
+ * `maxWidth >= minWidth` once `fillMaxSize` sets `minWidth = parent.maxWidth`.
+ */
+@Composable
+fun ThreePaneRouteContent(content: @Composable (Modifier) -> Unit) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.TopCenter,
+    ) {
+        // Cap = three pane caps + the two gaps between them.
+        // 640 + 16 + 640 + 16 + 640 = 1952.dp.
+        val cap = (ContentWidth.Standard * 3) + (Spacing.Screen * 2)
+        content(
+            Modifier
+                .widthIn(max = cap)
+                .fillMaxSize(),
+        )
+    }
+}

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/ContentWidthCapCheckTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/ContentWidthCapCheckTask.kt
@@ -41,8 +41,12 @@ abstract class ContentWidthCapCheckTask : DefaultTask() {
      *   neither sprawls past readable width on very wide windows. Same
      *   role as `RouteContent` for single-pane, just expressed twice.
      * - `ThreePaneDashboardContent.kt` — the Expanded-width three-pane
-     *   route wrapper. Same per-pane-cap rationale, three slots instead
-     *   of two.
+     *   dashboard wrapper. Same per-pane-cap rationale, three slots
+     *   instead of two.
+     * - `ThreePaneRouteContent.kt` — the Expanded-width route wrapper.
+     *   Caps the dashboard's total width at `3 * ContentWidth.Standard +
+     *   2 * Spacing.Screen` (`1952dp`); same role as `RouteContent` for
+     *   single-pane and `DashboardRouteContent` for two-pane.
      */
     @get:Input
     var exemptFileNames: List<String> = listOf(
@@ -51,6 +55,7 @@ abstract class ContentWidthCapCheckTask : DefaultTask() {
         "AnimatableGarageDoor.kt",
         "HomeDashboardContent.kt",
         "ThreePaneDashboardContent.kt",
+        "ThreePaneRouteContent.kt",
     )
 
     @TaskAction


### PR DESCRIPTION
## Summary
Phase B of the 3-pane Expanded-width layout. Phase A (#725) added the slot-based `ThreePaneDashboardContent` Composable + screenshot fixtures. This PR wires it into production.

## Changes
1. **`AppLayoutMode.Expanded`** — new sealed-type variant. Empty `visibleTabs` (no bottom nav). `mergedRoutes` collapses `History`, `Profile`, `FunctionList`, `Diagnostics` all to `Home` so each back-stack entry triggers the 3-pane dispatch; the dispatch reads the original (non-canonicalized) screen to pick the Settings slot's body.
2. **`fromWidthSizeClass`** — extends Compact/Wide split with Expanded at `WindowWidthSizeClass.Expanded` (≥840dp). Doc comment proposes a custom 1200dp threshold as fallback if landscape phones look cramped.
3. **`ThreePaneRouteContent`** — Expanded-width route wrapper. Caps total width at 1952dp (`3 * ContentWidth.Standard + 2 * Spacing.Screen`); centers within wider canvases.
4. **`Main.kt` dispatch** — adds `AppLayoutMode.Expanded` arm to the `Screen.Home` branch. Settings slot's body chosen by original `screen`: `FunctionListContent` / `DiagnosticsScreen` / `ProfileContent`.
5. **`Main.kt` Scaffold** — gates `bottomBar` slot on `currentAppLayoutMode().visibleTabs.isNotEmpty()` so Expanded drops bottom-nav chrome (recovers ~80dp).
6. **`ContentWidthCapCheckTask`** — exempts `ThreePaneRouteContent.kt`.

## Sub-screen overlay behavior
When back-stack tail is `FunctionList` or `Diagnostics` in Expanded mode, that entry AND its parent (`Home`) both render the 3-pane. NavDisplay shows only the top entry; the cross-fade between entries visually reads as "the Settings pane swaps content while Home and History stay still." Dual-rendering cost is acceptable; ViewModel state is shared via NavEntry ViewModelStore (no duplicate data fetch).

## TopAppBar
Unchanged (per design choice b in the discussion). Sub-screen titles + back arrow continue to display when those screens are on the back stack, signaling that back can be popped.

## Merge order
PR 2 of 2 in the 3-pane stack.
⚠️ Merge AFTER #725. Stacked on `ui/three-pane-dashboard-screenshots`.

## Test plan
- [x] `./scripts/validate.sh` green
- [x] All checks pass (sealed-type exhaustiveness; ContentWidthCap; AppLayoutModeBoundary; etc.)
- [ ] Manual smoke on tablet landscape: 3-pane visible, bottom nav hidden, tap Settings rows works, navigate to Diagnostics → Settings pane swaps, Home + History stay live, back arrow pops correctly
- [ ] Manual smoke on phone landscape (~916dp): observe whether 3-pane at ~280dp/pane is acceptable; if too cramped, switch to custom 1200dp threshold via the doc-noted fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)