### PR TITLE
fix(android): Diagnostics action buttons respect bottom inset (+ bump 2.16.15)

### DIFF
--- a/AndroidGarage/CHANGELOG.md
+++ b/AndroidGarage/CHANGELOG.md
@@ -15,6 +15,9 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
 
+## 2.16.15
+- **Fix: Diagnostics action buttons (Export CSV / Clear all) now respect the bottom inset.** In Wide / Expanded modes (landscape phones, foldables in landscape, tablets) the action buttons at the bottom of the Diagnostics screen previously sat under the gesture nav because the action Column only added 16dp visual chrome clearance — no system-inset awareness. Compact mode was unaffected (bottomBar already covers the gesture-nav region). Fix: action Column now wraps with `Modifier.windowInsetsPadding(LocalContentEdgeInsets.current)`, picking up the bottom edge inset that the body wrapper publishes per layout mode (zero in Compact, gesture-nav in Wide/None). The new `checkNoRawSafeDrawingPaddingValues` lint and `SafeListContentPaddingCanaryPreview` from 2.16.14 don't catch this class (they target LazyColumn `contentPadding` reads, not action-row Modifiers); the action-row pattern is rare enough in the codebase that the manual check during this audit was cheaper than another lint.
+
 ## 2.16.14
 - **Internal: PR-time guardrails against the inset-bridge regression class.** Two pieces of dev infrastructure (no user-visible change in this release):
   - **Lint:** `checkNoRawSafeDrawingPaddingValues` (in `validate.sh`) forbids direct `WindowInsets.<x>.asPaddingValues()` reads in app code outside `Spacing.kt`. That's the literal anti-pattern that broke 2.16.12 (the helper was non-consumption-aware and double-padded the status bar). The `safeListContentPadding()` helper + `LocalContentEdgeInsets` bridge are the sanctioned alternatives.

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/DiagnosticsContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/DiagnosticsContent.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Download
@@ -61,6 +62,7 @@ import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.ui.theme.ButtonSpacing
 import com.chriscartland.garage.ui.theme.CardPadding
 import com.chriscartland.garage.ui.theme.DividerInset
+import com.chriscartland.garage.ui.theme.LocalContentEdgeInsets
 import com.chriscartland.garage.ui.theme.PreviewScreenSurface
 import com.chriscartland.garage.ui.theme.Spacing
 import com.chriscartland.garage.usecase.DiagnosticsViewModel
@@ -195,9 +197,17 @@ fun DiagnosticsContent(
         // and bottom screen padding move from per-button modifiers to the
         // Column wrapper so the rule "single source of horizontal layout"
         // holds inside this section too.
+        //
+        // `windowInsetsPadding(LocalContentEdgeInsets.current)` adds the
+        // propagated bottom edge inset (zero in Compact since the bottomBar
+        // covers the gesture nav; gesture-nav height in Wide / None where
+        // there's no bottomBar). Without it, in Wide / Expanded modes the
+        // action buttons sit under the gesture nav. The 16dp `vertical`
+        // padding inside is the visual chrome clearance ABOVE the inset.
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .windowInsetsPadding(LocalContentEdgeInsets.current)
                 .padding(horizontal = Spacing.Screen)
                 .padding(vertical = Spacing.ListVertical),
             verticalArrangement = Arrangement.spacedBy(ButtonSpacing.Stacked),

--- a/AndroidGarage/version.properties
+++ b/AndroidGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.16.14
+versionName=2.16.15


### PR DESCRIPTION
## Summary

The action button Column at the bottom of the Diagnostics screen (Export CSV / Clear all) only added 16dp visual chrome clearance — no system-inset awareness. In Wide / Expanded modes (landscape phones, foldables in landscape, tablets) the buttons sit under the gesture nav. Compact mode is unaffected.

The LazyColumn above is fine (not at body's bottom edge). The action Column is the one at the body's bottom edge that needed inset awareness — and the Spacing.kt doc for \`ListContentPadding\` explicitly called out Diagnostics as the example "chrome clearance owned by the wrapper Column," but the wrapper never gained inset awareness when 2.16.12/2.16.13 added the bridge.

## Fix (one-liner + 2 imports)

\`Modifier.windowInsetsPadding(LocalContentEdgeInsets.current)\` on the action Column. Adds the propagated bottom edge inset (zero in Compact, gesture-nav in Wide/None). The existing 16dp \`vertical\` padding INSIDE remains the visual chrome clearance ABOVE the inset.

Bundling the version bump (2.16.14 → 2.16.15) + CHANGELOG entry in the same PR since the change is small.

## Why the new lint didn't catch it

\`checkNoRawSafeDrawingPaddingValues\` (2.16.14) targets LazyColumn \`contentPadding\` reads — \`WindowInsets.<x>.asPaddingValues()\`. The Diagnostics bug was the action Column missing a \`windowInsetsPadding\` modifier entirely, not a wrong inset read. The action-row pattern is rare enough in the codebase (only Diagnostics has one) that the manual audit during the inset check was cheaper than another lint.

## Test plan

- [x] \`./scripts/validate.sh\`
- [ ] Manual: rotate Pixel 9 Pro to landscape (Wide). Open Settings → Diagnostics. Action buttons (Export CSV / Clear all) should sit ABOVE the gesture nav, not under it.
- [ ] Manual: portrait (Compact). Buttons unchanged — 16dp above the bottomBar as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)