### PR TITLE
fix(android): Make bottom sheet content vertically scrollable

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/AccountBottomSheet.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/AccountBottomSheet.kt
@@ -24,6 +24,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -87,6 +89,7 @@ fun AccountSheetContent(
     Column(
         modifier = modifier
             .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
             .padding(horizontal = 24.dp, vertical = 24.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(8.dp),

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SnoozeBottomSheet.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SnoozeBottomSheet.kt
@@ -25,6 +25,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -99,6 +101,7 @@ fun SnoozeSheetContent(
     Column(
         modifier = modifier
             .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
             .padding(horizontal = 24.dp, vertical = 16.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/VersionBottomSheet.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/VersionBottomSheet.kt
@@ -24,6 +24,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Card
@@ -96,6 +98,7 @@ fun VersionSheetContent(
     Column(
         modifier = modifier
             .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
             .padding(horizontal = 24.dp, vertical = 24.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(8.dp),


### PR DESCRIPTION
## Summary
- All three `ModalBottomSheet` content Composables (Account, Snooze, Version) used a non-scrolling `Column` root. When the sheet's natural height exceeds the available viewport (landscape phones, small windows, large font scale), the overflow is silently clipped and rows at the bottom become unreachable.
- Add `Modifier.verticalScroll(rememberScrollState())` to each outer Column so overflowing content scrolls inside the sheet.

## Test plan
- [ ] Open Snooze bottom sheet in landscape — confirm Save/Cancel row reachable via scroll.
- [ ] Open Account bottom sheet at large font scale — confirm Sign out button reachable.
- [ ] Open Version bottom sheet at large font scale — confirm last copy row reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)