### PR TITLE
refactor(android): Drop HomeMapper.stateLabel + HomeStatusDisplay.stateLabel field (Phase 2B)

### DIFF
--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/AuthStateUIPropagationTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/AuthStateUIPropagationTest.kt
@@ -64,7 +64,6 @@ class AuthStateUIPropagationTest {
 
     private val unknownStatus = HomeStatusDisplay(
         doorPosition = DoorPosition.UNKNOWN,
-        stateLabel = "Unknown",
         sinceLine = "Last change time unknown",
     )
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
@@ -87,18 +87,18 @@ import com.chriscartland.garage.usecase.ButtonHealthDisplay
  * Stateless: every string is pre-formatted by the caller so screenshot tests
  * remain deterministic and the Composable carries no time math.
  *
- * @param doorPosition drives the [GarageIcon] visual + door coloring.
- * @param stateLabel headline text — e.g. "Open", "Closed", "Opening".
+ * @param doorPosition drives the [GarageIcon] visual + door coloring AND the
+ *   headline label — the Composable resolves position to a localized string
+ *   via [doorStateLabel] (Phase 2B of the string-resource migration plan).
  * @param sinceLine combined status line — e.g. "Since 9:47 AM · 2 hr 14 min".
  *   Replaces the two separate icon-text rows from the legacy
  *   `DoorStatusCard`.
- * @param warning optional warning supporting text, surfaced for
+ * @param warning optional typed warning supporting content, surfaced for
  *   `OPENING_TOO_LONG`, `OPEN_MISALIGNED`, `CLOSING_TOO_LONG`,
- *   `ERROR_SENSOR_CONFLICT`, etc.
+ *   `ERROR_SENSOR_CONFLICT`, etc. See [DoorWarning].
  */
 data class HomeStatusDisplay(
     val doorPosition: DoorPosition,
-    val stateLabel: String,
     val sinceLine: String,
     val warning: DoorWarning? = null,
     /** Drives the muted "stale" door color and disables animation when true. */
@@ -344,7 +344,7 @@ private fun HomeStatusCardBody(status: HomeStatusDisplay) {
             verticalArrangement = Arrangement.spacedBy(Spacing.Tight),
         ) {
             Text(
-                text = status.stateLabel,
+                text = doorStateLabel(status.doorPosition),
                 style = MaterialTheme.typography.titleLarge,
                 color = MaterialTheme.colorScheme.onSurface,
             )
@@ -403,6 +403,34 @@ private fun doorWarningText(warning: DoorWarning): String =
         DoorWarning.ClosingTooLong -> stringResource(R.string.home_warning_closing_too_long)
         DoorWarning.OpenMisaligned -> stringResource(R.string.home_warning_open_misaligned)
         DoorWarning.SensorConflict -> stringResource(R.string.home_warning_sensor_conflict)
+    }
+
+/**
+ * Resolves a [DoorPosition] to the headline label string for the Status card.
+ *
+ * Multiple positions share a label by design: `OPENING` and `OPENING_TOO_LONG`
+ * both render "Opening"; `OPEN` and `OPEN_MISALIGNED` both render "Open";
+ * `CLOSING` and `CLOSING_TOO_LONG` both render "Closing". The anomalous
+ * variants surface their distinguishing detail in the [DoorWarning] chip
+ * below, not in the headline.
+ *
+ * Phase 2B of the string-resource migration plan — replaces the previous
+ * `HomeMapper.stateLabel(DoorPosition): String` function. The mapper no
+ * longer emits user-visible text for the door state; the Composable
+ * resolves position to a localized resource at render time.
+ */
+@Composable
+private fun doorStateLabel(doorPosition: DoorPosition): String =
+    when (doorPosition) {
+        DoorPosition.OPEN -> stringResource(R.string.home_door_state_open)
+        DoorPosition.OPEN_MISALIGNED -> stringResource(R.string.home_door_state_open)
+        DoorPosition.CLOSED -> stringResource(R.string.home_door_state_closed)
+        DoorPosition.UNKNOWN -> stringResource(R.string.home_door_state_unknown)
+        DoorPosition.OPENING -> stringResource(R.string.home_door_state_opening)
+        DoorPosition.OPENING_TOO_LONG -> stringResource(R.string.home_door_state_opening)
+        DoorPosition.CLOSING -> stringResource(R.string.home_door_state_closing)
+        DoorPosition.CLOSING_TOO_LONG -> stringResource(R.string.home_door_state_closing)
+        DoorPosition.ERROR_SENSOR_CONFLICT -> stringResource(R.string.home_door_state_sensor_conflict)
     }
 
 @Composable
@@ -509,17 +537,14 @@ private fun HomeAlertCard(
 private object HomePreviewData {
     val openStatus = HomeStatusDisplay(
         doorPosition = DoorPosition.OPEN,
-        stateLabel = "Open",
         sinceLine = "Since 9:47 AM · 2 hr 14 min",
     )
     val closedStatus = HomeStatusDisplay(
         doorPosition = DoorPosition.CLOSED,
-        stateLabel = "Closed",
         sinceLine = "Since 11:22 AM · 38 min",
     )
     val openingTooLongStatus = HomeStatusDisplay(
         doorPosition = DoorPosition.OPENING_TOO_LONG,
-        stateLabel = "Opening",
         sinceLine = "Since 12:01 PM · 4 min",
         warning = DoorWarning.ServerMessage(
             "Taking longer than expected. Check the door for obstructions.",

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeMapper.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeMapper.kt
@@ -54,7 +54,6 @@ object HomeMapper {
         val doorPosition = event?.doorPosition ?: DoorPosition.UNKNOWN
         return HomeStatusDisplay(
             doorPosition = doorPosition,
-            stateLabel = stateLabel(doorPosition),
             sinceLine = sinceLine(event?.lastChangeTimeSeconds, now, zone),
             warning = warning(event),
             isStale = isCheckInStale,
@@ -100,19 +99,6 @@ object HomeMapper {
             AuthState.Unknown -> HomeAuthState.Unknown
             AuthState.Unauthenticated -> HomeAuthState.SignedOut
             is AuthState.Authenticated -> HomeAuthState.SignedIn
-        }
-
-    internal fun stateLabel(doorPosition: DoorPosition): String =
-        when (doorPosition) {
-            DoorPosition.OPEN -> "Open"
-            DoorPosition.CLOSED -> "Closed"
-            DoorPosition.UNKNOWN -> "Unknown"
-            DoorPosition.OPENING -> "Opening"
-            DoorPosition.OPENING_TOO_LONG -> "Opening"
-            DoorPosition.OPEN_MISALIGNED -> "Open"
-            DoorPosition.CLOSING -> "Closing"
-            DoorPosition.CLOSING_TOO_LONG -> "Closing"
-            DoorPosition.ERROR_SENSOR_CONFLICT -> "Sensor conflict"
         }
 
     /**

--- a/AndroidGarage/androidApp/src/main/res/values/strings.xml
+++ b/AndroidGarage/androidApp/src/main/res/values/strings.xml
@@ -114,6 +114,19 @@
     <string name="home_info_remote_control_body_para1">The remote button checks in frequently. \"Available\" means it just told us it\'s ready to open or close the door.</string>
     <string name="home_info_remote_control_body_para2">If contact stops, this shows when we last heard from it. Tapping the button may not work until it reconnects.</string>
 
+    <!-- Home → Door state labels (headline text on the Status card). -->
+    <!-- Several DoorPosition values share a label: OPENING_TOO_LONG and -->
+    <!-- OPENING both render "Opening"; OPEN_MISALIGNED and OPEN both render -->
+    <!-- "Open"; CLOSING_TOO_LONG and CLOSING both render "Closing". The -->
+    <!-- anomalous variants surface their distinguishing detail in the -->
+    <!-- warning chip below (DoorWarning sealed type, Phase 2A). -->
+    <string name="home_door_state_open">Open</string>
+    <string name="home_door_state_closed">Closed</string>
+    <string name="home_door_state_unknown">Unknown</string>
+    <string name="home_door_state_opening">Opening</string>
+    <string name="home_door_state_closing">Closing</string>
+    <string name="home_door_state_sensor_conflict">Sensor conflict</string>
+
     <!-- Home → Door warnings (fallback messages when server sends none). -->
     <string name="home_warning_opening_too_long">Opening, taking longer than expected</string>
     <string name="home_warning_closing_too_long">Closing, taking longer than expected</string>

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/home/HomeMapperTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/home/HomeMapperTest.kt
@@ -54,45 +54,11 @@ class HomeMapperTest {
         email = Email("chris@example.com"),
     )
 
-    // region stateLabel
-
-    @Test
-    fun stateLabel_open() = assertEquals("Open", HomeMapper.stateLabel(DoorPosition.OPEN))
-
-    @Test
-    fun stateLabel_closed() = assertEquals("Closed", HomeMapper.stateLabel(DoorPosition.CLOSED))
-
-    @Test
-    fun stateLabel_unknown() = assertEquals("Unknown", HomeMapper.stateLabel(DoorPosition.UNKNOWN))
-
-    @Test
-    fun stateLabel_opening() = assertEquals("Opening", HomeMapper.stateLabel(DoorPosition.OPENING))
-
-    @Test
-    fun stateLabel_openingTooLong_collapsesTo_opening() = assertEquals("Opening", HomeMapper.stateLabel(DoorPosition.OPENING_TOO_LONG))
-
-    @Test
-    fun stateLabel_openMisaligned_collapsesTo_open() = assertEquals("Open", HomeMapper.stateLabel(DoorPosition.OPEN_MISALIGNED))
-
-    @Test
-    fun stateLabel_closing() = assertEquals("Closing", HomeMapper.stateLabel(DoorPosition.CLOSING))
-
-    @Test
-    fun stateLabel_closingTooLong_collapsesTo_closing() = assertEquals("Closing", HomeMapper.stateLabel(DoorPosition.CLOSING_TOO_LONG))
-
-    @Test
-    fun stateLabel_sensorConflict() = assertEquals("Sensor conflict", HomeMapper.stateLabel(DoorPosition.ERROR_SENSOR_CONFLICT))
-
-    @Test
-    fun stateLabel_coversAllDoorPositionVariants() {
-        // Catch new DoorPosition variants that forget to update the mapper.
-        DoorPosition.entries.forEach { p ->
-            val label = HomeMapper.stateLabel(p)
-            assertTrue("Empty label for $p", label.isNotBlank())
-        }
-    }
-
-    // endregion
+    // (region stateLabel removed in Phase 2B — function deleted from
+    //  HomeMapper. The Composable doorStateLabel(doorPosition) in
+    //  HomeContent.kt does the position → string resolution at render
+    //  time. New DoorPosition variants are caught by exhaustiveness on
+    //  the `when` block in that Composable.)
 
     // region warning
     // Phase 2A of the string-resource migration: warning() returns a typed
@@ -290,7 +256,6 @@ class HomeMapperTest {
     fun toHomeStatusDisplay_null_event_returns_unknown() {
         val display = HomeMapper.toHomeStatusDisplay(LoadingResult.Complete(null), now, zone)
         assertEquals(DoorPosition.UNKNOWN, display.doorPosition)
-        assertEquals("Unknown", display.stateLabel)
         assertEquals("Last change time unknown", display.sinceLine)
         assertNull(display.warning)
     }
@@ -304,7 +269,6 @@ class HomeMapperTest {
         val event = event(DoorPosition.OPEN, secondsAgo = 60 * 38)
         val display = HomeMapper.toHomeStatusDisplay(LoadingResult.Loading(event), now, zone)
         assertEquals(DoorPosition.OPEN, display.doorPosition)
-        assertEquals("Open", display.stateLabel)
         assertTrue(display.sinceLine.startsWith("Since "))
     }
 
@@ -324,7 +288,6 @@ class HomeMapperTest {
         val event = event(DoorPosition.OPEN, secondsAgo = 2 * 3_600 + 13 * 60)
         val display = HomeMapper.toHomeStatusDisplay(LoadingResult.Complete(event), now, zone)
         assertEquals(DoorPosition.OPEN, display.doorPosition)
-        assertEquals("Open", display.stateLabel)
         assertTrue(display.sinceLine.contains("2 hr 13 min"))
         assertNull(display.warning)
     }
@@ -333,7 +296,6 @@ class HomeMapperTest {
     fun toHomeStatusDisplay_openingTooLong_surfaces_warning() {
         val event = event(DoorPosition.OPENING_TOO_LONG, secondsAgo = 4 * 60)
         val display = HomeMapper.toHomeStatusDisplay(LoadingResult.Complete(event), now, zone)
-        assertEquals("Opening", display.stateLabel)
         assertEquals(DoorPosition.OPENING_TOO_LONG, display.doorPosition)
         assertNotNull(display.warning)
     }


### PR DESCRIPTION
## Summary
Phase 2B of the string-resource migration. Mapper no longer produces a user-visible door-state label; the Composable resolves `DoorPosition` to a string at render time.

## Changes
| File | Change |
|---|---|
| `strings.xml` | 6 new resources (`home_door_state_*`). Multi-position collapse intentional (OPENING_TOO_LONG → "Opening", OPEN_MISALIGNED → "Open", CLOSING_TOO_LONG → "Closing"); the warning chip below carries the distinguishing detail |
| `HomeMapper.kt` | DELETE `stateLabel(DoorPosition)`. Drop `stateLabel = stateLabel(...)` from `toHomeStatusDisplay` |
| `HomeContent.kt` | DROP `val stateLabel: String` from `HomeStatusDisplay`. New `doorStateLabel(DoorPosition)` Composable resolver. `HomeStatusCardBody` reads `doorStateLabel(status.doorPosition)` |
| `HomeContent.kt` previews | Drop `stateLabel = "..."` from 3 fixtures |
| `AuthStateUIPropagationTest.kt` | Drop `stateLabel = "Unknown"` from fixture |
| `HomeMapperTest.kt` | DELETE 10 stateLabel tests + 1 exhaustiveness test. Composable's `when` block provides equivalent compile-time exhaustiveness. UPDATE 4 toHomeStatusDisplay assertions |

## Test coverage notes
The deleted `stateLabel_coversAllDoorPositionVariants` test asserted that every `DoorPosition` had a non-blank label. After this PR, `doorStateLabel`'s `when` block is the new safety net — if a new `DoorPosition` variant is added, the Composable fails compilation (Kotlin `when` exhaustiveness on sealed types/enums).

## Out of scope (queued)
- Phase 2C: `sinceLine` + duration formatting → Composable + util
- Phase 2D: `HomeAlert` default-arg drops
- Phase 2E: `HistoryMapper` parallel refactor
- Phase 2F: `NotificationPermissionCopy`

## Verified
- `validate.sh` PASS on this branch
- No screenshot churn — labels resolve to identical strings via `stringResource`