### PR TITLE
feat(android): Gate Settings → Developer on dedicated developerAccess allowlist

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
@@ -85,6 +85,7 @@ fun ProfileContent(
     val snoozeState by resolved.snoozeState.collectAsState()
     val snoozeAction by resolved.snoozeAction.collectAsState()
     val functionListAccess by resolved.functionListAccess.collectAsState()
+    val developerAccess by resolved.developerAccess.collectAsState()
     val layoutDebugEnabled by resolved.layoutDebugEnabled.collectAsState()
     val appConfig = component.appConfig
     val context = LocalContext.current
@@ -130,7 +131,8 @@ fun ProfileContent(
         accountState = accountState,
         snoozeState = snoozeRowState,
         showSnoozeRow = appConfig.snoozeNotificationsOption,
-        showDeveloperSection = functionListAccess == true,
+        showDeveloperSection = developerAccess == true,
+        showFunctionListRow = functionListAccess == true,
         versionName = appVersion.versionName,
         versionCode = appVersion.versionCode.toString(),
         layoutDebugEnabled = layoutDebugEnabled,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/TabPreviews.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/TabPreviews.kt
@@ -342,6 +342,7 @@ fun SettingsTabPreview() {
             snoozeState = SnoozeRowState.SnoozingUntil("5:30 PM"),
             showSnoozeRow = true,
             showDeveloperSection = true,
+            showFunctionListRow = true,
             versionName = "2.7.1",
             versionCode = "184",
             layoutDebugEnabled = false,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ThreePaneDashboardPreviews.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ThreePaneDashboardPreviews.kt
@@ -179,6 +179,7 @@ private fun SettingsPaneBody(modifier: Modifier) {
         snoozeState = SnoozeRowState.Off,
         showSnoozeRow = true,
         showDeveloperSection = false,
+        showFunctionListRow = false,
         versionName = "2.15.3",
         versionCode = "213",
         layoutDebugEnabled = false,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
@@ -104,6 +104,7 @@ fun SettingsContent(
     snoozeState: SnoozeRowState,
     showSnoozeRow: Boolean,
     showDeveloperSection: Boolean,
+    showFunctionListRow: Boolean,
     versionName: String,
     versionCode: String,
     layoutDebugEnabled: Boolean,
@@ -211,14 +212,16 @@ fun SettingsContent(
                         showChevron = true,
                         onClick = onDiagnosticsTap,
                     )
-                    HorizontalDivider(modifier = Modifier.padding(start = DividerInset.ListItem))
-                    SettingsRow(
-                        icon = Icons.AutoMirrored.Outlined.List,
-                        title = "Function list",
-                        subtitle = null,
-                        showChevron = true,
-                        onClick = onFunctionListTap,
-                    )
+                    if (showFunctionListRow) {
+                        HorizontalDivider(modifier = Modifier.padding(start = DividerInset.ListItem))
+                        SettingsRow(
+                            icon = Icons.AutoMirrored.Outlined.List,
+                            title = "Function list",
+                            subtitle = null,
+                            showChevron = true,
+                            onClick = onFunctionListTap,
+                        )
+                    }
                     HorizontalDivider(modifier = Modifier.padding(start = DividerInset.ListItem))
                     SettingsSwitchRow(
                         icon = Icons.Outlined.Palette,
@@ -376,6 +379,7 @@ fun SettingsContentSignedOutPreview() {
             snoozeState = SnoozeRowState.Off,
             showSnoozeRow = true,
             showDeveloperSection = false,
+            showFunctionListRow = false,
             versionName = "2.6.1",
             versionCode = "182",
             layoutDebugEnabled = false,
@@ -395,6 +399,7 @@ fun SettingsContentSignedInBasicPreview() {
             snoozeState = SnoozeRowState.Off,
             showSnoozeRow = true,
             showDeveloperSection = false,
+            showFunctionListRow = false,
             versionName = "2.6.1",
             versionCode = "182",
             layoutDebugEnabled = false,
@@ -414,6 +419,7 @@ fun SettingsContentSignedInAllowlistedPreview() {
             snoozeState = SnoozeRowState.SnoozingUntil("5:30 PM"),
             showSnoozeRow = true,
             showDeveloperSection = true,
+            showFunctionListRow = true,
             versionName = "2.6.1",
             versionCode = "182",
             layoutDebugEnabled = false,
@@ -433,6 +439,7 @@ fun SettingsContentPermissionDeniedPreview() {
             snoozeState = SnoozeRowState.PermissionDenied,
             showSnoozeRow = true,
             showDeveloperSection = false,
+            showFunctionListRow = false,
             versionName = "2.6.1",
             versionCode = "182",
             layoutDebugEnabled = false,
@@ -455,6 +462,7 @@ fun SettingsContentSnoozeInFlightPreview() {
             snoozeState = SnoozeRowState.Off,
             showSnoozeRow = true,
             showDeveloperSection = false,
+            showFunctionListRow = false,
             versionName = "2.6.1",
             versionCode = "182",
             layoutDebugEnabled = false,

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/ktor/KtorNetworkFeatureAllowlistDataSource.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/ktor/KtorNetworkFeatureAllowlistDataSource.kt
@@ -25,28 +25,58 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
+import io.ktor.client.statement.HttpResponse
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.Serializable
 
 class KtorNetworkFeatureAllowlistDataSource(
     private val client: HttpClient,
 ) : NetworkFeatureAllowlistDataSource {
+    /**
+     * Two independent server endpoints (`functionListAccess` and
+     * `developerAccess`). Calls are issued in parallel via `coroutineScope`
+     * + `async`. One-fail-all semantics: if either returns a non-2xx status
+     * the whole fetch maps to [NetworkResult.HttpError]; if either throws
+     * we map to [NetworkResult.ConnectionFailed]. Partial success would
+     * leave the cache in a confusing half-state, so we treat the pair as
+     * one transaction.
+     */
     override suspend fun fetchAllowlist(idToken: String): NetworkResult<FeatureAllowlist> {
         return try {
-            val response = client.get("functionListAccess") {
-                header("X-AuthTokenGoogle", idToken)
+            coroutineScope {
+                val functionListAsync = async {
+                    client.get("functionListAccess") {
+                        header("X-AuthTokenGoogle", idToken)
+                    }
+                }
+                val developerAsync = async {
+                    client.get("developerAccess") {
+                        header("X-AuthTokenGoogle", idToken)
+                    }
+                }
+                val functionListResponse: HttpResponse = functionListAsync.await()
+                val developerResponse: HttpResponse = developerAsync.await()
+
+                if (!functionListResponse.status.isSuccess()) {
+                    Logger.e { "functionListAccess response code is ${functionListResponse.status.value}" }
+                    return@coroutineScope NetworkResult.HttpError(functionListResponse.status.value)
+                }
+                if (!developerResponse.status.isSuccess()) {
+                    Logger.e { "developerAccess response code is ${developerResponse.status.value}" }
+                    return@coroutineScope NetworkResult.HttpError(developerResponse.status.value)
+                }
+                val functionListBody = functionListResponse.body<KtorAccessResponse>()
+                val developerBody = developerResponse.body<KtorAccessResponse>()
+                NetworkResult.Success(
+                    FeatureAllowlist(
+                        functionList = functionListBody.enabled,
+                        developer = developerBody.enabled,
+                    ),
+                )
             }
-            if (!response.status.isSuccess()) {
-                Logger.e { "Allowlist response code is ${response.status.value}" }
-                return NetworkResult.HttpError(response.status.value)
-            }
-            val body = response.body<KtorFunctionListAccessResponse>()
-            NetworkResult.Success(
-                FeatureAllowlist(
-                    functionList = body.enabled,
-                ),
-            )
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
@@ -57,6 +87,6 @@ class KtorNetworkFeatureAllowlistDataSource(
 }
 
 @Serializable
-private data class KtorFunctionListAccessResponse(
+private data class KtorAccessResponse(
     val enabled: Boolean = false,
 )

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/ktor/KtorNetworkFeatureAllowlistDataSourceTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/ktor/KtorNetworkFeatureAllowlistDataSourceTest.kt
@@ -41,18 +41,21 @@ import kotlin.test.assertIs
 /**
  * Wire-contract tests for [KtorNetworkFeatureAllowlistDataSource].
  *
- * These tests are the Android half of the wire-contract lock for
- * `GET /functionListAccess`. Server-side bytes come from the canonical
- * fixtures in `wire-contracts/functionListAccess/` (loaded by
- * `HttpFunctionListAccessTest.ts`); this test feeds those exact same
- * bytes into a Ktor [MockEngine] and asserts the decoded model.
+ * These tests are the Android half of the wire-contract lock for both
+ * `GET /functionListAccess` AND `GET /developerAccess`. The data source
+ * issues both calls in parallel and combines the results into a single
+ * [FeatureAllowlist]. Server-side bytes come from the canonical fixtures
+ * in `wire-contracts/functionListAccess/` and `wire-contracts/developerAccess/`
+ * (loaded by `HttpFunctionListAccessTest.ts` and `HttpDeveloperAccessTest.ts`);
+ * this test feeds those exact same bytes into a Ktor [MockEngine] keyed by
+ * URL path and asserts the decoded model.
  *
  * Drift detection: the happy-path tests decode the canonical fixtures
  * through the production data source. A unilateral server rename of
  * `enabled` would change the fixture (so the server's deep-equal test
  * fails), or fail to update the fixture (so the Android decoder reads
- * a default `false` and the `decodesEnabledTrueFixture` assertion
- * fails). Either way, one of the two trees breaks.
+ * a default `false` and the per-endpoint assertion fails). Either way,
+ * one of the two trees breaks.
  *
  * Portability: this test uses `java.io.File` to load fixtures from the
  * repo root (`../../wire-contracts/...`), which depends on the JVM
@@ -66,13 +69,15 @@ class KtorNetworkFeatureAllowlistDataSourceTest {
     // live at the repository root. Path is verified by the readFixture call —
     // failure here means the wire-contracts directory moved and both sides
     // need updating in lockstep.
-    private val fixtureDir = File("../../wire-contracts/functionListAccess")
+    private val functionListFixtureDir = File("../../wire-contracts/functionListAccess")
+    private val developerFixtureDir = File("../../wire-contracts/developerAccess")
 
-    private fun readFixture(name: String): String = File(fixtureDir, name).readText()
+    private fun readFunctionListFixture(name: String): String = File(functionListFixtureDir, name).readText()
+
+    private fun readDeveloperFixture(name: String): String = File(developerFixtureDir, name).readText()
 
     private fun mockClient(
-        statusCode: HttpStatusCode,
-        responseBody: String,
+        responses: Map<String, EndpointResponse>,
         capturedRequests: MutableList<RecordedRequest> = mutableListOf(),
     ): HttpClient =
         HttpClient(
@@ -84,9 +89,11 @@ class KtorNetworkFeatureAllowlistDataSourceTest {
                         headers = request.headers.entries().associate { it.key to it.value },
                     ),
                 )
+                val match = responses[request.url.encodedPath]
+                    ?: error("No mock response configured for ${request.url.encodedPath}")
                 respond(
-                    content = ByteReadChannel(responseBody),
-                    status = statusCode,
+                    content = ByteReadChannel(match.body),
+                    status = match.status,
                     headers = headersOf(HttpHeaders.ContentType, "application/json"),
                 )
             },
@@ -94,7 +101,7 @@ class KtorNetworkFeatureAllowlistDataSourceTest {
             install(ContentNegotiation) {
                 // Mirror production wire shape: tolerate unknown keys for
                 // forward-compat. Drift detection is the deep-equal of the
-                // canonical fixture in `decodesEnabledTrueFixture` — a
+                // canonical fixture in the per-endpoint decode tests — a
                 // server-side rename of `enabled` flips the decoded model
                 // value to the default and the assertion fails.
                 json(
@@ -109,6 +116,11 @@ class KtorNetworkFeatureAllowlistDataSourceTest {
             }
         }
 
+    private data class EndpointResponse(
+        val status: HttpStatusCode,
+        val body: String,
+    )
+
     private data class RecordedRequest(
         val method: HttpMethod,
         val urlPath: String,
@@ -116,54 +128,161 @@ class KtorNetworkFeatureAllowlistDataSourceTest {
     )
 
     @Test
-    fun decodesEnabledTrueFixture() =
+    fun decodesBothEndpointsEnabledTrue() =
         runTest {
-            val fixture = readFixture("response_enabled_true.json")
-            val client = mockClient(HttpStatusCode.OK, fixture)
+            val client = mockClient(
+                mapOf(
+                    "/functionListAccess" to EndpointResponse(
+                        HttpStatusCode.OK,
+                        readFunctionListFixture("response_enabled_true.json"),
+                    ),
+                    "/developerAccess" to EndpointResponse(
+                        HttpStatusCode.OK,
+                        readDeveloperFixture("response_enabled_true.json"),
+                    ),
+                ),
+            )
             val ds = KtorNetworkFeatureAllowlistDataSource(client)
 
             val result = ds.fetchAllowlist(idToken = "any")
 
             val success = assertIs<NetworkResult.Success<FeatureAllowlist>>(result)
-            assertEquals(FeatureAllowlist(functionList = true), success.data)
-        }
-
-    @Test
-    fun decodesEnabledFalseFixture() =
-        runTest {
-            val fixture = readFixture("response_enabled_false.json")
-            val client = mockClient(HttpStatusCode.OK, fixture)
-            val ds = KtorNetworkFeatureAllowlistDataSource(client)
-
-            val result = ds.fetchAllowlist(idToken = "any")
-
-            val success = assertIs<NetworkResult.Success<FeatureAllowlist>>(result)
-            assertEquals(FeatureAllowlist(functionList = false), success.data)
-        }
-
-    @Test
-    fun sendsAuthTokenHeaderAndUsesGet() =
-        runTest {
-            val fixture = readFixture("response_enabled_true.json")
-            val captured = mutableListOf<RecordedRequest>()
-            val client = mockClient(HttpStatusCode.OK, fixture, captured)
-            val ds = KtorNetworkFeatureAllowlistDataSource(client)
-
-            ds.fetchAllowlist(idToken = "test-id-token-xyz")
-
-            assertEquals(1, captured.size)
-            assertEquals(HttpMethod.Get, captured[0].method)
-            assertEquals("/functionListAccess", captured[0].urlPath)
             assertEquals(
-                listOf("test-id-token-xyz"),
-                captured[0].headers["X-AuthTokenGoogle"],
+                FeatureAllowlist(functionList = true, developer = true),
+                success.data,
             )
         }
 
     @Test
-    fun httpErrorMaps() =
+    fun decodesBothEndpointsEnabledFalse() =
         runTest {
-            val client = mockClient(HttpStatusCode.Unauthorized, """{"error":"Unauthorized"}""")
+            val client = mockClient(
+                mapOf(
+                    "/functionListAccess" to EndpointResponse(
+                        HttpStatusCode.OK,
+                        readFunctionListFixture("response_enabled_false.json"),
+                    ),
+                    "/developerAccess" to EndpointResponse(
+                        HttpStatusCode.OK,
+                        readDeveloperFixture("response_enabled_false.json"),
+                    ),
+                ),
+            )
+            val ds = KtorNetworkFeatureAllowlistDataSource(client)
+
+            val result = ds.fetchAllowlist(idToken = "any")
+
+            val success = assertIs<NetworkResult.Success<FeatureAllowlist>>(result)
+            assertEquals(
+                FeatureAllowlist(functionList = false, developer = false),
+                success.data,
+            )
+        }
+
+    @Test
+    fun decodesMixedEndpoints() =
+        runTest {
+            // The two endpoints are independent; the data source must combine
+            // them faithfully rather than collapse to a single boolean.
+            val client = mockClient(
+                mapOf(
+                    "/functionListAccess" to EndpointResponse(
+                        HttpStatusCode.OK,
+                        readFunctionListFixture("response_enabled_true.json"),
+                    ),
+                    "/developerAccess" to EndpointResponse(
+                        HttpStatusCode.OK,
+                        readDeveloperFixture("response_enabled_false.json"),
+                    ),
+                ),
+            )
+            val ds = KtorNetworkFeatureAllowlistDataSource(client)
+
+            val result = ds.fetchAllowlist(idToken = "any")
+
+            val success = assertIs<NetworkResult.Success<FeatureAllowlist>>(result)
+            assertEquals(
+                FeatureAllowlist(functionList = true, developer = false),
+                success.data,
+            )
+        }
+
+    @Test
+    fun sendsAuthTokenHeaderAndUsesGetForBothEndpoints() =
+        runTest {
+            val captured = mutableListOf<RecordedRequest>()
+            val client = mockClient(
+                mapOf(
+                    "/functionListAccess" to EndpointResponse(
+                        HttpStatusCode.OK,
+                        readFunctionListFixture("response_enabled_true.json"),
+                    ),
+                    "/developerAccess" to EndpointResponse(
+                        HttpStatusCode.OK,
+                        readDeveloperFixture("response_enabled_true.json"),
+                    ),
+                ),
+                captured,
+            )
+            val ds = KtorNetworkFeatureAllowlistDataSource(client)
+
+            ds.fetchAllowlist(idToken = "test-id-token-xyz")
+
+            assertEquals(2, captured.size)
+            // Order is non-deterministic (parallel async); check by path.
+            val byPath = captured.associateBy { it.urlPath }
+            val functionListReq = byPath.getValue("/functionListAccess")
+            val developerReq = byPath.getValue("/developerAccess")
+            assertEquals(HttpMethod.Get, functionListReq.method)
+            assertEquals(HttpMethod.Get, developerReq.method)
+            assertEquals(
+                listOf("test-id-token-xyz"),
+                functionListReq.headers["X-AuthTokenGoogle"],
+            )
+            assertEquals(
+                listOf("test-id-token-xyz"),
+                developerReq.headers["X-AuthTokenGoogle"],
+            )
+        }
+
+    @Test
+    fun httpErrorOnFunctionListMapsToHttpError() =
+        runTest {
+            val client = mockClient(
+                mapOf(
+                    "/functionListAccess" to EndpointResponse(
+                        HttpStatusCode.Unauthorized,
+                        """{"error":"Unauthorized"}""",
+                    ),
+                    "/developerAccess" to EndpointResponse(
+                        HttpStatusCode.OK,
+                        readDeveloperFixture("response_enabled_true.json"),
+                    ),
+                ),
+            )
+            val ds = KtorNetworkFeatureAllowlistDataSource(client)
+
+            val result = ds.fetchAllowlist(idToken = "any")
+
+            val httpError = assertIs<NetworkResult.HttpError>(result)
+            assertEquals(401, httpError.code)
+        }
+
+    @Test
+    fun httpErrorOnDeveloperEndpointMapsToHttpError() =
+        runTest {
+            val client = mockClient(
+                mapOf(
+                    "/functionListAccess" to EndpointResponse(
+                        HttpStatusCode.OK,
+                        readFunctionListFixture("response_enabled_true.json"),
+                    ),
+                    "/developerAccess" to EndpointResponse(
+                        HttpStatusCode.Unauthorized,
+                        """{"error":"Unauthorized"}""",
+                    ),
+                ),
+            )
             val ds = KtorNetworkFeatureAllowlistDataSource(client)
 
             val result = ds.fetchAllowlist(idToken = "any")

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/CachedFeatureAllowlistRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/CachedFeatureAllowlistRepositoryTest.kt
@@ -50,7 +50,7 @@ import kotlin.test.assertTrue
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class CachedFeatureAllowlistRepositoryTest {
-    private val sampleAllowlist = FeatureAllowlist(functionList = true)
+    private val sampleAllowlist = FeatureAllowlist(functionList = true, developer = false)
 
     private fun authenticatedState(email: String = "test@example.com"): AuthState.Authenticated =
         AuthState.Authenticated(
@@ -176,7 +176,7 @@ class CachedFeatureAllowlistRepositoryTest {
             // A's answer under B's session.
             val ds = object : com.chriscartland.garage.data.NetworkFeatureAllowlistDataSource {
                 var swapAuthDuringFetch: (() -> Unit)? = null
-                var resultToReturn: FeatureAllowlist = FeatureAllowlist(functionList = true)
+                var resultToReturn: FeatureAllowlist = FeatureAllowlist(functionList = true, developer = false)
 
                 override suspend fun fetchAllowlist(idToken: String): NetworkResult<FeatureAllowlist> {
                     swapAuthDuringFetch?.invoke()
@@ -205,10 +205,10 @@ class CachedFeatureAllowlistRepositoryTest {
             // null and Bob's fetch writes correctly. The key invariant:
             // cache reflects Bob's session, not A's discarded answer.
             ds.swapAuthDuringFetch = null
-            ds.resultToReturn = FeatureAllowlist(functionList = false)
+            ds.resultToReturn = FeatureAllowlist(functionList = false, developer = false)
             repo.fetchAllowlist()
             advanceUntilIdle()
-            assertEquals(FeatureAllowlist(functionList = false), repo.allowlist.value)
+            assertEquals(FeatureAllowlist(functionList = false, developer = false), repo.allowlist.value)
 
             externalScope.cancel()
         }
@@ -217,7 +217,7 @@ class CachedFeatureAllowlistRepositoryTest {
     fun userSwitchRefreshesCache() =
         runTest {
             val ds = FakeNetworkFeatureAllowlistDataSource().apply {
-                setFetchResult(NetworkResult.Success(FeatureAllowlist(functionList = true)))
+                setFetchResult(NetworkResult.Success(FeatureAllowlist(functionList = true, developer = false)))
             }
             val authRepo = FakeAuthRepository().apply {
                 setIdTokenResult(FirebaseIdToken(idToken = "alice-token", exp = Long.MAX_VALUE))
@@ -227,7 +227,7 @@ class CachedFeatureAllowlistRepositoryTest {
 
             val repo = CachedFeatureAllowlistRepository(ds, authRepo, externalScope)
             advanceUntilIdle()
-            assertEquals(FeatureAllowlist(functionList = true), repo.allowlist.value)
+            assertEquals(FeatureAllowlist(functionList = true, developer = false), repo.allowlist.value)
             assertEquals(listOf("alice-token"), ds.fetchIdTokens)
 
             // Sign out clears, sign in as a different user fetches fresh.
@@ -235,12 +235,12 @@ class CachedFeatureAllowlistRepositoryTest {
             advanceUntilIdle()
             assertNull(repo.allowlist.value)
 
-            ds.setFetchResult(NetworkResult.Success(FeatureAllowlist(functionList = false)))
+            ds.setFetchResult(NetworkResult.Success(FeatureAllowlist(functionList = false, developer = false)))
             authRepo.setIdTokenResult(FirebaseIdToken(idToken = "bob-token", exp = Long.MAX_VALUE))
             authRepo.setAuthState(authenticatedState(email = "bob@example.com"))
             advanceUntilIdle()
 
-            assertEquals(FeatureAllowlist(functionList = false), repo.allowlist.value)
+            assertEquals(FeatureAllowlist(functionList = false, developer = false), repo.allowlist.value)
             assertTrue(
                 ds.fetchIdTokens.containsAll(listOf("alice-token", "bob-token")),
                 "fetch must have been called with both tokens, was: ${ds.fetchIdTokens}",

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/FeatureAllowlist.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/FeatureAllowlist.kt
@@ -29,4 +29,5 @@ package com.chriscartland.garage.domain.model
  */
 data class FeatureAllowlist(
     val functionList: Boolean,
+    val developer: Boolean,
 )

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveFeatureAccessUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveFeatureAccessUseCase.kt
@@ -34,4 +34,6 @@ class ObserveFeatureAccessUseCase(
     private val featureAllowlistRepository: FeatureAllowlistRepository,
 ) {
     fun functionList(): Flow<Boolean?> = featureAllowlistRepository.allowlist.map { it?.functionList }
+
+    fun developer(): Flow<Boolean?> = featureAllowlistRepository.allowlist.map { it?.developer }
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ProfileViewModel.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ProfileViewModel.kt
@@ -57,11 +57,19 @@ interface ProfileViewModel {
 
     /**
      * Per-user access for the Function List feature, used to gate the
-     * Settings-screen developer entry. Tri-state: `null` (loading or denied),
-     * `false` (server says denied), `true` (allowed). Full convention in
-     * `docs/FEATURE_FLAGS.md`.
+     * Settings-screen Function-list entry. Tri-state: `null` (loading or
+     * denied), `false` (server says denied), `true` (allowed). Full
+     * convention in `docs/FEATURE_FLAGS.md`.
      */
     val functionListAccess: StateFlow<Boolean?>
+
+    /**
+     * Per-user access for the Developer section, used to gate the whole
+     * Settings → Developer block. Tri-state, same convention as
+     * [functionListAccess]. Replaces the temporary `functionListAccess`-as-
+     * Developer-gate shortcut from `android/196` (2.10.2).
+     */
+    val developerAccess: StateFlow<Boolean?>
 
     /**
      * Developer-only: when `true`, the chrome (TopAppBar / NavigationBar /
@@ -107,6 +115,9 @@ class DefaultProfileViewModel(
     private val _functionListAccess = MutableStateFlow<Boolean?>(null)
     override val functionListAccess: StateFlow<Boolean?> = _functionListAccess
 
+    private val _developerAccess = MutableStateFlow<Boolean?>(null)
+    override val developerAccess: StateFlow<Boolean?> = _developerAccess
+
     private val _layoutDebugEnabled = MutableStateFlow(false)
     override val layoutDebugEnabled: StateFlow<Boolean> = _layoutDebugEnabled
 
@@ -120,6 +131,9 @@ class DefaultProfileViewModel(
         }
         viewModelScope.launch(dispatchers.io) {
             observeFeatureAccessUseCase.functionList().collect { _functionListAccess.value = it }
+        }
+        viewModelScope.launch(dispatchers.io) {
+            observeFeatureAccessUseCase.developer().collect { _developerAccess.value = it }
         }
         viewModelScope.launch(dispatchers.io) {
             appSettings.observeLayoutDebugEnabled().collect { _layoutDebugEnabled.value = it }

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultFunctionListViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/DefaultFunctionListViewModelTest.kt
@@ -184,7 +184,7 @@ class DefaultFunctionListViewModelTest {
     fun accessGrantedReflectsAllowlistTrue() =
         runTest(testDispatcher) {
             val viewModel = createViewModel(authState = authenticated())
-            featureAllowlistRepository.setAllowlist(FeatureAllowlist(functionList = true))
+            featureAllowlistRepository.setAllowlist(FeatureAllowlist(functionList = true, developer = false))
             advanceUntilIdle()
             assertTrue(viewModel.accessGranted.value == true)
         }
@@ -193,7 +193,7 @@ class DefaultFunctionListViewModelTest {
     fun accessGrantedReflectsAllowlistFalse() =
         runTest(testDispatcher) {
             val viewModel = createViewModel(authState = authenticated())
-            featureAllowlistRepository.setAllowlist(FeatureAllowlist(functionList = false))
+            featureAllowlistRepository.setAllowlist(FeatureAllowlist(functionList = false, developer = false))
             advanceUntilIdle()
             assertFalse(viewModel.accessGranted.value == true)
             // Distinguish "false" from "null"
@@ -204,7 +204,7 @@ class DefaultFunctionListViewModelTest {
     fun accessGrantedClearsToNullWhenAllowlistClears() =
         runTest(testDispatcher) {
             val viewModel = createViewModel(authState = authenticated())
-            featureAllowlistRepository.setAllowlist(FeatureAllowlist(functionList = true))
+            featureAllowlistRepository.setAllowlist(FeatureAllowlist(functionList = true, developer = false))
             advanceUntilIdle()
             assertEquals(true, viewModel.accessGranted.value)
             featureAllowlistRepository.setAllowlist(null)

--- a/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ProfileViewModelTest.kt
+++ b/AndroidGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ProfileViewModelTest.kt
@@ -167,7 +167,7 @@ class ProfileViewModelTest {
     fun functionListAccessReflectsAllowlist() =
         runTest {
             featureAllowlistRepository.setAllowlist(
-                FeatureAllowlist(functionList = true),
+                FeatureAllowlist(functionList = true, developer = true),
             )
             val viewModel = createViewModel(
                 authState = AuthState.Authenticated(testUser),
@@ -187,6 +187,32 @@ class ProfileViewModelTest {
             advanceUntilIdle()
 
             assertNull(viewModel.functionListAccess.value)
+        }
+
+    @Test
+    fun developerAccessReflectsAllowlist() =
+        runTest {
+            featureAllowlistRepository.setAllowlist(
+                FeatureAllowlist(functionList = false, developer = true),
+            )
+            val viewModel = createViewModel(
+                authState = AuthState.Authenticated(testUser),
+            )
+            advanceUntilIdle()
+
+            assertEquals(true, viewModel.developerAccess.value)
+        }
+
+    @Test
+    fun developerAccessNullWhenAllowlistMissing() =
+        runTest {
+            val viewModel = createViewModel(
+                authState = AuthState.Authenticated(testUser),
+            )
+            featureAllowlistRepository.setAllowlist(null)
+            advanceUntilIdle()
+
+            assertNull(viewModel.developerAccess.value)
         }
 
     @Test


### PR DESCRIPTION
## Summary
- Replaces the temporary `functionListAccess`-as-Developer-gate shortcut from `android/196` (2.10.2). Settings → Developer is now gated by the new `developerAccess` allowlist (server side shipped in `server/26`); the Function-list row inside the section keeps its independent `functionListAccess` gate.
- `KtorNetworkFeatureAllowlistDataSource` now calls both endpoints in parallel via `coroutineScope` + `async`, combines into one `FeatureAllowlist`, treats the pair as one transaction (one-fail-all).
- Wire-contract decode test extended to assert both endpoints; canonical fixtures in `wire-contracts/developerAccess/` (already shipped in `server/26`) used unchanged.

## Architecture
- **Domain**: `FeatureAllowlist.developer: Boolean` (required, no default — matches `functionList`; deny is load-bearing).
- **Data**: parallel async fetch in `KtorNetworkFeatureAllowlistDataSource`. Repo (`CachedFeatureAllowlistRepository`) and DI wiring unchanged — the data-source-level abstraction "give me the whole allowlist" already covers the new feature.
- **UseCase**: `ObserveFeatureAccessUseCase.developer()` mirrors `functionList()`.
- **VM**: `ProfileViewModel.developerAccess: StateFlow<Boolean?>` added.
- **UI**: `SettingsContent` gains `showFunctionListRow: Boolean` so the nested gate is explicit; `ProfileContent` flips outer gate to `developerAccess == true` and passes `functionListAccess == true` for the row.

## Verified
- Server side already validated end-to-end this session with a fresh ID token: `GET /developerAccess` returns `{"enabled": true}` for `c.cartland@gmail.com`, `401` without a token.
- `./scripts/validate.sh` PASS on this branch (full pipeline — architecture lints, test-common compile, unit tests, screenshots).
- 12 files: 1 domain, 1 data prod, 1 data test, 1 usecase prod, 1 usecase test (ProfileViewModel), 1 usecase test (DefaultFunctionListViewModel — fixture update only), 1 data test (CachedFeatureAllowlistRepository — fixture update only), 4 UI (ProfileContent, SettingsContent + 3 preview wrappers).

## Test plan
- [ ] Smoke on a developer-allowlisted account: open Settings → Developer section appears with Diagnostics + Function list + Layout debug colors.
- [ ] Smoke on an account on `featureDeveloperAllowedEmails` but NOT `featureFunctionListAllowedEmails`: section appears, Function list row hidden.
- [ ] Smoke on an account on `featureFunctionListAllowedEmails` but NOT `featureDeveloperAllowedEmails`: section hidden entirely.
- [ ] Smoke on an account on neither list: section hidden entirely.
- [ ] Sign out: section disappears immediately (cache clears to null on Unauthenticated).
- [ ] Verify both calls fire on sign-in: ADB logcat should show both `functionListAccess` and `developerAccess` HTTP traffic in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)