### PR TITLE
fix(android): Eliminate Loading-flicker on every fresh screen entry

### DIFF
--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/di/ComponentGraphTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/di/ComponentGraphTest.kt
@@ -146,6 +146,21 @@ class ComponentGraphTest {
     }
 
     @Test
+    fun computeButtonHealthDisplayUseCaseIsSingleton() {
+        // Singleton-scoped because the use case maintains an Eagerly-started
+        // `stateIn` over a `combine(authState, buttonHealth, clock)` flow.
+        // A non-singleton would spin up multiple eager combine collectors
+        // (one per VM construction), each with its own initial `Loading`
+        // value — defeating the buttonHealthDisplay flicker fix.
+        val c = component
+        assertSame(
+            "ComputeButtonHealthDisplayUseCase must be singleton",
+            c.computeButtonHealthDisplayUseCase,
+            c.computeButtonHealthDisplayUseCase,
+        )
+    }
+
+    @Test
     fun initialDoorFetchManagerIsSingleton() {
         // Singleton-scoped so the cold-start fetch fires exactly once per
         // process even when MainActivity.onCreate fires multiple times

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -188,6 +188,7 @@ abstract class AppComponent(
     abstract val buttonHealthFcmSubscriptionManager: ButtonHealthFcmSubscriptionManager
     abstract val applyButtonHealthFcmUseCase: ApplyButtonHealthFcmUseCase
     abstract val initialDoorFetchManager: InitialDoorFetchManager
+    abstract val computeButtonHealthDisplayUseCase: ComputeButtonHealthDisplayUseCase
 
     // --- ViewModels ---
 
@@ -432,12 +433,25 @@ abstract class AppComponent(
     fun provideApplyButtonHealthFcmUseCase(buttonHealthRepository: ButtonHealthRepository): ApplyButtonHealthFcmUseCase =
         ApplyButtonHealthFcmUseCase(buttonHealthRepository)
 
+    // @Singleton-scoped: the underlying combine + stateIn must run exactly
+    // once per process. A non-singleton would spin up multiple eager combine
+    // collectors (one per VM construction), each maintaining its own
+    // independent StateFlow with its own initial `Loading` value — defeating
+    // the flicker fix.
     @Provides
+    @Singleton
     fun provideComputeButtonHealthDisplayUseCase(
         authRepository: AuthRepository,
         buttonHealthRepository: ButtonHealthRepository,
         liveClock: LiveClock,
-    ): ComputeButtonHealthDisplayUseCase = ComputeButtonHealthDisplayUseCase(authRepository, buttonHealthRepository, liveClock)
+        applicationScope: CoroutineScope,
+    ): ComputeButtonHealthDisplayUseCase =
+        ComputeButtonHealthDisplayUseCase(
+            authRepository = authRepository,
+            buttonHealthRepository = buttonHealthRepository,
+            liveClock = liveClock,
+            applicationScope = applicationScope,
+        )
 
     // --- @Singleton providers (bodies take parameters so caching is honored) ---
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/AnimatableGarageDoor.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/AnimatableGarageDoor.kt
@@ -87,29 +87,24 @@ object DoorAnimation {
     /**
      * Initial Animatable seed for a given state.
      *
-     * For motion states (OPENING/CLOSING) the seed is the "from" end so the
-     * tween animates the full motion when the icon first composes (e.g., app
-     * open, screen return mid-motion). For all other states, seed = target so
-     * the icon renders at rest with no animation on first frame.
+     * Always equal to [targetPositionFor] — a freshly composed icon
+     * renders at the target position with no animation. The motion
+     * animation (`OPENING` / `CLOSING`) only fires when [doorPosition]
+     * **changes** during the icon's lifetime (state CLOSED→OPENING
+     * triggers `LaunchedEffect` to animate from CLOSED to OPEN), not on
+     * every fresh composition.
      *
-     * Trade-off: when the app opens with a door in motion, the icon ignores
-     * the server's lastChangeTimeSeconds and animates from the "from" end.
-     * Computing elapsed time would require a clock-drift correction we don't
-     * have. See `AndroidGarage/docs/DOOR_ANIMATION.md` § Trade-offs.
+     * Pre-2.16.4 behavior was: `OPENING → CLOSED_POSITION` and
+     * `CLOSING → OPEN_POSITION` so the icon animated the full motion on
+     * first compose (including screen return mid-motion). That re-ran
+     * the open/close animation every time the user navigated back to
+     * Home while the server still reported a transient OPENING/CLOSING
+     * state — visible flicker that didn't represent reality (the
+     * animation timing didn't sync with the physical door). The
+     * [overlayFor] arrows (ARROW_UP / ARROW_DOWN) preserve the
+     * "in motion" visual cue without re-animating.
      */
-    fun initialPositionFor(doorPosition: DoorPosition): Float =
-        when (doorPosition) {
-            DoorPosition.OPENING -> CLOSED_POSITION
-            DoorPosition.CLOSING -> OPEN_POSITION
-            DoorPosition.UNKNOWN,
-            DoorPosition.CLOSED,
-            DoorPosition.OPENING_TOO_LONG,
-            DoorPosition.OPEN,
-            DoorPosition.OPEN_MISALIGNED,
-            DoorPosition.CLOSING_TOO_LONG,
-            DoorPosition.ERROR_SENSOR_CONFLICT,
-            -> targetPositionFor(doorPosition)
-        }
+    fun initialPositionFor(doorPosition: DoorPosition): Float = targetPositionFor(doorPosition)
 
     /**
      * Which animation spec family applies.

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -71,8 +71,12 @@ fun HomeContent(
     val buttonState by resolved.buttonState.collectAsState()
     val authState by resolved.authState.collectAsState()
     val isCheckInStale by resolved.isCheckInStale.collectAsState()
+    // No `initialValue` — `buttonHealthDisplay` is a StateFlow whose
+    // upstream is stateIn'd at app scope (Eagerly), so the cached current
+    // value is read synchronously on first composition. Avoids the
+    // brief "Checking…" flash on every fresh screen entry.
     val buttonHealthDisplay: ButtonHealthDisplay by resolved.buttonHealthDisplay
-        .collectAsStateWithLifecycle(initialValue = ButtonHealthDisplay.Loading)
+        .collectAsStateWithLifecycle()
 
     val notificationPermissionState = rememberNotificationPermissionState()
     // Survives rotation + process death so the alert flicker on rotation

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/GarageDoorAnimationMappingTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/GarageDoorAnimationMappingTest.kt
@@ -81,21 +81,12 @@ class GarageDoorAnimationMappingTest {
     // --- initialPositionFor ---------------------------------------------------
 
     @Test
-    fun initialPositionFor_opening_startsAtClosed() {
-        // Motion states start at the "from" end so the tween animates the full
-        // motion when the icon first composes.
-        assertEquals(CLOSED_POSITION, DoorAnimation.initialPositionFor(DoorPosition.OPENING))
-    }
-
-    @Test
-    fun initialPositionFor_closing_startsAtOpen() {
-        assertEquals(OPEN_POSITION, DoorAnimation.initialPositionFor(DoorPosition.CLOSING))
-    }
-
-    @Test
-    fun initialPositionFor_terminalStates_startAtTarget() {
-        // No first-frame animation for terminal/error states.
-        for (state in nonMotionStates) {
+    fun initialPositionFor_alwaysEqualsTarget() {
+        // Per 2.16.4: every state's initial == target. Motion animations
+        // (OPENING/CLOSING tweens) only fire when doorPosition CHANGES during
+        // the icon's lifetime, not on every fresh composition. The arrow
+        // overlays carry the "in motion" cue without re-animating.
+        for (state in DoorPosition.entries) {
             assertEquals(
                 "Initial position for $state should equal target",
                 DoorAnimation.targetPositionFor(state),

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepository.kt
@@ -56,13 +56,24 @@ class NetworkDoorRepository(
     private val _currentDoorEvent = MutableStateFlow<DoorEvent?>(null)
     override val currentDoorEvent: StateFlow<DoorEvent?> = _currentDoorEvent
 
-    override val recentDoorEvents: Flow<List<DoorEvent>> = localDoorDataSource.recentDoorEvents
+    // Same StateFlow + always-on collector pattern as currentDoorEvent.
+    // Exposing this as StateFlow lets `DoorHistoryViewModel` synchronously
+    // read `.value` to seed its initial loading-result with the cached
+    // events list, avoiding a one-frame `Loading(emptyList())` render on
+    // every fresh screen entry.
+    private val _recentDoorEvents = MutableStateFlow<List<DoorEvent>>(emptyList())
+    override val recentDoorEvents: StateFlow<List<DoorEvent>> = _recentDoorEvents
 
     init {
         externalScope.launch {
             localDoorDataSource.currentDoorEvent.collect { event ->
                 _currentDoorEvent.value = event
                 Logger.i { "currentDoorEvent <- $event (source=local)" }
+            }
+        }
+        externalScope.launch {
+            localDoorDataSource.recentDoorEvents.collect { events ->
+                _recentDoorEvents.value = events
             }
         }
     }

--- a/AndroidGarage/docs/DOOR_ANIMATION.md
+++ b/AndroidGarage/docs/DOOR_ANIMATION.md
@@ -32,13 +32,15 @@ Each is an exhaustive `when` over `DoorPosition` with no `else`. Adding a new en
 |-------|----------|-----------|------|---------|
 | `UNKNOWN` | `MIDWAY_POSITION` | target | spring | warning |
 | `CLOSED` | `CLOSED_POSITION` | target | spring | none |
-| `OPENING` | `OPEN_POSITION` | `CLOSED_POSITION` | tween (linear, 12s) | arrow up |
+| `OPENING` | `OPEN_POSITION` | target | tween (linear, 12s) | arrow up |
 | `OPENING_TOO_LONG` | `MIDWAY_POSITION` | target | spring | warning |
 | `OPEN` | `OPEN_POSITION` | target | spring | none |
 | `OPEN_MISALIGNED` | `OPEN_POSITION` | target | spring | none |
-| `CLOSING` | `CLOSED_POSITION` | `OPEN_POSITION` | tween (linear, 12s) | arrow down |
+| `CLOSING` | `CLOSED_POSITION` | target | tween (linear, 12s) | arrow down |
 | `CLOSING_TOO_LONG` | `MIDWAY_POSITION` | target | spring | warning |
 | `ERROR_SENSOR_CONFLICT` | `MIDWAY_POSITION` | target | spring | warning |
+
+`initial = target` for every state. The motion animation (tween for OPENING/CLOSING) only fires when `doorPosition` *changes* during the icon's lifetime — not on every fresh composition. Pre-2.16.4 used `OPENING → CLOSED_POSITION` and `CLOSING → OPEN_POSITION` so a freshly composed motion-state icon animated the full motion. That re-ran the animation on every screen re-entry while the server still reported a transient OPENING/CLOSING — visible flicker that didn't represent reality (animation timing didn't sync with the physical door). The arrow overlays preserve the "in motion" cue without re-animating.
 
 Position constants in `AnimatableGarageDoor.kt`:
 
@@ -76,7 +78,7 @@ Linear easing matches the roughly constant-speed motion of a real garage door.
 
 ## Trade-offs
 
-**No elapsed-time-based start position.** When the app opens with the door already in motion, the icon starts at the "from" end (`initialPositionFor`) and animates the full motion from scratch. We do not compute `now() - lastChangeTimeSeconds` to seed the position mid-motion because clock drift between the device and the server is significant — relying on it would put the icon in a wrong position silently. The visible cost is that opening the app mid-motion shows the icon "starting over" rather than catching up to physical reality. The animation is now an indicator of *state*, not an attempt to mirror the door's literal current position.
+**Fresh composition seeds at the target, not the "from" end.** When the app opens (or a screen re-enters) with the server reporting an in-motion state, the icon renders immediately at the target position (OPEN for OPENING, CLOSED for CLOSING) with the arrow overlay carrying the motion cue. Pre-2.16.4 the icon animated the full motion on every fresh composition; 2.16.4 changed `initialPositionFor` to always equal `targetPositionFor` so the animation only fires when `doorPosition` actually changes during the icon's lifetime (e.g., the user is looking at the screen when the server transitions CLOSED→OPENING). Computing `now() - lastChangeTimeSeconds` to seed mid-motion is still rejected because clock drift between device and server is significant — relying on it would put the icon at a silently wrong position.
 
 **Always animate to target on state change.** No `|current - target| < ε` skip — that would make behavior depend on current animation value, defeating the "target is pure" principle. If `current ≈ target`, the spring is a near-noop with no perceived movement.
 

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/DoorRepository.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/DoorRepository.kt
@@ -17,8 +17,15 @@ interface DoorRepository {
      */
     val currentDoorEvent: StateFlow<DoorEvent?>
 
-    /** Observation: recent door events from local cache (list-y, cold). */
-    val recentDoorEvents: Flow<List<DoorEvent>>
+    /**
+     * Observation: recent door events owned as a [StateFlow] (ADR-022 —
+     * state-y). Backed by an always-on collector over the local Room flow,
+     * same pattern as [currentDoorEvent]. Exposed as [StateFlow] so
+     * `DoorHistoryViewModel` can synchronously seed its initial loading-
+     * result with the cached events list (avoiding a one-frame
+     * `Loading(emptyList())` render on every fresh screen entry).
+     */
+    val recentDoorEvents: StateFlow<List<DoorEvent>>
 
     suspend fun fetchBuildTimestampCached(): String?
 

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeDoorRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeDoorRepository.kt
@@ -33,7 +33,7 @@ class FakeDoorRepository : DoorRepository {
 
     override val currentDoorPosition: Flow<DoorPosition> = _currentDoorPosition
     override val currentDoorEvent: StateFlow<DoorEvent?> = _currentDoorEvent
-    override val recentDoorEvents: Flow<List<DoorEvent>> = _recentDoorEvents
+    override val recentDoorEvents: StateFlow<List<DoorEvent>> = _recentDoorEvents
 
     var fetchCurrentDoorEventCount = 0
         private set

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ComputeButtonHealthDisplayUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ComputeButtonHealthDisplayUseCase.kt
@@ -19,31 +19,56 @@ package com.chriscartland.garage.usecase
 
 import com.chriscartland.garage.domain.repository.AuthRepository
 import com.chriscartland.garage.domain.repository.ButtonHealthRepository
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 
 /**
  * Combines auth state, the button-health snapshot, and the LiveClock
- * tick into a single [ButtonHealthDisplay] flow.
+ * tick into a single [ButtonHealthDisplay] [StateFlow].
  *
- * Returns [Flow] (not [kotlinx.coroutines.flow.StateFlow]) per ADR-022:
- * the consumer (Composable) collects via `collectAsStateWithLifecycle`
- * with an initial value, avoiding `stateIn(viewModelScope, ...)`.
+ * Returns [StateFlow] so the Composable can read `.value` synchronously
+ * on first composition (no `Loading` flicker on every fresh screen
+ * entry). The `combine(...)` result is naturally a cold [Flow]; we
+ * `stateIn(applicationScope, SharingStarted.Eagerly, Loading)` to
+ * convert it into a hot [StateFlow] with a cached current value.
+ *
+ * `Eagerly` (not `WhileSubscribed`) is intentional: the upstream
+ * sources are all `StateFlow`s + LiveClock ticks (cheap), so keeping
+ * the combine running for the lifetime of the process costs nothing
+ * meaningful and guarantees subsequent subscribers see the latest
+ * value immediately. `WhileSubscribed(timeout)` would re-emit the
+ * initial `Loading` value after the timeout window, reintroducing the
+ * flicker on the next subscription.
+ *
+ * The provider must be `@Singleton`-scoped so the eager combine runs
+ * exactly once per process — multiple instances would each spin up
+ * their own combine and waste cycles. See `ComponentGraphTest` for the
+ * `assertSame` identity check.
  *
  * Pure derivation lives in [ButtonHealthDisplayLogic.compute]; this
- * UseCase is the wiring + clock-tick combine.
+ * UseCase is the wiring + clock-tick combine + state caching.
  */
 class ComputeButtonHealthDisplayUseCase(
-    private val authRepository: AuthRepository,
-    private val buttonHealthRepository: ButtonHealthRepository,
-    private val liveClock: LiveClock,
+    authRepository: AuthRepository,
+    buttonHealthRepository: ButtonHealthRepository,
+    liveClock: LiveClock,
+    applicationScope: CoroutineScope,
 ) {
-    operator fun invoke(): Flow<ButtonHealthDisplay> =
+    private val state: StateFlow<ButtonHealthDisplay> =
         combine(
             authRepository.authState,
             buttonHealthRepository.buttonHealth,
             liveClock.nowEpochSeconds,
         ) { auth, health, now ->
             ButtonHealthDisplayLogic.compute(auth, health, now)
-        }
+        }.stateIn(
+            scope = applicationScope,
+            started = SharingStarted.Eagerly,
+            initialValue = ButtonHealthDisplay.Loading,
+        )
+
+    operator fun invoke(): StateFlow<ButtonHealthDisplay> = state
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorHistoryViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/DoorHistoryViewModel.kt
@@ -77,8 +77,15 @@ class DefaultDoorHistoryViewModel(
     // ADR-022: pass through LiveClock's StateFlow — no mirror.
     override val nowEpochSeconds: StateFlow<Long> = liveClock.nowEpochSeconds
 
+    // Seed from the singleton repo's StateFlow `.value` (pass-through via
+    // `observeDoorEvents.recent()` per ADR-022) so we never expose
+    // `Loading(emptyList())` on first composition. Without this seed, the
+    // history list would render empty for one frame on every fresh screen
+    // entry, then immediately fill in once the collect lambda below ran.
     private val _recentDoorEvents =
-        MutableStateFlow<LoadingResult<List<DoorEvent>>>(LoadingResult.Loading(listOf()))
+        MutableStateFlow<LoadingResult<List<DoorEvent>>>(
+            LoadingResult.Complete(observeDoorEvents.recent().value),
+        )
     override val recentDoorEvents: StateFlow<LoadingResult<List<DoorEvent>>> = _recentDoorEvents
 
     private val _isCheckInStale = MutableStateFlow(false)

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/HomeViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/HomeViewModel.kt
@@ -30,7 +30,6 @@ import com.chriscartland.garage.domain.model.FetchError
 import com.chriscartland.garage.domain.model.GoogleIdToken
 import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.domain.model.RemoteButtonState
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -64,10 +63,14 @@ interface HomeViewModel {
 
     /**
      * Display state for the remote-button device's online/offline pill.
-     * Per ADR-022, derived [Flow]; the Composable consumer collects via
-     * [androidx.compose.runtime.collectAsState] with an initial value.
+     * Per ADR-022, exposed as [StateFlow] (the upstream
+     * `ComputeButtonHealthDisplayUseCase` is `stateIn`'d at app scope so
+     * the cached value is available synchronously). The Composable
+     * collects via the no-initial-value `collectAsStateWithLifecycle()`
+     * overload — eliminates the brief `Loading` flash on every fresh
+     * screen entry.
      */
-    val buttonHealthDisplay: Flow<ButtonHealthDisplay>
+    val buttonHealthDisplay: StateFlow<ButtonHealthDisplay>
 
     fun signInWithGoogle(idToken: GoogleIdToken)
 
@@ -91,7 +94,7 @@ class DefaultHomeViewModel(
     private val pushRemoteButtonUseCase: PushRemoteButtonUseCase,
     private val checkInStalenessManager: CheckInStalenessManager,
     private val liveClock: LiveClock,
-    override val buttonHealthDisplay: Flow<ButtonHealthDisplay>,
+    override val buttonHealthDisplay: StateFlow<ButtonHealthDisplay>,
     private val appVersion: String,
     // Default false — cold-start fetch lives in `InitialDoorFetchManager`
     // (singleton, idempotent, fires once per process from `AppStartup`).

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveDoorEventsUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveDoorEventsUseCase.kt
@@ -29,25 +29,23 @@ import kotlinx.coroutines.flow.StateFlow
  * Wraps [DoorRepository] flows so ViewModels can depend on this UseCase
  * instead of the repository directly.
  *
- * Per ADR-022 "match the upstream, never wrap": [current] returns
- * [StateFlow] because the repo's `currentDoorEvent` IS a [StateFlow]
- * — passing it through preserves the synchronous `.value` accessor
- * the VM needs to seed its initial loading-result with the cached
- * door event (otherwise the VM exposes `Loading(null)` for one frame
- * on first composition, the door icon maps that to UNKNOWN/MIDWAY,
- * and the next frame's `Complete(actualEvent)` triggers a visible
- * MIDWAY→actual door animation on every fresh screen entry).
- *
- * [recent] and [position] stay [Flow] — `recent` is a Room flow (not
- * a StateFlow upstream) and `position` does `.map.distinctUntilChanged()`
- * (a transformation, not a pass-through).
+ * Per ADR-022 "match the upstream, never wrap":
+ * - [current] and [recent] return [StateFlow] because the repo's
+ *   `currentDoorEvent` and `recentDoorEvents` ARE [StateFlow]s — passing
+ *   them through preserves the synchronous `.value` accessor the VMs
+ *   need to seed initial loading-results with the cached data. Without
+ *   this, VMs expose `Loading(...)` for one frame on first composition,
+ *   the UI renders the loading state, and the next frame triggers a
+ *   visible flicker (door icon MIDWAY→actual, history list empty→full).
+ * - [position] stays [Flow] — does `.map.distinctUntilChanged()` (a
+ *   transformation, not a pass-through).
  */
 class ObserveDoorEventsUseCase(
     private val doorRepository: DoorRepository,
 ) {
     fun current(): StateFlow<DoorEvent?> = doorRepository.currentDoorEvent
 
-    fun recent(): Flow<List<DoorEvent>> = doorRepository.recentDoorEvents
+    fun recent(): StateFlow<List<DoorEvent>> = doorRepository.recentDoorEvents
 
     /** Stream of door position changes — needed by ButtonStateMachine. */
     fun position(): Flow<DoorPosition> = doorRepository.currentDoorPosition

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ComputeButtonHealthDisplayUseCaseTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ComputeButtonHealthDisplayUseCaseTest.kt
@@ -54,7 +54,12 @@ class ComputeButtonHealthDisplayUseCaseTest {
             val repo = TestButtonHealthRepository()
             val clock = TestLiveClock(MutableStateFlow(1_700_000_000L))
 
-            val display = ComputeButtonHealthDisplayUseCase(auth, repo, clock).invoke().first()
+            val display = ComputeButtonHealthDisplayUseCase(
+                auth,
+                repo,
+                clock,
+                applicationScope = backgroundScope,
+            ).invoke().awaitComputed()
 
             assertEquals(ButtonHealthDisplay.Unauthorized, display)
         }
@@ -69,7 +74,12 @@ class ComputeButtonHealthDisplayUseCaseTest {
             )
             val clock = TestLiveClock(MutableStateFlow(now))
 
-            val display = ComputeButtonHealthDisplayUseCase(auth, repo, clock).invoke().first()
+            val display = ComputeButtonHealthDisplayUseCase(
+                auth,
+                repo,
+                clock,
+                applicationScope = backgroundScope,
+            ).invoke().awaitComputed()
 
             assertEquals(ButtonHealthDisplay.Online, display)
         }
@@ -86,11 +96,23 @@ class ComputeButtonHealthDisplayUseCaseTest {
             )
             val clock = TestLiveClock(MutableStateFlow(now))
 
-            val display = ComputeButtonHealthDisplayUseCase(auth, repo, clock).invoke().first()
+            val display = ComputeButtonHealthDisplayUseCase(
+                auth,
+                repo,
+                clock,
+                applicationScope = backgroundScope,
+            ).invoke().awaitComputed()
 
             val offline = assertIs<ButtonHealthDisplay.Offline>(display)
             assertEquals("11 min ago", offline.durationLabel)
         }
+
+    /**
+     * Skip the initial `Loading` value the use case's `stateIn(Eagerly)` seeds
+     * with, and return the first emission from the underlying combine —
+     * which is what production observers actually display.
+     */
+    private suspend fun StateFlow<ButtonHealthDisplay>.awaitComputed(): ButtonHealthDisplay = first { it !is ButtonHealthDisplay.Loading }
 }
 
 // ---- Inline fakes ----

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/HomeViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/HomeViewModelTest.kt
@@ -115,6 +115,7 @@ class HomeViewModelTest {
             authRepository = authRepository,
             buttonHealthRepository = HomeTestNoopButtonHealthRepository(),
             liveClock = liveClock,
+            applicationScope = scope,
         )
         val vm = DefaultHomeViewModel(
             observeDoorEvents = ObserveDoorEventsUseCase(doorRepository),

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RealNetworkButtonHealthRepositoryPropagationTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RealNetworkButtonHealthRepositoryPropagationTest.kt
@@ -128,6 +128,7 @@ class RealNetworkButtonHealthRepositoryPropagationTest {
             authRepository = authRepo,
             buttonHealthRepository = healthRepo,
             liveClock = liveClock,
+            applicationScope = externalScope,
         )
         val doorRepo = FakeDoorRepository()
         val appLogger = FakeAppLoggerRepository()


### PR DESCRIPTION
## Summary

Three flicker sources identified in the route-change audit; this PR addresses the remaining two and rounds out the door-icon fix from #738.

## #2 — Recent door events list briefly empty

`DoorHistoryViewModel._recentDoorEvents` was initialized to `LoadingResult.Loading(emptyList())`. The Composable read the empty list on first composition before the collect lambda fired, so the history list visibly went empty → full on every fresh screen entry.

**Fix:** `NetworkDoorRepository` now exposes `recentDoorEvents` as a `StateFlow` backed by an always-on collector over the Room flow (same pattern as `currentDoorEvent`). Interface, `FakeDoorRepository`, and `ObserveDoorEventsUseCase.recent()` updated accordingly. `DoorHistoryViewModel` seeds `_recentDoorEvents` from `observeDoorEvents.recent().value` at construction.

## #3 — Remote-button pill briefly "Checking…"

`HomeContent` collected `buttonHealthDisplay` via `collectAsStateWithLifecycle(initialValue = ButtonHealthDisplay.Loading)`. On every screen re-entry the `produceState` slot was fresh, so the State held `Loading` until the upstream Flow re-emitted.

**Fix:** `ComputeButtonHealthDisplayUseCase` now exposes a `StateFlow`, `stateIn`'d at `applicationScope` with `SharingStarted.Eagerly`. The upstream sources are all `StateFlow`s + LiveClock ticks (cheap), so keeping the combine running for the lifetime of the process costs nothing meaningful and guarantees subsequent subscribers see the latest computed value immediately. The use case provider is `@Singleton`-scoped — multiple instances would each spin up their own combine, defeating the fix. `ComponentGraphTest` asserts the `@Singleton` identity. `HomeContent` switches to `collectAsStateWithLifecycle()` (StateFlow overload, no `initialValue`).

## #3b (bonus) — Motion-state door re-animation on screen re-entry

`AnimatableGarageDoor.initialPositionFor(OPENING)` used to return `CLOSED_POSITION` (and `CLOSING → OPEN_POSITION`) so the icon animated the full motion on every fresh composition — re-running the open/close animation every time the user navigated back to Home while the server still reported a transient OPENING/CLOSING.

**Fix:** `initialPositionFor` now always equals `targetPositionFor`. The motion animation only fires when `doorPosition` CHANGES during the icon's lifetime. The arrow overlays preserve the "in motion" cue without re-animating. `DOOR_ANIMATION.md` state table + trade-off note updated.

## Correctness checks
- StateFlow + always-on collector mirrors the existing `currentDoorEvent` pattern — no new architectural shape.
- `stateIn(applicationScope, Eagerly)` — applicationScope lives for the app lifetime; Eagerly ensures the combine starts immediately and never stops. `WhileSubscribed` would re-emit `Loading` after the timeout, reintroducing the flicker.
- `ComponentGraphTest` + `@Singleton` entry-point pattern enforces single-instance per the kotlin-inject "must be reachable via abstract val" rule.
- `ComputeButtonHealthDisplayUseCaseTest` gets an `awaitComputed()` helper that skips the initial `Loading` value, since the `stateIn(Eagerly)` seed is now the first emission.
- All other test sites updated for the new `applicationScope` constructor parameter.
- `FakeDoorRepository` updated for the `StateFlow` type change.

## Test plan
- [ ] Cold launch — Home shows actual door state immediately, pill shows actual state immediately.
- [ ] Tap History → tap Home — door icon stays put, pill stays put, no transient.
- [ ] Tap Home → tap History → tap Home — recent events list shows immediately, no empty flash.
- [ ] If door is OPENING/CLOSING when entering Home, icon shows at target with arrow overlay. Animation only fires if state CHANGES while watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)