### PR TITLE
refactor(android): Migrate home-ecosystem strings to strings.xml (Batch B)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
@@ -28,10 +28,12 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import co.touchlab.kermit.Logger
+import com.chriscartland.garage.R
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.domain.model.DoorEvent
@@ -94,8 +96,8 @@ fun DoorHistoryContent(
     Column(modifier = modifier.fillMaxSize()) {
         if (isCheckInStale) {
             ErrorCard(
-                text = "Not receiving updates from server",
-                buttonText = "Retry",
+                text = stringResource(R.string.home_history_stale_check_in_error),
+                buttonText = stringResource(R.string.home_history_retry_button),
                 onClick = {
                     Logger.e { "Trying to fix outdated info. Resetting FCM, and fetching data." }
                     onResetFcm()
@@ -108,9 +110,11 @@ fun DoorHistoryContent(
         }
         if (recentDoorEvents is LoadingResult.Error) {
             ErrorCard(
-                text = "Error fetching recent door events:" +
+                text = stringResource(
+                    R.string.home_history_fetch_error,
                     recentDoorEvents.exception.toString().take(500),
-                buttonText = "Retry",
+                ),
+                buttonText = stringResource(R.string.home_history_retry_button),
                 onClick = { onFetchRecentDoorEvents() },
                 modifier = Modifier
                     .fillMaxWidth()

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/InfoBottomSheet.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/InfoBottomSheet.kt
@@ -36,9 +36,11 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.chriscartland.garage.R
 
 /**
  * Bottom sheets that explain what the Status and Remote control
@@ -94,10 +96,10 @@ fun RemoteControlInfoBottomSheet(
 @Composable
 fun DoorStatusInfoSheetContent(modifier: Modifier = Modifier) {
     InfoSheetLayout(
-        title = "Door status",
+        title = stringResource(R.string.home_info_door_status_title),
         paragraphs = listOf(
-            "The door sensor checks in every 10 minutes, or whenever the door moves.",
-            "If we don't hear from it on schedule, this shows \"no signal\" so you know the sensor may be offline.",
+            stringResource(R.string.home_info_door_status_body_para1),
+            stringResource(R.string.home_info_door_status_body_para2),
         ),
         modifier = modifier,
     )
@@ -106,10 +108,10 @@ fun DoorStatusInfoSheetContent(modifier: Modifier = Modifier) {
 @Composable
 fun RemoteControlInfoSheetContent(modifier: Modifier = Modifier) {
     InfoSheetLayout(
-        title = "Remote control",
+        title = stringResource(R.string.home_info_remote_control_title),
         paragraphs = listOf(
-            "The remote button checks in frequently. \"Available\" means it just told us it's ready to open or close the door.",
-            "If contact stops, this shows when we last heard from it. Tapping the button may not work until it reconnects.",
+            stringResource(R.string.home_info_remote_control_body_para1),
+            stringResource(R.string.home_info_remote_control_body_para2),
         ),
         modifier = modifier,
     )

--- a/AndroidGarage/androidApp/src/main/res/values/strings.xml
+++ b/AndroidGarage/androidApp/src/main/res/values/strings.xml
@@ -97,4 +97,20 @@
 
     <!-- Auth — Toast when copy auth token tapped while signed out. -->
     <string name="auth_token_copier_sign_in_required">Sign in to copy auth token</string>
+
+    <!-- History tab — error / stale-data banner copy. -->
+    <string name="home_history_stale_check_in_error">Not receiving updates from server</string>
+    <string name="home_history_retry_button">Retry</string>
+    <!-- History tab — fetch-error banner. %1$s is the truncated exception message. -->
+    <string name="home_history_fetch_error">Error fetching recent door events:%1$s</string>
+
+    <!-- Home → Door status info bottom sheet. -->
+    <string name="home_info_door_status_title">Door status</string>
+    <string name="home_info_door_status_body_para1">The door sensor checks in every 10 minutes, or whenever the door moves.</string>
+    <string name="home_info_door_status_body_para2">If we don\'t hear from it on schedule, this shows \"no signal\" so you know the sensor may be offline.</string>
+
+    <!-- Home → Remote control info bottom sheet. -->
+    <string name="home_info_remote_control_title">Remote control</string>
+    <string name="home_info_remote_control_body_para1">The remote button checks in frequently. \"Available\" means it just told us it\'s ready to open or close the door.</string>
+    <string name="home_info_remote_control_body_para2">If contact stops, this shows when we last heard from it. Tapping the button may not work until it reconnects.</string>
 </resources>


### PR DESCRIPTION
## Summary
Phase 1 Batch B of the string-resource migration ([plan in PENDING_FOLLOWUPS.md item 1](AndroidGarage/docs/PENDING_FOLLOWUPS.md)). Two files, 10 strings.

| File | Strings |
|---|---|
| `DoorHistoryContent.kt` | 3 — stale-update banner text + retry, fetch-error banner with `%1$s` exception placeholder |
| `InfoBottomSheet.kt` | 6 — door-status sheet title + 2 paragraphs, remote-control sheet title + 2 paragraphs |

## Verified
- `validate.sh` PASS on this branch
- No screenshot churn — values byte-identical to pre-migration