### PR TITLE
docs: 2.16.13 top-padding fix smoke item

### DIFF
--- a/AndroidGarage/docs/PENDING_SMOKE_TESTS.md
+++ b/AndroidGarage/docs/PENDING_SMOKE_TESTS.md
@@ -19,7 +19,7 @@ User-facing changes that have shipped to the **internal Play Store track** but n
 
 **Why this lives in the repo, not memory:** the smoke queue is project-specific TODO state. Agents should not write it to memory (see `feedback_dump_context_repo_first.md`); the user maintains it across sessions and across machines.
 
-## Cumulative queue (9 items, last updated 2026-05-10 after `android/226` / 2.16.12)
+## Cumulative queue (10 items, last updated 2026-05-10 after `android/227` / 2.16.13)
 
 Recommend testing all of these in one device session — most can be exercised in a few minutes by rotating, tapping, and watching the network log.
 
@@ -32,6 +32,7 @@ Recommend testing all of these in one device session — most can be exercised i
 7. **Navigation rail in Wide mode (2.16.10 / `android/224`)** — rotate Pixel 9 Pro to landscape (~916dp): bottom bar disappears, `NavigationRail` appears on the start edge with Home + Settings tabs, Home highlighted. Tap Settings: rail item highlights, content swaps. Rotate back to portrait: rail disappears, bottom bar returns. Verify on a hole-punch phone in landscape: no double-padding on the rail-side cutout (rail items shifted inward, content not padded again).
 8. **Rail items vertically centered (2.16.11 / `android/225`)** — in landscape, the Home + Settings rail items should sit at the rail's vertical midpoint, not at the top. The bottom-bar version (Compact / portrait) is unaffected and still shows tabs anchored at the bottom.
 9. **Edge-to-edge content (2.16.12 / `android/226`)** — landscape (Wide mode, no bottom bar). Open Home or History; scroll the list **all the way to the bottom**. The last item should be reachable in the unobstructed area above the gesture nav (no harsh cutoff). Mid-scroll, items should draw under the gesture nav (visible-but-unsafe area). Portrait (Compact) should be unchanged — bottom bar covers the bottom, items scroll under it as before. **This is a verification-gap item — Compose previews render with zero system insets, so the bug only appeared after release.** Going forward, screenshot fixtures with simulated insets should be added so the next change of this kind catches at PR time. See `feedback_verify_before_release.md`.
+10. **Top-padding regression fix (2.16.13 / `android/227`)** — portrait phone (Compact mode). The space above the first item on Home, History, Settings, and Function list should match pre-2.16.12 builds (~88dp = topBar + 8dp content padding). Specifically: 2.16.12 added ~24dp of unwanted top padding above the STATUS label / first list item; 2.16.13 removes it. Side-by-side comparison: install 2.16.13 over 2.16.12 and confirm the top space tightened back to expected. Bottom should be unchanged from 2.16.12. **Same verification gap as item #9** — fixed via a new `LocalContentEdgeInsets` CompositionLocal that decouples leaf padding math from raw `WindowInsets.safeDrawing` (which is NOT consumption-aware and was being double-counted). The recommended-B follow-up (lint flagging the anti-pattern + an inset canary fixture) would have caught both this regression AND the original 2.16.12 bug at PR time.
 
 ## Open follow-ups (release-related but not smoke-test items)
 


### PR DESCRIPTION
## Summary

Adds smoke item #10 to \`AndroidGarage/docs/PENDING_SMOKE_TESTS.md\` for the 2.16.13 top-padding regression fix (#763 → \`android/227\`).

## Test plan

- [x] Doc-only fast path

🤖 Generated with [Claude Code](https://claude.com/claude-code)