### PR TITLE
refactor(android): HomeMapper sinceLine + HomeAlert defaults → typed (Phase 2C+2D)

### DIFF
--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/AuthStateUIPropagationTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/AuthStateUIPropagationTest.kt
@@ -64,8 +64,10 @@ class AuthStateUIPropagationTest {
 
     private val unknownStatus = HomeStatusDisplay(
         doorPosition = DoorPosition.UNKNOWN,
-        sinceLine = "Last change time unknown",
+        lastChangeTimeSeconds = null,
     )
+
+    private val unknownSinceLine = "Last change time unknown"
 
     private val noDataCheckIn = DeviceCheckInDisplay(
         durationLabel = "No data yet",
@@ -79,6 +81,7 @@ class AuthStateUIPropagationTest {
         composeTestRule.setContent {
             HomeStatelessContent(
                 status = unknownStatus,
+                sinceLine = unknownSinceLine,
                 authState = HomeMapper.toHomeAuthState(AuthState.Unknown),
                 deviceCheckIn = noDataCheckIn,
                 buttonHealthDisplay = ButtonHealthDisplay.Loading,
@@ -92,6 +95,7 @@ class AuthStateUIPropagationTest {
         composeTestRule.setContent {
             HomeStatelessContent(
                 status = unknownStatus,
+                sinceLine = unknownSinceLine,
                 authState = HomeMapper.toHomeAuthState(AuthState.Unauthenticated),
                 deviceCheckIn = noDataCheckIn,
                 buttonHealthDisplay = ButtonHealthDisplay.Loading,
@@ -105,6 +109,7 @@ class AuthStateUIPropagationTest {
         composeTestRule.setContent {
             HomeStatelessContent(
                 status = unknownStatus,
+                sinceLine = unknownSinceLine,
                 authState = HomeMapper.toHomeAuthState(AuthState.Authenticated(testUser)),
                 deviceCheckIn = noDataCheckIn,
                 buttonHealthDisplay = ButtonHealthDisplay.Loading,
@@ -123,6 +128,7 @@ class AuthStateUIPropagationTest {
             val authState by authStateFlow.collectAsState()
             HomeStatelessContent(
                 status = unknownStatus,
+                sinceLine = unknownSinceLine,
                 authState = HomeMapper.toHomeAuthState(authState),
                 deviceCheckIn = noDataCheckIn,
                 buttonHealthDisplay = ButtonHealthDisplay.Loading,
@@ -149,6 +155,7 @@ class AuthStateUIPropagationTest {
             val authState by authStateFlow.collectAsState()
             HomeStatelessContent(
                 status = unknownStatus,
+                sinceLine = unknownSinceLine,
                 authState = HomeMapper.toHomeAuthState(authState),
                 deviceCheckIn = noDataCheckIn,
                 buttonHealthDisplay = ButtonHealthDisplay.Loading,
@@ -174,6 +181,7 @@ class AuthStateUIPropagationTest {
             val authState by authStateFlow.collectAsState()
             HomeStatelessContent(
                 status = unknownStatus,
+                sinceLine = unknownSinceLine,
                 authState = HomeMapper.toHomeAuthState(authState),
                 deviceCheckIn = noDataCheckIn,
                 buttonHealthDisplay = ButtonHealthDisplay.Loading,
@@ -196,6 +204,7 @@ class AuthStateUIPropagationTest {
             val authState by authStateFlow.collectAsState()
             HomeStatelessContent(
                 status = unknownStatus,
+                sinceLine = unknownSinceLine,
                 authState = HomeMapper.toHomeAuthState(authState),
                 deviceCheckIn = noDataCheckIn,
                 buttonHealthDisplay = ButtonHealthDisplay.Loading,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -38,6 +38,7 @@ import com.chriscartland.garage.permissions.rememberNotificationPermissionState
 import com.chriscartland.garage.ui.home.DeviceCheckIn
 import com.chriscartland.garage.ui.home.HomeAlert
 import com.chriscartland.garage.ui.home.HomeMapper
+import com.chriscartland.garage.ui.home.rememberSinceLine
 import com.chriscartland.garage.usecase.ButtonHealthDisplay
 import com.chriscartland.garage.usecase.HomeViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -90,7 +91,8 @@ fun HomeContent(
     val now = remember(nowEpochSeconds) { Instant.ofEpochSecond(nowEpochSeconds) }
     val zone = remember { ZoneId.systemDefault() }
 
-    val status = HomeMapper.toHomeStatusDisplay(currentDoorEvent, now, zone, isCheckInStale)
+    val status = HomeMapper.toHomeStatusDisplay(currentDoorEvent, isCheckInStale)
+    val sinceLine = rememberSinceLine(status.lastChangeTimeSeconds, now, zone)
     val alerts = HomeMapper.toHomeAlerts(
         currentDoorEvent = currentDoorEvent,
         isCheckInStale = isCheckInStale,
@@ -105,6 +107,7 @@ fun HomeContent(
 
     HomeContentInternal(
         status = status,
+        sinceLine = sinceLine,
         authState = homeAuthState,
         modifier = modifier,
         remoteButtonState = buttonState,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeDashboardPreviews.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeDashboardPreviews.kt
@@ -50,6 +50,7 @@ import com.chriscartland.garage.presentation.demoDoorEvents
 import com.chriscartland.garage.ui.home.DeviceCheckIn
 import com.chriscartland.garage.ui.home.HomeAuthState
 import com.chriscartland.garage.ui.home.HomeMapper
+import com.chriscartland.garage.ui.home.rememberSinceLine
 import com.chriscartland.garage.ui.theme.PreviewWithSimulatedInsets
 import com.chriscartland.garage.ui.theme.Spacing
 import com.chriscartland.garage.ui.theme.safeListContentPadding
@@ -179,6 +180,9 @@ private fun WideHomeBody(modifier: Modifier = Modifier) {
     val event = demoDoorEvents.firstOrNull()
     val status = HomeMapper.toHomeStatusDisplay(
         currentDoorEvent = LoadingResult.Complete(event),
+    )
+    val sinceLine = rememberSinceLine(
+        lastChangeTimeSeconds = status.lastChangeTimeSeconds,
         now = DashboardDemoData.now,
         zone = DashboardDemoData.zone,
     )
@@ -192,6 +196,7 @@ private fun WideHomeBody(modifier: Modifier = Modifier) {
         homePane = { paneModifier ->
             HomeStatelessContent(
                 status = status,
+                sinceLine = sinceLine,
                 authState = HomeAuthState.SignedIn,
                 modifier = paneModifier,
                 remoteButtonState = RemoteButtonState.Ready,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/TabPreviews.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/TabPreviews.kt
@@ -47,6 +47,7 @@ import com.chriscartland.garage.presentation.demoDoorEvents
 import com.chriscartland.garage.ui.home.DeviceCheckIn
 import com.chriscartland.garage.ui.home.HomeAuthState
 import com.chriscartland.garage.ui.home.HomeMapper
+import com.chriscartland.garage.ui.home.rememberSinceLine
 import com.chriscartland.garage.ui.settings.AccountRowState
 import com.chriscartland.garage.ui.settings.SettingsContent
 import com.chriscartland.garage.ui.settings.SnoozeRowState
@@ -142,7 +143,8 @@ fun HomeTabPreview() {
     //     case, comfortably under the 11-min staleness threshold.
     val event = demoDoorEvents.firstOrNull()
     val now = Instant.parse("2026-04-29T12:00:00Z")
-    val status = HomeMapper.toHomeStatusDisplay(LoadingResult.Complete(event), now, ZoneOffset.UTC)
+    val status = HomeMapper.toHomeStatusDisplay(LoadingResult.Complete(event))
+    val sinceLine = rememberSinceLine(status.lastChangeTimeSeconds, now, ZoneOffset.UTC)
     val deviceCheckIn = DeviceCheckIn.format(
         lastCheckInSeconds = now.epochSecond - (5 * 60),
         nowSeconds = now.epochSecond,
@@ -150,6 +152,7 @@ fun HomeTabPreview() {
     TabPreviewScaffold(selectedScreen = Screen.Home) { modifier ->
         HomeStatelessContent(
             status = status,
+            sinceLine = sinceLine,
             authState = HomeAuthState.SignedIn,
             modifier = modifier,
             remoteButtonState = RemoteButtonState.Ready,
@@ -174,7 +177,8 @@ fun HomeTabStalePillPreview() {
     // `HomeTabPreview` (typical case).
     val event = demoDoorEvents.firstOrNull()
     val now = Instant.parse("2026-04-29T12:00:00Z")
-    val status = HomeMapper.toHomeStatusDisplay(LoadingResult.Complete(event), now, ZoneOffset.UTC)
+    val status = HomeMapper.toHomeStatusDisplay(LoadingResult.Complete(event))
+    val sinceLine = rememberSinceLine(status.lastChangeTimeSeconds, now, ZoneOffset.UTC)
     val deviceCheckIn = DeviceCheckIn.format(
         lastCheckInSeconds = now.epochSecond - (23 * 60),
         nowSeconds = now.epochSecond,
@@ -182,6 +186,7 @@ fun HomeTabStalePillPreview() {
     TabPreviewScaffold(selectedScreen = Screen.Home) { modifier ->
         HomeStatelessContent(
             status = status,
+            sinceLine = sinceLine,
             authState = HomeAuthState.SignedIn,
             modifier = modifier,
             remoteButtonState = RemoteButtonState.Ready,
@@ -401,7 +406,8 @@ private fun WideTabPreviewScaffold(
 fun HomeRailPreview700dp() {
     val event = demoDoorEvents.firstOrNull()
     val now = Instant.parse("2026-04-29T12:00:00Z")
-    val status = HomeMapper.toHomeStatusDisplay(LoadingResult.Complete(event), now, ZoneOffset.UTC)
+    val status = HomeMapper.toHomeStatusDisplay(LoadingResult.Complete(event))
+    val sinceLine = rememberSinceLine(status.lastChangeTimeSeconds, now, ZoneOffset.UTC)
     val deviceCheckIn = DeviceCheckIn.format(
         lastCheckInSeconds = now.epochSecond - (5 * 60),
         nowSeconds = now.epochSecond,
@@ -409,6 +415,7 @@ fun HomeRailPreview700dp() {
     WideTabPreviewScaffold(selectedScreen = Screen.Home) { modifier ->
         HomeStatelessContent(
             status = status,
+            sinceLine = sinceLine,
             authState = HomeAuthState.SignedIn,
             modifier = modifier,
             remoteButtonState = RemoteButtonState.Ready,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ThreePaneDashboardPreviews.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ThreePaneDashboardPreviews.kt
@@ -33,6 +33,7 @@ import com.chriscartland.garage.presentation.demoDoorEvents
 import com.chriscartland.garage.ui.home.DeviceCheckIn
 import com.chriscartland.garage.ui.home.HomeAuthState
 import com.chriscartland.garage.ui.home.HomeMapper
+import com.chriscartland.garage.ui.home.rememberSinceLine
 import com.chriscartland.garage.ui.settings.AccountRowState
 import com.chriscartland.garage.ui.settings.DiagnosticsContent
 import com.chriscartland.garage.ui.settings.DiagnosticsCounter
@@ -142,6 +143,9 @@ private fun HomePaneBody(modifier: Modifier) {
     val event = demoDoorEvents.firstOrNull()
     val status = HomeMapper.toHomeStatusDisplay(
         currentDoorEvent = LoadingResult.Complete(event),
+    )
+    val sinceLine = rememberSinceLine(
+        lastChangeTimeSeconds = status.lastChangeTimeSeconds,
         now = ThreePaneDemoData.now,
         zone = ThreePaneDemoData.zone,
     )
@@ -151,6 +155,7 @@ private fun HomePaneBody(modifier: Modifier) {
     )
     HomeStatelessContent(
         status = status,
+        sinceLine = sinceLine,
         authState = HomeAuthState.SignedIn,
         modifier = modifier,
         remoteButtonState = RemoteButtonState.Ready,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
@@ -53,6 +53,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -80,26 +81,32 @@ import com.chriscartland.garage.ui.theme.doorColorSet
 import com.chriscartland.garage.ui.theme.doorColorState
 import com.chriscartland.garage.ui.theme.safeListContentPadding
 import com.chriscartland.garage.usecase.ButtonHealthDisplay
+import java.time.Instant
+import java.time.ZoneId
 
 /**
  * Display data for the Home tab's status card.
  *
- * Stateless: every string is pre-formatted by the caller so screenshot tests
- * remain deterministic and the Composable carries no time math.
+ * Pure typed shape: no user-visible strings. The Composable layer resolves
+ * [doorPosition] → label and [lastChangeTimeSeconds] → "Since X · Y" via
+ * [doorStateLabel] / [rememberSinceLine] at render time.
  *
  * @param doorPosition drives the [GarageIcon] visual + door coloring AND the
- *   headline label — the Composable resolves position to a localized string
- *   via [doorStateLabel] (Phase 2B of the string-resource migration plan).
- * @param sinceLine combined status line — e.g. "Since 9:47 AM · 2 hr 14 min".
- *   Replaces the two separate icon-text rows from the legacy
- *   `DoorStatusCard`.
- * @param warning optional typed warning supporting content, surfaced for
- *   `OPENING_TOO_LONG`, `OPEN_MISALIGNED`, `CLOSING_TOO_LONG`,
- *   `ERROR_SENSOR_CONFLICT`, etc. See [DoorWarning].
+ *   headline label.
+ * @param lastChangeTimeSeconds raw epoch seconds for the "Since X · Y" line.
+ * @param warning optional typed warning, surfaced for `OPENING_TOO_LONG`,
+ *   `OPEN_MISALIGNED`, `CLOSING_TOO_LONG`, `ERROR_SENSOR_CONFLICT`, etc.
+ *   See [DoorWarning].
  */
 data class HomeStatusDisplay(
     val doorPosition: DoorPosition,
-    val sinceLine: String,
+    /**
+     * Epoch seconds of the door's last position change, or null if unknown.
+     * The Composable assembles the "Since X · Y" line from this + a clock
+     * via [rememberSinceLine] (Phase 2C of the string-resource migration —
+     * the mapper no longer formats user-visible duration text).
+     */
+    val lastChangeTimeSeconds: Long?,
     val warning: DoorWarning? = null,
     /** Drives the muted "stale" door color and disables animation when true. */
     val isStale: Boolean = false,
@@ -126,22 +133,33 @@ sealed interface HomeAuthState {
  * informational alerts.
  */
 sealed interface HomeAlert {
-    /** Door telemetry hasn't arrived recently — server may be down. */
-    data class Stale(
-        val message: String = "Not receiving updates from server",
-        val actionLabel: String = "Retry",
-    ) : HomeAlert
+    /**
+     * Door telemetry hasn't arrived recently — server may be down. The
+     * Composable resolves the message + action label to localized strings
+     * via [HomeAlertCard]. Phase 2D of the string-resource migration —
+     * the previous `message: String = "..."` and `actionLabel: String = "Retry"`
+     * defaults were dropped.
+     */
+    data object Stale : HomeAlert
 
-    /** Notification permission denied/never asked. */
+    /**
+     * Notification permission denied / never asked. [message] still carries
+     * the server-formatted justification text from
+     * [com.chriscartland.garage.permissions.NotificationPermissionCopy] —
+     * that lifecycle moves to a typed `NotificationJustification` shape in
+     * Phase 2F.
+     */
     data class PermissionMissing(
         val message: String,
-        val actionLabel: String = "Allow",
     ) : HomeAlert
 
-    /** A door-event fetch failed. */
+    /**
+     * A door-event fetch failed. [truncatedException] carries the raw,
+     * length-bounded exception text — the Composable interpolates it via
+     * `formatArgs` into the localized "Error fetching ..." string.
+     */
     data class FetchError(
-        val message: String,
-        val actionLabel: String = "Retry",
+        val truncatedException: String,
     ) : HomeAlert
 }
 
@@ -164,6 +182,7 @@ sealed interface HomeAlert {
 @Composable
 fun HomeContent(
     status: HomeStatusDisplay,
+    sinceLine: String,
     authState: HomeAuthState,
     deviceCheckIn: DeviceCheckInDisplay,
     buttonHealthDisplay: ButtonHealthDisplay,
@@ -213,7 +232,7 @@ fun HomeContent(
                         )
                     },
                 ) {
-                    HomeStatusCardBody(status = status)
+                    HomeStatusCardBody(status = status, sinceLine = sinceLine)
                 }
             }
 
@@ -309,7 +328,10 @@ private fun HomeSection(
 }
 
 @Composable
-private fun HomeStatusCardBody(status: HomeStatusDisplay) {
+private fun HomeStatusCardBody(
+    status: HomeStatusDisplay,
+    sinceLine: String,
+) {
     val colorSet = LocalDoorStatusColorScheme.current.doorColorSet(isStale = status.isStale)
     val doorColor = when (DoorEvent(doorPosition = status.doorPosition).doorColorState()) {
         DoorColorState.OPEN -> colorSet.open
@@ -349,7 +371,7 @@ private fun HomeStatusCardBody(status: HomeStatusDisplay) {
                 color = MaterialTheme.colorScheme.onSurface,
             )
             Text(
-                text = status.sinceLine,
+                text = sinceLine,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
@@ -433,6 +455,48 @@ private fun doorStateLabel(doorPosition: DoorPosition): String =
         DoorPosition.ERROR_SENSOR_CONFLICT -> stringResource(R.string.home_door_state_sensor_conflict)
     }
 
+/**
+ * Resolves a raw [lastChangeTimeSeconds] (epoch) + clock + timezone into the
+ * "Since X · Y" status line, fully localized.
+ *
+ * Phase 2C of the string-resource migration plan
+ * (`AndroidGarage/docs/PENDING_FOLLOWUPS.md` item #1) — this Composable
+ * replaces `HomeMapper.sinceLine()` (deleted). The pure-function bits
+ * (`formatTimeOrDate`, `durationParts`) live in [HomeStatusFormatter] and
+ * stay unit-testable; localization happens here via `stringResource` +
+ * `pluralStringResource`.
+ *
+ * Returns `R.string.home_since_unknown` ("Last change time unknown") when
+ * [lastChangeTimeSeconds] is null.
+ */
+@Composable
+fun rememberSinceLine(
+    lastChangeTimeSeconds: Long?,
+    now: Instant,
+    zone: ZoneId,
+): String {
+    if (lastChangeTimeSeconds == null) {
+        return stringResource(R.string.home_since_unknown)
+    }
+    val instant = remember(lastChangeTimeSeconds) { Instant.ofEpochSecond(lastChangeTimeSeconds) }
+    val timeText = remember(instant, now, zone) {
+        HomeStatusFormatter.formatTimeOrDate(instant, now, zone)
+    }
+    val totalSeconds = (now.epochSecond - lastChangeTimeSeconds).coerceAtLeast(0L)
+    val parts = remember(totalSeconds) { HomeStatusFormatter.durationParts(totalSeconds) }
+    val durationText = when {
+        parts.days >= 1 ->
+            pluralStringResource(R.plurals.home_duration_days, parts.days, parts.days)
+        parts.hours >= 1 ->
+            stringResource(R.string.home_duration_hours_minutes, parts.hours, parts.minutes)
+        parts.minutes >= 1 ->
+            pluralStringResource(R.plurals.home_duration_minutes, parts.minutes, parts.minutes)
+        else ->
+            pluralStringResource(R.plurals.home_duration_seconds, parts.seconds, parts.seconds)
+    }
+    return stringResource(R.string.home_since_format, timeText, durationText)
+}
+
 @Composable
 private fun HomeRemoteButtonBody(
     state: RemoteButtonState,
@@ -494,13 +558,21 @@ private fun HomeAlertCard(
     alert: HomeAlert,
     onAction: () -> Unit,
 ) {
-    val (icon, message, actionLabel) = when (alert) {
-        is HomeAlert.Stale ->
-            Triple(Icons.Outlined.SignalWifiOff, alert.message, alert.actionLabel)
-        is HomeAlert.PermissionMissing ->
-            Triple(Icons.Outlined.NotificationsActive, alert.message, alert.actionLabel)
+    val icon = when (alert) {
+        HomeAlert.Stale -> Icons.Outlined.SignalWifiOff
+        is HomeAlert.PermissionMissing -> Icons.Outlined.NotificationsActive
+        is HomeAlert.FetchError -> Icons.Outlined.WarningAmber
+    }
+    val message = when (alert) {
+        HomeAlert.Stale -> stringResource(R.string.home_alert_stale_message)
+        is HomeAlert.PermissionMissing -> alert.message
         is HomeAlert.FetchError ->
-            Triple(Icons.Outlined.WarningAmber, alert.message, alert.actionLabel)
+            stringResource(R.string.home_alert_fetch_error_format, alert.truncatedException)
+    }
+    val actionLabel = when (alert) {
+        HomeAlert.Stale -> stringResource(R.string.home_alert_action_retry)
+        is HomeAlert.PermissionMissing -> stringResource(R.string.home_alert_action_allow)
+        is HomeAlert.FetchError -> stringResource(R.string.home_alert_action_retry)
     }
     Surface(
         color = MaterialTheme.colorScheme.errorContainer,
@@ -535,22 +607,30 @@ private fun HomeAlertCard(
 // region Preview helpers
 
 private object HomePreviewData {
+    // Hardcoded preview-only sinceLine strings (passed to HomeContent as the
+    // separate `sinceLine: String` parameter). These are preview fake data,
+    // not user-visible at runtime — preview composables provide the formatted
+    // text directly rather than computing from lastChangeTimeSeconds + a clock.
+    const val OPEN_SINCE_LINE = "Since 9:47 AM · 2 hr 14 min"
+    const val CLOSED_SINCE_LINE = "Since 11:22 AM · 38 min"
+    const val OPENING_TOO_LONG_SINCE_LINE = "Since 12:01 PM · 4 min"
+
     val openStatus = HomeStatusDisplay(
         doorPosition = DoorPosition.OPEN,
-        sinceLine = "Since 9:47 AM · 2 hr 14 min",
+        lastChangeTimeSeconds = null,
     )
     val closedStatus = HomeStatusDisplay(
         doorPosition = DoorPosition.CLOSED,
-        sinceLine = "Since 11:22 AM · 38 min",
+        lastChangeTimeSeconds = null,
     )
     val openingTooLongStatus = HomeStatusDisplay(
         doorPosition = DoorPosition.OPENING_TOO_LONG,
-        sinceLine = "Since 12:01 PM · 4 min",
+        lastChangeTimeSeconds = null,
         warning = DoorWarning.ServerMessage(
             "Taking longer than expected. Check the door for obstructions.",
         ),
     )
-    val staleAlert = HomeAlert.Stale()
+    val staleAlert = HomeAlert.Stale
     val permissionAlert = HomeAlert.PermissionMissing(
         message = NotificationPermissionCopy.justificationText(0),
     )
@@ -573,6 +653,7 @@ fun HomeContentOpenSignedInPreview() =
     PreviewScreenSurface {
         HomeContent(
             status = HomePreviewData.openStatus,
+            sinceLine = HomePreviewData.OPEN_SINCE_LINE,
             authState = HomeAuthState.SignedIn,
             remoteButtonState = RemoteButtonState.Ready,
             deviceCheckIn = HomePreviewData.freshCheckIn,
@@ -587,6 +668,7 @@ fun HomeContentClosedSignedInPreview() =
     PreviewScreenSurface {
         HomeContent(
             status = HomePreviewData.closedStatus,
+            sinceLine = HomePreviewData.CLOSED_SINCE_LINE,
             authState = HomeAuthState.SignedIn,
             remoteButtonState = RemoteButtonState.Ready,
             deviceCheckIn = HomePreviewData.freshCheckIn,
@@ -601,6 +683,7 @@ fun HomeContentAwaitingConfirmationPreview() =
     PreviewScreenSurface {
         HomeContent(
             status = HomePreviewData.closedStatus,
+            sinceLine = HomePreviewData.CLOSED_SINCE_LINE,
             authState = HomeAuthState.SignedIn,
             remoteButtonState = RemoteButtonState.AwaitingConfirmation,
             deviceCheckIn = HomePreviewData.freshCheckIn,
@@ -615,6 +698,7 @@ fun HomeContentSendingToDoorPreview() =
     PreviewScreenSurface {
         HomeContent(
             status = HomePreviewData.closedStatus,
+            sinceLine = HomePreviewData.CLOSED_SINCE_LINE,
             authState = HomeAuthState.SignedIn,
             remoteButtonState = RemoteButtonState.SendingToDoor,
             deviceCheckIn = HomePreviewData.freshCheckIn,
@@ -629,6 +713,7 @@ fun HomeContentOpeningTooLongPreview() =
     PreviewScreenSurface {
         HomeContent(
             status = HomePreviewData.openingTooLongStatus,
+            sinceLine = HomePreviewData.OPENING_TOO_LONG_SINCE_LINE,
             authState = HomeAuthState.SignedIn,
             remoteButtonState = RemoteButtonState.Ready,
             deviceCheckIn = HomePreviewData.freshCheckIn,
@@ -643,6 +728,7 @@ fun HomeContentStaleBannerPreview() =
     PreviewScreenSurface {
         HomeContent(
             status = HomePreviewData.openStatus,
+            sinceLine = HomePreviewData.OPEN_SINCE_LINE,
             authState = HomeAuthState.SignedIn,
             remoteButtonState = RemoteButtonState.Ready,
             alerts = listOf(HomePreviewData.staleAlert),
@@ -658,6 +744,7 @@ fun HomeContentPermissionMissingPreview() =
     PreviewScreenSurface {
         HomeContent(
             status = HomePreviewData.openStatus,
+            sinceLine = HomePreviewData.OPEN_SINCE_LINE,
             authState = HomeAuthState.SignedIn,
             remoteButtonState = RemoteButtonState.Ready,
             alerts = listOf(HomePreviewData.permissionAlert),
@@ -673,6 +760,7 @@ fun HomeContentSignedOutPreview() =
     PreviewScreenSurface {
         HomeContent(
             status = HomePreviewData.openStatus,
+            sinceLine = HomePreviewData.OPEN_SINCE_LINE,
             authState = HomeAuthState.SignedOut,
             deviceCheckIn = HomePreviewData.freshCheckIn,
             buttonHealthDisplay = ButtonHealthDisplay.Loading,
@@ -691,6 +779,7 @@ fun HomeContentRemotePillUnauthorizedPreview() =
     PreviewScreenSurface {
         HomeContent(
             status = HomePreviewData.closedStatus,
+            sinceLine = HomePreviewData.CLOSED_SINCE_LINE,
             authState = HomeAuthState.SignedIn,
             remoteButtonState = RemoteButtonState.Ready,
             deviceCheckIn = HomePreviewData.freshCheckIn,
@@ -705,6 +794,7 @@ fun HomeContentRemotePillLoadingPreview() =
     PreviewScreenSurface {
         HomeContent(
             status = HomePreviewData.closedStatus,
+            sinceLine = HomePreviewData.CLOSED_SINCE_LINE,
             authState = HomeAuthState.SignedIn,
             remoteButtonState = RemoteButtonState.Ready,
             deviceCheckIn = HomePreviewData.freshCheckIn,
@@ -719,6 +809,7 @@ fun HomeContentRemotePillUnknownPreview() =
     PreviewScreenSurface {
         HomeContent(
             status = HomePreviewData.closedStatus,
+            sinceLine = HomePreviewData.CLOSED_SINCE_LINE,
             authState = HomeAuthState.SignedIn,
             remoteButtonState = RemoteButtonState.Ready,
             deviceCheckIn = HomePreviewData.freshCheckIn,
@@ -733,6 +824,7 @@ fun HomeContentRemotePillOnlinePreview() =
     PreviewScreenSurface {
         HomeContent(
             status = HomePreviewData.closedStatus,
+            sinceLine = HomePreviewData.CLOSED_SINCE_LINE,
             authState = HomeAuthState.SignedIn,
             remoteButtonState = RemoteButtonState.Ready,
             deviceCheckIn = HomePreviewData.freshCheckIn,
@@ -747,6 +839,7 @@ fun HomeContentRemotePillOfflinePreview() =
     PreviewScreenSurface {
         HomeContent(
             status = HomePreviewData.closedStatus,
+            sinceLine = HomePreviewData.CLOSED_SINCE_LINE,
             authState = HomeAuthState.SignedIn,
             remoteButtonState = RemoteButtonState.Ready,
             deviceCheckIn = HomePreviewData.freshCheckIn,
@@ -772,6 +865,7 @@ fun HomeContentOnTabletPreview() =
         RouteContent { routeModifier ->
             HomeContent(
                 status = HomePreviewData.openStatus,
+                sinceLine = HomePreviewData.OPEN_SINCE_LINE,
                 authState = HomeAuthState.SignedIn,
                 remoteButtonState = RemoteButtonState.Ready,
                 deviceCheckIn = HomePreviewData.freshCheckIn,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeMapper.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeMapper.kt
@@ -22,15 +22,23 @@ import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.permissions.NotificationPermissionCopy
-import java.time.Instant
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 
 /**
  * Pure-function mapper that converts the Home tab's domain inputs into the
- * stateless display data consumed by [HomeContent]. All time/duration
- * formatting, alert assembly, and friendly-name decisions live here so the
- * Composable carries no logic and the entire pipeline is unit-testable.
+ * stateless display data consumed by [HomeContent].
+ *
+ * Per the string-resource migration plan
+ * (`AndroidGarage/docs/PENDING_FOLLOWUPS.md` item #1, Phases 2A/2B/2C),
+ * this mapper does NOT produce user-visible text. It emits typed states
+ * ([HomeStatusDisplay], [DoorWarning], [HomeAlert]) and raw data (epoch
+ * seconds, exception text). The Composable layer resolves typed values to
+ * localized strings via `stringResource` / `pluralStringResource` at render
+ * time.
+ *
+ * The "Since X · Y" status line is now built by the production HomeContent
+ * wrapper (Composable scope) using [HomeStatusFormatter] + plurals, then
+ * passed into the stateless `HomeContent` Composable as a separate
+ * `sinceLine: String` parameter.
  *
  * Mirrors the `HistoryMapper` pattern from PR #598.
  */
@@ -38,23 +46,18 @@ object HomeMapper {
     /**
      * @param currentDoorEvent latest door event flow value (Loading/Complete/Error).
      *   Loading and Complete may carry a cached event; Error has no data.
-     * @param now used for "Since X · Y" duration computation.
-     * @param zone used to compute the local-day boundary for whether to show
-     *   "9:47 AM" vs. "Apr 28, 9:47 PM".
      * @param isCheckInStale picks the muted door-color variant when the
      *   device hasn't checked in recently.
      */
     fun toHomeStatusDisplay(
         currentDoorEvent: LoadingResult<DoorEvent?>,
-        now: Instant,
-        zone: ZoneId,
         isCheckInStale: Boolean = false,
     ): HomeStatusDisplay {
         val event = currentDoorEvent.data
         val doorPosition = event?.doorPosition ?: DoorPosition.UNKNOWN
         return HomeStatusDisplay(
             doorPosition = doorPosition,
-            sinceLine = sinceLine(event?.lastChangeTimeSeconds, now, zone),
+            lastChangeTimeSeconds = event?.lastChangeTimeSeconds,
             warning = warning(event),
             isStale = isCheckInStale,
         )
@@ -64,8 +67,15 @@ object HomeMapper {
      * Returns the alerts to render in the banner stack above the Status card,
      * in display order: stale first, then permission, then fetch error.
      *
-     * @param notificationRequestCount drives the [NotificationPermissionCopy]
-     *   justification text variants — same source the legacy ErrorCard used.
+     * Phase 2D — `HomeAlert.Stale` and `HomeAlert.FetchError` no longer carry
+     * default user-visible strings. The Composable resolves the alert TYPE
+     * to a localized resource. `HomeAlert.FetchError.truncatedException`
+     * carries only the raw exception text (data, not a label) for the
+     * Composable to interpolate via `formatArgs`.
+     *
+     * `HomeAlert.PermissionMissing.message` still carries a String produced
+     * by [NotificationPermissionCopy] for now; that lifecycle moves to a
+     * typed shape in Phase 2F.
      */
     fun toHomeAlerts(
         currentDoorEvent: LoadingResult<DoorEvent?>,
@@ -75,7 +85,7 @@ object HomeMapper {
     ): List<HomeAlert> =
         buildList {
             if (isCheckInStale) {
-                add(HomeAlert.Stale())
+                add(HomeAlert.Stale)
             }
             if (!notificationPermissionGranted) {
                 add(
@@ -87,8 +97,9 @@ object HomeMapper {
             if (currentDoorEvent is LoadingResult.Error) {
                 add(
                     HomeAlert.FetchError(
-                        message = "Error fetching current door event: " +
-                            currentDoorEvent.exception.toString().take(MAX_ERROR_MESSAGE_LEN),
+                        truncatedException = currentDoorEvent.exception
+                            .toString()
+                            .take(MAX_ERROR_MESSAGE_LEN),
                     ),
                 )
             }
@@ -107,10 +118,6 @@ object HomeMapper {
      * ([DoorWarning.ServerMessage]); falls back to a typed enum case per
      * [DoorPosition] so the Composable can render a localized string from
      * `strings.xml` when the server sends nothing.
-     *
-     * Per the string-resource migration plan (PENDING_FOLLOWUPS.md item #1),
-     * the mapper does not return user-visible text — it returns a type, and
-     * the Composable resolves the type to a string via `stringResource(...)`.
      */
     internal fun warning(event: DoorEvent?): DoorWarning? {
         if (event == null) return null
@@ -129,56 +136,5 @@ object HomeMapper {
         }
     }
 
-    internal fun sinceLine(
-        timeSeconds: Long?,
-        now: Instant,
-        zone: ZoneId,
-    ): String {
-        if (timeSeconds == null) return "Last change time unknown"
-        val instant = Instant.ofEpochSecond(timeSeconds)
-        val timeText = formatTimeOrDate(instant, now, zone)
-        val durationText = formatDuration(now.epochSecond - timeSeconds)
-        return "Since $timeText · $durationText"
-    }
-
-    /**
-     * Same-day → "9:47 AM"; different day → "Apr 28, 9:47 PM".
-     */
-    internal fun formatTimeOrDate(
-        instant: Instant,
-        now: Instant,
-        zone: ZoneId,
-    ): String {
-        val zonedTime = instant.atZone(zone)
-        val zonedNow = now.atZone(zone)
-        val sameDay = zonedTime.toLocalDate() == zonedNow.toLocalDate()
-        return zonedTime.format(if (sameDay) TIME_ONLY else DATE_AND_TIME)
-    }
-
-    /**
-     * Duration between the door's last change and `now`, formatted compactly
-     * for the "Since X · Y" line. Negative inputs are clamped to zero so
-     * clock skew can't produce "-3 sec".
-     */
-    internal fun formatDuration(totalSeconds: Long): String {
-        val s = totalSeconds.coerceAtLeast(0L)
-        val days = s / SECONDS_PER_DAY
-        val hours = (s % SECONDS_PER_DAY) / SECONDS_PER_HOUR
-        val minutes = (s % SECONDS_PER_HOUR) / SECONDS_PER_MIN
-        val seconds = s % SECONDS_PER_MIN
-        return when {
-            days >= 2 -> "$days days"
-            days == 1L -> "1 day"
-            hours >= 1 -> "$hours hr $minutes min"
-            minutes >= 1 -> "$minutes min"
-            else -> "$seconds sec"
-        }
-    }
-
-    private val TIME_ONLY = DateTimeFormatter.ofPattern("h:mm a")
-    private val DATE_AND_TIME = DateTimeFormatter.ofPattern("MMM d, h:mm a")
-    private const val SECONDS_PER_MIN = 60L
-    private const val SECONDS_PER_HOUR = 3_600L
-    private const val SECONDS_PER_DAY = 86_400L
     private const val MAX_ERROR_MESSAGE_LEN = 500
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeStatusFormatter.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeStatusFormatter.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui.home
+
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+/**
+ * Pure-function utilities for the Home tab's "Since X · Y" status line.
+ *
+ * Phase 2C of the string-resource migration plan
+ * (`AndroidGarage/docs/PENDING_FOLLOWUPS.md` item #1) — the time / date
+ * formatting and duration breakdown live here as testable pure functions;
+ * the Composable layer assembles the final localized string via
+ * `stringResource` + `pluralStringResource`.
+ *
+ * No user-visible strings are produced here. [DurationParts] returns
+ * raw integer counts; the Composable picks the granularity and renders.
+ *
+ * Replaces the previous string-emitting helpers in `HomeMapper`
+ * (`formatTimeOrDate`, `formatDuration`, `sinceLine`).
+ */
+object HomeStatusFormatter {
+    /**
+     * Same-day → "9:47 AM"; different day → "Apr 28, 9:47 PM".
+     *
+     * Returns a localized time / date string built via [DateTimeFormatter].
+     * Pattern is locale-aware via the default Locale of the JVM at format
+     * time. Tests use `Locale.US` reproducibility — this matches the
+     * legacy `HomeMapper.formatTimeOrDate` behavior.
+     */
+    fun formatTimeOrDate(
+        instant: Instant,
+        now: Instant,
+        zone: ZoneId,
+    ): String {
+        val zonedTime = instant.atZone(zone)
+        val zonedNow = now.atZone(zone)
+        val sameDay = zonedTime.toLocalDate() == zonedNow.toLocalDate()
+        return zonedTime.format(if (sameDay) TIME_ONLY else DATE_AND_TIME)
+    }
+
+    /**
+     * Decompose a duration in seconds into days/hours/minutes/seconds parts.
+     *
+     * Negative inputs are clamped to zero so wall-clock skew can't produce
+     * "-3 sec" durations. Total seconds modular-decomposed; a 90061-second
+     * duration becomes [DurationParts(days = 1, hours = 1, minutes = 1, seconds = 1)].
+     *
+     * The Composable layer picks the display granularity:
+     *  - days >= 1 → render days (special-case 1 vs 2+)
+     *  - hours >= 1 → render "X hr Y min"
+     *  - minutes >= 1 → render "X min"
+     *  - else → render "X sec"
+     */
+    fun durationParts(totalSeconds: Long): DurationParts {
+        val safe = totalSeconds.coerceAtLeast(0L)
+        val days = (safe / SECONDS_PER_DAY).toInt()
+        val hours = ((safe % SECONDS_PER_DAY) / SECONDS_PER_HOUR).toInt()
+        val minutes = ((safe % SECONDS_PER_HOUR) / SECONDS_PER_MIN).toInt()
+        val seconds = (safe % SECONDS_PER_MIN).toInt()
+        return DurationParts(days, hours, minutes, seconds)
+    }
+
+    private val TIME_ONLY = DateTimeFormatter.ofPattern("h:mm a")
+    private val DATE_AND_TIME = DateTimeFormatter.ofPattern("MMM d, h:mm a")
+    private const val SECONDS_PER_MIN = 60L
+    private const val SECONDS_PER_HOUR = 3_600L
+    private const val SECONDS_PER_DAY = 86_400L
+}
+
+/**
+ * Decomposed duration. Each field is an Int because the values are bounded:
+ * `seconds` < 60, `minutes` < 60, `hours` < 24, `days` < ~25K-year limit
+ * before overflow (well past anything the app would ever display).
+ */
+data class DurationParts(
+    val days: Int,
+    val hours: Int,
+    val minutes: Int,
+    val seconds: Int,
+)

--- a/AndroidGarage/androidApp/src/main/res/values/plurals.xml
+++ b/AndroidGarage/androidApp/src/main/res/values/plurals.xml
@@ -1,0 +1,41 @@
+<!--
+  ~ Copyright 2026 Chris Cartland. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<!--
+  Plural-aware count strings — used via pluralStringResource(R.plurals.X, count, count).
+  Phase 2C of the string-resource migration plan
+  (AndroidGarage/docs/PENDING_FOLLOWUPS.md item #1) introduced these for the
+  Home tab's "Since X · Y" duration formatting.
+
+  English-only quantity classes used here: `one` (1) and `other` (everything
+  else). Other locales add `zero`, `two`, `few`, `many` as needed when a
+  values-<lang>/plurals.xml is added.
+-->
+<resources>
+    <plurals name="home_duration_seconds">
+        <item quantity="one">1 sec</item>
+        <item quantity="other">%d sec</item>
+    </plurals>
+    <plurals name="home_duration_minutes">
+        <item quantity="one">1 min</item>
+        <item quantity="other">%d min</item>
+    </plurals>
+    <plurals name="home_duration_days">
+        <item quantity="one">1 day</item>
+        <item quantity="other">%d days</item>
+    </plurals>
+</resources>

--- a/AndroidGarage/androidApp/src/main/res/values/strings.xml
+++ b/AndroidGarage/androidApp/src/main/res/values/strings.xml
@@ -133,6 +133,20 @@
     <string name="home_warning_open_misaligned">Door is open and misaligned</string>
     <string name="home_warning_sensor_conflict">Sensor conflict. Check the door.</string>
 
+    <!-- Home → Status card "Since X · Y" line + duration formatting. -->
+    <string name="home_since_unknown">Last change time unknown</string>
+    <!-- "Since X · Y" line. %1$s is a time (e.g. "9:47 AM"); %2$s is a duration (e.g. "2 hr 14 min"). -->
+    <string name="home_since_format">Since %1$s · %2$s</string>
+    <!-- Duration when hours and minutes are both shown ("2 hr 14 min"). -->
+    <string name="home_duration_hours_minutes">%1$d hr %2$d min</string>
+
+    <!-- Home → Alert banners surfaced above the Status card. -->
+    <string name="home_alert_stale_message">Not receiving updates from server</string>
+    <string name="home_alert_action_retry">Retry</string>
+    <string name="home_alert_action_allow">Allow</string>
+    <!-- Fetch error banner. %1$s is the truncated exception message. -->
+    <string name="home_alert_fetch_error_format">Error fetching current door event: %1$s</string>
+
     <!-- Function List screen — warning paragraph + per-action button labels. -->
     <string name="function_list_warning">Each button below performs a real action immediately. No confirmation prompts. Tapping triggers calls to the server, modifies app state, or wipes local data. Double-check the label before tapping.</string>
     <string name="function_list_access_denied">Access not enabled for your account.</string>

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/home/HomeMapperTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/home/HomeMapperTest.kt
@@ -30,12 +30,12 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.Instant
-import java.time.ZoneOffset
 
 class HomeMapperTest {
-    private val zone = ZoneOffset.UTC
-
-    // 2026-04-29 12:00:00 UTC
+    // 2026-04-29 12:00:00 UTC — used to compute the relative `lastChangeTimeSeconds`
+    // for test events (see [event]). The mapper itself no longer takes
+    // now/zone — duration formatting moved to HomeStatusFormatter + the
+    // Composable layer in Phase 2C.
     private val now: Instant = Instant.parse("2026-04-29T12:00:00Z")
 
     private fun event(
@@ -133,130 +133,20 @@ class HomeMapperTest {
 
     // endregion
 
-    // region formatDuration
-
-    @Test
-    fun formatDuration_zero() = assertEquals("0 sec", HomeMapper.formatDuration(0))
-
-    @Test
-    fun formatDuration_negative_clamped() = assertEquals("0 sec", HomeMapper.formatDuration(-100))
-
-    @Test
-    fun formatDuration_seconds_under_minute() {
-        assertEquals("1 sec", HomeMapper.formatDuration(1))
-        assertEquals("38 sec", HomeMapper.formatDuration(38))
-        assertEquals("59 sec", HomeMapper.formatDuration(59))
-    }
-
-    @Test
-    fun formatDuration_minutes_under_hour() {
-        assertEquals("1 min", HomeMapper.formatDuration(60))
-        assertEquals("4 min", HomeMapper.formatDuration(60L * 4))
-        assertEquals("38 min", HomeMapper.formatDuration(60L * 38 + 30)) // partial seconds dropped
-        assertEquals("59 min", HomeMapper.formatDuration(60L * 59 + 59))
-    }
-
-    @Test
-    fun formatDuration_hours_show_minutes_too() {
-        assertEquals("1 hr 0 min", HomeMapper.formatDuration(3_600))
-        assertEquals("2 hr 14 min", HomeMapper.formatDuration(2 * 3_600L + 14 * 60))
-        assertEquals("23 hr 59 min", HomeMapper.formatDuration(23 * 3_600L + 59 * 60))
-    }
-
-    @Test
-    fun formatDuration_one_day() {
-        assertEquals("1 day", HomeMapper.formatDuration(86_400))
-        assertEquals("1 day", HomeMapper.formatDuration(86_400 + 5 * 3_600))
-    }
-
-    @Test
-    fun formatDuration_two_days_plural() {
-        assertEquals("2 days", HomeMapper.formatDuration(2 * 86_400L))
-        assertEquals("7 days", HomeMapper.formatDuration(7 * 86_400L))
-    }
-
-    // endregion
-
-    // region formatTimeOrDate
-
-    @Test
-    fun formatTimeOrDate_sameDay_shows_only_time() {
-        // 9:47 AM UTC on 2026-04-29.
-        val instant = Instant.parse("2026-04-29T09:47:00Z")
-        assertEquals("9:47 AM", HomeMapper.formatTimeOrDate(instant, now, zone))
-    }
-
-    @Test
-    fun formatTimeOrDate_sameDay_pm() {
-        val instant = Instant.parse("2026-04-29T11:22:00Z")
-        assertEquals("11:22 AM", HomeMapper.formatTimeOrDate(instant, now, zone))
-    }
-
-    @Test
-    fun formatTimeOrDate_differentDay_shows_month_day_and_time() {
-        val instant = Instant.parse("2026-04-28T21:47:00Z")
-        assertEquals("Apr 28, 9:47 PM", HomeMapper.formatTimeOrDate(instant, now, zone))
-    }
-
-    @Test
-    fun formatTimeOrDate_differentMonth() {
-        val instant = Instant.parse("2026-03-15T08:05:00Z")
-        assertEquals("Mar 15, 8:05 AM", HomeMapper.formatTimeOrDate(instant, now, zone))
-    }
-
-    // endregion
-
-    // region sinceLine
-
-    @Test
-    fun sinceLine_null_timestamp() {
-        assertEquals("Last change time unknown", HomeMapper.sinceLine(null, now, zone))
-    }
-
-    @Test
-    fun sinceLine_today_minutes_ago() {
-        val timeSeconds = Instant.parse("2026-04-29T11:22:00Z").epochSecond
-        assertEquals("Since 11:22 AM · 38 min", HomeMapper.sinceLine(timeSeconds, now, zone))
-    }
-
-    @Test
-    fun sinceLine_today_hours_ago() {
-        // 9:47 AM today, now is 12:00 PM → 2 hr 13 min
-        val timeSeconds = Instant.parse("2026-04-29T09:47:00Z").epochSecond
-        assertEquals("Since 9:47 AM · 2 hr 13 min", HomeMapper.sinceLine(timeSeconds, now, zone))
-    }
-
-    @Test
-    fun sinceLine_yesterday() {
-        // Apr 28 9:47 PM → 14 hr 13 min vs Apr 29 12:00 PM
-        val timeSeconds = Instant.parse("2026-04-28T21:47:00Z").epochSecond
-        assertEquals("Since Apr 28, 9:47 PM · 14 hr 13 min", HomeMapper.sinceLine(timeSeconds, now, zone))
-    }
-
-    @Test
-    fun sinceLine_two_days_ago() {
-        val timeSeconds = Instant.parse("2026-04-27T12:00:00Z").epochSecond
-        assertEquals("Since Apr 27, 12:00 PM · 2 days", HomeMapper.sinceLine(timeSeconds, now, zone))
-    }
-
-    @Test
-    fun sinceLine_negative_clock_skew_clamped_to_zero() {
-        // Door event timestamped IN THE FUTURE relative to now (clock skew).
-        // Should not produce "-3 sec".
-        val timeSeconds = now.epochSecond + 3
-        val result = HomeMapper.sinceLine(timeSeconds, now, zone)
-        assertTrue("Got: $result", result.endsWith("0 sec"))
-    }
-
-    // endregion
+    // (regions formatDuration, formatTimeOrDate, sinceLine were removed in
+    //  Phase 2C — those helpers moved to HomeStatusFormatter as pure
+    //  functions and are tested in HomeStatusFormatterTest. The Composable
+    //  rememberSinceLine in HomeContent.kt assembles the final localized
+    //  "Since X · Y" string at render time using stringResource +
+    //  pluralStringResource.)
 
     // region toHomeStatusDisplay
 
     @Test
     fun toHomeStatusDisplay_null_event_returns_unknown() {
-        val display = HomeMapper.toHomeStatusDisplay(LoadingResult.Complete(null), now, zone)
+        val display = HomeMapper.toHomeStatusDisplay(LoadingResult.Complete(null))
         assertEquals(DoorPosition.UNKNOWN, display.doorPosition)
-        assertEquals("Last change time unknown", display.sinceLine)
+        assertNull(display.lastChangeTimeSeconds)
         assertNull(display.warning)
     }
 
@@ -267,9 +157,9 @@ class HomeMapperTest {
         // the loading affordance, so the status card should keep showing
         // the latest known state instead of blanking to "Unknown".
         val event = event(DoorPosition.OPEN, secondsAgo = 60 * 38)
-        val display = HomeMapper.toHomeStatusDisplay(LoadingResult.Loading(event), now, zone)
+        val display = HomeMapper.toHomeStatusDisplay(LoadingResult.Loading(event))
         assertEquals(DoorPosition.OPEN, display.doorPosition)
-        assertTrue(display.sinceLine.startsWith("Since "))
+        assertEquals(event.lastChangeTimeSeconds, display.lastChangeTimeSeconds)
     }
 
     @Test
@@ -277,25 +167,24 @@ class HomeMapperTest {
         // Error has no cached data; the alert banner surfaces the error.
         val display = HomeMapper.toHomeStatusDisplay(
             LoadingResult.Error(RuntimeException("boom")),
-            now,
-            zone,
         )
         assertEquals(DoorPosition.UNKNOWN, display.doorPosition)
+        assertNull(display.lastChangeTimeSeconds)
     }
 
     @Test
     fun toHomeStatusDisplay_open_today() {
         val event = event(DoorPosition.OPEN, secondsAgo = 2 * 3_600 + 13 * 60)
-        val display = HomeMapper.toHomeStatusDisplay(LoadingResult.Complete(event), now, zone)
+        val display = HomeMapper.toHomeStatusDisplay(LoadingResult.Complete(event))
         assertEquals(DoorPosition.OPEN, display.doorPosition)
-        assertTrue(display.sinceLine.contains("2 hr 13 min"))
+        assertEquals(event.lastChangeTimeSeconds, display.lastChangeTimeSeconds)
         assertNull(display.warning)
     }
 
     @Test
     fun toHomeStatusDisplay_openingTooLong_surfaces_warning() {
         val event = event(DoorPosition.OPENING_TOO_LONG, secondsAgo = 4 * 60)
-        val display = HomeMapper.toHomeStatusDisplay(LoadingResult.Complete(event), now, zone)
+        val display = HomeMapper.toHomeStatusDisplay(LoadingResult.Complete(event))
         assertEquals(DoorPosition.OPENING_TOO_LONG, display.doorPosition)
         assertNotNull(display.warning)
     }
@@ -324,7 +213,8 @@ class HomeMapperTest {
             notificationRequestCount = 0,
         )
         assertEquals(1, alerts.size)
-        assertTrue(alerts[0] is HomeAlert.Stale)
+        // Phase 2D: HomeAlert.Stale is now a `data object`, no message field.
+        assertEquals(HomeAlert.Stale, alerts[0])
     }
 
     @Test
@@ -371,7 +261,10 @@ class HomeMapperTest {
         )
         assertEquals(1, alerts.size)
         val a = alerts[0] as HomeAlert.FetchError
-        assertTrue(a.message.contains("boom"))
+        // Phase 2D: FetchError now carries `truncatedException` (raw exception
+        // text only); the Composable interpolates it into the localized
+        // "Error fetching ..." string at render time.
+        assertTrue(a.truncatedException.contains("boom"))
     }
 
     @Test
@@ -384,8 +277,9 @@ class HomeMapperTest {
             notificationRequestCount = 0,
         )
         val a = alerts[0] as HomeAlert.FetchError
-        // Prefix + truncated tail, total bounded.
-        assertTrue("Got len=${a.message.length}", a.message.length <= 600)
+        // truncatedException is bounded to 500 chars; the localized prefix
+        // is added by the Composable, not stored in the typed alert.
+        assertTrue("Got len=${a.truncatedException.length}", a.truncatedException.length <= 500)
     }
 
     @Test

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/home/HomeStatusFormatterTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/home/HomeStatusFormatterTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui.home
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.Instant
+import java.time.ZoneOffset
+
+/**
+ * Tests for [HomeStatusFormatter].
+ *
+ * Phase 2C of the string-resource migration plan
+ * (`AndroidGarage/docs/PENDING_FOLLOWUPS.md` item #1) — `formatTimeOrDate`
+ * was moved here from `HomeMapper` (along with the duration-decomposition
+ * logic, now expressed as [HomeStatusFormatter.durationParts] returning a
+ * typed [DurationParts]).
+ *
+ * These tests cover the pure-function formatting boundaries; the localized
+ * "Since X · Y" assembly happens in `rememberSinceLine` (Composable, in
+ * `HomeContent.kt`) and is verified via screenshot tests + the `home_*`
+ * resources in `strings.xml` / `plurals.xml`.
+ */
+class HomeStatusFormatterTest {
+    private val zone = ZoneOffset.UTC
+
+    // 2026-04-29 12:00:00 UTC.
+    private val now: Instant = Instant.parse("2026-04-29T12:00:00Z")
+
+    // region formatTimeOrDate
+
+    @Test
+    fun formatTimeOrDate_sameDay_shows_only_time() {
+        // 9:47 AM UTC on 2026-04-29.
+        val instant = Instant.parse("2026-04-29T09:47:00Z")
+        assertEquals("9:47 AM", HomeStatusFormatter.formatTimeOrDate(instant, now, zone))
+    }
+
+    @Test
+    fun formatTimeOrDate_sameDay_pm() {
+        val instant = Instant.parse("2026-04-29T11:22:00Z")
+        assertEquals("11:22 AM", HomeStatusFormatter.formatTimeOrDate(instant, now, zone))
+    }
+
+    @Test
+    fun formatTimeOrDate_differentDay_shows_month_day_and_time() {
+        val instant = Instant.parse("2026-04-28T21:47:00Z")
+        assertEquals("Apr 28, 9:47 PM", HomeStatusFormatter.formatTimeOrDate(instant, now, zone))
+    }
+
+    @Test
+    fun formatTimeOrDate_differentMonth() {
+        val instant = Instant.parse("2026-03-15T08:05:00Z")
+        assertEquals("Mar 15, 8:05 AM", HomeStatusFormatter.formatTimeOrDate(instant, now, zone))
+    }
+
+    // endregion
+
+    // region durationParts
+
+    @Test
+    fun durationParts_zero() {
+        assertEquals(DurationParts(days = 0, hours = 0, minutes = 0, seconds = 0), HomeStatusFormatter.durationParts(0))
+    }
+
+    @Test
+    fun durationParts_negative_clamped() {
+        assertEquals(DurationParts(0, 0, 0, 0), HomeStatusFormatter.durationParts(-100))
+    }
+
+    @Test
+    fun durationParts_seconds_under_minute() {
+        assertEquals(DurationParts(0, 0, 0, 1), HomeStatusFormatter.durationParts(1))
+        assertEquals(DurationParts(0, 0, 0, 38), HomeStatusFormatter.durationParts(38))
+        assertEquals(DurationParts(0, 0, 0, 59), HomeStatusFormatter.durationParts(59))
+    }
+
+    @Test
+    fun durationParts_minutes_under_hour() {
+        assertEquals(DurationParts(0, 0, 1, 0), HomeStatusFormatter.durationParts(60))
+        assertEquals(DurationParts(0, 0, 4, 0), HomeStatusFormatter.durationParts(60L * 4))
+        assertEquals(DurationParts(0, 0, 38, 30), HomeStatusFormatter.durationParts(60L * 38 + 30))
+        assertEquals(DurationParts(0, 0, 59, 59), HomeStatusFormatter.durationParts(60L * 59 + 59))
+    }
+
+    @Test
+    fun durationParts_hours_decompose_into_hours_and_minutes() {
+        assertEquals(DurationParts(0, 1, 0, 0), HomeStatusFormatter.durationParts(3_600))
+        assertEquals(DurationParts(0, 2, 14, 0), HomeStatusFormatter.durationParts(2 * 3_600L + 14 * 60))
+        assertEquals(DurationParts(0, 23, 59, 0), HomeStatusFormatter.durationParts(23 * 3_600L + 59 * 60))
+    }
+
+    @Test
+    fun durationParts_one_day() {
+        assertEquals(DurationParts(1, 0, 0, 0), HomeStatusFormatter.durationParts(86_400))
+        assertEquals(DurationParts(1, 5, 0, 0), HomeStatusFormatter.durationParts(86_400 + 5 * 3_600))
+    }
+
+    @Test
+    fun durationParts_multi_day() {
+        assertEquals(DurationParts(2, 0, 0, 0), HomeStatusFormatter.durationParts(2 * 86_400L))
+        assertEquals(DurationParts(7, 0, 0, 0), HomeStatusFormatter.durationParts(7 * 86_400L))
+    }
+
+    // endregion
+}


### PR DESCRIPTION
## Summary
Combined PR for Phases 2C + 2D of the [string-resource migration plan](AndroidGarage/docs/PENDING_FOLLOWUPS.md). Both touch the same HomeContent.kt + HomeMapper.kt files, so combining keeps the diff self-consistent and saves a CI cycle.

## Phase 2C — sinceLine + duration formatting
The mapper no longer formats user-visible "Since X · Y" duration text. Pure-function bits live in a new `HomeStatusFormatter` utility (testable in isolation); the Composable layer assembles localized strings via `stringResource` + `pluralStringResource`.

| Change | File |
|---|---|
| NEW utility | `HomeStatusFormatter.kt` — `formatTimeOrDate`, `durationParts(): DurationParts` |
| NEW Composable | `rememberSinceLine(lastChangeTimeSeconds, now, zone)` in `HomeContent.kt` |
| NEW tests | `HomeStatusFormatterTest.kt` — 12 tests (assert on typed `DurationParts`, not text) |
| HomeStatusDisplay | drop `sinceLine: String`, add `lastChangeTimeSeconds: Long?` |
| HomeMapper | DELETE `sinceLine`, `formatDuration`, `formatTimeOrDate`. `toHomeStatusDisplay` drops `now`/`zone` params |
| Plurals (NEW file) | `home_duration_seconds`, `home_duration_minutes`, `home_duration_days` (one/other) |

## Phase 2D — HomeAlert default-arg drops
| Change | Notes |
|---|---|
| `HomeAlert.Stale` → `data object` | dropped `message`/`actionLabel` defaults |
| `HomeAlert.PermissionMissing` | dropped `actionLabel` default. `message` stays — wires to `NotificationPermissionCopy`, will flip in Phase 2F |
| `HomeAlert.FetchError` | dropped `actionLabel` default. `message` → `truncatedException` (raw exception text only; Composable interpolates via `formatArgs`) |
| `HomeAlertCard` | `when (alert)` → `stringResource(...)` for each variant's message + action label |
| New strings | `home_alert_stale_message`, `home_alert_action_retry`, `home_alert_action_allow`, `home_alert_fetch_error_format` |

## Call-site updates
Production wrapper (`ui/HomeContent.kt`), 3 dashboard/preview files, `AuthStateUIPropagationTest`, and `HomeMapperTest` all updated. Stateless `HomeContent` now takes a `sinceLine: String` parameter alongside `status: HomeStatusDisplay`.

## Out of scope (queued)
- Phase 2E: HistoryMapper parallel refactor
- Phase 2F: NotificationPermissionCopy → typed (will also flip `HomeAlert.PermissionMissing` to a typed shape)

## Verified
- `validate.sh` PASS on this branch (full pipeline including the new lint from #792)
- 12 files changed, 492 insertions, 245 deletions
- No screenshot churn — preview fixture sinceLine strings match formatter+Composable output for the same inputs

## Test plan
- [ ] CI green
- [ ] Screenshot tests pass with no PNG diff