### PR TITLE
refactor(android): NotificationPermissionCopy → NotificationJustification typed (Phase 2F)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/permissions/NotificationPermission.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/permissions/NotificationPermission.kt
@@ -60,28 +60,18 @@ fun rememberPermissionAlwaysGranted(permission: String): PermissionState =
     }
 
 /**
- * Copy for the notification-permission justification prompt.
+ * Typed justification for the notification-permission prompt. Replaces
+ * the previous `NotificationPermissionCopy.justificationText(int): String`
+ * builder.
  *
- * Produces increasingly detailed messages as the attempt count grows, in
- * line with Android's "system might block you" behavior.
+ * Phase 2F of the string-resource migration plan
+ * (`AndroidGarage/docs/PENDING_FOLLOWUPS.md` item #1) — the typed value
+ * carries only the [attemptCount]; the Composable layer assembles the
+ * multi-line localized message at render time using `stringResource` +
+ * conditional appends for the escalation lines (attempts 3+, 4+, 5+).
+ *
+ * Tests assert on [attemptCount] directly, decoupled from the copy text.
  */
-object NotificationPermissionCopy {
-    fun justificationText(attemptCount: Int = 0): String {
-        val baseText = "Turn on notifications to get alerted when the door is left open."
-        return buildString {
-            append(baseText)
-            if (attemptCount > 2) {
-                append("\nYou can manage permissions in the Android system settings.")
-            }
-            if (attemptCount > 3) {
-                append(
-                    "\nAndroid might be blocking requests because " +
-                        "the permission was denied multiple times.",
-                )
-            }
-            if (attemptCount > 4) {
-                append("\nYou have clicked the button $attemptCount times.")
-            }
-        }
-    }
-}
+data class NotificationJustification(
+    val attemptCount: Int = 0,
+)

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
@@ -62,7 +62,7 @@ import com.chriscartland.garage.R
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.model.RemoteButtonState
-import com.chriscartland.garage.permissions.NotificationPermissionCopy
+import com.chriscartland.garage.permissions.NotificationJustification
 import com.chriscartland.garage.ui.DeviceCheckInPill
 import com.chriscartland.garage.ui.DoorStatusInfoBottomSheet
 import com.chriscartland.garage.ui.GarageIcon
@@ -143,14 +143,16 @@ sealed interface HomeAlert {
     data object Stale : HomeAlert
 
     /**
-     * Notification permission denied / never asked. [message] still carries
-     * the server-formatted justification text from
-     * [com.chriscartland.garage.permissions.NotificationPermissionCopy] —
-     * that lifecycle moves to a typed `NotificationJustification` shape in
-     * Phase 2F.
+     * Notification permission denied / never asked. [justification] carries
+     * a typed [com.chriscartland.garage.permissions.NotificationJustification]
+     * — its [com.chriscartland.garage.permissions.NotificationJustification.attemptCount]
+     * drives the escalation lines (3+, 4+, 5+). The Composable resolver in
+     * `HomeAlertCard` assembles the multi-line localized message at
+     * render time. Phase 2F of the string-resource migration plan
+     * (`AndroidGarage/docs/PENDING_FOLLOWUPS.md` item #1).
      */
     data class PermissionMissing(
-        val message: String,
+        val justification: NotificationJustification,
     ) : HomeAlert
 
     /**
@@ -428,6 +430,43 @@ private fun doorWarningText(warning: DoorWarning): String =
     }
 
 /**
+ * Resolves a typed [NotificationJustification] to the multi-line localized
+ * message rendered in the `HomeAlert.PermissionMissing` banner. The base
+ * line always shows; escalation lines append at attempt counts 3+, 4+, 5+
+ * — same shape as the legacy `NotificationPermissionCopy.justificationText`.
+ *
+ * Phase 2F of the string-resource migration plan
+ * (`AndroidGarage/docs/PENDING_FOLLOWUPS.md` item #1) — replaces the
+ * non-Composable string-builder so the mapper can emit a typed value.
+ */
+@Composable
+private fun notificationJustificationText(justification: NotificationJustification): String {
+    val base = stringResource(R.string.notification_justification_base)
+    val attempt = justification.attemptCount
+    val attempt3 = if (attempt > 2) {
+        stringResource(R.string.notification_justification_attempt_3)
+    } else {
+        null
+    }
+    val attempt4 = if (attempt > 3) {
+        stringResource(R.string.notification_justification_attempt_4)
+    } else {
+        null
+    }
+    val attempt5 = if (attempt > 4) {
+        stringResource(R.string.notification_justification_attempt_5, attempt)
+    } else {
+        null
+    }
+    return buildString {
+        append(base)
+        attempt3?.let { append("\n").append(it) }
+        attempt4?.let { append("\n").append(it) }
+        attempt5?.let { append("\n").append(it) }
+    }
+}
+
+/**
  * Resolves a [DoorPosition] to the headline label string for the Status card.
  *
  * Multiple positions share a label by design: `OPENING` and `OPENING_TOO_LONG`
@@ -565,7 +604,7 @@ private fun HomeAlertCard(
     }
     val message = when (alert) {
         HomeAlert.Stale -> stringResource(R.string.home_alert_stale_message)
-        is HomeAlert.PermissionMissing -> alert.message
+        is HomeAlert.PermissionMissing -> notificationJustificationText(alert.justification)
         is HomeAlert.FetchError ->
             stringResource(R.string.home_alert_fetch_error_format, alert.truncatedException)
     }
@@ -632,7 +671,7 @@ private object HomePreviewData {
     )
     val staleAlert = HomeAlert.Stale
     val permissionAlert = HomeAlert.PermissionMissing(
-        message = NotificationPermissionCopy.justificationText(0),
+        justification = NotificationJustification(attemptCount = 0),
     )
 
     // Heartbeat cadence is ~10 min, so a representative typical pill reads

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeMapper.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeMapper.kt
@@ -21,7 +21,7 @@ import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.model.LoadingResult
-import com.chriscartland.garage.permissions.NotificationPermissionCopy
+import com.chriscartland.garage.permissions.NotificationJustification
 
 /**
  * Pure-function mapper that converts the Home tab's domain inputs into the
@@ -73,9 +73,10 @@ object HomeMapper {
      * carries only the raw exception text (data, not a label) for the
      * Composable to interpolate via `formatArgs`.
      *
-     * `HomeAlert.PermissionMissing.message` still carries a String produced
-     * by [NotificationPermissionCopy] for now; that lifecycle moves to a
-     * typed shape in Phase 2F.
+     * `HomeAlert.PermissionMissing.justification` (Phase 2F) carries the
+     * typed [NotificationJustification] shape; the Composable layer
+     * assembles the multi-line localized message from
+     * [NotificationJustification.attemptCount] at render time.
      */
     fun toHomeAlerts(
         currentDoorEvent: LoadingResult<DoorEvent?>,
@@ -90,7 +91,7 @@ object HomeMapper {
             if (!notificationPermissionGranted) {
                 add(
                     HomeAlert.PermissionMissing(
-                        message = NotificationPermissionCopy.justificationText(notificationRequestCount),
+                        justification = NotificationJustification(notificationRequestCount),
                     ),
                 )
             }

--- a/AndroidGarage/androidApp/src/main/res/values/strings.xml
+++ b/AndroidGarage/androidApp/src/main/res/values/strings.xml
@@ -206,4 +206,15 @@
     <!-- History tab — empty state. -->
     <string name="history_empty_title">No events yet</string>
     <string name="history_empty_subtitle">Open or close the garage and check back here.</string>
+
+    <!-- Notification permission justification — base + escalation lines. -->
+    <!-- Composable assembles base + conditional escalation appends in -->
+    <!-- HomeContent.kt's notificationJustificationText resolver. -->
+    <string name="notification_justification_base">Turn on notifications to get alerted when the door is left open.</string>
+    <!-- Appended at attempt count 3+. -->
+    <string name="notification_justification_attempt_3">You can manage permissions in the Android system settings.</string>
+    <!-- Appended at attempt count 4+. -->
+    <string name="notification_justification_attempt_4">Android might be blocking requests because the permission was denied multiple times.</string>
+    <!-- Appended at attempt count 5+. %1$d is the attempt count. -->
+    <string name="notification_justification_attempt_5">You have clicked the button %1$d times.</string>
 </resources>

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/home/HomeMapperTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/home/HomeMapperTest.kt
@@ -226,14 +226,15 @@ class HomeMapperTest {
             notificationRequestCount = 0,
         )
         assertEquals(1, alerts.size)
-        assertTrue(alerts[0] is HomeAlert.PermissionMissing)
-        // The justification text should not be empty.
+        // Phase 2F: PermissionMissing carries a typed NotificationJustification
+        // instead of a String message. The Composable layer renders the
+        // multi-line localized message at the call site.
         val pm = alerts[0] as HomeAlert.PermissionMissing
-        assertTrue(pm.message.isNotBlank())
+        assertEquals(0, pm.justification.attemptCount)
     }
 
     @Test
-    fun toHomeAlerts_permission_message_grows_with_attempts() {
+    fun toHomeAlerts_permission_attemptCount_passes_through() {
         val firstAttempt = HomeMapper
             .toHomeAlerts(
                 currentDoorEvent = LoadingResult.Complete(event(DoorPosition.OPEN)),
@@ -248,7 +249,11 @@ class HomeMapperTest {
                 notificationPermissionGranted = false,
                 notificationRequestCount = 5,
             ).first() as HomeAlert.PermissionMissing
-        assertTrue(manyAttempts.message.length > firstAttempt.message.length)
+        // Mapper passes the count through verbatim; the Composable's
+        // notificationJustificationText resolver appends escalation lines
+        // at counts 3+, 4+, 5+.
+        assertEquals(0, firstAttempt.justification.attemptCount)
+        assertEquals(5, manyAttempts.justification.attemptCount)
     }
 
     @Test


### PR DESCRIPTION
## Summary
**Final Phase 2 PR.** Replaces the last mapper-emits-string case in the codebase with a typed-hint refactor.

| File | Change |
|---|---|
| `NotificationPermission.kt` | DELETE `NotificationPermissionCopy.justificationText(int): String`. NEW `data class NotificationJustification(attemptCount: Int)` |
| `HomeContent.kt` | `HomeAlert.PermissionMissing.message: String` → `justification: NotificationJustification`. New `notificationJustificationText()` Composable resolver assembles the multi-line localized message via conditional `stringResource` appends |
| `HomeMapper.kt` | `toHomeAlerts` emits `PermissionMissing(justification = NotificationJustification(...))` |
| `strings.xml` | 4 new resources (`notification_justification_*` for base + escalation lines) |
| `HomeMapperTest.kt` | Permission tests assert on `justification.attemptCount` (typed shape) instead of String length |

## Migration complete
This closes Phase 2 of the [string-resource migration plan](AndroidGarage/docs/PENDING_FOLLOWUPS.md). Every mapper in the app now emits typed values; no production mapper / ViewModel produces user-visible text. The lint from #792 (`checkNoLiteralStringsInCompose`) guards against regression.

**Phase 2 summary:**
- Phase 2A (#790): `DoorWarning` sealed type
- Phase 2B (#791): `HomeMapper.stateLabel` deleted
- Phase 2C+2D (#793): `sinceLine` + `HomeAlert` defaults dropped
- Phase 2E (#794): `HistoryMapper` full refactor
- Phase 2F (this PR): `NotificationJustification` typed

## Verified
- `validate.sh` PASS on this branch