### PR TITLE
fix(android): Stop refetching door state on every NavBackStackEntry

### DIFF
--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/di/ComponentGraphTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/di/ComponentGraphTest.kt
@@ -146,6 +146,17 @@ class ComponentGraphTest {
     }
 
     @Test
+    fun initialDoorFetchManagerIsSingleton() {
+        // Singleton-scoped so the cold-start fetch fires exactly once per
+        // process even when MainActivity.onCreate fires multiple times
+        // (rotation, app resume after Activity destroy). A non-singleton
+        // here would re-fetch on every config change — exactly the
+        // VM-init-fetch problem we just removed, in a different layer.
+        val c = component
+        assertSame("InitialDoorFetchManager must be singleton", c.initialDoorFetchManager, c.initialDoorFetchManager)
+    }
+
+    @Test
     fun liveClockIsSingleton() {
         val c = component
         assertSame("LiveClock must be singleton", c.liveClock, c.liveClock)

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/AppStartup.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/AppStartup.kt
@@ -23,6 +23,7 @@ import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.usecase.ButtonHealthFcmSubscriptionManager
 import com.chriscartland.garage.usecase.CheckInStalenessManager
 import com.chriscartland.garage.usecase.FcmRegistrationManager
+import com.chriscartland.garage.usecase.InitialDoorFetchManager
 import com.chriscartland.garage.usecase.LiveClock
 import com.chriscartland.garage.usecase.LogAppEventUseCase
 import com.chriscartland.garage.usecase.RunStartupDiagnosticsMaintenanceUseCase
@@ -47,6 +48,7 @@ class AppStartup(
     private val logAppEvent: LogAppEventUseCase,
     private val runStartupDiagnosticsMaintenance: RunStartupDiagnosticsMaintenanceUseCase,
     private val buttonHealthFcmSubscriptionManager: ButtonHealthFcmSubscriptionManager,
+    private val initialDoorFetchManager: InitialDoorFetchManager,
     private val externalScope: CoroutineScope,
     private val dispatchers: DispatcherProvider,
 ) {
@@ -73,6 +75,10 @@ class AppStartup(
         Logger.d { "AppStartup: Starting button health FCM subscription manager" }
         buttonHealthFcmSubscriptionManager.start()
         actions.add("startButtonHealthFcmSubscription")
+
+        Logger.d { "AppStartup: Starting initial door fetch (one-shot per process)" }
+        initialDoorFetchManager.start()
+        actions.add("startInitialDoorFetch")
 
         externalScope.launch(dispatchers.io) {
             logAppEvent(AppLoggerKeys.ON_CREATE_FCM_SUBSCRIBE_TOPIC)

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -92,6 +92,7 @@ import com.chriscartland.garage.usecase.FetchCurrentDoorEventUseCase
 import com.chriscartland.garage.usecase.FetchFcmStatusUseCase
 import com.chriscartland.garage.usecase.FetchRecentDoorEventsUseCase
 import com.chriscartland.garage.usecase.FetchSnoozeStatusUseCase
+import com.chriscartland.garage.usecase.InitialDoorFetchManager
 import com.chriscartland.garage.usecase.LiveClock
 import com.chriscartland.garage.usecase.LogAppEventUseCase
 import com.chriscartland.garage.usecase.ObserveAuthStateUseCase
@@ -186,6 +187,7 @@ abstract class AppComponent(
     abstract val buttonHealthFcmRepository: ButtonHealthFcmRepository
     abstract val buttonHealthFcmSubscriptionManager: ButtonHealthFcmSubscriptionManager
     abstract val applyButtonHealthFcmUseCase: ApplyButtonHealthFcmUseCase
+    abstract val initialDoorFetchManager: InitialDoorFetchManager
 
     // --- ViewModels ---
 
@@ -689,6 +691,23 @@ abstract class AppComponent(
         )
 
     @Provides
+    @Singleton
+    fun provideInitialDoorFetchManager(
+        fetchCurrentDoorEvent: FetchCurrentDoorEventUseCase,
+        fetchRecentDoorEvents: FetchRecentDoorEventsUseCase,
+        logAppEvent: LogAppEventUseCase,
+        applicationScope: CoroutineScope,
+        dispatchers: DispatcherProvider,
+    ): InitialDoorFetchManager =
+        InitialDoorFetchManager(
+            fetchCurrentDoorEvent = fetchCurrentDoorEvent,
+            fetchRecentDoorEvents = fetchRecentDoorEvents,
+            logAppEvent = logAppEvent,
+            scope = applicationScope,
+            dispatcher = dispatchers.io,
+        )
+
+    @Provides
     fun provideAppStartup(
         fcmRegistrationManager: FcmRegistrationManager,
         checkInStalenessManager: CheckInStalenessManager,
@@ -696,6 +715,7 @@ abstract class AppComponent(
         logAppEvent: LogAppEventUseCase,
         runStartupDiagnosticsMaintenance: RunStartupDiagnosticsMaintenanceUseCase,
         buttonHealthFcmSubscriptionManager: ButtonHealthFcmSubscriptionManager,
+        initialDoorFetchManager: InitialDoorFetchManager,
         applicationScope: CoroutineScope,
         dispatchers: DispatcherProvider,
     ): AppStartup =
@@ -706,6 +726,7 @@ abstract class AppComponent(
             logAppEvent = logAppEvent,
             runStartupDiagnosticsMaintenance = runStartupDiagnosticsMaintenance,
             buttonHealthFcmSubscriptionManager = buttonHealthFcmSubscriptionManager,
+            initialDoorFetchManager = initialDoorFetchManager,
             externalScope = applicationScope,
             dispatchers = dispatchers,
         )

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/AppStartupTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/AppStartupTest.kt
@@ -39,6 +39,9 @@ import com.chriscartland.garage.usecase.CheckInStalenessManager
 import com.chriscartland.garage.usecase.DefaultLiveClock
 import com.chriscartland.garage.usecase.FcmRegistrationManager
 import com.chriscartland.garage.usecase.FetchButtonHealthUseCase
+import com.chriscartland.garage.usecase.FetchCurrentDoorEventUseCase
+import com.chriscartland.garage.usecase.FetchRecentDoorEventsUseCase
+import com.chriscartland.garage.usecase.InitialDoorFetchManager
 import com.chriscartland.garage.usecase.LogAppEventUseCase
 import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
 import com.chriscartland.garage.usecase.PruneDiagnosticsLogUseCase
@@ -125,6 +128,21 @@ class AppStartupTest {
         )
     }
 
+    private fun createInitialDoorFetchManager(
+        scope: TestScope,
+        logger: FakeAppLoggerRepository,
+        counters: FakeDiagnosticsCountersRepository,
+    ): InitialDoorFetchManager {
+        val doorRepo = FakeDoorRepository()
+        return InitialDoorFetchManager(
+            fetchCurrentDoorEvent = FetchCurrentDoorEventUseCase(doorRepo),
+            fetchRecentDoorEvents = FetchRecentDoorEventsUseCase(doorRepo),
+            logAppEvent = LogAppEventUseCase(logger, counters),
+            scope = scope.backgroundScope,
+            dispatcher = testDispatcher,
+        )
+    }
+
     private fun createAppStartup(
         scope: TestScope,
         logger: FakeAppLoggerRepository = FakeAppLoggerRepository(),
@@ -134,6 +152,7 @@ class AppStartupTest {
         val stalenessManager = createStalenessManager(scope)
         val liveClock = createLiveClock(scope)
         val buttonHealthMgr = createButtonHealthFcmSubscriptionManager(scope)
+        val initialDoorFetchMgr = createInitialDoorFetchManager(scope, logger, counters)
         // UnconfinedTestDispatcher for the IO dispatcher so AppStartup's
         // fire-and-forget launches resolve synchronously inside the test.
         // backgroundScope by itself has subtle interactions with
@@ -150,6 +169,7 @@ class AppStartupTest {
                 prune = PruneDiagnosticsLogUseCase(logger),
             ),
             buttonHealthFcmSubscriptionManager = buttonHealthMgr,
+            initialDoorFetchManager = initialDoorFetchMgr,
             externalScope = scope.backgroundScope,
             dispatchers = TestDispatcherProvider(ioDispatcher),
         )
@@ -183,6 +203,7 @@ class AppStartupTest {
                     "startCheckInStaleness",
                     "startLiveClock",
                     "startButtonHealthFcmSubscription",
+                    "startInitialDoorFetch",
                     "logFcmSubscribe",
                     "runDiagnosticsMaintenance",
                 ),

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorHistoryViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorHistoryViewModel.kt
@@ -66,7 +66,12 @@ class DefaultDoorHistoryViewModel(
     private val deregisterFcmUseCase: DeregisterFcmUseCase,
     private val checkInStalenessManager: CheckInStalenessManager,
     private val liveClock: LiveClock,
-    private val fetchOnInit: Boolean = true,
+    // Default false — cold-start fetch lives in `InitialDoorFetchManager`
+    // (singleton, idempotent, fires once per process from `AppStartup`).
+    // Per-VM init fetch fired on every fresh `NavBackStackEntry`, causing
+    // a redundant round-trip on every tab tap even though FCM already
+    // covers live updates while the app is open.
+    private val fetchOnInit: Boolean = false,
 ) : ViewModel(),
     DoorHistoryViewModel {
     // ADR-022: pass through LiveClock's StateFlow — no mirror.

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/HomeViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/HomeViewModel.kt
@@ -93,7 +93,12 @@ class DefaultHomeViewModel(
     private val liveClock: LiveClock,
     override val buttonHealthDisplay: Flow<ButtonHealthDisplay>,
     private val appVersion: String,
-    private val fetchOnInit: Boolean = true,
+    // Default false — cold-start fetch lives in `InitialDoorFetchManager`
+    // (singleton, idempotent, fires once per process from `AppStartup`).
+    // Per-VM init fetch fired on every fresh `NavBackStackEntry`, causing
+    // a redundant round-trip on every tab tap even though FCM already
+    // covers live updates while the app is open.
+    private val fetchOnInit: Boolean = false,
 ) : ViewModel(),
     HomeViewModel {
     // ADR-022: pass through the repository's StateFlow by reference — no mirror.

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/InitialDoorFetchManager.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/InitialDoorFetchManager.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import co.touchlab.kermit.Logger
+import com.chriscartland.garage.domain.model.AppLoggerKeys
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+/**
+ * App-scoped one-shot fetch of door state at process start (ADR-015).
+ *
+ * Why this exists: `DefaultHomeViewModel` and `DefaultDoorHistoryViewModel`
+ * used to call `fetchCurrentDoorEvent()` / `fetchRecentDoorEvents()` from
+ * their `init {}` blocks, which fired on every fresh `NavBackStackEntry` —
+ * so every History tab tap triggered a redundant network round-trip even
+ * though FCM had already pushed any new event into Room. While the app is
+ * open and FCM is connected, the Room flow + FCM-fed insert path is the
+ * source of truth for door state — manual fetches should be (a) cold-start,
+ * (b) user-initiated (pull-to-refresh, alert action). [start] covers (a).
+ *
+ * [start] is idempotent — calling twice is a no-op. Combined with
+ * `@Singleton` provisioning, this guarantees the cold-start fetch fires
+ * exactly once per process even when `MainActivity.onCreate` fires
+ * multiple times (rotation, app resume after Activity destroy).
+ *
+ * Errors are intentionally swallowed (logged via the UseCases' own
+ * logging). Cold-start failure is recoverable: pull-to-refresh, FCM, or
+ * the app's stale-data alert path will all surface the issue and let the
+ * user retry.
+ */
+class InitialDoorFetchManager(
+    private val fetchCurrentDoorEvent: FetchCurrentDoorEventUseCase,
+    private val fetchRecentDoorEvents: FetchRecentDoorEventsUseCase,
+    private val logAppEvent: LogAppEventUseCase,
+    private val scope: CoroutineScope,
+    private val dispatcher: CoroutineDispatcher,
+) {
+    private var job: Job? = null
+
+    /**
+     * Fetch current + recent door events once. Idempotent — subsequent
+     * calls are no-ops while the first attempt is in flight or after it
+     * has completed.
+     */
+    fun start() {
+        if (job != null) {
+            Logger.d { "InitialDoorFetchManager: already started" }
+            return
+        }
+        job = scope.launch(dispatcher) {
+            Logger.d { "InitialDoorFetchManager: fetching current + recent door events" }
+            logAppEvent(AppLoggerKeys.INIT_CURRENT_DOOR)
+            fetchCurrentDoorEvent()
+            logAppEvent(AppLoggerKeys.INIT_RECENT_DOOR)
+            fetchRecentDoorEvents()
+        }
+    }
+}

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/InitialDoorFetchManagerTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/InitialDoorFetchManagerTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
+import com.chriscartland.garage.testcommon.FakeDiagnosticsCountersRepository
+import com.chriscartland.garage.testcommon.FakeDoorRepository
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class InitialDoorFetchManagerTest {
+    private fun createManager(
+        scope: kotlinx.coroutines.test.TestScope,
+        doorRepo: FakeDoorRepository,
+    ): InitialDoorFetchManager {
+        val logger = FakeAppLoggerRepository()
+        val counters = FakeDiagnosticsCountersRepository()
+        val dispatcher = UnconfinedTestDispatcher(scope.testScheduler)
+        return InitialDoorFetchManager(
+            fetchCurrentDoorEvent = FetchCurrentDoorEventUseCase(doorRepo),
+            fetchRecentDoorEvents = FetchRecentDoorEventsUseCase(doorRepo),
+            logAppEvent = LogAppEventUseCase(logger, counters),
+            scope = scope.backgroundScope,
+            dispatcher = dispatcher,
+        )
+    }
+
+    @Test
+    fun startFetchesCurrentAndRecentOnce() =
+        runTest {
+            val doorRepo = FakeDoorRepository()
+            val manager = createManager(this, doorRepo)
+
+            manager.start()
+
+            assertEquals(1, doorRepo.fetchCurrentDoorEventCount)
+            assertEquals(1, doorRepo.fetchRecentDoorEventsCount)
+        }
+
+    @Test
+    fun startIsIdempotent() =
+        runTest {
+            val doorRepo = FakeDoorRepository()
+            val manager = createManager(this, doorRepo)
+
+            manager.start()
+            manager.start()
+            manager.start()
+
+            // Three start() calls but only ONE pair of fetches —
+            // matches the per-process semantics that motivate the
+            // singleton scope (rotation, app resume after Activity
+            // destroy, etc.).
+            assertEquals(1, doorRepo.fetchCurrentDoorEventCount)
+            assertEquals(1, doorRepo.fetchRecentDoorEventsCount)
+        }
+}


### PR DESCRIPTION
## Summary

`DefaultHomeViewModel` and `DefaultDoorHistoryViewModel` called their fetch UseCases from `init {}` (with `fetchOnInit = true` default). With Nav3's per-entry ViewModelStore, every fresh `NavBackStackEntry` constructed a fresh VM and fired the init fetch — so every History tab tap (and every wide-dashboard re-creation) triggered a redundant network round-trip even though FCM had already pushed any new event into Room.

While the app is open and FCM is connected, the Room flow + FCM-fed insert path is the source of truth for door state. Manual fetches should be (a) cold-start-once-per-process or (b) user-initiated (pull-to-refresh, alert action).

## Audit summary

| Assumption | Verdict |
|---|---|
| Tab nav refreshes Home + History | ✅ TRUE for History (every tap → fresh entry → fresh VM → init fetch). Home only on first launch since it's preserved at the bottom of the back stack. |
| FCM sufficient while app is open | ✅ TRUE. FCM door message → `ReceiveFcmDoorEventUseCase` → `doorRepository.insertDoorEvent` → Room write → Room flow emits → both VMs' StateFlows update. |
| Configuration change refreshes | ⚠️ Likely FALSE for pure rotation — `rememberViewModelStoreNavEntryDecorator` retains per-entry stores. The user's "config change" observation is most likely tab nav under a different label. The tab-nav fix removes the dominant source. |

## Changes

- Flip `fetchOnInit` default `true` → `false` in `DefaultHomeViewModel` and `DefaultDoorHistoryViewModel`.
- New `InitialDoorFetchManager` (singleton, idempotent `start()`) — fetches current + recent door events once per process. Mirrors the `FcmRegistrationManager` pattern.
- `AppStartup.run()` calls `initialDoorFetchManager.start()`. Singleton scope guarantees fire-once-per-process even when `MainActivity.onCreate` fires on rotation/Activity-restart.
- `ComponentGraphTest` entry asserts `@Singleton` identity for the new manager.
- Updated `AppStartupTest` expectations (new `"startInitialDoorFetch"` action in returned list).
- New unit test for `InitialDoorFetchManager` covering single-fetch + idempotent-`start()`.

## Test plan
- [ ] App launch (cold start) — Home and History show fresh data within ~1 second.
- [ ] Tap History tab repeatedly — no network spam (logcat / network inspector).
- [ ] Rotate device — no fetch fires.
- [ ] Pull-to-refresh — works as before.
- [ ] FCM-triggered door event — Home and History both update without manual refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)