### PR TITLE
build(android): Add checkNoLiteralStringsInCompose lint (Phase 3)

### DIFF
--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -201,6 +201,13 @@ tasks.register<architecture.NoRawDispatchersTask>("checkNoRawDispatchers") {
     )
 }
 
+tasks.register<architecture.LiteralStringsInComposeCheckTask>("checkNoLiteralStringsInCompose") {
+    sourceDirs = listOf(
+        "$rootDir/androidApp/src/main/java",
+    )
+    exemptionsFile = "$rootDir/string-literal-exemptions.txt"
+}
+
 tasks.register<architecture.NoBareTopLevelFunctionsTask>("checkNoBareTopLevelFunctions") {
     sourceDirs = listOf(
         "$rootDir/androidApp/src/main/java",

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/LiteralStringsInComposeCheckTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/LiteralStringsInComposeCheckTask.kt
@@ -1,0 +1,135 @@
+package architecture
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Phase 3 of the string-resource migration plan
+ * (`AndroidGarage/docs/PENDING_FOLLOWUPS.md` item #1). Forbids hardcoded
+ * `Text("literal")` and `Text(text = "literal")` patterns in production
+ * Composable code so user-visible labels can't regress to inline strings
+ * after the migration.
+ *
+ * **What gets flagged:**
+ * - `Text("anything")`
+ * - `Text(text = "anything")`
+ *
+ * **What gets exempted (not flagged):**
+ * - Files matching the configured [exemptFilePatterns] — preview-only
+ *   files (`*Preview*.kt`, theme tokens previews) construct fake fixture
+ *   data with literal strings. Per the plan, preview fake data is not
+ *   user-visible at runtime and stays as Kotlin literals.
+ * - KDoc / multi-line-comment lines (start with `*`) — code examples
+ *   inside doc comments aren't compiled.
+ * - Empty / whitespace-only string literals (`Text("")`, `Text("\n")`).
+ * - Lines listed in the [exemptionsFile] — the ratchet pattern. Existing
+ *   violations at lint-introduction time go in the exemption file; new
+ *   violations are blocked.
+ *
+ * **Exemption file format:** one violation per line, in the form
+ * `relative/path/File.kt:lineNumber`. Lines starting with `#` are comments.
+ * If the file does not exist, no exemptions are applied (treat as empty).
+ *
+ * Detection strategy: simple regex over each `.kt` file. Not AST-aware,
+ * so does NOT distinguish between `Text("...")` inside a `@Composable`
+ * function vs. inside a `data class` default arg vs. inside a regular
+ * function body — but since we only care about Composable bodies, the
+ * exemption mechanism handles edge cases (data class defaults that
+ * legitimately carry strings can be moved to the exemption file or, in
+ * the long run, refactored to typed-hint shapes per Phase 2 of the plan).
+ */
+abstract class LiteralStringsInComposeCheckTask : DefaultTask() {
+    @get:Input
+    var sourceDirs: List<String> = emptyList()
+
+    @get:Input
+    var exemptFilePatterns: List<String> = listOf(
+        ".*Preview.*\\.kt",
+        ".*Tokens.*Preview\\.kt",
+    )
+
+    @get:Input
+    var exemptionsFile: String = ""
+
+    @TaskAction
+    fun check() {
+        val violations = mutableListOf<String>()
+        val filePatterns = exemptFilePatterns.map(::Regex)
+        val exemptions = loadExemptions()
+        // Match Text("..."), Text(text = "..."), Text(text="..."). Tolerates
+        // whitespace and an optional argument-name keyword. Captures the
+        // string content so we can skip empty/whitespace-only literals.
+        val textPattern = Regex("""\bText\s*\(\s*(?:text\s*=\s*)?"([^"]*)"\s*[,)]""")
+
+        sourceDirs.forEach { dir ->
+            val rootFile = File(dir)
+            if (!rootFile.exists()) return@forEach
+
+            rootFile
+                .walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .filterNot { file ->
+                    val name = file.name
+                    filePatterns.any { it.matches(name) }
+                }.forEach { file ->
+                    val relativePath = file.relativeTo(rootFile).path
+                    file.readLines().forEachIndexed { index, line ->
+                        val trimmed = line.trim()
+                        if (trimmed.startsWith("*") || trimmed.startsWith("//")) return@forEachIndexed
+
+                        val match = textPattern.find(line) ?: return@forEachIndexed
+                        val literal = match.groupValues[1]
+                        // Empty / whitespace-only literals are never user-visible.
+                        if (literal.isBlank()) return@forEachIndexed
+
+                        val location = "$relativePath:${index + 1}"
+                        if (location in exemptions) return@forEachIndexed
+                        violations.add("$location: ${line.trim()}")
+                    }
+                }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    append("LiteralStringsInCompose check FAILED: ")
+                    append(violations.size)
+                    append(" violation(s).\n\n")
+                    violations.forEach { append("  - $it\n") }
+                    append("\n")
+                    append("Phase 3 of the string-resource migration plan\n")
+                    append("(AndroidGarage/docs/PENDING_FOLLOWUPS.md item #1):\n")
+                    append("user-visible Text() literals must move to res/values/strings.xml\n")
+                    append("and use stringResource(R.string.X). The mapper / ViewModel layer\n")
+                    append("emits typed states; the Composable resolves type → string at\n")
+                    append("render time.\n\n")
+                    append("Fix:\n")
+                    append("  - Add the string to AndroidGarage/androidApp/src/main/res/values/strings.xml\n")
+                    append("  - Replace the literal with stringResource(R.string.<key>)\n")
+                    append("  - Use formatArgs (%1\$s, %2\$d) for interpolated strings\n")
+                    append("  - Use <plurals> + pluralStringResource for count-based strings\n\n")
+                    append("If the string is genuinely not user-visible (preview fake data,\n")
+                    append("test fixture, dead code), add it to the exemption file:\n")
+                    append("  AndroidGarage/string-literal-exemptions.txt\n")
+                    append("Format: one entry per line, e.g. `androidApp/src/main/.../File.kt:42`\n")
+                },
+            )
+        }
+
+        logger.lifecycle("LiteralStringsInCompose check passed: no hardcoded Text() literals found.")
+    }
+
+    private fun loadExemptions(): Set<String> {
+        if (exemptionsFile.isBlank()) return emptySet()
+        val file = File(exemptionsFile)
+        if (!file.exists()) return emptySet()
+        return file
+            .readLines()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && !it.startsWith("#") }
+            .toSet()
+    }
+}

--- a/AndroidGarage/string-literal-exemptions.txt
+++ b/AndroidGarage/string-literal-exemptions.txt
@@ -1,0 +1,19 @@
+# String-literal exemptions for checkNoLiteralStringsInCompose lint.
+#
+# Phase 3 of the string-resource migration plan
+# (AndroidGarage/docs/PENDING_FOLLOWUPS.md item #1).
+#
+# Each entry: relative-to-source-dir path + line number, e.g.
+#   ui/HomeContent.kt:42
+#
+# Lines starting with `#` are comments. Blank lines ignored.
+#
+# This file is the ratchet: as Phase 1 + Phase 2 migration PRs land,
+# entries should DECREASE. Adding a new entry requires PR review;
+# the long-term goal is empty.
+#
+# Currently empty — Phases 1A/1B/1C and 2A/2B landed all production
+# Composable strings into strings.xml. The remaining literal Text() in
+# main sources are all preview-only files (filtered by file-name pattern,
+# see exemptFilePatterns in build.gradle.kts) or KDoc code examples
+# (filtered by line-prefix `*` check in the task).

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -52,6 +52,9 @@ $GRADLE checkNoRawDispatchers && pass "no raw dispatchers" || fail "no raw dispa
 step "No bare top-level functions (ADR-009 — group in object {})"
 $GRADLE checkNoBareTopLevelFunctions && pass "no bare top-level functions" || fail "no bare top-level functions"
 
+step "No literal Text() in Composable scope (Phase 3 — string-resource migration)"
+$GRADLE checkNoLiteralStringsInCompose && pass "no literal Text() in Composable" || fail "no literal Text() in Composable"
+
 step "No *Impl suffix on class names (ADR-008 — use descriptive prefix)"
 $GRADLE checkNoImplSuffix && pass "no *Impl suffix" || fail "no *Impl suffix"
 


### PR DESCRIPTION
## Summary
Phase 3 of the [string-resource migration plan](AndroidGarage/docs/PENDING_FOLLOWUPS.md). Locks in the gains: hardcoded `Text("literal")` in production Composable code now fails the build.

Lint passes today with the exemption file empty (Phase 1 + Phase 2A/2B already migrated all production strings; the only remaining literal `Text()` matches are in preview files, filtered by file-name pattern).

## Files
| File | Change |
|---|---|
| `buildSrc/.../LiteralStringsInComposeCheckTask.kt` (NEW) | Gradle task. Regex-scans for `Text("...")` patterns; supports file-pattern + per-line exemptions |
| `build.gradle.kts` | Registers `checkNoLiteralStringsInCompose` |
| `scripts/validate.sh` | Wires the task into the validation pipeline |
| `string-literal-exemptions.txt` (NEW) | Empty ratchet baseline. Goal: stays empty |

## Built-in exemptions
- `*Preview*.kt` and `*Tokens*Preview.kt` (file-name pattern) — preview fake data per the plan
- Comment lines (`*`, `//`)
- Empty / whitespace-only literals (`Text("")`)
- Per-line entries in `string-literal-exemptions.txt`

## Defense-in-depth
- This lint catches new `Text("literal")` introductions
- Phase 2 typed-hint refactors (`DoorWarning`, `doorStateLabel(DoorPosition)`) prevent mappers from producing strings to put inside `Text()` in the first place
- Two layers means a refactor that breaks one still has the other

## Verified
- `validate.sh` PASS on this branch
- Lint output: "no literal Text() in Composable scope: PASS"