### PR TITLE
fix(android): Consume horizontal display-cutout insets in route wrappers

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DashboardRouteContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DashboardRouteContent.kt
@@ -17,8 +17,13 @@
 package com.chriscartland.garage.ui
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -29,6 +34,11 @@ import com.chriscartland.garage.ui.theme.Spacing
  * Wide-screen sibling of [RouteContent]. Caps the dashboard width at
  * `2 * ContentWidth.Standard + Spacing.Screen` (`1296dp`) and centers
  * within the canvas.
+ *
+ * Also consumes the **horizontal** [WindowInsets.safeDrawing] inset (display
+ * cutout, side-mounted system bars) — same rationale as [RouteContent], and
+ * crucial here because Wide mode is exactly the orientation (landscape phone
+ * / tablet portrait) where side cutouts appear.
  *
  * Use ONLY for the wide-screen Home dashboard route. Single-pane routes
  * (Profile, Diagnostics, FunctionList, narrow-screen Home/History)
@@ -42,7 +52,9 @@ import com.chriscartland.garage.ui.theme.Spacing
 @Composable
 fun DashboardRouteContent(content: @Composable (Modifier) -> Unit) {
     Box(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)),
         contentAlignment = Alignment.TopCenter,
     ) {
         // Cap = both panes' caps + the gap between them.

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/RouteContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/RouteContent.kt
@@ -18,8 +18,13 @@
 package com.chriscartland.garage.ui
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,6 +39,15 @@ import com.chriscartland.garage.ui.theme.ContentWidth
  * landscape phones, content centers within the cap and excess width becomes
  * margin.
  *
+ * Also consumes the **horizontal** [WindowInsets.safeDrawing] inset (display
+ * cutout, side-mounted system bars in landscape, IME-side insets) so content
+ * never draws under a side camera cutout. `Scaffold` only consumes vertical
+ * insets via its `topBar`/`bottomBar` slots — the body content is the route
+ * wrapper's responsibility, and since the wrapper owns horizontal padding it
+ * also owns horizontal inset consumption. Vertical safe-drawing insets are
+ * already covered by Scaffold's TopAppBar + NavigationBar slots, so this
+ * wrapper deliberately scopes inset consumption to `Horizontal`.
+ *
  * Forward-compatible with the future two-pane experiment: when two-pane
  * mode lands behind a runtime toggle, it consumes the same `ContentWidth`
  * tokens — the list pane in two-pane mode reuses these widths rather than
@@ -41,18 +55,20 @@ import com.chriscartland.garage.ui.theme.ContentWidth
  * the canonical fallback.
  *
  * Use ONCE per route entry in `Main.kt`. Child screens must not re-apply
- * the width cap or the centering wrapper.
+ * the width cap, the centering wrapper, or horizontal cutout consumption.
  *
  * @param content the screen-level Composable. The provided [Modifier] is
  *   the one [content] should attach: it has the width cap and `fillMaxSize`
  *   pre-applied. Any horizontal padding the content needs (e.g.
  *   `Spacing.Screen`) is the content's responsibility — `RouteContent`
- *   does not opine on padding, only on width and centering.
+ *   does not opine on padding, only on width, centering, and inset consumption.
  */
 @Composable
 fun RouteContent(content: @Composable (Modifier) -> Unit) {
     Box(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)),
         contentAlignment = Alignment.TopCenter,
     ) {
         // Modifier order matters: widthIn(max=...) MUST come before

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ThreePaneRouteContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ThreePaneRouteContent.kt
@@ -17,8 +17,13 @@
 package com.chriscartland.garage.ui
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,6 +35,11 @@ import com.chriscartland.garage.ui.theme.Spacing
  * Caps the 3-pane dashboard width at `3 * ContentWidth.Standard +
  * 2 * Spacing.Screen` (`1952dp`) and centers within the canvas.
  *
+ * Also consumes the **horizontal** [WindowInsets.safeDrawing] inset (display
+ * cutout, side-mounted system bars) — same rationale as [RouteContent]. On
+ * a tablet in landscape with a side cutout, the 3-pane dashboard would
+ * otherwise extend its leftmost or rightmost pane behind the cutout.
+ *
  * Use ONLY for the Expanded-width Home dashboard route.
  *
  * Modifier order matters here for the same reason as [RouteContent]:
@@ -40,7 +50,9 @@ import com.chriscartland.garage.ui.theme.Spacing
 @Composable
 fun ThreePaneRouteContent(content: @Composable (Modifier) -> Unit) {
     Box(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)),
         contentAlignment = Alignment.TopCenter,
     ) {
         // Cap = three pane caps + the two gaps between them.


### PR DESCRIPTION
## Summary

In landscape with a side display cutout (camera notch on a phone in landscape, side hole-punch), content drew under the cutout because nothing in the body consumed the horizontal inset.

## Audit

**Background:** `MainActivity.onCreate` calls `enableEdgeToEdge()` (required for Android 15+, target SDK 35), which lets content draw under system bars. Material 3 `Scaffold` then uses its `topBar`/`bottomBar` slots to consume **vertical** insets and exposes the remaining vertical inset as `innerPadding` to its content lambda. But `Scaffold` does NOT apply any horizontal inset consumption to the body — that's the caller's job.

The route wrappers (`RouteContent`, `DashboardRouteContent`, `ThreePaneRouteContent`) own horizontal padding per the SPACING_PLAN single-source rule, so they're the right home for horizontal inset consumption too.

## Fix

Apply `Modifier.windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal))` to each wrapper's outer Box.

The horizontal-only scope is deliberate: vertical `safeDrawing` insets are already covered by Scaffold's `TopAppBar` + `NavigationBar` slots, so re-consuming them would double-pad. `safeDrawing` covers display cutouts AND any side-mounted system bars (rare but possible on some tablets in landscape).

No screenshot churn — the screenshot tests don't simulate window insets, and the cap + centering geometry is unchanged at zero-inset canvases.

## Test plan
- [ ] Pixel-class phone in landscape with side hole-punch — confirm Status pill, Home content, History content all stay clear of the cutout
- [ ] Tablet in landscape with display cutout (rare) — same check
- [ ] Portrait phone — no visible change (no horizontal cutout)
- [ ] Bottom nav unchanged (NavigationBar handles its own bottom + horizontal-at-bottom insets)
- [ ] TopAppBar unchanged (TopAppBar handles its own top + horizontal-at-top insets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)