### PR TITLE
refactor(android): HomeMapper.warning() returns DoorWarning sealed type (Phase 2A)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/DoorWarning.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/DoorWarning.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui.home
+
+/**
+ * Typed warning surfaced inside the Home tab's Status card for stuck or
+ * anomalous door states. Replaces the previous `String?` field on
+ * [HomeStatusDisplay] (Phase 2A of the string-resource migration plan
+ * in `AndroidGarage/docs/PENDING_FOLLOWUPS.md` item #1).
+ *
+ * The mapper produces a typed value; the Composable resolves it to a
+ * localized string at render time via `stringResource(...)`. This keeps
+ * [HomeMapper] pure-function unit-testable without `Context` /
+ * `Resources`, lets tests assert on type rather than text (so a copy
+ * revision doesn't break the mapper test), and unblocks future
+ * localization.
+ *
+ * Two shapes:
+ * - [ServerMessage]: server-supplied warning text — passed through
+ *   verbatim because the server's own message is intended to be more
+ *   specific than any hardcoded fallback.
+ * - The four fallback `data object` variants: used when the server
+ *   provides no message for a known anomalous state. Each maps to a
+ *   string resource via [warningTextRes].
+ */
+sealed interface DoorWarning {
+    /** Server-supplied warning text — render verbatim, no localization. */
+    data class ServerMessage(
+        val text: String,
+    ) : DoorWarning
+
+    /** Fallback for [com.chriscartland.garage.domain.model.DoorPosition.OPENING_TOO_LONG]. */
+    data object OpeningTooLong : DoorWarning
+
+    /** Fallback for [com.chriscartland.garage.domain.model.DoorPosition.CLOSING_TOO_LONG]. */
+    data object ClosingTooLong : DoorWarning
+
+    /** Fallback for [com.chriscartland.garage.domain.model.DoorPosition.OPEN_MISALIGNED]. */
+    data object OpenMisaligned : DoorWarning
+
+    /** Fallback for [com.chriscartland.garage.domain.model.DoorPosition.ERROR_SENSOR_CONFLICT]. */
+    data object SensorConflict : DoorWarning
+}

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
@@ -100,7 +100,7 @@ data class HomeStatusDisplay(
     val doorPosition: DoorPosition,
     val stateLabel: String,
     val sinceLine: String,
-    val warning: String? = null,
+    val warning: DoorWarning? = null,
     /** Drives the muted "stale" door color and disables animation when true. */
     val isStale: Boolean = false,
 )
@@ -354,7 +354,8 @@ private fun HomeStatusCardBody(status: HomeStatusDisplay) {
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
             )
-            if (status.warning != null) {
+            val warning = status.warning
+            if (warning != null) {
                 Spacer(modifier = Modifier.height(Spacing.Tight))
                 Surface(
                     color = MaterialTheme.colorScheme.errorContainer,
@@ -372,7 +373,7 @@ private fun HomeStatusCardBody(status: HomeStatusDisplay) {
                             modifier = Modifier.size(18.dp),
                         )
                         Text(
-                            text = status.warning,
+                            text = doorWarningText(warning),
                             style = MaterialTheme.typography.bodySmall,
                             textAlign = TextAlign.Start,
                         )
@@ -382,6 +383,27 @@ private fun HomeStatusCardBody(status: HomeStatusDisplay) {
         }
     }
 }
+
+/**
+ * Resolves a typed [DoorWarning] to its display string. Server-supplied
+ * messages render verbatim; the four fallback variants resolve to
+ * `strings.xml` resources so the chip always says something useful even
+ * when the server sends nothing for an anomalous state.
+ *
+ * Phase 2A of the string-resource migration plan
+ * (`AndroidGarage/docs/PENDING_FOLLOWUPS.md` item #1) — keeps the mapper
+ * pure-function and unit-testable on type while pushing the localization
+ * boundary into the Composable layer.
+ */
+@Composable
+private fun doorWarningText(warning: DoorWarning): String =
+    when (warning) {
+        is DoorWarning.ServerMessage -> warning.text
+        DoorWarning.OpeningTooLong -> stringResource(R.string.home_warning_opening_too_long)
+        DoorWarning.ClosingTooLong -> stringResource(R.string.home_warning_closing_too_long)
+        DoorWarning.OpenMisaligned -> stringResource(R.string.home_warning_open_misaligned)
+        DoorWarning.SensorConflict -> stringResource(R.string.home_warning_sensor_conflict)
+    }
 
 @Composable
 private fun HomeRemoteButtonBody(
@@ -499,7 +521,9 @@ private object HomePreviewData {
         doorPosition = DoorPosition.OPENING_TOO_LONG,
         stateLabel = "Opening",
         sinceLine = "Since 12:01 PM · 4 min",
-        warning = "Taking longer than expected. Check the door for obstructions.",
+        warning = DoorWarning.ServerMessage(
+            "Taking longer than expected. Check the door for obstructions.",
+        ),
     )
     val staleAlert = HomeAlert.Stale()
     val permissionAlert = HomeAlert.PermissionMissing(

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeMapper.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeMapper.kt
@@ -116,24 +116,29 @@ object HomeMapper {
         }
 
     /**
-     * Returns the warning string to surface inside the Status card for stuck
-     * or anomalous states. Prefers the server-supplied message; falls back
-     * to a fixed string per [DoorPosition] so the chip always says something
-     * useful when shown.
+     * Returns the typed warning to surface inside the Status card for stuck
+     * or anomalous states. Prefers the server-supplied message
+     * ([DoorWarning.ServerMessage]); falls back to a typed enum case per
+     * [DoorPosition] so the Composable can render a localized string from
+     * `strings.xml` when the server sends nothing.
+     *
+     * Per the string-resource migration plan (PENDING_FOLLOWUPS.md item #1),
+     * the mapper does not return user-visible text — it returns a type, and
+     * the Composable resolves the type to a string via `stringResource(...)`.
      */
-    internal fun warning(event: DoorEvent?): String? {
+    internal fun warning(event: DoorEvent?): DoorWarning? {
         if (event == null) return null
         val message = event.message?.takeIf { it.isNotBlank() }
         return when (event.doorPosition) {
             DoorPosition.OPENING_TOO_LONG ->
-                message ?: "Opening, taking longer than expected"
+                message?.let(DoorWarning::ServerMessage) ?: DoorWarning.OpeningTooLong
             DoorPosition.CLOSING_TOO_LONG ->
-                message ?: "Closing, taking longer than expected"
+                message?.let(DoorWarning::ServerMessage) ?: DoorWarning.ClosingTooLong
             DoorPosition.OPEN_MISALIGNED ->
-                message ?: "Door is open and misaligned"
+                message?.let(DoorWarning::ServerMessage) ?: DoorWarning.OpenMisaligned
             DoorPosition.ERROR_SENSOR_CONFLICT ->
-                message ?: "Sensor conflict. Check the door."
-            DoorPosition.UNKNOWN -> message
+                message?.let(DoorWarning::ServerMessage) ?: DoorWarning.SensorConflict
+            DoorPosition.UNKNOWN -> message?.let(DoorWarning::ServerMessage)
             else -> null
         }
     }

--- a/AndroidGarage/androidApp/src/main/res/values/strings.xml
+++ b/AndroidGarage/androidApp/src/main/res/values/strings.xml
@@ -114,6 +114,12 @@
     <string name="home_info_remote_control_body_para1">The remote button checks in frequently. \"Available\" means it just told us it\'s ready to open or close the door.</string>
     <string name="home_info_remote_control_body_para2">If contact stops, this shows when we last heard from it. Tapping the button may not work until it reconnects.</string>
 
+    <!-- Home → Door warnings (fallback messages when server sends none). -->
+    <string name="home_warning_opening_too_long">Opening, taking longer than expected</string>
+    <string name="home_warning_closing_too_long">Closing, taking longer than expected</string>
+    <string name="home_warning_open_misaligned">Door is open and misaligned</string>
+    <string name="home_warning_sensor_conflict">Sensor conflict. Check the door.</string>
+
     <!-- Function List screen — warning paragraph + per-action button labels. -->
     <string name="function_list_warning">Each button below performs a real action immediately. No confirmation prompts. Tapping triggers calls to the server, modifies app state, or wipes local data. Double-check the label before tapping.</string>
     <string name="function_list_access_denied">Access not enabled for your account.</string>

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/home/HomeMapperTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/home/HomeMapperTest.kt
@@ -95,6 +95,9 @@ class HomeMapperTest {
     // endregion
 
     // region warning
+    // Phase 2A of the string-resource migration: warning() returns a typed
+    // DoorWarning?, not a String?. Tests assert on type so a copy revision
+    // doesn't break them.
 
     @Test
     fun warning_null_event_returns_null() = assertNull(HomeMapper.warning(null))
@@ -116,48 +119,48 @@ class HomeMapperTest {
         val w = HomeMapper.warning(
             DoorEvent(doorPosition = DoorPosition.OPENING_TOO_LONG, message = "Specific server text"),
         )
-        assertEquals("Specific server text", w)
+        assertEquals(DoorWarning.ServerMessage("Specific server text"), w)
     }
 
     @Test
-    fun warning_openingTooLong_falls_back_to_default_when_message_null() {
+    fun warning_openingTooLong_falls_back_to_typed_default_when_message_null() {
         val w = HomeMapper.warning(DoorEvent(doorPosition = DoorPosition.OPENING_TOO_LONG))
-        assertEquals("Opening, taking longer than expected", w)
+        assertEquals(DoorWarning.OpeningTooLong, w)
     }
 
     @Test
-    fun warning_openingTooLong_falls_back_to_default_when_message_blank() {
+    fun warning_openingTooLong_falls_back_to_typed_default_when_message_blank() {
         val w = HomeMapper.warning(
             DoorEvent(doorPosition = DoorPosition.OPENING_TOO_LONG, message = "   "),
         )
-        assertEquals("Opening, taking longer than expected", w)
+        assertEquals(DoorWarning.OpeningTooLong, w)
     }
 
     @Test
     fun warning_closingTooLong_default() {
         val w = HomeMapper.warning(DoorEvent(doorPosition = DoorPosition.CLOSING_TOO_LONG))
-        assertEquals("Closing, taking longer than expected", w)
+        assertEquals(DoorWarning.ClosingTooLong, w)
     }
 
     @Test
     fun warning_openMisaligned_default() {
         val w = HomeMapper.warning(DoorEvent(doorPosition = DoorPosition.OPEN_MISALIGNED))
-        assertEquals("Door is open and misaligned", w)
+        assertEquals(DoorWarning.OpenMisaligned, w)
     }
 
     @Test
     fun warning_sensorConflict_default() {
         val w = HomeMapper.warning(DoorEvent(doorPosition = DoorPosition.ERROR_SENSOR_CONFLICT))
-        assertEquals("Sensor conflict. Check the door.", w)
+        assertEquals(DoorWarning.SensorConflict, w)
     }
 
     @Test
-    fun warning_unknown_uses_message_only_no_default() {
+    fun warning_unknown_uses_server_message_only_no_default() {
         // Unknown is too vague for a fixed default, so only the server's
         // own message is surfaced — and only when non-blank.
         assertNull(HomeMapper.warning(DoorEvent(doorPosition = DoorPosition.UNKNOWN)))
         assertEquals(
-            "Server says X",
+            DoorWarning.ServerMessage("Server says X"),
             HomeMapper.warning(DoorEvent(doorPosition = DoorPosition.UNKNOWN, message = "Server says X")),
         )
     }


### PR DESCRIPTION
## Summary
First Phase 2 PR in the string-resource migration. Replaces `HomeMapper.warning(): String?` with `HomeMapper.warning(): DoorWarning?` — a typed sealed type the Composable resolves to a localized string at render time.

## DoorWarning shape
```kotlin
sealed interface DoorWarning {
    data class ServerMessage(val text: String) : DoorWarning
    data object OpeningTooLong : DoorWarning
    data object ClosingTooLong : DoorWarning
    data object OpenMisaligned : DoorWarning
    data object SensorConflict : DoorWarning
}
```

`ServerMessage` carries the verbatim server-supplied text (renders as-is). The four `data object` fallback variants resolve to `strings.xml` (`home_warning_*`).

## Why
Per [PENDING_FOLLOWUPS.md item #1](AndroidGarage/docs/PENDING_FOLLOWUPS.md), mappers must not return user-visible strings. Tests can now assert on type (`assertEquals(DoorWarning.OpeningTooLong, w)`) instead of fragile text — a copy revision in `strings.xml` will not break the mapper test.

## Files
| File | Change |
|---|---|
| `DoorWarning.kt` (NEW) | sealed type definition |
| `HomeMapper.kt` | `warning()` return type → `DoorWarning?` |
| `HomeContent.kt` | `HomeStatusDisplay.warning: DoorWarning?` + new `doorWarningText()` Composable resolver |
| `strings.xml` | 4 new fallback resources |
| `HomeMapperTest.kt` | 11 warning tests rewritten from text → type |

## Out of scope (queued)
| Phase | What |
|---|---|
| 2B | `stateLabel` deletion (Composable does `when (doorPosition) → stringResource`) |
| 2C | `sinceLine` + duration formatting → Composable + `HomeStatusFormatter` util + `pluralStringResource` |
| 2D | `HomeAlert` default-arg drops |
| 2E | `HistoryMapper` parallel refactor |
| 2F | `NotificationPermissionCopy` |

## Verified
- `validate.sh` PASS on this branch
- 11 rewritten warning tests + 30 unchanged HomeMapper tests pass
- No screenshot churn — preview fixture text is identical (DoorWarning.ServerMessage wraps the same string)