### PR TITLE
refactor(android): Migrate HomeContent strings to strings.xml (Phase 1)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
@@ -53,9 +53,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.chriscartland.garage.R
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.model.RemoteButtonState
@@ -203,7 +205,7 @@ fun HomeContent(
 
             item(key = "status") {
                 HomeSection(
-                    label = "Status",
+                    label = stringResource(R.string.home_section_status),
                     trailing = {
                         DeviceCheckInPill(
                             display = deviceCheckIn,
@@ -218,18 +220,18 @@ fun HomeContent(
             item(key = "action") {
                 when (authState) {
                     HomeAuthState.Unknown -> {
-                        HomeSection(label = "Remote control") {
+                        HomeSection(label = stringResource(R.string.home_section_remote_control)) {
                             HomeAuthLoadingBody()
                         }
                     }
                     HomeAuthState.SignedOut -> {
-                        HomeSection(label = "Sign in") {
+                        HomeSection(label = stringResource(R.string.home_section_sign_in)) {
                             HomeSignInBody(onSignIn = onSignIn)
                         }
                     }
                     HomeAuthState.SignedIn -> {
                         HomeSection(
-                            label = "Remote control",
+                            label = stringResource(R.string.home_section_remote_control),
                             trailing = {
                                 // TEMPORARY (debug): always-on pill for every ButtonHealthDisplay arm.
                                 // To revert to production-only "Remote offline" behavior, swap back
@@ -405,8 +407,8 @@ private fun HomeSignInBody(onSignIn: () -> Unit) {
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         },
-        headlineContent = { Text("Sign in with Google") },
-        supportingContent = { Text("Required to use the remote button") },
+        headlineContent = { Text(stringResource(R.string.home_sign_in_title)) },
+        supportingContent = { Text(stringResource(R.string.home_sign_in_subtitle)) },
         trailingContent = {
             Icon(
                 imageVector = Icons.Filled.ChevronRight,
@@ -430,7 +432,7 @@ private fun HomeAuthLoadingBody() {
         contentAlignment = Alignment.Center,
     ) {
         Text(
-            text = "Checking sign-in…",
+            text = stringResource(R.string.home_auth_loading),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/AndroidGarage/androidApp/src/main/res/values/strings.xml
+++ b/AndroidGarage/androidApp/src/main/res/values/strings.xml
@@ -47,4 +47,16 @@
     <string name="settings_developer_function_list_title">Function list</string>
     <string name="settings_developer_layout_debug_title">Layout debug colors</string>
     <string name="settings_developer_layout_debug_subtitle">Tints chrome regions to visualize layout boundaries</string>
+
+    <!-- Home screen — section labels. -->
+    <string name="home_section_status">Status</string>
+    <string name="home_section_remote_control">Remote control</string>
+    <string name="home_section_sign_in">Sign in</string>
+
+    <!-- Home — signed-out remote-button placeholder. -->
+    <string name="home_sign_in_title">Sign in with Google</string>
+    <string name="home_sign_in_subtitle">Required to use the remote button</string>
+
+    <!-- Home — auth state still resolving (between Unknown and resolved). -->
+    <string name="home_auth_loading">Checking sign-in…</string>
 </resources>


### PR DESCRIPTION
## Summary
Second Phase 1 PR in the string-resource migration (plan: [PENDING_FOLLOWUPS.md item 1](AndroidGarage/docs/PENDING_FOLLOWUPS.md), introduced in #785). After SettingsContent in #784.

7 strings extracted from `HomeContent.kt`:
- Section labels: Status, Remote control, Sign in
- Sign-in placeholder body: title + subtitle
- Auth-loading text: "Checking sign-in…"

## Out of scope (Phase 2 — typed-hint refactor)
`HomeAlert.Stale` / `PermissionMissing` / `FetchError` carry default `message` / `actionLabel` String args set in the data-class definition. Per the plan, Phase 2 will:
- Drop the String fields from `HomeAlert` entirely
- `HomeAlertCard` will resolve `when (alert)` → `stringResource(...)` directly

This avoids touching the alert type in this PR (which would force the mapper test assertions to change at the same time).

## Verified
- `validate.sh` PASS on this branch (full pipeline)
- No screenshot churn — text byte-identical to pre-migration
- Preview fake data (`HomePreviewData.openStatus.stateLabel = "Open"` etc.) deliberately not migrated; not user-visible at runtime

## Test plan
- [ ] CI green