### PR TITLE
refactor(android): Migrate FunctionListContent strings to strings.xml (Batch C)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/FunctionListContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/FunctionListContent.kt
@@ -31,10 +31,12 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.chriscartland.garage.R
 import com.chriscartland.garage.auth.rememberGoogleSignIn
 import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.ui.auth.rememberAuthTokenCopier
@@ -100,25 +102,25 @@ fun FunctionListContent(
             verticalArrangement = Arrangement.spacedBy(Spacing.BetweenItems),
         ) {
             item { FunctionListWarning() }
-            item { FunctionButton("Open or close garage door", onOpenOrCloseDoor) }
-            item { FunctionButton("Refresh door status", onRefreshDoorStatus) }
-            item { FunctionButton("Refresh door history", onRefreshDoorHistory) }
-            item { FunctionButton("Refresh snooze status", onRefreshSnoozeStatus) }
-            item { FunctionButton("Refresh button health", onRefreshButtonHealth) }
-            item { FunctionButton("Snooze notifications for 1 hour", onSnoozeOneHour) }
-            item { FunctionButton("Sign in with Google", onSignIn) }
-            item { FunctionButton("Sign out", onSignOut) }
-            item { FunctionButton("Clear all diagnostics", onClearDiagnostics) }
-            item { FunctionButton("Prune diagnostics log", onPruneDiagnosticsLog) }
-            item { FunctionButton("Re-register FCM", onRegisterFcm) }
-            item { FunctionButton("Deregister FCM", onDeregisterFcm) }
+            item { FunctionButton(stringResource(R.string.function_list_door_action), onOpenOrCloseDoor) }
+            item { FunctionButton(stringResource(R.string.function_list_refresh_door_status), onRefreshDoorStatus) }
+            item { FunctionButton(stringResource(R.string.function_list_refresh_door_history), onRefreshDoorHistory) }
+            item { FunctionButton(stringResource(R.string.function_list_refresh_snooze_status), onRefreshSnoozeStatus) }
+            item { FunctionButton(stringResource(R.string.function_list_refresh_button_health), onRefreshButtonHealth) }
+            item { FunctionButton(stringResource(R.string.function_list_snooze_one_hour), onSnoozeOneHour) }
+            item { FunctionButton(stringResource(R.string.function_list_sign_in_google), onSignIn) }
+            item { FunctionButton(stringResource(R.string.function_list_sign_out), onSignOut) }
+            item { FunctionButton(stringResource(R.string.function_list_clear_diagnostics), onClearDiagnostics) }
+            item { FunctionButton(stringResource(R.string.function_list_prune_diagnostics), onPruneDiagnosticsLog) }
+            item { FunctionButton(stringResource(R.string.function_list_register_fcm), onRegisterFcm) }
+            item { FunctionButton(stringResource(R.string.function_list_deregister_fcm), onDeregisterFcm) }
             // API-gated to Android 13+ — same redaction-flag rationale as the
             // Diagnostics surface (see AuthTokenCopier kdoc). Both screens
             // share rememberAuthTokenCopier() so a regression in the
             // clipboard / token-fetch path breaks both at once, which is
             // the verification property the user asked for.
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                item { FunctionButton("Copy auth token (sensitive)", onCopyAuthToken) }
+                item { FunctionButton(stringResource(R.string.function_list_copy_auth_token), onCopyAuthToken) }
             }
         }
     } else {
@@ -133,10 +135,7 @@ fun FunctionListContent(
 @Composable
 private fun FunctionListWarning() {
     Text(
-        text = "Each button below performs a real action immediately. " +
-            "No confirmation prompts. Tapping triggers calls to the server, " +
-            "modifies app state, or wipes local data. Double-check the label " +
-            "before tapping.",
+        text = stringResource(R.string.function_list_warning),
         style = MaterialTheme.typography.bodyMedium,
         modifier = Modifier
             .fillMaxWidth()
@@ -151,7 +150,7 @@ private fun FunctionListAccessDeniedContent(modifier: Modifier = Modifier) {
         contentAlignment = Alignment.Center,
     ) {
         Text(
-            text = "Access not enabled for your account.",
+            text = stringResource(R.string.function_list_access_denied),
             style = MaterialTheme.typography.bodyLarge,
             textAlign = TextAlign.Center,
         )

--- a/AndroidGarage/androidApp/src/main/res/values/strings.xml
+++ b/AndroidGarage/androidApp/src/main/res/values/strings.xml
@@ -113,4 +113,21 @@
     <string name="home_info_remote_control_title">Remote control</string>
     <string name="home_info_remote_control_body_para1">The remote button checks in frequently. \"Available\" means it just told us it\'s ready to open or close the door.</string>
     <string name="home_info_remote_control_body_para2">If contact stops, this shows when we last heard from it. Tapping the button may not work until it reconnects.</string>
+
+    <!-- Function List screen — warning paragraph + per-action button labels. -->
+    <string name="function_list_warning">Each button below performs a real action immediately. No confirmation prompts. Tapping triggers calls to the server, modifies app state, or wipes local data. Double-check the label before tapping.</string>
+    <string name="function_list_access_denied">Access not enabled for your account.</string>
+    <string name="function_list_door_action">Open or close garage door</string>
+    <string name="function_list_refresh_door_status">Refresh door status</string>
+    <string name="function_list_refresh_door_history">Refresh door history</string>
+    <string name="function_list_refresh_snooze_status">Refresh snooze status</string>
+    <string name="function_list_refresh_button_health">Refresh button health</string>
+    <string name="function_list_snooze_one_hour">Snooze notifications for 1 hour</string>
+    <string name="function_list_sign_in_google">Sign in with Google</string>
+    <string name="function_list_sign_out">Sign out</string>
+    <string name="function_list_clear_diagnostics">Clear all diagnostics</string>
+    <string name="function_list_prune_diagnostics">Prune diagnostics log</string>
+    <string name="function_list_register_fcm">Re-register FCM</string>
+    <string name="function_list_deregister_fcm">Deregister FCM</string>
+    <string name="function_list_copy_auth_token">Copy auth token (sensitive)</string>
 </resources>


### PR DESCRIPTION
## Summary
Phase 1 Batch C — final mechanical Composable-scope migration. 15 strings in `FunctionListContent.kt`:
- Warning paragraph
- Access-denied message
- 13 per-action button labels (door action, refreshes, snooze, sign-in/out, diagnostics, FCM, copy auth token)

## Phase 1 status after this PR
All 12 Composable-scope files in the plan are migrated. Remaining work moves to Phase 2 (typed-hint refactor of mappers + sealed-type defaults) and Phase 3 (lint enforcement).

## Verified
- `validate.sh` PASS on this branch
- No screenshot churn — values byte-identical to pre-migration