### PR TITLE
refactor(android): HistoryMapper full typed-hint refactor (Phase 2E)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
@@ -123,6 +123,7 @@ fun DoorHistoryContent(
         }
         HistoryContent(
             days = days,
+            zone = zone,
             isRefreshing = recentDoorEvents is LoadingResult.Loading,
             onRefresh = onFetchRecentDoorEvents,
             modifier = Modifier.fillMaxWidth(),

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/AnomalyKind.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/AnomalyKind.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui.history
+
+/**
+ * Typed kind of door-history anomaly. Replaces the previous
+ * `title: String` field on `HistoryEntry.Anomaly`.
+ *
+ * Phase 2E of the string-resource migration plan
+ * (`AndroidGarage/docs/PENDING_FOLLOWUPS.md` item #1) — `HistoryMapper`
+ * emits a typed `kind`, the Composable resolves to a localized string
+ * via `stringResource(...)` at render time.
+ */
+sealed interface AnomalyKind {
+    /** [com.chriscartland.garage.domain.model.DoorPosition.ERROR_SENSOR_CONFLICT]. */
+    data object SensorConflict : AnomalyKind
+
+    /** [com.chriscartland.garage.domain.model.DoorPosition.UNKNOWN]. */
+    data object UnknownState : AnomalyKind
+
+    /** `OPENING_TOO_LONG` that never reached its terminal `OPEN`. */
+    data object StuckOpening : AnomalyKind
+
+    /** `CLOSING_TOO_LONG` that never reached its terminal `CLOSED`. */
+    data object StuckClosing : AnomalyKind
+
+    /**
+     * `OPEN_MISALIGNED` arriving without a prior `Opening` and with no
+     * recent `Opened` to attach to — surfaced as a standalone anomaly
+     * so the data isn't dropped. Distinct from the `misaligned` flag
+     * on a normal `Opened` row.
+     */
+    data object OpenMisaligned : AnomalyKind
+}

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/DayLabel.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/DayLabel.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui.history
+
+import java.time.LocalDate
+
+/**
+ * Typed day label for [HistoryDay]. Replaces the previous `label: String`
+ * field.
+ *
+ * Phase 2E of the string-resource migration plan — the mapper emits a
+ * typed value, the Composable resolves to a localized string at render
+ * time. [Today] / [Yesterday] map to `R.string.history_day_*` resources;
+ * [Date] carries the [LocalDate] and the Composable formats it via the
+ * locale-aware `DateTimeFormatter`.
+ */
+sealed interface DayLabel {
+    /** Today, in the user's local time zone. */
+    data object Today : DayLabel
+
+    /** One day before [Today]. */
+    data object Yesterday : DayLabel
+
+    /** Two or more days ago — render the full date (e.g. "Mon, Apr 27"). */
+    data class Date(
+        val date: LocalDate,
+    ) : DayLabel
+}

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryContent.kt
@@ -41,11 +41,15 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.chriscartland.garage.R
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.ui.GarageIcon
@@ -57,6 +61,7 @@ import com.chriscartland.garage.ui.theme.Spacing
 import com.chriscartland.garage.ui.theme.doorColorSet
 import com.chriscartland.garage.ui.theme.doorColorState
 import com.chriscartland.garage.ui.theme.safeListContentPadding
+import java.time.ZoneId
 
 /**
  * One entry in the history list.
@@ -65,38 +70,42 @@ import com.chriscartland.garage.ui.theme.safeListContentPadding
  * boundary). Each row carries the duration of *that* state (until the next
  * opposite-state event), not the duration of the prior state.
  *
- * Display strings (times, durations, transit warnings) are pre-formatted by
- * the caller so the Composable stays purely presentational and screenshot
- * tests stay deterministic — Phase 2 of the redesign carries no live time
- * math.
+ * Phase 2E of the string-resource migration plan
+ * (`AndroidGarage/docs/PENDING_FOLLOWUPS.md` item #1) — no user-visible
+ * strings live on this type. Times are raw epoch seconds, durations are
+ * raw second counts, anomaly kinds + transit warnings are typed sealed
+ * types ([AnomalyKind], [TransitWarning]). The Composable layer assembles
+ * localized display strings via `stringResource` + `pluralStringResource`
+ * at render time.
  */
 sealed interface HistoryEntry {
     /**
      * The door was opened.
      *
-     * @param timeDisplay e.g. "9:47 AM"
-     * @param durationDisplay e.g. "Open for 6 min" or "12 min and counting"
+     * @param timeSeconds epoch seconds of the open event (Composable formats).
+     * @param durationSeconds how long the door stayed open after this event
+     *   (until the next CLOSE), or "and counting" seconds when this is the
+     *   most-recent terminal and the door is still open.
      * @param isCurrent true when this is the most recent event and the door
      *   is still open. Drives "Open · Since X" wording instead of past-tense
      *   "Opened at X".
-     * @param transitWarning non-null when an `OPENING_TOO_LONG` was merged
-     *   into this Opened row. Example: "Took 4 min to open, longer than
-     *   expected." Rendered as a warning tag below the duration.
+     * @param transitWarning non-null ([TransitWarning.ToOpen]) when an
+     *   `OPENING_TOO_LONG` was merged into this row.
      */
     data class Opened(
-        val timeDisplay: String,
-        val durationDisplay: String,
+        val timeSeconds: Long,
+        val durationSeconds: Long,
         val isCurrent: Boolean = false,
-        val transitWarning: String? = null,
+        val transitWarning: TransitWarning? = null,
         val misaligned: Boolean = false,
     ) : HistoryEntry
 
     /** The door was closed. Mirrors [Opened]. */
     data class Closed(
-        val timeDisplay: String,
-        val durationDisplay: String,
+        val timeSeconds: Long,
+        val durationSeconds: Long,
         val isCurrent: Boolean = false,
-        val transitWarning: String? = null,
+        val transitWarning: TransitWarning? = null,
     ) : HistoryEntry
 
     /**
@@ -106,17 +115,20 @@ sealed interface HistoryEntry {
      *
      * @param doorPosition drives the GarageIcon leading visual (e.g. an
      *   `OPEN_MISALIGNED` anomaly shows the open door art).
+     * @param kind typed anomaly kind; the Composable resolves to a
+     *   localized title via `stringResource`. See [AnomalyKind].
+     * @param timeSeconds epoch seconds of the anomaly event.
      */
     data class Anomaly(
         val doorPosition: DoorPosition,
-        val title: String,
-        val timeDisplay: String,
+        val kind: AnomalyKind,
+        val timeSeconds: Long,
     ) : HistoryEntry
 }
 
 /** A single day's worth of entries, newest-first. */
 data class HistoryDay(
-    val label: String,
+    val label: DayLabel,
     val entries: List<HistoryEntry>,
 )
 
@@ -139,6 +151,7 @@ data class HistoryDay(
 @Composable
 fun HistoryContent(
     days: List<HistoryDay>,
+    zone: ZoneId,
     modifier: Modifier = Modifier,
     isRefreshing: Boolean = false,
     onRefresh: () -> Unit = {},
@@ -157,8 +170,8 @@ fun HistoryContent(
                 item { HistoryEmptyState() }
             } else {
                 days.forEach { day ->
-                    item(key = day.label) {
-                        HistoryDaySection(day = day)
+                    item(key = HistoryDayKey.forLabel(day.label)) {
+                        HistoryDaySection(day = day, zone = zone)
                     }
                 }
             }
@@ -166,11 +179,29 @@ fun HistoryContent(
     }
 }
 
+/**
+ * Stable keys for [LazyColumn]'s `item(key = ...)` slot. Wrapped in a
+ * named object per ADR-009 (no bare top-level functions). `Today` /
+ * `Yesterday` are stable singletons; `Date` uses the LocalDate which
+ * is unique per day and stable across recompositions.
+ */
+private object HistoryDayKey {
+    fun forLabel(label: DayLabel): Any =
+        when (label) {
+            DayLabel.Today -> "today"
+            DayLabel.Yesterday -> "yesterday"
+            is DayLabel.Date -> label.date.toString()
+        }
+}
+
 @Composable
-private fun HistoryDaySection(day: HistoryDay) {
+private fun HistoryDaySection(
+    day: HistoryDay,
+    zone: ZoneId,
+) {
     Column {
         Text(
-            text = day.label.uppercase(),
+            text = dayLabelText(day.label).uppercase(),
             style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.primary,
             modifier = Modifier.padding(
@@ -191,7 +222,7 @@ private fun HistoryDaySection(day: HistoryDay) {
                     if (index > 0) {
                         HorizontalDivider(modifier = Modifier.padding(start = DividerInset.LargeLeading))
                     }
-                    HistoryEntryRow(entry = entry)
+                    HistoryEntryRow(entry = entry, zone = zone)
                 }
             }
         }
@@ -199,47 +230,184 @@ private fun HistoryDaySection(day: HistoryDay) {
 }
 
 @Composable
-private fun HistoryEntryRow(entry: HistoryEntry) {
+private fun HistoryEntryRow(
+    entry: HistoryEntry,
+    zone: ZoneId,
+) {
     when (entry) {
-        is HistoryEntry.Opened -> HistoryStateRow(
-            // When misaligned, render the OPEN_MISALIGNED door art so the
-            // misalignment is visible even on a row that's just an "Opened"
-            // event with the misalignment property set.
-            doorPosition = if (entry.misaligned) DoorPosition.OPEN_MISALIGNED else DoorPosition.OPEN,
-            headline = when {
-                entry.isCurrent && entry.misaligned -> "Open (misaligned)"
-                entry.isCurrent -> "Open"
-                else -> "Opened at ${entry.timeDisplay}"
-            },
-            supporting = if (entry.isCurrent) {
-                "Since ${entry.timeDisplay} · ${entry.durationDisplay}"
+        is HistoryEntry.Opened -> {
+            val timeDisplay = remember(entry.timeSeconds, zone) {
+                HistoryFormatter.formatTime(entry.timeSeconds, zone)
+            }
+            val durationDisplay = stateDurationDisplay(
+                durationSeconds = entry.durationSeconds,
+                isCurrent = entry.isCurrent,
+                isOpenState = true,
+            )
+            HistoryStateRow(
+                // When misaligned, render the OPEN_MISALIGNED door art so the
+                // misalignment is visible even on a row that's just an "Opened"
+                // event with the misalignment property set.
+                doorPosition = if (entry.misaligned) DoorPosition.OPEN_MISALIGNED else DoorPosition.OPEN,
+                headline = when {
+                    entry.isCurrent && entry.misaligned ->
+                        stringResource(R.string.history_headline_open_misaligned)
+                    entry.isCurrent ->
+                        stringResource(R.string.history_headline_open)
+                    else ->
+                        stringResource(R.string.history_headline_opened_at, timeDisplay)
+                },
+                supporting = if (entry.isCurrent) {
+                    stringResource(R.string.history_supporting_since_format, timeDisplay, durationDisplay)
+                } else {
+                    durationDisplay
+                },
+                warnings = listOfNotNull(
+                    entry.transitWarning?.let { transitWarningText(it) },
+                    // For past Opened rows, surface misalignment as a tag below
+                    // the duration. When isCurrent, the headline already says
+                    // "Open (misaligned)" — no need for a duplicate tag.
+                    if (entry.misaligned && !entry.isCurrent) {
+                        stringResource(R.string.history_warning_misaligned)
+                    } else {
+                        null
+                    },
+                ),
+            )
+        }
+        is HistoryEntry.Closed -> {
+            val timeDisplay = remember(entry.timeSeconds, zone) {
+                HistoryFormatter.formatTime(entry.timeSeconds, zone)
+            }
+            val durationDisplay = stateDurationDisplay(
+                durationSeconds = entry.durationSeconds,
+                isCurrent = entry.isCurrent,
+                isOpenState = false,
+            )
+            HistoryStateRow(
+                doorPosition = DoorPosition.CLOSED,
+                headline = if (entry.isCurrent) {
+                    stringResource(R.string.history_headline_closed)
+                } else {
+                    stringResource(R.string.history_headline_closed_at, timeDisplay)
+                },
+                supporting = if (entry.isCurrent) {
+                    stringResource(R.string.history_supporting_since_format, timeDisplay, durationDisplay)
+                } else {
+                    durationDisplay
+                },
+                warnings = listOfNotNull(entry.transitWarning?.let { transitWarningText(it) }),
+            )
+        }
+        is HistoryEntry.Anomaly -> {
+            val timeDisplay = remember(entry.timeSeconds, zone) {
+                HistoryFormatter.formatTime(entry.timeSeconds, zone)
+            }
+            HistoryStateRow(
+                doorPosition = entry.doorPosition,
+                headline = anomalyTitle(entry.kind),
+                supporting = timeDisplay,
+                warnings = emptyList(),
+            )
+        }
+    }
+}
+
+/**
+ * Resolve a [DayLabel] to a localized day-section header string.
+ * `Today` / `Yesterday` map to resources; `Date` formats via
+ * [HistoryFormatter.formatDate] (locale-aware DateTimeFormatter).
+ */
+@Composable
+private fun dayLabelText(label: DayLabel): String =
+    when (label) {
+        DayLabel.Today -> stringResource(R.string.history_day_today)
+        DayLabel.Yesterday -> stringResource(R.string.history_day_yesterday)
+        is DayLabel.Date -> HistoryFormatter.formatDate(label.date)
+    }
+
+/** Resolve an [AnomalyKind] to its localized headline string. */
+@Composable
+private fun anomalyTitle(kind: AnomalyKind): String =
+    when (kind) {
+        AnomalyKind.SensorConflict -> stringResource(R.string.history_anomaly_sensor_conflict)
+        AnomalyKind.UnknownState -> stringResource(R.string.history_anomaly_unknown_state)
+        AnomalyKind.StuckOpening -> stringResource(R.string.history_anomaly_stuck_opening)
+        AnomalyKind.StuckClosing -> stringResource(R.string.history_anomaly_stuck_closing)
+        AnomalyKind.OpenMisaligned -> stringResource(R.string.history_anomaly_open_misaligned)
+    }
+
+/**
+ * Assemble the localized "Open for X" / "Closed for X" / "X and counting"
+ * string for a state-span duration, picking plural / single-unit / multi-unit
+ * granularity based on [HistoryFormatter.stateDurationParts].
+ */
+@Composable
+private fun stateDurationDisplay(
+    durationSeconds: Long,
+    isCurrent: Boolean,
+    isOpenState: Boolean,
+): String {
+    val parts = remember(durationSeconds) { HistoryFormatter.stateDurationParts(durationSeconds) }
+    val durationText = when {
+        parts.days >= 1 -> {
+            if (parts.hours == 0) {
+                pluralStringResource(R.plurals.home_duration_days, parts.days, parts.days)
             } else {
-                entry.durationDisplay
-            },
-            warnings = listOfNotNull(
-                entry.transitWarning,
-                // For past Opened rows, surface misalignment as a tag below
-                // the duration. When isCurrent, the headline already says
-                // "Open (misaligned)" — no need for a duplicate tag.
-                if (entry.misaligned && !entry.isCurrent) "Door was misaligned" else null,
-            ),
-        )
-        is HistoryEntry.Closed -> HistoryStateRow(
-            doorPosition = DoorPosition.CLOSED,
-            headline = if (entry.isCurrent) "Closed" else "Closed at ${entry.timeDisplay}",
-            supporting = if (entry.isCurrent) {
-                "Since ${entry.timeDisplay} · ${entry.durationDisplay}"
+                stringResource(R.string.history_state_duration_days_with_hours, parts.days, parts.hours)
+            }
+        }
+        parts.hours >= 1 -> {
+            if (parts.minutes == 0) {
+                stringResource(R.string.history_state_duration_hours_only, parts.hours)
             } else {
-                entry.durationDisplay
-            },
-            warnings = listOfNotNull(entry.transitWarning),
-        )
-        is HistoryEntry.Anomaly -> HistoryStateRow(
-            doorPosition = entry.doorPosition,
-            headline = entry.title,
-            supporting = entry.timeDisplay,
-            warnings = emptyList(),
-        )
+                stringResource(R.string.home_duration_hours_minutes, parts.hours, parts.minutes)
+            }
+        }
+        parts.minutes >= 1 ->
+            pluralStringResource(R.plurals.home_duration_minutes, parts.minutes, parts.minutes)
+        else ->
+            pluralStringResource(R.plurals.home_duration_seconds, parts.seconds, parts.seconds)
+    }
+    return when {
+        isCurrent -> stringResource(R.string.history_state_duration_and_counting, durationText)
+        isOpenState -> stringResource(R.string.history_state_duration_open_for, durationText)
+        else -> stringResource(R.string.history_state_duration_closed_for, durationText)
+    }
+}
+
+/**
+ * Assemble the localized "Took X to open/close, longer than expected"
+ * tag for a [TransitWarning].
+ */
+@Composable
+private fun transitWarningText(warning: TransitWarning): String {
+    val parts = remember(warning.transitSeconds) {
+        HistoryFormatter.transitDurationParts(warning.transitSeconds)
+    }
+    val durationText = when {
+        parts.hours >= 1 -> {
+            if (parts.minutes == 0) {
+                stringResource(R.string.history_state_duration_hours_only, parts.hours)
+            } else {
+                stringResource(R.string.home_duration_hours_minutes, parts.hours, parts.minutes)
+            }
+        }
+        parts.minutes >= 1 -> {
+            if (parts.seconds == 0) {
+                pluralStringResource(R.plurals.home_duration_minutes, parts.minutes, parts.minutes)
+            } else {
+                stringResource(R.string.history_transit_minutes_seconds, parts.minutes, parts.seconds)
+            }
+        }
+        else ->
+            pluralStringResource(R.plurals.home_duration_seconds, parts.seconds, parts.seconds)
+    }
+    return when (warning) {
+        is TransitWarning.ToOpen ->
+            stringResource(R.string.history_warning_transit_to_open, durationText)
+        is TransitWarning.ToClose ->
+            stringResource(R.string.history_warning_transit_to_close, durationText)
     }
 }
 
@@ -310,12 +478,12 @@ private fun HistoryEmptyState() {
         )
         Spacer(Modifier.height(16.dp))
         Text(
-            text = "No events yet",
+            text = stringResource(R.string.history_empty_title),
             style = MaterialTheme.typography.titleMedium,
         )
         Spacer(Modifier.height(ParagraphSpacing.TitleToBody))
         Text(
-            text = "Open or close the garage and check back here.",
+            text = stringResource(R.string.history_empty_subtitle),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -386,7 +554,7 @@ fun HistoryContentMultiDayPreview() {
         now = java.time.Instant.parse("2026-04-29T10:27:00Z"),
         zone = HistoryPreviewData.zone,
     )
-    HistoryContent(days = days)
+    HistoryContent(days = days, zone = HistoryPreviewData.zone)
 }
 
 /**
@@ -419,11 +587,11 @@ fun HistoryContentMultiDayClosedPreview() {
         now = java.time.Instant.parse("2026-04-29T12:17:00Z"),
         zone = HistoryPreviewData.zone,
     )
-    HistoryContent(days = days)
+    HistoryContent(days = days, zone = HistoryPreviewData.zone)
 }
 
 @Preview
 @Composable
 fun HistoryContentEmptyPreview() {
-    HistoryContent(days = emptyList())
+    HistoryContent(days = emptyList(), zone = HistoryPreviewData.zone)
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryFormatter.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryFormatter.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui.history
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+/**
+ * Pure-function utilities for the History tab.
+ *
+ * Phase 2E of the string-resource migration plan
+ * (`AndroidGarage/docs/PENDING_FOLLOWUPS.md` item #1) — locale-aware
+ * formatting of times and date labels lives here, alongside the
+ * [StateDurationParts] / [TransitDurationParts] decomposition that
+ * mirrors `HomeStatusFormatter` for the History context's
+ * different display granularities.
+ *
+ * No user-visible label strings are produced here. The Composable
+ * layer assembles localized strings via `stringResource` +
+ * `pluralStringResource`.
+ */
+object HistoryFormatter {
+    /**
+     * Format an epoch-seconds time as a locale-aware "h:mm a" string
+     * (e.g. "9:47 AM"). Tests use [Locale.US] for reproducibility —
+     * production renders in the device locale.
+     */
+    fun formatTime(
+        timeSeconds: Long,
+        zone: ZoneId,
+    ): String =
+        Instant
+            .ofEpochSecond(timeSeconds)
+            .atZone(zone)
+            .format(timeFormatter)
+
+    /**
+     * Format a [LocalDate] as a short day-and-date string (e.g.
+     * "Mon, Apr 27"). Used for [DayLabel.Date] rendering.
+     */
+    fun formatDate(date: LocalDate): String = date.format(dateFormatter)
+
+    /**
+     * Convert an epoch-seconds value into the local date in [zone],
+     * used by [HistoryMapper.toHistoryDays] for day grouping and by
+     * the Composable for [DayLabel] resolution.
+     */
+    fun localDate(
+        timeSeconds: Long,
+        zone: ZoneId,
+    ): LocalDate =
+        Instant
+            .ofEpochSecond(timeSeconds)
+            .atZone(zone)
+            .toLocalDate()
+
+    /**
+     * Decompose a state-span duration in seconds into the parts the
+     * Composable uses to pick a granularity:
+     *  - `days >= 1` → render `"$days day [$hours hr]"` (drop hours when 0)
+     *  - `hours >= 1` → render `"$hours hr [$mins min]"` (drop minutes when 0)
+     *  - `minutes >= 1` → render `"$minutes min"`
+     *  - else → render `"$seconds sec"`
+     *
+     * Mirrors `HomeStatusFormatter.durationParts` but drops sub-day
+     * granularity differently — History shows "1 day 5 hr" while Home
+     * shows just "1 day" (Home's "Since X" line stays compact; History's
+     * "Open for X" line wants more precision).
+     */
+    fun stateDurationParts(seconds: Long): StateDurationParts {
+        val safe = seconds.coerceAtLeast(0L)
+        val days = (safe / SECONDS_PER_DAY).toInt()
+        val hours = ((safe % SECONDS_PER_DAY) / SECONDS_PER_HOUR).toInt()
+        val minutes = ((safe % SECONDS_PER_HOUR) / SECONDS_PER_MIN).toInt()
+        val seconds = (safe % SECONDS_PER_MIN).toInt()
+        return StateDurationParts(days, hours, minutes, seconds)
+    }
+
+    /**
+     * Decompose a transit-span duration in seconds. Transits are
+     * typically seconds, occasionally minutes for `_TOO_LONG` cases —
+     * keep seconds suffix at minute scale (the precision helps), drop
+     * seconds at hour scale (rare; readable).
+     *
+     *  - `hours >= 1` → render `"$hours hr [$mins min]"`
+     *  - `minutes >= 1` → render `"$minutes min [$secs sec]"`
+     *  - else → render `"$seconds sec"`
+     */
+    fun transitDurationParts(seconds: Long): TransitDurationParts {
+        val safe = seconds.coerceAtLeast(0L)
+        val hours = (safe / SECONDS_PER_HOUR).toInt()
+        val minutes = ((safe % SECONDS_PER_HOUR) / SECONDS_PER_MIN).toInt()
+        val seconds = (safe % SECONDS_PER_MIN).toInt()
+        return TransitDurationParts(hours, minutes, seconds)
+    }
+
+    private val timeFormatter: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("h:mm a", Locale.US)
+    private val dateFormatter: DateTimeFormatter =
+        DateTimeFormatter.ofPattern("EEE, MMM d", Locale.US)
+    private const val SECONDS_PER_MIN = 60L
+    private const val SECONDS_PER_HOUR = 3_600L
+    private const val SECONDS_PER_DAY = 86_400L
+}
+
+/**
+ * Decomposed state-span duration. The Composable renders only the
+ * top-most non-zero granularity (e.g. days dominates; minutes are
+ * shown alongside hours but seconds aren't shown alongside minutes).
+ */
+data class StateDurationParts(
+    val days: Int,
+    val hours: Int,
+    val minutes: Int,
+    val seconds: Int,
+)
+
+/**
+ * Decomposed transit-span duration. Different shape from
+ * [StateDurationParts] because transits never carry day-scale data
+ * (they're typically <1 minute, occasionally minutes).
+ */
+data class TransitDurationParts(
+    val hours: Int,
+    val minutes: Int,
+    val seconds: Int,
+)

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryMapper.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryMapper.kt
@@ -22,8 +22,6 @@ import com.chriscartland.garage.domain.model.DoorPosition
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
-import java.time.format.DateTimeFormatter
-import java.util.Locale
 
 /**
  * Pure-function pipeline that converts raw [DoorEvent]s into the display-ready
@@ -108,7 +106,7 @@ object HistoryMapper {
         data class Anomaly(
             override val timeSeconds: Long,
             val position: DoorPosition,
-            val title: String,
+            val kind: AnomalyKind,
         ) : MergedRecord
     }
 
@@ -162,9 +160,9 @@ object HistoryMapper {
                 DoorPosition.CLOSED -> handleClosed(time)
                 DoorPosition.OPEN_MISALIGNED -> handleOpenMisaligned(time)
                 DoorPosition.ERROR_SENSOR_CONFLICT ->
-                    result += MergedRecord.Anomaly(time, pos, "Sensor conflict")
+                    result += MergedRecord.Anomaly(time, pos, AnomalyKind.SensorConflict)
                 DoorPosition.UNKNOWN ->
-                    result += MergedRecord.Anomaly(time, pos, "Unknown state")
+                    result += MergedRecord.Anomaly(time, pos, AnomalyKind.UnknownState)
             }
         }
 
@@ -238,7 +236,7 @@ object HistoryMapper {
                 val existing = result[mergeIndex] as MergedRecord.Opened
                 result[mergeIndex] = existing.copy(misaligned = true)
             } else {
-                result += MergedRecord.Anomaly(time, DoorPosition.OPEN_MISALIGNED, "Open (misaligned)")
+                result += MergedRecord.Anomaly(time, DoorPosition.OPEN_MISALIGNED, AnomalyKind.OpenMisaligned)
             }
         }
 
@@ -247,11 +245,11 @@ object HistoryMapper {
             when (val p = pending) {
                 is PendingTransition.Opening ->
                     if (p.tooLong) {
-                        result += MergedRecord.Anomaly(p.startTimeSeconds, DoorPosition.OPENING_TOO_LONG, "Stuck opening")
+                        result += MergedRecord.Anomaly(p.startTimeSeconds, DoorPosition.OPENING_TOO_LONG, AnomalyKind.StuckOpening)
                     }
                 is PendingTransition.Closing ->
                     if (p.tooLong) {
-                        result += MergedRecord.Anomaly(p.startTimeSeconds, DoorPosition.CLOSING_TOO_LONG, "Stuck closing")
+                        result += MergedRecord.Anomaly(p.startTimeSeconds, DoorPosition.CLOSING_TOO_LONG, AnomalyKind.StuckClosing)
                     }
                 null -> Unit
             }
@@ -296,7 +294,7 @@ object HistoryMapper {
                     result += MergedRecord.Anomaly(
                         timeSeconds = pending.startTimeSeconds,
                         position = DoorPosition.OPENING_TOO_LONG,
-                        title = "Stuck opening",
+                        kind = AnomalyKind.StuckOpening,
                     )
                 }
                 null
@@ -308,7 +306,7 @@ object HistoryMapper {
                     result += MergedRecord.Anomaly(
                         timeSeconds = pending.startTimeSeconds,
                         position = DoorPosition.CLOSING_TOO_LONG,
-                        title = "Stuck closing",
+                        kind = AnomalyKind.StuckClosing,
                     )
                 }
                 null
@@ -377,112 +375,43 @@ object HistoryMapper {
         return reversed.reversed()
     }
 
-    private fun WithDuration.toHistoryEntry(zone: ZoneId): HistoryEntry =
+    private fun WithDuration.toHistoryEntry(): HistoryEntry =
         when (val r = record) {
             is MergedRecord.Opened -> HistoryEntry.Opened(
-                timeDisplay = formatTime(r.timeSeconds, zone),
-                durationDisplay = formatStateDurationLabel(
-                    durationSeconds = durationSeconds ?: 0L,
-                    isCurrent = isCurrent,
-                    isOpenState = true,
-                ),
+                timeSeconds = r.timeSeconds,
+                durationSeconds = durationSeconds ?: 0L,
                 isCurrent = isCurrent,
-                transitWarning = r.transitDurationSeconds?.let {
-                    "Took ${formatTransitDuration(it)} to open, longer than expected"
-                },
+                transitWarning = r.transitDurationSeconds?.let { TransitWarning.ToOpen(it) },
                 misaligned = r.misaligned,
             )
             is MergedRecord.Closed -> HistoryEntry.Closed(
-                timeDisplay = formatTime(r.timeSeconds, zone),
-                durationDisplay = formatStateDurationLabel(
-                    durationSeconds = durationSeconds ?: 0L,
-                    isCurrent = isCurrent,
-                    isOpenState = false,
-                ),
+                timeSeconds = r.timeSeconds,
+                durationSeconds = durationSeconds ?: 0L,
                 isCurrent = isCurrent,
-                transitWarning = r.transitDurationSeconds?.let {
-                    "Took ${formatTransitDuration(it)} to close, longer than expected"
-                },
+                transitWarning = r.transitDurationSeconds?.let { TransitWarning.ToClose(it) },
             )
             is MergedRecord.Anomaly -> HistoryEntry.Anomaly(
                 doorPosition = r.position,
-                title = r.title,
-                timeDisplay = formatTime(r.timeSeconds, zone),
+                kind = r.kind,
+                timeSeconds = r.timeSeconds,
             )
         }
 
-    // ---------- Step 5: formatting ----------
-
-    private val timeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("h:mm a", Locale.US)
-    private val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("EEE, MMM d", Locale.US)
-
-    internal fun formatTime(
-        timeSeconds: Long,
-        zone: ZoneId,
-    ): String = Instant.ofEpochSecond(timeSeconds).atZone(zone).format(timeFormatter)
-
-    internal fun formatStateDurationLabel(
-        durationSeconds: Long,
-        isCurrent: Boolean,
-        isOpenState: Boolean,
-    ): String {
-        val duration = formatStateDuration(durationSeconds)
-        return when {
-            isCurrent -> "$duration and counting"
-            isOpenState -> "Open for $duration"
-            else -> "Closed for $duration"
-        }
-    }
-
-    /**
-     * Format an open/closed-state duration. Bias toward casual readability —
-     * drop seconds at minute scale, drop minutes at day scale.
-     */
-    internal fun formatStateDuration(seconds: Long): String {
-        val safe = seconds.coerceAtLeast(0L)
-        if (safe < 60) return "$safe sec"
-        val totalMin = safe / 60
-        if (totalMin < 60) return "$totalMin min"
-        val hours = totalMin / 60
-        val mins = totalMin % 60
-        if (hours < 24) {
-            return if (mins == 0L) "$hours hr" else "$hours hr $mins min"
-        }
-        val days = hours / 24
-        val remHours = hours % 24
-        return if (remHours == 0L) "$days day" else "$days day $remHours hr"
-    }
-
-    /**
-     * Format a transit (OPENING / CLOSING) duration. Transits are typically
-     * seconds, occasionally minutes for `_TOO_LONG` cases. We keep the
-     * seconds suffix at minute scale (transits are short, the precision
-     * helps), but drop seconds at hour scale to stay readable on the rare
-     * inputs where the data is malformed.
-     */
-    internal fun formatTransitDuration(seconds: Long): String {
-        val safe = seconds.coerceAtLeast(0L)
-        if (safe < 60) return "$safe sec"
-        val totalMin = safe / 60
-        val secs = safe % 60
-        if (totalMin < 60) {
-            return if (secs == 0L) "$totalMin min" else "$totalMin min $secs sec"
-        }
-        val hours = totalMin / 60
-        val mins = totalMin % 60
-        return if (mins == 0L) "$hours hr" else "$hours hr $mins min"
-    }
-
     // ---------- Step 6: group by day ----------
 
-    internal fun formatDayLabel(
+    /**
+     * Decide the [DayLabel] for a calendar date relative to "today".
+     * Phase 2E — returns a typed value; the Composable resolves to a
+     * localized string at render time.
+     */
+    internal fun dayLabel(
         date: LocalDate,
         today: LocalDate,
-    ): String =
+    ): DayLabel =
         when (today.toEpochDay() - date.toEpochDay()) {
-            0L -> "Today"
-            1L -> "Yesterday"
-            else -> date.format(dateFormatter)
+            0L -> DayLabel.Today
+            1L -> DayLabel.Yesterday
+            else -> DayLabel.Date(date)
         }
 
     /**
@@ -501,10 +430,10 @@ object HistoryMapper {
         val groups = LinkedHashMap<LocalDate, MutableList<HistoryEntry>>()
         for (rec in records) {
             val date = Instant.ofEpochSecond(rec.record.timeSeconds).atZone(zone).toLocalDate()
-            groups.getOrPut(date) { mutableListOf() }.add(rec.toHistoryEntry(zone))
+            groups.getOrPut(date) { mutableListOf() }.add(rec.toHistoryEntry())
         }
         return groups.map { (date, list) ->
-            HistoryDay(label = formatDayLabel(date, today), entries = list)
+            HistoryDay(label = dayLabel(date, today), entries = list)
         }
     }
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/TransitWarning.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/TransitWarning.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui.history
+
+/**
+ * Typed "transit took longer than expected" tag for [HistoryEntry].
+ *
+ * Replaces the previous `transitWarning: String?` field. The mapper
+ * carries the raw seconds; the Composable formats the duration and
+ * assembles the localized "Took X to open/close, longer than expected"
+ * string at render time.
+ */
+sealed interface TransitWarning {
+    val transitSeconds: Long
+
+    /** `OPENING_TOO_LONG` carried into a successful `Opened` row. */
+    data class ToOpen(
+        override val transitSeconds: Long,
+    ) : TransitWarning
+
+    /** `CLOSING_TOO_LONG` carried into a successful `Closed` row. */
+    data class ToClose(
+        override val transitSeconds: Long,
+    ) : TransitWarning
+}

--- a/AndroidGarage/androidApp/src/main/res/values/strings.xml
+++ b/AndroidGarage/androidApp/src/main/res/values/strings.xml
@@ -163,4 +163,47 @@
     <string name="function_list_register_fcm">Re-register FCM</string>
     <string name="function_list_deregister_fcm">Deregister FCM</string>
     <string name="function_list_copy_auth_token">Copy auth token (sensitive)</string>
+
+    <!-- History tab — day section labels (uppercased at render time). -->
+    <!-- Today / Yesterday are typed; older days render via DateTimeFormatter. -->
+    <string name="history_day_today">Today</string>
+    <string name="history_day_yesterday">Yesterday</string>
+
+    <!-- History tab — anomaly headlines (Sensor conflict / Unknown / etc.). -->
+    <string name="history_anomaly_sensor_conflict">Sensor conflict</string>
+    <string name="history_anomaly_unknown_state">Unknown state</string>
+    <string name="history_anomaly_stuck_opening">Stuck opening</string>
+    <string name="history_anomaly_stuck_closing">Stuck closing</string>
+    <string name="history_anomaly_open_misaligned">Open (misaligned)</string>
+
+    <!-- History tab — Opened/Closed row headlines. %1$s is a time (e.g. "9:47 AM"). -->
+    <string name="history_headline_open">Open</string>
+    <string name="history_headline_open_misaligned">Open (misaligned)</string>
+    <string name="history_headline_opened_at">Opened at %1$s</string>
+    <string name="history_headline_closed">Closed</string>
+    <string name="history_headline_closed_at">Closed at %1$s</string>
+
+    <!-- History tab — supporting line for the current entry. %1$s is a time, %2$s is a duration. -->
+    <string name="history_supporting_since_format">Since %1$s · %2$s</string>
+
+    <!-- History tab — state-span duration labels. %1$s is a duration like "5 min" or "2 hr 14 min". -->
+    <string name="history_state_duration_open_for">Open for %1$s</string>
+    <string name="history_state_duration_closed_for">Closed for %1$s</string>
+    <string name="history_state_duration_and_counting">%1$s and counting</string>
+    <!-- "5 hr" — used when the state lasted exactly N whole hours (no minutes). -->
+    <string name="history_state_duration_hours_only">%1$d hr</string>
+    <!-- "2 day 5 hr" — for state spans of one or more days plus extra hours. -->
+    <string name="history_state_duration_days_with_hours">%1$d day %2$d hr</string>
+
+    <!-- History tab — transit warnings (the "_TOO_LONG" tag below an Opened/Closed row). %1$s is a duration. -->
+    <string name="history_warning_transit_to_open">Took %1$s to open, longer than expected</string>
+    <string name="history_warning_transit_to_close">Took %1$s to close, longer than expected</string>
+    <!-- Transit duration variant — e.g. "2 min 30 sec" — used inside transit warnings only. -->
+    <string name="history_transit_minutes_seconds">%1$d min %2$d sec</string>
+    <!-- "Door was misaligned" tag below past Opened rows where misalignment was carried in. -->
+    <string name="history_warning_misaligned">Door was misaligned</string>
+
+    <!-- History tab — empty state. -->
+    <string name="history_empty_title">No events yet</string>
+    <string name="history_empty_subtitle">Open or close the garage and check back here.</string>
 </resources>

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/history/HistoryFormatterTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/history/HistoryFormatterTest.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui.history
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * Tests for [HistoryFormatter].
+ *
+ * Phase 2E of the string-resource migration plan
+ * (`AndroidGarage/docs/PENDING_FOLLOWUPS.md` item #1) — `formatTime`,
+ * `stateDurationParts`, `transitDurationParts`, and `formatDate` were
+ * moved here from `HistoryMapper`. The Composable layer assembles the
+ * final localized strings via `stringResource` + `pluralStringResource`.
+ *
+ * Tests cover the pure-function decomposition; the localized
+ * "Open for X" / "Took Y to open" assembly is screenshot-tested in the
+ * `HistoryContent` previews.
+ */
+class HistoryFormatterTest {
+    // ---------- formatTime ----------
+
+    @Test
+    fun formatTime_midnightUTC() {
+        val t = Instant.parse("2026-04-29T00:00:00Z").epochSecond
+        assertEquals("12:00 AM", HistoryFormatter.formatTime(t, ZoneOffset.UTC))
+    }
+
+    @Test
+    fun formatTime_noonUTC() {
+        val t = Instant.parse("2026-04-29T12:00:00Z").epochSecond
+        assertEquals("12:00 PM", HistoryFormatter.formatTime(t, ZoneOffset.UTC))
+    }
+
+    @Test
+    fun formatTime_morningUTC() {
+        val t = Instant.parse("2026-04-29T10:15:00Z").epochSecond
+        assertEquals("10:15 AM", HistoryFormatter.formatTime(t, ZoneOffset.UTC))
+    }
+
+    @Test
+    fun formatTime_eveningUTC() {
+        val t = Instant.parse("2026-04-28T20:30:00Z").epochSecond
+        assertEquals("8:30 PM", HistoryFormatter.formatTime(t, ZoneOffset.UTC))
+    }
+
+    @Test
+    fun formatTime_zoneOffsetShifts() {
+        // 10:15 AM in UTC = 7:15 AM in UTC-3
+        val t = Instant.parse("2026-04-29T10:15:00Z").epochSecond
+        assertEquals("7:15 AM", HistoryFormatter.formatTime(t, ZoneOffset.ofHours(-3)))
+    }
+
+    // ---------- formatDate ----------
+
+    @Test
+    fun formatDate_monday() {
+        assertEquals("Mon, Apr 27", HistoryFormatter.formatDate(LocalDate.parse("2026-04-27")))
+    }
+
+    @Test
+    fun formatDate_wednesday() {
+        assertEquals("Wed, Apr 22", HistoryFormatter.formatDate(LocalDate.parse("2026-04-22")))
+    }
+
+    // ---------- stateDurationParts ----------
+
+    @Test
+    fun stateDurationParts_zero() {
+        assertEquals(StateDurationParts(0, 0, 0, 0), HistoryFormatter.stateDurationParts(0))
+    }
+
+    @Test
+    fun stateDurationParts_negativeClampsToZero() {
+        assertEquals(StateDurationParts(0, 0, 0, 0), HistoryFormatter.stateDurationParts(-100))
+    }
+
+    @Test
+    fun stateDurationParts_secondsOnly() {
+        assertEquals(StateDurationParts(0, 0, 0, 30), HistoryFormatter.stateDurationParts(30))
+        assertEquals(StateDurationParts(0, 0, 0, 59), HistoryFormatter.stateDurationParts(59))
+    }
+
+    @Test
+    fun stateDurationParts_minutesOnly() {
+        assertEquals(StateDurationParts(0, 0, 1, 0), HistoryFormatter.stateDurationParts(60))
+        assertEquals(StateDurationParts(0, 0, 6, 0), HistoryFormatter.stateDurationParts(6 * 60))
+        assertEquals(StateDurationParts(0, 0, 59, 0), HistoryFormatter.stateDurationParts(59 * 60))
+    }
+
+    @Test
+    fun stateDurationParts_hours() {
+        assertEquals(StateDurationParts(0, 1, 0, 0), HistoryFormatter.stateDurationParts(60 * 60))
+        assertEquals(StateDurationParts(0, 1, 30, 0), HistoryFormatter.stateDurationParts(90 * 60))
+        assertEquals(StateDurationParts(0, 13, 17, 0), HistoryFormatter.stateDurationParts((13 * 60 + 17) * 60L))
+    }
+
+    @Test
+    fun stateDurationParts_days() {
+        assertEquals(StateDurationParts(1, 0, 0, 0), HistoryFormatter.stateDurationParts(24 * 60 * 60))
+        assertEquals(StateDurationParts(1, 1, 0, 0), HistoryFormatter.stateDurationParts(25 * 60 * 60))
+        assertEquals(StateDurationParts(3, 0, 0, 0), HistoryFormatter.stateDurationParts(3 * 24 * 60 * 60))
+    }
+
+    // ---------- transitDurationParts ----------
+
+    @Test
+    fun transitDurationParts_zero() {
+        assertEquals(TransitDurationParts(0, 0, 0), HistoryFormatter.transitDurationParts(0))
+    }
+
+    @Test
+    fun transitDurationParts_negativeClamps() {
+        assertEquals(TransitDurationParts(0, 0, 0), HistoryFormatter.transitDurationParts(-50))
+    }
+
+    @Test
+    fun transitDurationParts_secondsOnly() {
+        assertEquals(TransitDurationParts(0, 0, 30), HistoryFormatter.transitDurationParts(30))
+    }
+
+    @Test
+    fun transitDurationParts_minutes() {
+        assertEquals(TransitDurationParts(0, 1, 0), HistoryFormatter.transitDurationParts(60))
+        assertEquals(TransitDurationParts(0, 1, 30), HistoryFormatter.transitDurationParts(90))
+        assertEquals(TransitDurationParts(0, 4, 0), HistoryFormatter.transitDurationParts(240))
+    }
+
+    @Test
+    fun transitDurationParts_hours() {
+        assertEquals(TransitDurationParts(1, 0, 0), HistoryFormatter.transitDurationParts(60 * 60))
+        assertEquals(TransitDurationParts(1, 30, 0), HistoryFormatter.transitDurationParts(90 * 60))
+        assertEquals(TransitDurationParts(14, 30, 8), HistoryFormatter.transitDurationParts(14 * 3600 + 30 * 60 + 8L))
+    }
+}

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/history/HistoryMapperTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/history/HistoryMapperTest.kt
@@ -148,7 +148,7 @@ class HistoryMapperTest {
                 MergedRecord.Anomaly(
                     timeSeconds = 90,
                     position = DoorPosition.OPENING_TOO_LONG,
-                    title = "Stuck opening",
+                    kind = AnomalyKind.StuckOpening,
                 ),
             ),
             out,
@@ -180,7 +180,7 @@ class HistoryMapperTest {
         )
         assertEquals(
             listOf(
-                MergedRecord.Anomaly(timeSeconds = 80, position = DoorPosition.OPENING_TOO_LONG, title = "Stuck opening"),
+                MergedRecord.Anomaly(timeSeconds = 80, position = DoorPosition.OPENING_TOO_LONG, kind = AnomalyKind.StuckOpening),
                 MergedRecord.Closed(timeSeconds = 100, transitDurationSeconds = null),
             ),
             out,
@@ -214,7 +214,7 @@ class HistoryMapperTest {
         val out = HistoryMapper.mergeEvents(listOf(event(DoorPosition.CLOSING_TOO_LONG, 90)))
         assertEquals(
             listOf(
-                MergedRecord.Anomaly(timeSeconds = 90, position = DoorPosition.CLOSING_TOO_LONG, title = "Stuck closing"),
+                MergedRecord.Anomaly(timeSeconds = 90, position = DoorPosition.CLOSING_TOO_LONG, kind = AnomalyKind.StuckClosing),
             ),
             out,
         )
@@ -308,7 +308,7 @@ class HistoryMapperTest {
         assertEquals(
             listOf(
                 MergedRecord.Opened(timeSeconds = 100, transitDurationSeconds = null, misaligned = true),
-                MergedRecord.Anomaly(timeSeconds = 110, position = DoorPosition.ERROR_SENSOR_CONFLICT, title = "Sensor conflict"),
+                MergedRecord.Anomaly(timeSeconds = 110, position = DoorPosition.ERROR_SENSOR_CONFLICT, kind = AnomalyKind.SensorConflict),
             ),
             out,
         )
@@ -329,7 +329,7 @@ class HistoryMapperTest {
             listOf(
                 MergedRecord.Opened(timeSeconds = 100, transitDurationSeconds = null, misaligned = false),
                 MergedRecord.Closed(timeSeconds = 200, transitDurationSeconds = null),
-                MergedRecord.Anomaly(timeSeconds = 300, position = DoorPosition.OPEN_MISALIGNED, title = "Open (misaligned)"),
+                MergedRecord.Anomaly(timeSeconds = 300, position = DoorPosition.OPEN_MISALIGNED, kind = AnomalyKind.OpenMisaligned),
             ),
             out,
         )
@@ -342,7 +342,7 @@ class HistoryMapperTest {
         val out = HistoryMapper.mergeEvents(listOf(event(DoorPosition.OPEN_MISALIGNED, 100)))
         assertEquals(
             listOf(
-                MergedRecord.Anomaly(timeSeconds = 100, position = DoorPosition.OPEN_MISALIGNED, title = "Open (misaligned)"),
+                MergedRecord.Anomaly(timeSeconds = 100, position = DoorPosition.OPEN_MISALIGNED, kind = AnomalyKind.OpenMisaligned),
             ),
             out,
         )
@@ -353,7 +353,7 @@ class HistoryMapperTest {
         val out = HistoryMapper.mergeEvents(listOf(event(DoorPosition.ERROR_SENSOR_CONFLICT, 100)))
         assertEquals(
             listOf(
-                MergedRecord.Anomaly(timeSeconds = 100, position = DoorPosition.ERROR_SENSOR_CONFLICT, title = "Sensor conflict"),
+                MergedRecord.Anomaly(timeSeconds = 100, position = DoorPosition.ERROR_SENSOR_CONFLICT, kind = AnomalyKind.SensorConflict),
             ),
             out,
         )
@@ -364,7 +364,7 @@ class HistoryMapperTest {
         val out = HistoryMapper.mergeEvents(listOf(event(DoorPosition.UNKNOWN, 100)))
         assertEquals(
             listOf(
-                MergedRecord.Anomaly(timeSeconds = 100, position = DoorPosition.UNKNOWN, title = "Unknown state"),
+                MergedRecord.Anomaly(timeSeconds = 100, position = DoorPosition.UNKNOWN, kind = AnomalyKind.UnknownState),
             ),
             out,
         )
@@ -404,7 +404,7 @@ class HistoryMapperTest {
         // resolves into the eventual OPEN with a transit warning.
         assertEquals(
             listOf(
-                MergedRecord.Anomaly(timeSeconds = 90, position = DoorPosition.ERROR_SENSOR_CONFLICT, title = "Sensor conflict"),
+                MergedRecord.Anomaly(timeSeconds = 90, position = DoorPosition.ERROR_SENSOR_CONFLICT, kind = AnomalyKind.SensorConflict),
                 MergedRecord.Opened(timeSeconds = 100, transitDurationSeconds = 20),
             ),
             out,
@@ -425,7 +425,7 @@ class HistoryMapperTest {
         )
         assertEquals(
             listOf(
-                MergedRecord.Anomaly(timeSeconds = 80, position = DoorPosition.CLOSING_TOO_LONG, title = "Stuck closing"),
+                MergedRecord.Anomaly(timeSeconds = 80, position = DoorPosition.CLOSING_TOO_LONG, kind = AnomalyKind.StuckClosing),
                 MergedRecord.Opened(timeSeconds = 100, transitDurationSeconds = null),
             ),
             out,
@@ -444,7 +444,7 @@ class HistoryMapperTest {
         )
         assertEquals(
             listOf(
-                MergedRecord.Anomaly(timeSeconds = 80, position = DoorPosition.OPENING_TOO_LONG, title = "Stuck opening"),
+                MergedRecord.Anomaly(timeSeconds = 80, position = DoorPosition.OPENING_TOO_LONG, kind = AnomalyKind.StuckOpening),
                 MergedRecord.Closed(timeSeconds = 100, transitDurationSeconds = null),
             ),
             out,
@@ -532,7 +532,11 @@ class HistoryMapperTest {
 
     @Test
     fun durations_anomaliesPassThroughWithoutDuration() {
-        val anomaly = MergedRecord.Anomaly(timeSeconds = now.epochSecond - 100, position = DoorPosition.UNKNOWN, title = "Unknown state")
+        val anomaly = MergedRecord.Anomaly(
+            timeSeconds = now.epochSecond - 100,
+            position = DoorPosition.UNKNOWN,
+            kind = AnomalyKind.UnknownState,
+        )
         val out = HistoryMapper.computeDurations(listOf(anomaly), now)
         assertEquals(1, out.size)
         assertEquals(null, out[0].durationSeconds)
@@ -570,7 +574,7 @@ class HistoryMapperTest {
     @Test
     fun durations_anomalyBetweenTerminalsDoesNotInterfere() {
         val o = MergedRecord.Opened(timeSeconds = now.epochSecond - 3000, transitDurationSeconds = null)
-        val a = MergedRecord.Anomaly(timeSeconds = now.epochSecond - 1500, position = DoorPosition.UNKNOWN, title = "Unknown state")
+        val a = MergedRecord.Anomaly(timeSeconds = now.epochSecond - 1500, position = DoorPosition.UNKNOWN, kind = AnomalyKind.UnknownState)
         val c = MergedRecord.Closed(timeSeconds = now.epochSecond - 600, transitDurationSeconds = null)
         val out = HistoryMapper.computeDurations(listOf(o, a, c), now)
         // Opened reaches forward through anomaly to closed at -600 → 2400s
@@ -582,121 +586,42 @@ class HistoryMapperTest {
         assertTrue(out[2].isCurrent)
     }
 
-    // ---------- formatStateDuration ----------
-
-    @Test fun formatState_zeroSec() = assertEquals("0 sec", HistoryMapper.formatStateDuration(0))
-
-    @Test fun formatState_30Sec() = assertEquals("30 sec", HistoryMapper.formatStateDuration(30))
-
-    @Test fun formatState_59Sec() = assertEquals("59 sec", HistoryMapper.formatStateDuration(59))
-
-    @Test fun formatState_1Min() = assertEquals("1 min", HistoryMapper.formatStateDuration(60))
-
-    @Test fun formatState_90SecRoundsToOneMin() = assertEquals("1 min", HistoryMapper.formatStateDuration(90))
-
-    @Test fun formatState_6Min() = assertEquals("6 min", HistoryMapper.formatStateDuration(6 * 60))
-
-    @Test fun formatState_59Min() = assertEquals("59 min", HistoryMapper.formatStateDuration(59 * 60))
-
-    @Test fun formatState_60Min() = assertEquals("1 hr", HistoryMapper.formatStateDuration(60 * 60))
-
-    @Test fun formatState_90Min() = assertEquals("1 hr 30 min", HistoryMapper.formatStateDuration(90 * 60))
-
-    @Test fun formatState_2Hours() = assertEquals("2 hr", HistoryMapper.formatStateDuration(2 * 60 * 60))
-
-    @Test fun formatState_13Hr17Min() = assertEquals("13 hr 17 min", HistoryMapper.formatStateDuration((13 * 60 + 17) * 60L))
-
-    @Test fun formatState_24Hours() = assertEquals("1 day", HistoryMapper.formatStateDuration(24 * 60 * 60))
-
-    @Test fun formatState_25Hours() = assertEquals("1 day 1 hr", HistoryMapper.formatStateDuration(25 * 60 * 60))
-
-    @Test fun formatState_3Days() = assertEquals("3 day", HistoryMapper.formatStateDuration(3 * 24 * 60 * 60))
-
-    @Test fun formatState_negativeCoercesToZero() = assertEquals("0 sec", HistoryMapper.formatStateDuration(-100))
-
-    // ---------- formatTransitDuration ----------
-
-    @Test fun formatTransit_30Sec() = assertEquals("30 sec", HistoryMapper.formatTransitDuration(30))
-
-    @Test fun formatTransit_60Sec() = assertEquals("1 min", HistoryMapper.formatTransitDuration(60))
-
-    @Test fun formatTransit_90SecKeepsSeconds() = assertEquals("1 min 30 sec", HistoryMapper.formatTransitDuration(90))
-
-    @Test fun formatTransit_240Sec() = assertEquals("4 min", HistoryMapper.formatTransitDuration(240))
-
-    @Test fun formatTransit_negativeCoercesToZero() = assertEquals("0 sec", HistoryMapper.formatTransitDuration(-50))
-
-    @Test fun formatTransit_60MinScalesToHours() = assertEquals("1 hr", HistoryMapper.formatTransitDuration(60 * 60))
-
-    @Test fun formatTransit_90MinScalesToHoursMin() = assertEquals("1 hr 30 min", HistoryMapper.formatTransitDuration(90 * 60))
-
-    @Test
-    fun formatTransit_14Hr30MinDropsSeconds() {
-        // Defensive: a malformed input that produces a 14h30m8s transit should
-        // round to "14 hr 30 min" rather than "870 min 8 sec".
-        assertEquals("14 hr 30 min", HistoryMapper.formatTransitDuration(14 * 3600 + 30 * 60 + 8L))
-    }
-
-    // ---------- formatTime ----------
-
-    @Test
-    fun formatTime_midnightUTC() {
-        val t = Instant.parse("2026-04-29T00:00:00Z").epochSecond
-        assertEquals("12:00 AM", HistoryMapper.formatTime(t, ZoneOffset.UTC))
-    }
-
-    @Test
-    fun formatTime_noonUTC() {
-        val t = Instant.parse("2026-04-29T12:00:00Z").epochSecond
-        assertEquals("12:00 PM", HistoryMapper.formatTime(t, ZoneOffset.UTC))
-    }
-
-    @Test
-    fun formatTime_morningUTC() {
-        val t = Instant.parse("2026-04-29T10:15:00Z").epochSecond
-        assertEquals("10:15 AM", HistoryMapper.formatTime(t, ZoneOffset.UTC))
-    }
-
-    @Test
-    fun formatTime_eveningUTC() {
-        val t = Instant.parse("2026-04-28T20:30:00Z").epochSecond
-        assertEquals("8:30 PM", HistoryMapper.formatTime(t, ZoneOffset.UTC))
-    }
-
-    @Test
-    fun formatTime_zoneOffsetShifts() {
-        // 10:15 AM in UTC = 7:15 AM in UTC-3
-        val t = Instant.parse("2026-04-29T10:15:00Z").epochSecond
-        assertEquals("7:15 AM", HistoryMapper.formatTime(t, ZoneOffset.ofHours(-3)))
-    }
-
-    // ---------- formatDayLabel ----------
+    // ---------- typed dayLabel ----------
+    //
+    // (Phase 2E — formatStateDuration / formatTransitDuration / formatTime
+    //  were removed from HistoryMapper. Their pure-function equivalents live
+    //  in HistoryStatusFormatter (`formatTime`, `stateDurationParts`,
+    //  `transitDurationParts`) and are tested in HistoryFormatterTest. The
+    //  Composable layer in HistoryContent.kt assembles the final localized
+    //  strings via `stringResource` + `pluralStringResource` at render time.
+    //  formatDayLabel is replaced by `dayLabel` returning a typed [DayLabel]
+    //  — tested below.)
 
     @Test
     fun dayLabel_today() {
         val today = LocalDate.parse("2026-04-29")
-        assertEquals("Today", HistoryMapper.formatDayLabel(today, today))
+        assertEquals(DayLabel.Today, HistoryMapper.dayLabel(today, today))
     }
 
     @Test
     fun dayLabel_yesterday() {
         val today = LocalDate.parse("2026-04-29")
         val yesterday = today.minusDays(1)
-        assertEquals("Yesterday", HistoryMapper.formatDayLabel(yesterday, today))
+        assertEquals(DayLabel.Yesterday, HistoryMapper.dayLabel(yesterday, today))
     }
 
     @Test
     fun dayLabel_twoDaysAgo() {
         val today = LocalDate.parse("2026-04-29")
         val twoAgo = today.minusDays(2)
-        assertEquals("Mon, Apr 27", HistoryMapper.formatDayLabel(twoAgo, today))
+        assertEquals(DayLabel.Date(twoAgo), HistoryMapper.dayLabel(twoAgo, today))
     }
 
     @Test
     fun dayLabel_lastWeek() {
         val today = LocalDate.parse("2026-04-29")
         val lastWeek = today.minusDays(7)
-        assertEquals("Wed, Apr 22", HistoryMapper.formatDayLabel(lastWeek, today))
+        assertEquals(DayLabel.Date(lastWeek), HistoryMapper.dayLabel(lastWeek, today))
     }
 
     // ---------- toHistoryDays end-to-end ----------
@@ -716,7 +641,7 @@ class HistoryMapperTest {
         val days = HistoryMapper.toHistoryDays(events, now, zone)
         assertEquals(1, days.size)
         assertEquals(1, days[0].entries.size)
-        assertEquals("Today", days[0].label)
+        assertEquals(DayLabel.Today, days[0].label)
     }
 
     @Test
@@ -724,10 +649,10 @@ class HistoryMapperTest {
         val events = listOf(event(DoorPosition.OPEN, now.epochSecond - 720))
         val days = HistoryMapper.toHistoryDays(events, now, zone)
         assertEquals(1, days.size)
-        assertEquals("Today", days[0].label)
+        assertEquals(DayLabel.Today, days[0].label)
         val entry = days[0].entries.single() as HistoryEntry.Opened
         assertTrue(entry.isCurrent)
-        assertEquals("12 min and counting", entry.durationDisplay)
+        assertEquals(720L, entry.durationSeconds) // 12 min
         assertEquals(null, entry.transitWarning)
     }
 
@@ -737,7 +662,7 @@ class HistoryMapperTest {
         val days = HistoryMapper.toHistoryDays(events, now, zone)
         val entry = days[0].entries.single() as HistoryEntry.Closed
         assertTrue(entry.isCurrent)
-        assertEquals("12 min and counting", entry.durationDisplay)
+        assertEquals(720L, entry.durationSeconds) // 12 min
     }
 
     @Test
@@ -754,7 +679,7 @@ class HistoryMapperTest {
         val opened = days[0].entries[1] as HistoryEntry.Opened
         assertTrue(closed.isCurrent)
         assertEquals(false, opened.isCurrent)
-        assertEquals("Open for 12 min", opened.durationDisplay)
+        assertEquals(720L, opened.durationSeconds) // 12 min
     }
 
     @Test
@@ -766,7 +691,7 @@ class HistoryMapperTest {
         )
         val days = HistoryMapper.toHistoryDays(events, now, zone)
         val opened = days[0].entries.last() as HistoryEntry.Opened
-        assertEquals("Took 4 min to open, longer than expected", opened.transitWarning)
+        assertEquals(TransitWarning.ToOpen(transitSeconds = 240L), opened.transitWarning)
     }
 
     @Test
@@ -779,7 +704,7 @@ class HistoryMapperTest {
         val days = HistoryMapper.toHistoryDays(events, now, zone)
         // Newest-first: closed, opened
         val closed = days[0].entries[0] as HistoryEntry.Closed
-        assertEquals("Took 3 min to close, longer than expected", closed.transitWarning)
+        assertEquals(TransitWarning.ToClose(transitSeconds = 180L), closed.transitWarning)
     }
 
     @Test
@@ -815,7 +740,7 @@ class HistoryMapperTest {
         val days = HistoryMapper.toHistoryDays(events, now, zone)
         // Newest-first: Anomaly, Closed, Opened.
         val anomaly = days[0].entries[0] as HistoryEntry.Anomaly
-        assertEquals("Open (misaligned)", anomaly.title)
+        assertEquals(AnomalyKind.OpenMisaligned, anomaly.kind)
         assertEquals(DoorPosition.OPEN_MISALIGNED, anomaly.doorPosition)
     }
 
@@ -838,9 +763,9 @@ class HistoryMapperTest {
         val openedNew = days[0].entries[1] as HistoryEntry.Opened
         val openedMisaligned = days[0].entries[2] as HistoryEntry.Opened
         // openedMisaligned (older, t1): bounded by next Opened at t2 → 1200s = 20 min.
-        assertEquals("Open for 20 min", openedMisaligned.durationDisplay)
+        assertEquals(1200L, openedMisaligned.durationSeconds) // 20 min
         // openedNew (t2): bounded by Closed at tClosed → 1200s = 20 min.
-        assertEquals("Open for 20 min", openedNew.durationDisplay)
+        assertEquals(1200L, openedNew.durationSeconds) // 20 min
     }
 
     @Test
@@ -860,7 +785,7 @@ class HistoryMapperTest {
         val events = listOf(event(DoorPosition.UNKNOWN, now.epochSecond - 600))
         val days = HistoryMapper.toHistoryDays(events, now, zone)
         val anomaly = days[0].entries.single() as HistoryEntry.Anomaly
-        assertEquals("Unknown state", anomaly.title)
+        assertEquals(AnomalyKind.UnknownState, anomaly.kind)
         assertEquals(DoorPosition.UNKNOWN, anomaly.doorPosition)
     }
 
@@ -869,7 +794,7 @@ class HistoryMapperTest {
         val events = listOf(event(DoorPosition.ERROR_SENSOR_CONFLICT, now.epochSecond - 600))
         val days = HistoryMapper.toHistoryDays(events, now, zone)
         val anomaly = days[0].entries.single() as HistoryEntry.Anomaly
-        assertEquals("Sensor conflict", anomaly.title)
+        assertEquals(AnomalyKind.SensorConflict, anomaly.kind)
     }
 
     @Test
@@ -877,7 +802,7 @@ class HistoryMapperTest {
         val events = listOf(event(DoorPosition.OPENING_TOO_LONG, now.epochSecond - 600))
         val days = HistoryMapper.toHistoryDays(events, now, zone)
         val anomaly = days[0].entries.single() as HistoryEntry.Anomaly
-        assertEquals("Stuck opening", anomaly.title)
+        assertEquals(AnomalyKind.StuckOpening, anomaly.kind)
         assertEquals(DoorPosition.OPENING_TOO_LONG, anomaly.doorPosition)
     }
 
@@ -886,7 +811,7 @@ class HistoryMapperTest {
         val events = listOf(event(DoorPosition.CLOSING_TOO_LONG, now.epochSecond - 600))
         val days = HistoryMapper.toHistoryDays(events, now, zone)
         val anomaly = days[0].entries.single() as HistoryEntry.Anomaly
-        assertEquals("Stuck closing", anomaly.title)
+        assertEquals(AnomalyKind.StuckClosing, anomaly.kind)
         assertEquals(DoorPosition.CLOSING_TOO_LONG, anomaly.doorPosition)
     }
 
@@ -902,9 +827,9 @@ class HistoryMapperTest {
         )
         val days = HistoryMapper.toHistoryDays(events, now, zone)
         assertEquals(3, days.size)
-        assertEquals("Today", days[0].label)
-        assertEquals("Yesterday", days[1].label)
-        assertEquals("Mon, Apr 27", days[2].label)
+        assertEquals(DayLabel.Today, days[0].label)
+        assertEquals(DayLabel.Yesterday, days[1].label)
+        assertEquals(DayLabel.Date(LocalDate.parse("2026-04-27")), days[2].label)
     }
 
     @Test
@@ -922,7 +847,7 @@ class HistoryMapperTest {
         val opened = days[0].entries[1] as HistoryEntry.Opened
         // Opened at the FIRST OPEN's timestamp, not the heartbeats — the
         // duration spans from the first OPEN to the eventual CLOSED.
-        assertEquals("Open for 20 min", opened.durationDisplay)
+        assertEquals(1200L, opened.durationSeconds) // 20 min
     }
 
     @Test


### PR DESCRIPTION
## Summary
Phase 2E of the [string-resource migration plan](AndroidGarage/docs/PENDING_FOLLOWUPS.md). Final mapper-side refactor — `HistoryMapper` no longer emits user-visible text; every display string is built by the Composable layer via `stringResource` + `pluralStringResource` at render time.

## New typed sealed types
| File | Replaces |
|---|---|
| `AnomalyKind.kt` (NEW) | `HistoryEntry.Anomaly.title: String` + `MergedRecord.Anomaly.title: String` |
| `DayLabel.kt` (NEW) | `HistoryDay.label: String` |
| `TransitWarning.kt` (NEW) | `HistoryEntry.{Opened,Closed}.transitWarning: String?` |

## New utility
`HistoryFormatter.kt` — pure-function helpers parallel to `HomeStatusFormatter`. Returns typed `StateDurationParts` / `TransitDurationParts` decomposition for the Composable to render with plurals.

## HistoryEntry shape
| Field | Old | New |
|---|---|---|
| `Opened.timeDisplay` | `String "9:47 AM"` | DELETED → `timeSeconds: Long` |
| `Opened.durationDisplay` | `String "Open for 6 min"` | DELETED → `durationSeconds: Long` |
| `Opened.transitWarning` | `String "Took ... to open ..."` | `TransitWarning?` typed |
| `Closed.*` | parallel | parallel |
| `Anomaly.title` | `String "Sensor conflict"` | DELETED → `kind: AnomalyKind` |
| `Anomaly.timeDisplay` | `String "9:47 AM"` | DELETED → `timeSeconds: Long` |
| `HistoryDay.label` | `String "Today"` | `DayLabel` typed |

## HistoryContent rendering
- `HistoryDayKey` object (per ADR-009 — no bare top-level functions) for stable LazyColumn item keys
- 4 new Composable resolvers: `dayLabelText`, `anomalyTitle`, `stateDurationDisplay`, `transitWarningText`
- `HistoryEntryRow` + top-level `HistoryContent` take a new `zone: ZoneId` parameter so `timeSeconds` can be formatted via `HistoryFormatter.formatTime`

## Strings + plurals
~20 new resources (`history_day_*`, `history_anomaly_*`, `history_headline_*`, `history_supporting_*`, `history_state_duration_*`, `history_warning_*`, `history_transit_*`, `history_empty_*`); reuses `home_duration_*` plurals (shared count-based count strings).

## Tests
- `HistoryMapperTest`: ~50 assertions rewritten from text → type. Deleted formatter test sections (formatStateDuration, formatTransitDuration, formatTime, formatDayLabel) point to the new test
- `HistoryFormatterTest` (NEW): tests the pure-function decomposition asserted on typed shape

## Out of scope (queued)
- Phase 2F: `NotificationPermissionCopy → NotificationJustification` typed (last remaining mapper-emits-string case)

## Verified
- `validate.sh` PASS on this branch
- 10 files changed, 786 insertions, 289 deletions