### PR TITLE
refactor(android): Migrate settings-ecosystem strings to strings.xml (Batch A)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
@@ -31,9 +31,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.core.net.toUri
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.chriscartland.garage.R
 import com.chriscartland.garage.auth.rememberGoogleSignIn
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.AuthState
@@ -111,11 +113,12 @@ fun ProfileContent(
         }
     }
 
+    val unknownNameFallback = stringResource(R.string.profile_account_name_unknown)
     val accountState = when (val s = authState) {
         is AuthState.Authenticated -> AccountRowState.SignedIn(
             displayName = s.user.name
                 .asString()
-                .ifBlank { "(unknown)" },
+                .ifBlank { unknownNameFallback },
             email = s.user.email.asString(),
         )
         AuthState.Unauthenticated, AuthState.Unknown -> AccountRowState.SignedOut
@@ -194,7 +197,12 @@ fun ProfileContent(
                 // chip after a `setText`. Showing a Toast on top of that
                 // is duplicate noise — gate to older API levels only.
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-                    Toast.makeText(context, "Copied $label", Toast.LENGTH_SHORT).show()
+                    Toast
+                        .makeText(
+                            context,
+                            context.getString(R.string.profile_version_toast_copied, label),
+                            Toast.LENGTH_SHORT,
+                        ).show()
                 }
             },
             onDismiss = { versionSheetOpen = false },

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/auth/AuthTokenCopier.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/auth/AuthTokenCopier.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
+import com.chriscartland.garage.R
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.AppResult
 import kotlinx.coroutines.Dispatchers
@@ -74,7 +75,12 @@ fun rememberAuthTokenCopier(): () -> Unit {
                 when (result) {
                     is AppResult.Success -> SensitiveClipboard.write(context, result.data)
                     is AppResult.Error ->
-                        Toast.makeText(context, "Sign in to copy auth token", Toast.LENGTH_SHORT).show()
+                        Toast
+                            .makeText(
+                                context,
+                                context.getString(R.string.auth_token_copier_sign_in_required),
+                                Toast.LENGTH_SHORT,
+                            ).show()
                 }
             }
         }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/AccountBottomSheet.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/AccountBottomSheet.kt
@@ -39,8 +39,10 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.chriscartland.garage.R
 
 /**
  * Production wrapper. Shows the sheet content inside a [ModalBottomSheet].
@@ -114,7 +116,7 @@ fun AccountSheetContent(
         OutlinedButton(
             onClick = onSignOut,
             modifier = Modifier.fillMaxWidth(),
-        ) { Text("Sign out") }
+        ) { Text(stringResource(R.string.settings_account_sign_out)) }
     }
 }
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/DiagnosticsContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/DiagnosticsContent.kt
@@ -53,10 +53,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.chriscartland.garage.GarageApplication
+import com.chriscartland.garage.R
 import com.chriscartland.garage.applogger.exportAppLogCsvToUri
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.ui.auth.rememberAuthTokenCopier
@@ -233,7 +235,7 @@ fun DiagnosticsContent(
                             contentDescription = null,
                         )
                         Text(
-                            text = "Copy auth token (sensitive)",
+                            text = stringResource(R.string.settings_diagnostics_copy_auth_token),
                             modifier = Modifier.padding(start = ButtonSpacing.IconText),
                         )
                     }
@@ -247,7 +249,7 @@ fun DiagnosticsContent(
                         contentDescription = null,
                     )
                     Text(
-                        text = "Export CSV",
+                        text = stringResource(R.string.settings_diagnostics_export_csv),
                         modifier = Modifier.padding(start = ButtonSpacing.IconText),
                     )
                 }
@@ -269,7 +271,7 @@ fun DiagnosticsContent(
                             modifier = Modifier.size(20.dp),
                         )
                         Text(
-                            text = "Clearing…",
+                            text = stringResource(R.string.settings_diagnostics_clearing_in_flight),
                             modifier = Modifier.padding(start = ButtonSpacing.IconText),
                         )
                     } else {
@@ -278,7 +280,7 @@ fun DiagnosticsContent(
                             contentDescription = null,
                         )
                         Text(
-                            text = "Clear all diagnostics",
+                            text = stringResource(R.string.settings_diagnostics_clear_all),
                             modifier = Modifier.padding(start = ButtonSpacing.IconText),
                         )
                     }
@@ -317,13 +319,9 @@ fun ClearDiagnosticsDialog(
                 tint = MaterialTheme.colorScheme.error,
             )
         },
-        title = { Text("Clear all diagnostics?") },
+        title = { Text(stringResource(R.string.settings_diagnostics_confirm_title)) },
         text = {
-            Text(
-                "Resets every counter on this screen to 0 and deletes the " +
-                    "exportable event log. Door history and other app " +
-                    "settings are not affected. This cannot be undone.",
-            )
+            Text(stringResource(R.string.settings_diagnostics_confirm_message))
         },
         confirmButton = {
             TextButton(
@@ -331,10 +329,10 @@ fun ClearDiagnosticsDialog(
                 colors = ButtonDefaults.textButtonColors(
                     contentColor = MaterialTheme.colorScheme.error,
                 ),
-            ) { Text("Clear") }
+            ) { Text(stringResource(R.string.settings_diagnostics_confirm_button)) }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Cancel") }
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.settings_diagnostics_cancel_button)) }
         },
     )
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SnoozeBottomSheet.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SnoozeBottomSheet.kt
@@ -45,8 +45,10 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.chriscartland.garage.R
 import com.chriscartland.garage.domain.model.SnoozeDurationUIOption
 
 /**
@@ -106,37 +108,37 @@ fun SnoozeSheetContent(
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Text(
-            text = "Snooze notifications",
+            text = stringResource(R.string.settings_snooze_title),
             style = MaterialTheme.typography.titleLarge,
             modifier = Modifier.padding(bottom = 8.dp),
         )
 
         SnoozeOptionRow(
-            label = "Don't snooze",
+            label = stringResource(R.string.settings_snooze_option_none),
             selected = selectedOption == SnoozeDurationUIOption.None,
             onClick = { onOptionSelected(SnoozeDurationUIOption.None) },
         )
         HorizontalDivider()
         SnoozeOptionRow(
-            label = "1 hour",
+            label = stringResource(R.string.settings_snooze_option_one_hour),
             selected = selectedOption == SnoozeDurationUIOption.OneHour,
             onClick = { onOptionSelected(SnoozeDurationUIOption.OneHour) },
         )
         HorizontalDivider()
         SnoozeOptionRow(
-            label = "4 hours",
+            label = stringResource(R.string.settings_snooze_option_four_hours),
             selected = selectedOption == SnoozeDurationUIOption.FourHours,
             onClick = { onOptionSelected(SnoozeDurationUIOption.FourHours) },
         )
         HorizontalDivider()
         SnoozeOptionRow(
-            label = "8 hours",
+            label = stringResource(R.string.settings_snooze_option_eight_hours),
             selected = selectedOption == SnoozeDurationUIOption.EightHours,
             onClick = { onOptionSelected(SnoozeDurationUIOption.EightHours) },
         )
         HorizontalDivider()
         SnoozeOptionRow(
-            label = "12 hours",
+            label = stringResource(R.string.settings_snooze_option_twelve_hours),
             selected = selectedOption == SnoozeDurationUIOption.TwelveHours,
             onClick = { onOptionSelected(SnoozeDurationUIOption.TwelveHours) },
         )
@@ -146,9 +148,9 @@ fun SnoozeSheetContent(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.End,
         ) {
-            TextButton(onClick = onCancel) { Text("Cancel") }
+            TextButton(onClick = onCancel) { Text(stringResource(R.string.settings_snooze_cancel)) }
             Spacer(Modifier.padding(horizontal = 4.dp))
-            Button(onClick = onSave) { Text("Save") }
+            Button(onClick = onSave) { Text(stringResource(R.string.settings_snooze_save)) }
         }
     }
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/VersionBottomSheet.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/VersionBottomSheet.kt
@@ -40,8 +40,10 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.chriscartland.garage.R
 
 /**
  * Production wrapper. Shows extended version metadata inside a
@@ -111,15 +113,31 @@ fun VersionSheetContent(
         )
         Spacer(Modifier.height(8.dp))
         Text(
-            text = "App version",
+            text = stringResource(R.string.settings_version_title),
             style = MaterialTheme.typography.titleLarge,
         )
         Spacer(Modifier.height(16.dp))
 
-        VersionFieldRow(label = "Version", value = versionName, onCopy = onCopy)
-        VersionFieldRow(label = "Build", value = versionCode, onCopy = onCopy)
-        VersionFieldRow(label = "Package", value = packageName, onCopy = onCopy)
-        VersionFieldRow(label = "Built", value = buildTimestamp, onCopy = onCopy)
+        VersionFieldRow(
+            label = stringResource(R.string.settings_version_field_version),
+            value = versionName,
+            onCopy = onCopy,
+        )
+        VersionFieldRow(
+            label = stringResource(R.string.settings_version_field_build),
+            value = versionCode,
+            onCopy = onCopy,
+        )
+        VersionFieldRow(
+            label = stringResource(R.string.settings_version_field_package),
+            value = packageName,
+            onCopy = onCopy,
+        )
+        VersionFieldRow(
+            label = stringResource(R.string.settings_version_field_built),
+            value = buildTimestamp,
+            onCopy = onCopy,
+        )
     }
 }
 

--- a/AndroidGarage/androidApp/src/main/res/values/strings.xml
+++ b/AndroidGarage/androidApp/src/main/res/values/strings.xml
@@ -59,4 +59,42 @@
 
     <!-- Home — auth state still resolving (between Unknown and resolved). -->
     <string name="home_auth_loading">Checking sign-in…</string>
+
+    <!-- Settings → Diagnostics — action buttons + clear-confirm dialog. -->
+    <string name="settings_diagnostics_copy_auth_token">Copy auth token (sensitive)</string>
+    <string name="settings_diagnostics_export_csv">Export CSV</string>
+    <string name="settings_diagnostics_clearing_in_flight">Clearing…</string>
+    <string name="settings_diagnostics_clear_all">Clear all diagnostics</string>
+    <string name="settings_diagnostics_confirm_title">Clear all diagnostics?</string>
+    <string name="settings_diagnostics_confirm_message">Resets every counter on this screen to 0 and deletes the exportable event log. Door history and other app settings are not affected. This cannot be undone.</string>
+    <string name="settings_diagnostics_confirm_button">Clear</string>
+    <string name="settings_diagnostics_cancel_button">Cancel</string>
+
+    <!-- Settings → Snooze bottom sheet — duration picker. -->
+    <string name="settings_snooze_title">Snooze notifications</string>
+    <string name="settings_snooze_option_none">Don\'t snooze</string>
+    <string name="settings_snooze_option_one_hour">1 hour</string>
+    <string name="settings_snooze_option_four_hours">4 hours</string>
+    <string name="settings_snooze_option_eight_hours">8 hours</string>
+    <string name="settings_snooze_option_twelve_hours">12 hours</string>
+    <string name="settings_snooze_cancel">Cancel</string>
+    <string name="settings_snooze_save">Save</string>
+
+    <!-- Settings → Account bottom sheet — sign out action. -->
+    <string name="settings_account_sign_out">Sign out</string>
+
+    <!-- Settings → Version bottom sheet — fields and labels. -->
+    <string name="settings_version_title">App version</string>
+    <string name="settings_version_field_version">Version</string>
+    <string name="settings_version_field_build">Build</string>
+    <string name="settings_version_field_package">Package</string>
+    <string name="settings_version_field_built">Built</string>
+
+    <!-- Profile — account name fallback when display name is blank. -->
+    <string name="profile_account_name_unknown">(unknown)</string>
+    <!-- Profile → Version sheet — Toast on copy (Android 12 and older). %1$s is the field label. -->
+    <string name="profile_version_toast_copied">Copied %1$s</string>
+
+    <!-- Auth — Toast when copy auth token tapped while signed out. -->
+    <string name="auth_token_copier_sign_in_required">Sign in to copy auth token</string>
 </resources>


### PR DESCRIPTION
## Summary
Phase 1 Batch A of the string-resource migration ([plan in PENDING_FOLLOWUPS.md item 1](AndroidGarage/docs/PENDING_FOLLOWUPS.md), introduced in #785). Six files, 25 strings migrated.

| File | Strings |
|---|---|
| `DiagnosticsContent.kt` | 8 — action button labels, clearing in-flight label, clear-all dialog title/body/buttons |
| `SnoozeBottomSheet.kt` | 8 — sheet title, 5 duration options, cancel/save buttons |
| `AccountBottomSheet.kt` | 1 — "Sign out" |
| `VersionBottomSheet.kt` | 5 — sheet title + 4 field labels |
| `ProfileContent.kt` | 2 — `"(unknown)"` name fallback, `"Copied %1$s"` Toast (Android < 13) |
| `AuthTokenCopier.kt` | 1 — "Sign in to copy auth token" Toast |

## Out of scope (Phase 2 — typed-hint refactor)
- `HomeAlert.Stale` / `PermissionMissing` / `FetchError` default-arg messages
- `HomeMapper` / `HistoryMapper` / `NotificationPermissionCopy` (string-emitting non-Composable code)
- The text inside `HomeAlertCard` that renders those messages

## Patterns established
- Toast call sites use `context.getString(R.string.X, args)` (different call form than `stringResource(...)`) — both forms now coexist correctly in the codebase.
- Strings with format args use `formatArgs` placeholders (`%1$s`).
- All values byte-identical to pre-migration → no screenshot churn.

## Test plan
- [ ] CI green
- [ ] Screenshot tests pass with no PNG diff