### PR TITLE
fix(android): Stop door icon from animating MIDWAY→actual on every fresh screen entry

### DIFF
--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/HomeViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/HomeViewModel.kt
@@ -107,8 +107,17 @@ class DefaultHomeViewModel(
     // ADR-022: pass through LiveClock's StateFlow — no mirror.
     override val nowEpochSeconds: StateFlow<Long> = liveClock.nowEpochSeconds
 
+    // Seed from the singleton repo's StateFlow `.value` (pass-through via
+    // `observeDoorEvents.current()` per ADR-022) so we never expose
+    // `Loading(null)` on first composition. Without this seed, the
+    // Composable would briefly read `Loading(null)` → map to UNKNOWN/MIDWAY,
+    // then the collect lambda below would update to `Complete(actualEvent)` →
+    // map to OPEN/CLOSED — and `LaunchedEffect(doorPosition)` in `GarageIcon`
+    // would visibly animate MIDWAY→actual on every fresh screen entry.
     private val _currentDoorEvent =
-        MutableStateFlow<LoadingResult<DoorEvent?>>(LoadingResult.Loading(null))
+        MutableStateFlow<LoadingResult<DoorEvent?>>(
+            LoadingResult.Complete(observeDoorEvents.current().value),
+        )
     override val currentDoorEvent: StateFlow<LoadingResult<DoorEvent?>> = _currentDoorEvent
 
     private val _isCheckInStale = MutableStateFlow(false)

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveDoorEventsUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveDoorEventsUseCase.kt
@@ -21,17 +21,31 @@ import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.repository.DoorRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Observes the current and recent door events from the repository.
  *
  * Wraps [DoorRepository] flows so ViewModels can depend on this UseCase
  * instead of the repository directly.
+ *
+ * Per ADR-022 "match the upstream, never wrap": [current] returns
+ * [StateFlow] because the repo's `currentDoorEvent` IS a [StateFlow]
+ * — passing it through preserves the synchronous `.value` accessor
+ * the VM needs to seed its initial loading-result with the cached
+ * door event (otherwise the VM exposes `Loading(null)` for one frame
+ * on first composition, the door icon maps that to UNKNOWN/MIDWAY,
+ * and the next frame's `Complete(actualEvent)` triggers a visible
+ * MIDWAY→actual door animation on every fresh screen entry).
+ *
+ * [recent] and [position] stay [Flow] — `recent` is a Room flow (not
+ * a StateFlow upstream) and `position` does `.map.distinctUntilChanged()`
+ * (a transformation, not a pass-through).
  */
 class ObserveDoorEventsUseCase(
     private val doorRepository: DoorRepository,
 ) {
-    fun current(): Flow<DoorEvent?> = doorRepository.currentDoorEvent
+    fun current(): StateFlow<DoorEvent?> = doorRepository.currentDoorEvent
 
     fun recent(): Flow<List<DoorEvent>> = doorRepository.recentDoorEvents
 


### PR DESCRIPTION
## Audit

The user reported the door animation changes on route change, with "other things flickering" too. Three flicker sources identified:

1. **Door icon (UNKNOWN → actual on first Home enter)** — fixed here.
2. **Pills using `collectAsStateWithLifecycle(initialValue = Loading)`** on screen RE-ENTRY — `produceState` slot is fresh on every composition, so initial value is `Loading` until upstream re-emits. Brief "Checking…" flash. Deferred.
3. **Motion-state door animation re-runs** — `remember { Animatable(initialPositionFor(...)) }` is recreated per composition; for OPENING/CLOSING, seed = "from" position. Per `DOOR_ANIMATION.md` this is intentional, with the trade-off documented inline.

This PR fixes #1, the dominant cause.

## Mechanism

`DefaultHomeViewModel._currentDoorEvent` was initialized to `LoadingResult.Loading(null)`. On first composition the Composable read that, the `HomeMapper` coerced the null door event to `DoorPosition.UNKNOWN` (`MIDWAY`), and `LaunchedEffect(doorPosition)` in `GarageIcon` seeded an `Animatable` at `MIDWAY`. The collect lambda in `init` then asynchronously emitted `Complete(actualEvent)` → `OPEN`/`CLOSED`, the LaunchedEffect re-fired with the new key, and the door icon visibly animated `MIDWAY → actual` on every fresh screen entry. Since FCM + the singleton repo's StateFlow always already hold the cached door event, this transient is purely a per-VM-init artifact.

## Fix

- Change `ObserveDoorEventsUseCase.current()` return type from `Flow<DoorEvent?>` to `StateFlow<DoorEvent?>` — pass-through (per ADR-022 "match the upstream, never wrap"). The repo's `currentDoorEvent` IS a `StateFlow`; the previous narrowing to `Flow` was the only thing preventing the VM from seeding from `.value`.
- `DefaultHomeViewModel` seeds `_currentDoorEvent` with `LoadingResult.Complete(observeDoorEvents.current().value)` at construction. Initial frame already shows the cached door event — no UNKNOWN transient, no spurious door animation.

## Out of scope (deferred)

- `DoorHistoryViewModel._recentDoorEvents` starts at `Loading(emptyList())` for the same reason. Fix requires StateFlow-ifying the Room flow at the repo layer (not a pure pass-through anymore).
- The `collectAsStateWithLifecycle(initialValue = ...)` flickers on re-entry need a different fix: either expose source as StateFlow (cached value), or hold State across composition boundaries.

## Test plan
- [ ] Cold-start the app on Home — door icon shows the actual position with no opening animation
- [ ] Tap History → tap Home — door icon stays at the actual position, no animation
- [ ] If door is OPENING/CLOSING, the motion animation IS expected on first composition (intentional, per `DOOR_ANIMATION.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)