### PR TITLE
feat(firebase): button-health 1-min pubsub + lastPollAtSeconds on wire/FCM

### DIFF
--- a/FirebaseServer/src/controller/ButtonHealthUpdates.ts
+++ b/FirebaseServer/src/controller/ButtonHealthUpdates.ts
@@ -68,6 +68,6 @@ export async function handleButtonHealthFromPollWrite(buildTimestamp: string): P
   const { didTransition, newRecord } = detectTransition(prior, computed, nowSeconds);
   if (didTransition) {
     await BUTTON_HEALTH_DATABASE.save(buildTimestamp, newRecord);
-    await ButtonHealthFCMService.sendForTransition(buildTimestamp, newRecord);
+    await ButtonHealthFCMService.sendForTransition(buildTimestamp, newRecord, lastPollSeconds);
   }
 }

--- a/FirebaseServer/src/controller/fcm/ButtonHealthFCM.ts
+++ b/FirebaseServer/src/controller/fcm/ButtonHealthFCM.ts
@@ -25,12 +25,20 @@ import { buildTimestampToButtonHealthFcmTopic } from '../../model/ButtonHealthFc
  * never sent over FCM (it's a wire/Android concern only).
  */
 export interface ButtonHealthFCMService {
-  sendForTransition(buildTimestamp: string, record: ButtonHealthRecord): Promise<TopicMessage>;
+  sendForTransition(
+    buildTimestamp: string,
+    record: ButtonHealthRecord,
+    lastPollAtSeconds: number | null,
+  ): Promise<TopicMessage>;
 }
 
 class DefaultButtonHealthFCMService implements ButtonHealthFCMService {
-  async sendForTransition(buildTimestamp: string, record: ButtonHealthRecord): Promise<TopicMessage> {
-    const message = buildTransitionPayload(buildTimestamp, record);
+  async sendForTransition(
+    buildTimestamp: string,
+    record: ButtonHealthRecord,
+    lastPollAtSeconds: number | null,
+  ): Promise<TopicMessage> {
+    const message = buildTransitionPayload(buildTimestamp, record, lastPollAtSeconds);
     console.log('Sending button health FCM', JSON.stringify(message));
     await firebase.messaging().send(message)
       .then((response) => {
@@ -46,7 +54,7 @@ class DefaultButtonHealthFCMService implements ButtonHealthFCMService {
 let _instance: ButtonHealthFCMService = new DefaultButtonHealthFCMService();
 
 export const SERVICE: ButtonHealthFCMService = {
-  sendForTransition: (t, r) => _instance.sendForTransition(t, r),
+  sendForTransition: (t, r, lp) => _instance.sendForTransition(t, r, lp),
 };
 
 /** TEST-ONLY: swap in a fake implementation. */
@@ -59,15 +67,33 @@ export function resetImpl(): void { _instance = new DefaultButtonHealthFCMServic
  * Pure helper — builds the FCM payload for a button health transition.
  * No side effects. Covered by ButtonHealthFCMTest.ts and reused by
  * DefaultButtonHealthFCMService.
+ *
+ * `lastPollAtSeconds` is the unix-seconds timestamp of the most recent
+ * device poll the server had observed at the moment of transition. For
+ * an OFFLINE transition this is "when the device was last seen alive."
+ * For an ONLINE transition this is "the poll that brought it back."
+ * Null only when no poll record exists at all (bootstrap edge).
+ *
+ * FCM data values must be strings — `lastPollAtSeconds` is serialized
+ * to a string when present, omitted entirely when null (mobile parser
+ * treats missing key as null).
  */
-export function buildTransitionPayload(buildTimestamp: string, record: ButtonHealthRecord): TopicMessage {
+export function buildTransitionPayload(
+  buildTimestamp: string,
+  record: ButtonHealthRecord,
+  lastPollAtSeconds: number | null,
+): TopicMessage {
   const message = <TopicMessage>{};
   message.topic = buildTimestampToButtonHealthFcmTopic(buildTimestamp);
-  message.data = {
+  const data: { [k: string]: string } = {
     buttonState: record.state,
     stateChangedAtSeconds: String(record.stateChangedAtSeconds),
     buildTimestamp: buildTimestamp,
   };
+  if (lastPollAtSeconds !== null) {
+    data.lastPollAtSeconds = String(lastPollAtSeconds);
+  }
+  message.data = data;
   message.android = <AndroidConfig>{};
   message.android.collapse_key = 'button_health_update';
   message.android.priority = AndroidMessagePriority.HIGH;

--- a/FirebaseServer/src/functions/http/ButtonHealth.ts
+++ b/FirebaseServer/src/functions/http/ButtonHealth.ts
@@ -12,6 +12,7 @@ import * as functions from 'firebase-functions/v1';
 
 import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
 import { DATABASE as BUTTON_HEALTH_DATABASE } from '../../database/ButtonHealthDatabase';
+import { DATABASE as REMOTE_BUTTON_REQUEST_DATABASE } from '../../database/RemoteButtonRequestDatabase';
 import {
   isRemoteButtonEnabled,
   getRemoteButtonPushKey,
@@ -22,6 +23,7 @@ import { SERVICE as AuthService } from '../../controller/AuthService';
 import { HandlerResult, ok, err } from '../HandlerResult';
 
 const BUILD_TIMESTAMP_PARAM_KEY = 'buildTimestamp';
+const DATABASE_TIMESTAMP_SECONDS_KEY = 'FIRESTORE_databaseTimestampSeconds';
 
 /**
  * Cold-start endpoint for mobile clients. Returns the current health
@@ -79,18 +81,27 @@ export async function handleButtonHealth(input: {
   }
 
   const record = await BUTTON_HEALTH_DATABASE.getCurrent(buildTimestamp);
+  // `lastPollAtSeconds` is computed fresh from the polling history rather
+  // than persisted in `buttonHealthCurrent` — this avoids ~17K Firestore
+  // writes/day to one doc just to keep a freshness counter, at the cost of
+  // one extra Firestore read per cold-start fetch (low frequency).
+  const latestRequest = await REMOTE_BUTTON_REQUEST_DATABASE.getCurrent(buildTimestamp);
+  const lastPollAtSeconds: number | null =
+    latestRequest?.[DATABASE_TIMESTAMP_SECONDS_KEY] ?? null;
   if (!record) {
     // No doc yet — wire returns UNKNOWN per the design's bootstrap behavior.
     return ok({
       buildTimestamp,
       buttonState: 'UNKNOWN',
       stateChangedAtSeconds: null,
+      lastPollAtSeconds,
     });
   }
   return ok({
     buildTimestamp,
     buttonState: record.state,
     stateChangedAtSeconds: record.stateChangedAtSeconds,
+    lastPollAtSeconds,
   });
 }
 

--- a/FirebaseServer/src/functions/pubsub/ButtonHealth.ts
+++ b/FirebaseServer/src/functions/pubsub/ButtonHealth.ts
@@ -21,7 +21,7 @@ import { isRemoteButtonEnabled, getRemoteButtonBuildTimestamp, requireBuildTimes
 const DATABASE_TIMESTAMP_SECONDS_KEY = 'FIRESTORE_databaseTimestampSeconds';
 
 /**
- * Pure handler core for the every-10-min sweep.
+ * Pure handler core for the every-minute sweep.
  *
  * Reads the latest poll record + the prior persisted health state,
  * computes the new state via the same pure function the trigger uses,
@@ -52,12 +52,16 @@ export async function handleCheckButtonHealth(): Promise<void> {
   const { didTransition, newRecord } = detectTransition(prior, computed, nowSeconds);
   if (didTransition) {
     await BUTTON_HEALTH_DATABASE.save(buildTimestamp, newRecord);
-    await ButtonHealthFCMService.sendForTransition(buildTimestamp, newRecord);
+    await ButtonHealthFCMService.sendForTransition(buildTimestamp, newRecord, lastPollSeconds);
   }
 }
 
+// Schedule cadence is the OFFLINE-detection ceiling. Tightened from
+// 10 min to 1 min on 2026-05-10 to bound worst-case OFFLINE-detection
+// latency to ~1 min. Cost: ~1.4K invocations/day (well under free
+// tier). Cannot affect device path. See BUTTON_HEALTH_ARCHITECTURE.md.
 export const pubsubCheckButtonHealth = functions.pubsub
-  .schedule('every 10 minutes').timeZone('America/Los_Angeles')
+  .schedule('every 1 minutes').timeZone('America/Los_Angeles')
   .onRun(async (_context) => {
     await handleCheckButtonHealth();
     return null;

--- a/FirebaseServer/test/controller/ButtonHealthUpdatesTest.ts
+++ b/FirebaseServer/test/controller/ButtonHealthUpdatesTest.ts
@@ -127,6 +127,7 @@ describe('handleButtonHealthFromPollWrite', () => {
     expect(healthDB.saved[0][1].state).to.equal('ONLINE');
     expect(fcm.sends).to.have.length(1);
     expect(fcm.sends[0].record.state).to.equal('ONLINE');
+    expect(fcm.sends[0].lastPollAtSeconds).to.equal(nowSeconds);
   });
 
   it('writes ONLINE + sends FCM on OFFLINE -> ONLINE recovery', async () => {
@@ -143,6 +144,7 @@ describe('handleButtonHealthFromPollWrite', () => {
     expect(healthDB.saved[0][1].state).to.equal('ONLINE');
     expect(fcm.sends).to.have.length(1);
     expect(fcm.sends[0].record.state).to.equal('ONLINE');
+    expect(fcm.sends[0].lastPollAtSeconds).to.equal(nowSeconds);
   });
 
   it('does NOT write or send FCM on ONLINE -> ONLINE no-op', async () => {

--- a/FirebaseServer/test/controller/fcm/ButtonHealthFCMTest.ts
+++ b/FirebaseServer/test/controller/fcm/ButtonHealthFCMTest.ts
@@ -21,12 +21,13 @@ describe('buildTransitionPayload', () => {
       state: 'ONLINE',
       stateChangedAtSeconds: 1_730_000_000,
     };
-    const message = buildTransitionPayload(buildTimestamp, record);
+    const message = buildTransitionPayload(buildTimestamp, record, 1_730_000_500);
     expect(message.topic).to.equal('buttonHealth-Sat.Apr.10.23.57.32.2021');
     expect(message.data).to.deep.equal({
       buttonState: 'ONLINE',
       stateChangedAtSeconds: '1730000000',
       buildTimestamp: 'Sat Apr 10 23:57:32 2021',
+      lastPollAtSeconds: '1730000500',
     });
     expect(message.android.collapse_key).to.equal('button_health_update');
     expect(message.android.priority).to.equal(AndroidMessagePriority.HIGH);
@@ -37,9 +38,10 @@ describe('buildTransitionPayload', () => {
       state: 'OFFLINE',
       stateChangedAtSeconds: 1_730_000_500,
     };
-    const message = buildTransitionPayload(buildTimestamp, record);
+    const message = buildTransitionPayload(buildTimestamp, record, 1_730_000_300);
     expect(message.data.buttonState).to.equal('OFFLINE');
     expect(message.data.stateChangedAtSeconds).to.equal('1730000500');
+    expect(message.data.lastPollAtSeconds).to.equal('1730000300');
   });
 
   it('omits the notification block (data-only by design)', () => {
@@ -47,7 +49,7 @@ describe('buildTransitionPayload', () => {
       state: 'OFFLINE',
       stateChangedAtSeconds: 1_730_000_000,
     };
-    const message = buildTransitionPayload(buildTimestamp, record);
+    const message = buildTransitionPayload(buildTimestamp, record, 1_730_000_000);
     // data-only — must NEVER carry a `notification` block.
     expect(message.notification).to.equal(undefined);
   });
@@ -59,7 +61,7 @@ describe('buildTransitionPayload', () => {
       state: 'ONLINE',
       stateChangedAtSeconds: 1_730_000_000,
     };
-    const message = buildTransitionPayload(buildTimestamp, record);
+    const message = buildTransitionPayload(buildTimestamp, record, 1_730_000_500);
     expect(message.data.buildTimestamp).to.equal(buildTimestamp);
     expect(message.data.buildTimestamp).to.not.equal(message.topic);
   });
@@ -69,8 +71,30 @@ describe('buildTransitionPayload', () => {
       state: 'ONLINE',
       stateChangedAtSeconds: 42,
     };
-    const message = buildTransitionPayload(buildTimestamp, record);
+    const message = buildTransitionPayload(buildTimestamp, record, 99);
     expect(message.data.stateChangedAtSeconds).to.be.a('string');
     expect(message.data.stateChangedAtSeconds).to.equal('42');
+  });
+
+  it('serializes lastPollAtSeconds as a string when present', () => {
+    const record: ButtonHealthRecord = {
+      state: 'ONLINE',
+      stateChangedAtSeconds: 1_730_000_000,
+    };
+    const message = buildTransitionPayload(buildTimestamp, record, 1_730_000_500);
+    expect(message.data.lastPollAtSeconds).to.be.a('string');
+    expect(message.data.lastPollAtSeconds).to.equal('1730000500');
+  });
+
+  it('omits lastPollAtSeconds entirely when null (mobile parser treats missing key as null)', () => {
+    // Bootstrap edge: pubsub flips OFFLINE on a device that has never polled.
+    // No lastPoll exists, so the key is omitted from the payload.
+    const record: ButtonHealthRecord = {
+      state: 'OFFLINE',
+      stateChangedAtSeconds: 1_730_000_000,
+    };
+    const message = buildTransitionPayload(buildTimestamp, record, null);
+    expect(message.data.lastPollAtSeconds).to.equal(undefined);
+    expect(Object.keys(message.data)).to.not.include('lastPollAtSeconds');
   });
 });

--- a/FirebaseServer/test/fakes/FakeButtonHealthFCMService.ts
+++ b/FirebaseServer/test/fakes/FakeButtonHealthFCMService.ts
@@ -14,13 +14,21 @@ import { TopicMessage } from '../../src/model/FCM';
 
 export class FakeButtonHealthFCMService implements ButtonHealthFCMService {
   /** Audit log of all sendForTransition() calls. */
-  readonly sends: Array<{ buildTimestamp: string; record: ButtonHealthRecord }> = [];
+  readonly sends: Array<{
+    buildTimestamp: string;
+    record: ButtonHealthRecord;
+    lastPollAtSeconds: number | null;
+  }> = [];
 
-  async sendForTransition(buildTimestamp: string, record: ButtonHealthRecord): Promise<TopicMessage> {
-    this.sends.push({ buildTimestamp, record });
+  async sendForTransition(
+    buildTimestamp: string,
+    record: ButtonHealthRecord,
+    lastPollAtSeconds: number | null,
+  ): Promise<TopicMessage> {
+    this.sends.push({ buildTimestamp, record, lastPollAtSeconds });
     // Return the same payload the production impl would build, so callers
     // that inspect the return value see realistic data.
-    return buildTransitionPayload(buildTimestamp, record);
+    return buildTransitionPayload(buildTimestamp, record, lastPollAtSeconds);
   }
 
   /** Test-only helper: wipe audit logs. */

--- a/FirebaseServer/test/functions/http/HttpButtonHealthTest.ts
+++ b/FirebaseServer/test/functions/http/HttpButtonHealthTest.ts
@@ -22,11 +22,16 @@ import {
   resetImpl as resetButtonHealthDBImpl,
 } from '../../../src/database/ButtonHealthDatabase';
 import {
+  setImpl as setRemoteButtonRequestDBImpl,
+  resetImpl as resetRemoteButtonRequestDBImpl,
+} from '../../../src/database/RemoteButtonRequestDatabase';
+import {
   setImpl as setAuthServiceImpl,
   resetImpl as resetAuthServiceImpl,
 } from '../../../src/controller/AuthService';
 import { FakeServerConfigDatabase } from '../../fakes/FakeServerConfigDatabase';
 import { FakeButtonHealthDatabase } from '../../fakes/FakeButtonHealthDatabase';
+import { FakeRemoteButtonRequestDatabase } from '../../fakes/FakeRemoteButtonRequestDatabase';
 import { FakeAuthService } from '../../fakes/FakeAuthService';
 
 const ALLOWED_EMAIL = 'allowed@example.com';
@@ -53,18 +58,26 @@ const FORBIDDEN_USER_FIXTURE = JSON.parse(
   fs.readFileSync(path.join(FIXTURE_DIR, 'response_forbidden_user.json'), 'utf8'),
 );
 
+// Pinned for deterministic deep-equal against the wire-contract fixtures.
+const FIXTURE_LAST_POLL_ONLINE = 1730000500;
+const FIXTURE_LAST_POLL_OFFLINE = 1729999700;
+const DATABASE_TIMESTAMP_SECONDS_KEY = 'FIRESTORE_databaseTimestampSeconds';
+
 describe('handleButtonHealth (pure handler core)', () => {
   let fakeConfig: FakeServerConfigDatabase;
   let fakeAuth: FakeAuthService;
   let fakeHealthDB: FakeButtonHealthDatabase;
+  let fakeRequestDB: FakeRemoteButtonRequestDatabase;
 
   beforeEach(() => {
     fakeConfig = new FakeServerConfigDatabase();
     fakeAuth = new FakeAuthService();
     fakeHealthDB = new FakeButtonHealthDatabase();
+    fakeRequestDB = new FakeRemoteButtonRequestDatabase();
     setServerConfigDBImpl(fakeConfig);
     setAuthServiceImpl(fakeAuth);
     setButtonHealthDBImpl(fakeHealthDB);
+    setRemoteButtonRequestDBImpl(fakeRequestDB);
     fakeConfig.seed({
       body: {
         remoteButtonEnabled: true,
@@ -79,6 +92,7 @@ describe('handleButtonHealth (pure handler core)', () => {
     resetServerConfigDBImpl();
     resetAuthServiceImpl();
     resetButtonHealthDBImpl();
+    resetRemoteButtonRequestDBImpl();
   });
 
   const happyInput = (overrides: any = {}) => ({
@@ -159,6 +173,9 @@ describe('handleButtonHealth (pure handler core)', () => {
       state: 'ONLINE',
       stateChangedAtSeconds: 1730000000,
     });
+    fakeRequestDB.seed(BUILD_TIMESTAMP, {
+      [DATABASE_TIMESTAMP_SECONDS_KEY]: FIXTURE_LAST_POLL_ONLINE,
+    });
     const result = await handleButtonHealth(happyInput());
     expect(result).to.deep.equal({ kind: 'ok', data: ONLINE_FIXTURE });
   });
@@ -168,13 +185,53 @@ describe('handleButtonHealth (pure handler core)', () => {
       state: 'OFFLINE',
       stateChangedAtSeconds: 1730000000,
     });
+    fakeRequestDB.seed(BUILD_TIMESTAMP, {
+      [DATABASE_TIMESTAMP_SECONDS_KEY]: FIXTURE_LAST_POLL_OFFLINE,
+    });
     const result = await handleButtonHealth(happyInput());
     expect(result).to.deep.equal({ kind: 'ok', data: OFFLINE_FIXTURE });
   });
 
   it('returns the UNKNOWN fixture when no buttonHealthCurrent doc exists', async () => {
-    // No fakeHealthDB.seed call.
+    // No fakeHealthDB.seed and no fakeRequestDB.seed — neither doc exists.
+    // Both stateChangedAtSeconds and lastPollAtSeconds are null on the wire.
     const result = await handleButtonHealth(happyInput());
     expect(result).to.deep.equal({ kind: 'ok', data: UNKNOWN_FIXTURE });
+  });
+
+  it('reads lastPollAtSeconds from RemoteButtonRequestDatabase, not from the health doc', async () => {
+    // The health doc's stateChangedAtSeconds may be hours old (steady ONLINE);
+    // lastPollAtSeconds reflects the freshest poll the server has seen.
+    const stateChangeTs = 1700000000;
+    const freshPollTs = 1730005000;
+    fakeHealthDB.seed(BUILD_TIMESTAMP, {
+      state: 'ONLINE',
+      stateChangedAtSeconds: stateChangeTs,
+    });
+    fakeRequestDB.seed(BUILD_TIMESTAMP, {
+      [DATABASE_TIMESTAMP_SECONDS_KEY]: freshPollTs,
+    });
+    const result = await handleButtonHealth(happyInput());
+    expect(result).to.deep.equal({
+      kind: 'ok',
+      data: {
+        buildTimestamp: BUILD_TIMESTAMP,
+        buttonState: 'ONLINE',
+        stateChangedAtSeconds: stateChangeTs,
+        lastPollAtSeconds: freshPollTs,
+      },
+    });
+  });
+
+  it('returns lastPollAtSeconds: null when no poll record exists yet (edge: device has never polled)', async () => {
+    fakeHealthDB.seed(BUILD_TIMESTAMP, {
+      state: 'OFFLINE',
+      stateChangedAtSeconds: 1730000000,
+    });
+    // No requestDB.seed — RemoteButtonRequestDatabase.getCurrent returns null.
+    const result = await handleButtonHealth(happyInput());
+    expect(result.kind).to.equal('ok');
+    if (result.kind !== 'ok') return;
+    expect(result.data.lastPollAtSeconds).to.equal(null);
   });
 });

--- a/FirebaseServer/test/functions/pubsub/ButtonHealthTest.ts
+++ b/FirebaseServer/test/functions/pubsub/ButtonHealthTest.ts
@@ -101,6 +101,9 @@ describe('handleCheckButtonHealth (pubsub state-machine rows 1:1)', () => {
     expect(healthDB.saved[0][1].state).to.equal('OFFLINE');
     expect(fcm.sends).to.have.length(1);
     expect(fcm.sends[0].record.state).to.equal('OFFLINE');
+    // lastPollAtSeconds carries the timestamp of the last (now-stale) poll —
+    // exactly what the OFFLINE label wants ("last seen 2 min ago").
+    expect(fcm.sends[0].lastPollAtSeconds).to.equal(now - 120);
   });
 
   it('row 3: pubsub no poll record + no prior buttonHealth doc -> OFFLINE + FCM', async () => {
@@ -111,6 +114,8 @@ describe('handleCheckButtonHealth (pubsub state-machine rows 1:1)', () => {
     expect(healthDB.saved[0][1].state).to.equal('OFFLINE');
     expect(fcm.sends).to.have.length(1);
     expect(fcm.sends[0].record.state).to.equal('OFFLINE');
+    // No poll record exists — lastPollAtSeconds is null.
+    expect(fcm.sends[0].lastPollAtSeconds).to.equal(null);
   });
 
   // Additional coverage beyond the table — kill switch and bootstrap edges.
@@ -137,6 +142,7 @@ describe('handleCheckButtonHealth (pubsub state-machine rows 1:1)', () => {
     expect(healthDB.saved[0][1].state).to.equal('ONLINE');
     expect(fcm.sends).to.have.length(1);
     expect(fcm.sends[0].record.state).to.equal('ONLINE');
+    expect(fcm.sends[0].lastPollAtSeconds).to.equal(now - 10);
   });
 
   it('OFFLINE -> ONLINE recovery (the pubsub-side fallback for missed trigger)', async () => {
@@ -150,6 +156,7 @@ describe('handleCheckButtonHealth (pubsub state-machine rows 1:1)', () => {
     expect(healthDB.saved[0][1].state).to.equal('ONLINE');
     expect(fcm.sends).to.have.length(1);
     expect(fcm.sends[0].record.state).to.equal('ONLINE');
+    expect(fcm.sends[0].lastPollAtSeconds).to.equal(now - 10);
   });
 
   it('preserves stateChangedAtSeconds on no-op writes (OFFLINE -> OFFLINE)', async () => {

--- a/docs/BUTTON_HEALTH_ARCHITECTURE.md
+++ b/docs/BUTTON_HEALTH_ARCHITECTURE.md
@@ -32,10 +32,10 @@ One constant: `ONLINE_THRESHOLD_SEC = 60`.
 | Trigger source | Condition | New persisted state | FCM |
 |---|---|---|---|
 | Firestore trigger (poll arrived) | always | `ONLINE` | only on transition |
-| Pubsub (every 10 min) | last poll ≤ 60 sec ago | `ONLINE` | only on transition |
-| Pubsub (every 10 min) | last poll > 60 sec ago OR no poll record | `OFFLINE` | only on transition |
+| Pubsub (every 1 min) | last poll ≤ 60 sec ago | `ONLINE` | only on transition |
+| Pubsub (every 1 min) | last poll > 60 sec ago OR no poll record | `OFFLINE` | only on transition |
 
-No-op writes (state unchanged) MUST NOT bump `stateChangedAtSeconds` and MUST NOT send FCM. Worst-case `OFFLINE`-detection latency: ~10 min. Trigger-side recovery is sub-second.
+No-op writes (state unchanged) MUST NOT bump `stateChangedAtSeconds` and MUST NOT send FCM. Worst-case `OFFLINE`-detection latency: ~1 min (tightened from 10 min on 2026-05-10). Trigger-side recovery is sub-second.
 
 ## Why a Firestore trigger, not an HTTP-handler modification
 
@@ -106,12 +106,14 @@ export function buildTimestampToButtonHealthFcmTopic(buildTimestamp: string): st
 NEW directory `wire-contracts/buttonHealth/`:
 
 ```
-response_online.json         { buttonState: "ONLINE",  stateChangedAtSeconds: <n>,    buildTimestamp: "..." }
-response_offline.json        { buttonState: "OFFLINE", stateChangedAtSeconds: <n>,    buildTimestamp: "..." }
-response_unknown.json        { buttonState: "UNKNOWN", stateChangedAtSeconds: null,   buildTimestamp: "..." }
+response_online.json         { buttonState: "ONLINE",  stateChangedAtSeconds: <n>,    buildTimestamp: "...", lastPollAtSeconds: <n> }
+response_offline.json        { buttonState: "OFFLINE", stateChangedAtSeconds: <n>,    buildTimestamp: "...", lastPollAtSeconds: <n> }
+response_unknown.json        { buttonState: "UNKNOWN", stateChangedAtSeconds: null,   buildTimestamp: "...", lastPollAtSeconds: null }
 response_unauthorized.json   401
 response_forbidden_user.json 403
 ```
+
+`lastPollAtSeconds` is the unix-seconds timestamp of the most recent device poll the server had observed when the response was assembled. Computed fresh from `RemoteButtonRequestDatabase.getCurrent()` rather than persisted in `buttonHealthCurrent` — avoids ~17K writes/day to one doc just to keep a freshness counter, at the cost of one extra Firestore read per cold-start fetch (negligible).
 
 `UNKNOWN` only appears on the wire when the server has no doc for that `buildTimestamp` (cold-start before first poll seen). Android side: `KtorButtonHealthDataSourceTest` (in `data/src/commonTest/.../buttonhealth/`) loads these in strict mode (`ignoreUnknownKeys = false`); production decode stays `ignoreUnknownKeys = true`. Mocha-side test loads the same fixtures for `httpButtonHealth`.
 
@@ -123,13 +125,14 @@ response_forbidden_user.json 403
   "data": {
     "buttonState": "ONLINE" | "OFFLINE",
     "stateChangedAtSeconds": "<epoch-seconds>",
-    "buildTimestamp": "<original-buildTimestamp>"
+    "buildTimestamp": "<original-buildTimestamp>",
+    "lastPollAtSeconds": "<epoch-seconds>"
   },
   "android": { "priority": "HIGH", "collapse_key": "button_health_update" }
 }
 ```
 
-`UNKNOWN` is never sent over FCM.
+`UNKNOWN` is never sent over FCM. `lastPollAtSeconds` is omitted from the data payload when null (bootstrap edge: device has never polled, but pubsub flipped to OFFLINE anyway). Mobile parser treats missing key as null.
 
 ### Pubsub test convention
 

--- a/wire-contracts/buttonHealth/response_offline.json
+++ b/wire-contracts/buttonHealth/response_offline.json
@@ -1,1 +1,1 @@
-{"buildTimestamp":"Sat Apr 10 23:57:32 2021","buttonState":"OFFLINE","stateChangedAtSeconds":1730000000}
+{"buildTimestamp":"Sat Apr 10 23:57:32 2021","buttonState":"OFFLINE","stateChangedAtSeconds":1730000000,"lastPollAtSeconds":1729999700}

--- a/wire-contracts/buttonHealth/response_online.json
+++ b/wire-contracts/buttonHealth/response_online.json
@@ -1,1 +1,1 @@
-{"buildTimestamp":"Sat Apr 10 23:57:32 2021","buttonState":"ONLINE","stateChangedAtSeconds":1730000000}
+{"buildTimestamp":"Sat Apr 10 23:57:32 2021","buttonState":"ONLINE","stateChangedAtSeconds":1730000000,"lastPollAtSeconds":1730000500}

--- a/wire-contracts/buttonHealth/response_unknown.json
+++ b/wire-contracts/buttonHealth/response_unknown.json
@@ -1,1 +1,1 @@
-{"buildTimestamp":"Sat Apr 10 23:57:32 2021","buttonState":"UNKNOWN","stateChangedAtSeconds":null}
+{"buildTimestamp":"Sat Apr 10 23:57:32 2021","buttonState":"UNKNOWN","stateChangedAtSeconds":null,"lastPollAtSeconds":null}


### PR DESCRIPTION
## Summary

Two changes to the button-health feature, both server-only:

1. **Pubsub schedule: every 10 min → every 1 min.** Worst-case OFFLINE-detection latency drops from ~10 min to ~1 min. Cost: ~1.4K invocations/day (well under free tier). Cannot affect device path — runs after the device's HTTP response is on the wire.

2. **`lastPollAtSeconds: number | null` added to wire response and FCM payload.** Computed fresh from \`RemoteButtonRequestDatabase\`, NOT denormalized into \`buttonHealthCurrent\` (avoids ~17K writes/day per poll). Mobile parser doesn't consume the field yet — that's a follow-up PR. Production decode is \`ignoreUnknownKeys = true\` so old clients ignore it silently.

## Why transition-only FCM (not heartbeat)

Three-agent review of "every minute heartbeat FCM" vs "transition-only FCM" converged on transition-only. Heartbeats wake the app process every minute (~1440 wake-ups/day = noticeable battery drain) for marginal UX gain on a single-device personal app. The user explicitly chose this option after the review.

## Mobile-side follow-up (separate PR)

\`lastPollAtSeconds\` will be used to improve the OFFLINE pill label from "Remote offline · {since stateChange}" to "Remote offline · last seen {since lastPoll}." Tiny code change in \`ButtonHealthDurationFormatter\`. ONLINE pill semantics unchanged — the user-stated reasoning ("no state change means things are still good") makes timestamp display redundant in steady-state.

## Test plan

- [x] All 302 Firebase tests pass (\`./scripts/validate-firebase.sh\`)
- [x] New tests pin \`lastPollAtSeconds\` carries through every transition (trigger + pubsub paths)
- [x] New tests pin "fresh poll vs stale state-change ts" semantics on the HTTP endpoint
- [x] Wire-contract fixtures updated; HTTP test deep-equals against them
- [x] Bootstrap edge (no poll record) returns null on wire and omits key from FCM payload
- [ ] Smoke-test on production Cloud Logs after deploy: pubsub fires every minute, transition FCMs include \`lastPollAtSeconds\`
- [ ] Smoke-test: unplug ESP32, verify OFFLINE detected within ~1 min (was ~10 min)

## Architecture doc

\`docs/BUTTON_HEALTH_ARCHITECTURE.md\` updated: state-machine table cadence, wire-contract section (new field + source-of-truth note), FCM payload section (omit-when-null rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)