### PR TITLE
ui(android): Edge-to-edge content via WindowInsets propagation

### DIFF
--- a/AndroidGarage/android-screenshot-tests/SCREENSHOT_GALLERY.md
+++ b/AndroidGarage/android-screenshot-tests/SCREENSHOT_GALLERY.md
@@ -2,7 +2,7 @@
 
 # Screenshot Gallery
 
-Generated on Sun May 10 08:50:34 PDT 2026
+Generated on Sun May 10 10:37:25 PDT 2026
 
 ## Table of Contents
 - [ComponentsScreenshotTestKt](#componentsscreenshottestkt)

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/FunctionListContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/FunctionListContent.kt
@@ -38,6 +38,7 @@ import com.chriscartland.garage.auth.rememberGoogleSignIn
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.ui.theme.PreviewScreenSurface
 import com.chriscartland.garage.ui.theme.Spacing
+import com.chriscartland.garage.ui.theme.safeListContentPadding
 import com.chriscartland.garage.usecase.FunctionListViewModel
 
 @Composable
@@ -90,7 +91,7 @@ fun FunctionListContent(
     if (accessGranted == true) {
         LazyColumn(
             modifier = modifier,
-            contentPadding = Spacing.ListContentPadding,
+            contentPadding = safeListContentPadding(),
             verticalArrangement = Arrangement.spacedBy(Spacing.BetweenItems),
         ) {
             item { FunctionListWarning() }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -244,20 +244,36 @@ fun AppNavigation() {
                 },
             )
         }
+        // Edge-to-edge inset propagation contract (see CLAUDE.md):
+        //   * Outer body container consumes ONLY what it structurally
+        //     handles (top inset for the TopAppBar; in Compact mode also
+        //     the bottom inset for the bottomBar).
+        //   * The bottom inset in Rail/None modes deliberately flows
+        //     through to scrollable leaves, which read it via
+        //     `Spacing.safeListContentPadding()` and apply it as
+        //     `contentPadding` so the last item can scroll past the
+        //     gesture nav into the safe area.
+        //   * Horizontal cutout insets are owned by the route wrappers
+        //     (`RouteContent` / `DashboardRouteContent` /
+        //     `ThreePaneRouteContent`) via `windowInsetsPadding(safeDrawing.only(Horizontal))`,
+        //     which both pads visibly AND consumes for descendants.
         when (mode.navPlacement) {
             AppLayoutMode.NavPlacement.Rail -> {
-                // Rail is a sibling of NavDisplay inside a Row. The Row gets
-                // Scaffold's innerPadding (top from TopAppBar; bottom from
-                // contentWindowInsets default since there's no bottomBar).
+                // Rail is a sibling of NavDisplay inside a Row. The Row
+                // pads visibly by the top inset (TopAppBar height) AND
+                // consumes that inset so descendants reading
+                // `WindowInsets.safeDrawing` see top = 0. Bottom is
+                // intentionally NOT consumed — flows to scrollable leaves.
                 //
-                // Inset division for the start (cutout / start gesture):
-                //   * The rail's items are pushed inward via NavigationRail's
-                //     `windowInsets = safeDrawing.only(Start)`.
-                //   * The content sibling declares `consumeWindowInsets(start)`
-                //     so RouteContent's `safeDrawing.only(Horizontal)` reading
-                //     transparently shrinks to "end side only" — no double
-                //     padding on the start side.
-                Row(modifier = Modifier.padding(innerPadding)) {
+                // Start cutout inset is consumed by NavigationRail's own
+                // `windowInsets` parameter + the content sibling's
+                // `consumeWindowInsets(start)` below.
+                val topInset = innerPadding.calculateTopPadding()
+                Row(
+                    modifier = Modifier
+                        .padding(top = topInset)
+                        .consumeWindowInsets(WindowInsets(top = topInset)),
+                ) {
                     NavigationRailLeft(
                         currentScreen = backStack.lastOrNull() as? Screen,
                         onTabSelected = { screen -> TabNavigation.navigateToTab(backStack, screen) },
@@ -269,19 +285,37 @@ fun AppNavigation() {
                             .fillMaxHeight()
                             .consumeWindowInsets(WindowInsets.safeDrawing.only(WindowInsetsSides.Start)),
                     ) {
-                        // Content stays at its natural body-region top.
-                        // The rail's items are vertically centered (see
-                        // [NavigationRailLeft]), so there is no visual
-                        // icon-vs-content alignment to maintain — they
-                        // sit in different vertical zones intentionally.
+                        // Content extends edge-to-edge to the body's
+                        // bottom (no bottom padding here). Rail items
+                        // are vertically centered (see [NavigationRailLeft]).
                         navDisplay(Modifier.fillMaxSize())
                     }
                 }
             }
-            AppLayoutMode.NavPlacement.Bottom,
-            AppLayoutMode.NavPlacement.None,
-            -> {
-                navDisplay(Modifier.padding(innerPadding))
+            AppLayoutMode.NavPlacement.None -> {
+                // No bottom chrome — same edge-to-edge treatment as Rail
+                // for the body's bottom inset.
+                val topInset = innerPadding.calculateTopPadding()
+                navDisplay(
+                    Modifier
+                        .fillMaxSize()
+                        .padding(top = topInset)
+                        .consumeWindowInsets(WindowInsets(top = topInset)),
+                )
+            }
+            AppLayoutMode.NavPlacement.Bottom -> {
+                // Compact mode has a bottomBar that occupies the bottom
+                // safe-drawing inset. Body padding consumes the full
+                // innerPadding (top + bottom), so descendants reading
+                // `WindowInsets.safeDrawing` see both as 0 — chrome
+                // clearance lives entirely in the bottomBar / topBar,
+                // and `Spacing.safeListContentPadding()` reduces to the
+                // legacy 8/24dp values for screen-level scrollables.
+                navDisplay(
+                    Modifier
+                        .padding(innerPadding)
+                        .consumeWindowInsets(innerPadding),
+                )
             }
         }
     }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryContent.kt
@@ -56,6 +56,7 @@ import com.chriscartland.garage.ui.theme.ParagraphSpacing
 import com.chriscartland.garage.ui.theme.Spacing
 import com.chriscartland.garage.ui.theme.doorColorSet
 import com.chriscartland.garage.ui.theme.doorColorState
+import com.chriscartland.garage.ui.theme.safeListContentPadding
 
 /**
  * One entry in the history list.
@@ -149,7 +150,7 @@ fun HistoryContent(
     ) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
-            contentPadding = Spacing.ListContentPadding,
+            contentPadding = safeListContentPadding(),
             verticalArrangement = Arrangement.spacedBy(Spacing.BetweenItems),
         ) {
             if (days.isEmpty()) {

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
@@ -76,6 +76,7 @@ import com.chriscartland.garage.ui.theme.PreviewScreenSurface
 import com.chriscartland.garage.ui.theme.Spacing
 import com.chriscartland.garage.ui.theme.doorColorSet
 import com.chriscartland.garage.ui.theme.doorColorState
+import com.chriscartland.garage.ui.theme.safeListContentPadding
 import com.chriscartland.garage.usecase.ButtonHealthDisplay
 
 /**
@@ -184,7 +185,7 @@ fun HomeContent(
     ) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
-            contentPadding = Spacing.ListContentPadding,
+            contentPadding = safeListContentPadding(),
             verticalArrangement = Arrangement.spacedBy(Spacing.BetweenItems),
         ) {
             if (alerts.isNotEmpty()) {

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
@@ -58,6 +58,7 @@ import com.chriscartland.garage.ui.theme.AppAnimatedVisibility
 import com.chriscartland.garage.ui.theme.DividerInset
 import com.chriscartland.garage.ui.theme.PreviewScreenSurface
 import com.chriscartland.garage.ui.theme.Spacing
+import com.chriscartland.garage.ui.theme.safeListContentPadding
 
 /**
  * Account section row state. Determines whether the row shows a sign-in
@@ -116,7 +117,7 @@ fun SettingsContent(
 ) {
     LazyColumn(
         modifier = modifier.fillMaxSize(),
-        contentPadding = Spacing.ListContentPadding,
+        contentPadding = safeListContentPadding(),
         verticalArrangement = Arrangement.spacedBy(Spacing.BetweenItems),
     ) {
         item {

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/theme/Spacing.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/theme/Spacing.kt
@@ -18,6 +18,13 @@
 package com.chriscartland.garage.ui.theme
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
 
 /**
@@ -92,6 +99,48 @@ object Spacing {
      * LazyColumn, so the chrome clearance is owned by the wrapper Column).
      */
     val ListContentPadding = PaddingValues(top = 8.dp, bottom = 24.dp)
+}
+
+/**
+ * Edge-to-edge `contentPadding` for screen-level scrollables.
+ *
+ * Combines the existing [Spacing.ListContentPadding] visual chrome
+ * clearance (8dp top, 24dp bottom) with [WindowInsets.safeDrawing] —
+ * the system-level safe area (gesture nav, status bar, display cutout,
+ * IME). The scrollable's content drawing area extends edge-to-edge,
+ * but the **scrollable padding** keeps the first/last items reachable
+ * in the unobstructed region (last item can scroll up past the gesture
+ * nav, first can scroll down past the topAppBar).
+ *
+ * **Inset-propagation contract** (see CLAUDE.md):
+ *  * Outer layout (Scaffold body, route wrapper) consumes whatever it
+ *    structurally handles via `Modifier.consumeWindowInsets(...)` or
+ *    `Modifier.windowInsetsPadding(...)`.
+ *  * This helper reads `WindowInsets.safeDrawing` AFTER that consumption,
+ *    so values reflect only what's still occluded by the system.
+ *  * In Compact mode (bottom bar), the body container consumes the bottom
+ *    inset — `safeDrawing.bottom` here is 0, the helper returns the same
+ *    8/24dp values as the legacy [Spacing.ListContentPadding].
+ *  * In Wide / Expanded modes (no bottom bar), nothing consumes the
+ *    bottom inset — `safeDrawing.bottom` here equals the gesture nav
+ *    height, the helper adds it to the 24dp bottom clearance, and the
+ *    last item can scroll past the gesture nav into the safe area.
+ *
+ * Composables call this instead of [Spacing.ListContentPadding] when
+ * the scrollable's bottom edge reaches the body's bottom edge (i.e.
+ * any screen-level scrollable that isn't followed by an action row or
+ * footer Composable).
+ */
+@Composable
+fun safeListContentPadding(): PaddingValues {
+    val safe = WindowInsets.safeDrawing.asPaddingValues()
+    val layoutDirection = LocalLayoutDirection.current
+    return PaddingValues(
+        start = safe.calculateStartPadding(layoutDirection),
+        end = safe.calculateEndPadding(layoutDirection),
+        top = safe.calculateTopPadding() + 8.dp,
+        bottom = safe.calculateBottomPadding() + 24.dp,
+    )
 }
 
 /**


### PR DESCRIPTION
## Summary

Wide / Expanded modes (no bottomBar) had a harsh content cutoff at the gesture-nav line. This PR ships proper edge-to-edge: content draws through to the viewport bottom, scrollable leaves get the bottom inset as `contentPadding` so the last item can scroll past the gesture nav into the safe area.

## Inset-propagation contract

Each layer of layout consumes only what it structurally handles. Leaves read `WindowInsets.safeDrawing` and get whatever's left.

| Inset side | Consumed by | Read by |
|---|---|---|
| Top | Scaffold body wrapper (in every mode) | nobody downstream |
| Horizontal cutout | Route wrappers (`RouteContent` etc.) | nobody downstream |
| Start (rail mode) | `NavigationRail.windowInsets` + content sibling `consumeWindowInsets` | nobody downstream |
| **Bottom (Rail / None)** | **NOBODY upstream** | **scrollable leaves** via `safeListContentPadding()` |
| Bottom (Compact) | Body wrapper consumes innerPadding (which already includes bottomBar height) | leaves see `safeDrawing.bottom = 0` — same legacy 8/24dp values |

## Changes

- **`Spacing.kt`** — new `@Composable fun safeListContentPadding()` helper. Combines the existing 8/24dp chrome clearance with `WindowInsets.safeDrawing` via `asPaddingValues()`. One-liner per scrollable, mode-agnostic.
- **`Main.kt`** — Scaffold body wrapper per `navPlacement`:
  - Rail / None: pad + consume top inset only
  - Compact (Bottom): pad + consume full innerPadding
  - All branches use \`Modifier.consumeWindowInsets(...)\` paired with the visible padding so descendants reading `safeDrawing` see the right reduced value.
- **Four screen-level LazyColumns** — `HomeContent`, `HistoryContent`, `SettingsContent`, `FunctionListContent` — switched from `Spacing.ListContentPadding` to `safeListContentPadding()`. Bottom-sheet vertical scrolls are unaffected (modal overlays handle their own insets).
- Screenshot reference PNGs unchanged (previews have no system insets — the change is invisible in Layoutlib but works on real device).

## Test plan

- [x] `./scripts/validate.sh`
- [x] `./scripts/generate-android-screenshots.sh` — 208 healthy, no diffs
- [ ] Manual: rotate Pixel 9 Pro to landscape (rail mode). Scroll Home or History up — last item should now scroll past the gesture nav into the visible area, no harsh cutoff.
- [ ] Manual: portrait (Compact). Behavior should be unchanged — bottomBar covers the bottom, items scroll under it as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)