### PR TITLE
ui(android): Derive Nav rail default top padding from named constants (2.16.31)

### DIFF
--- a/AndroidGarage/CHANGELOG.md
+++ b/AndroidGarage/CHANGELOG.md
@@ -15,6 +15,14 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
 
+## 2.16.31
+- **Default Nav rail top padding is now derived, not hardcoded.** Pre-2.16.31 the value `8` appeared as a literal in 8 places (`DataStoreAppSettings`, `FakeAppSettingsRepository`, `ProfileViewModel` initial state, 5 preview call sites). The relationship between `8` and `Spacing.ListContentPadding.top` (16 dp) was implicit — a future bump of `Spacing.ListContentPadding.top` (e.g. for a more spacious section rhythm) would silently break rail-vs-content alignment until someone smoke-tested on hardware. Now the default is **derived** from a single named relationship: `DEFAULT_TOP_PADDING_DP = BODY_CONTENT_TOP_DP − RAIL_INTRINSIC_PILL_OFFSET_DP`.
+  - **User-facing**: no behavior change. Default is still 8 dp; users can still override via Settings → Developer → Nav rail.
+  - **Internal: new domain object `NavigationRailLayout`** (in `:domain/.../model/NavigationRailLayout.kt`) with three named constants — `BODY_CONTENT_TOP_DP = 16`, `RAIL_INTRINSIC_PILL_OFFSET_DP = 8`, `DEFAULT_TOP_PADDING_DP = 8` (derived). Class KDoc explains the math (body-content-top vs rail-internal-padding) and the M3-internals drift risk (the `8` sum captures `NavigationRailVerticalPadding` 4 dp + `NavigationRailItem`'s own pre-pill padding 4 dp, neither of which is exposed by `androidx.compose.material3`).
+  - **Internal: 3 source-of-truth defaults** updated to use the derived constant: `DataStoreAppSettings.navigationRailTopPaddingDp`, `FakeAppSettingsRepository.navigationRailTopPaddingDp`, `ProfileViewModel._navigationRailTopPaddingDp`.
+  - **Internal: 7 preview call sites** in `:androidApp` updated from `navigationRailTopPaddingDp = 8` → `NavigationRailLayout.DEFAULT_TOP_PADDING_DP`.
+  - **Internal: build-time pin** — new `SpacingTest.navRailBodyContentTopMatchesListContentPaddingTop` asserts `Spacing.ListContentPadding.top.value == NavigationRailLayout.BODY_CONTENT_TOP_DP`. If a future PR bumps `Spacing.ListContentPadding.top` (e.g. 16 → 24) without also updating the domain constant, the test fails the build with a message pointing at `NavigationRailLayout` KDoc.
+
 ## 2.16.30
 - **Spacing rule audit fixes — bottom sheets and history.** Follow-up to 2.16.29 ("container owns the gap"). An audit found 5 more violations of the same rule across bottom sheets and the door-history screen. All fixed in this release; no children claim a vertical gap above or below themselves.
   - **Snooze sheet**: dropped `Modifier.padding(bottom = 8.dp)` from the title `Text`. The parent Column already provides 8 dp via `spacedBy(8.dp)`; the title was double-padding to **16 dp** while subsequent radio rows had **8 dp** — visible inconsistency.

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/TabPreviews.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/TabPreviews.kt
@@ -43,6 +43,7 @@ import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.domain.model.NavigationRailItemPosition
+import com.chriscartland.garage.domain.model.NavigationRailLayout
 import com.chriscartland.garage.domain.model.RemoteButtonState
 import com.chriscartland.garage.presentation.demoDoorEvents
 import com.chriscartland.garage.ui.home.DeviceCheckIn
@@ -353,7 +354,7 @@ fun SettingsTabPreview() {
             versionCode = "184",
             layoutDebugEnabled = false,
             navigationRailItemPosition = NavigationRailItemPosition.CenteredVertically,
-            navigationRailTopPaddingDp = 8,
+            navigationRailTopPaddingDp = NavigationRailLayout.DEFAULT_TOP_PADDING_DP,
         )
     }
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ThreePaneDashboardPreviews.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ThreePaneDashboardPreviews.kt
@@ -29,6 +29,7 @@ import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.domain.model.NavigationRailItemPosition
+import com.chriscartland.garage.domain.model.NavigationRailLayout
 import com.chriscartland.garage.domain.model.RemoteButtonState
 import com.chriscartland.garage.presentation.demoDoorEvents
 import com.chriscartland.garage.ui.home.DeviceCheckIn
@@ -190,7 +191,7 @@ private fun SettingsPaneBody(modifier: Modifier) {
         versionCode = "213",
         layoutDebugEnabled = false,
         navigationRailItemPosition = NavigationRailItemPosition.CenteredVertically,
-        navigationRailTopPaddingDp = 8,
+        navigationRailTopPaddingDp = NavigationRailLayout.DEFAULT_TOP_PADDING_DP,
         modifier = modifier,
     )
 }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.chriscartland.garage.R
 import com.chriscartland.garage.domain.model.NavigationRailItemPosition
+import com.chriscartland.garage.domain.model.NavigationRailLayout
 import com.chriscartland.garage.ui.theme.AppAnimatedVisibility
 import com.chriscartland.garage.ui.theme.DividerInset
 import com.chriscartland.garage.ui.theme.PreviewScreenSurface
@@ -422,7 +423,7 @@ fun SettingsContentSignedOutPreview() {
             versionCode = "182",
             layoutDebugEnabled = false,
             navigationRailItemPosition = NavigationRailItemPosition.CenteredVertically,
-            navigationRailTopPaddingDp = 8,
+            navigationRailTopPaddingDp = NavigationRailLayout.DEFAULT_TOP_PADDING_DP,
         )
     }
 }
@@ -444,7 +445,7 @@ fun SettingsContentSignedInBasicPreview() {
             versionCode = "182",
             layoutDebugEnabled = false,
             navigationRailItemPosition = NavigationRailItemPosition.CenteredVertically,
-            navigationRailTopPaddingDp = 8,
+            navigationRailTopPaddingDp = NavigationRailLayout.DEFAULT_TOP_PADDING_DP,
         )
     }
 }
@@ -466,7 +467,7 @@ fun SettingsContentSignedInAllowlistedPreview() {
             versionCode = "182",
             layoutDebugEnabled = false,
             navigationRailItemPosition = NavigationRailItemPosition.TopAligned,
-            navigationRailTopPaddingDp = 8,
+            navigationRailTopPaddingDp = NavigationRailLayout.DEFAULT_TOP_PADDING_DP,
         )
     }
 }
@@ -488,7 +489,7 @@ fun SettingsContentPermissionDeniedPreview() {
             versionCode = "182",
             layoutDebugEnabled = false,
             navigationRailItemPosition = NavigationRailItemPosition.CenteredVertically,
-            navigationRailTopPaddingDp = 8,
+            navigationRailTopPaddingDp = NavigationRailLayout.DEFAULT_TOP_PADDING_DP,
         )
     }
 }
@@ -513,7 +514,7 @@ fun SettingsContentSnoozeInFlightPreview() {
             versionCode = "182",
             layoutDebugEnabled = false,
             navigationRailItemPosition = NavigationRailItemPosition.CenteredVertically,
-            navigationRailTopPaddingDp = 8,
+            navigationRailTopPaddingDp = NavigationRailLayout.DEFAULT_TOP_PADDING_DP,
             snoozeInFlight = true,
         )
     }

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/theme/SpacingTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/ui/theme/SpacingTest.kt
@@ -18,6 +18,7 @@
 package com.chriscartland.garage.ui.theme
 
 import androidx.compose.ui.unit.dp
+import com.chriscartland.garage.domain.model.NavigationRailLayout
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -60,5 +61,25 @@ class SpacingTest {
         val pv = Spacing.ListContentPadding
         assertEquals(16.dp, pv.calculateTopPadding())
         assertEquals(24.dp, pv.calculateBottomPadding())
+    }
+
+    /**
+     * The Wide-mode NavigationRail's default extra top padding is
+     * derived from `Spacing.ListContentPadding.top` minus M3's
+     * intrinsic pre-pill offset (see `NavigationRailLayout` KDoc).
+     * If `Spacing.ListContentPadding.top` and
+     * `NavigationRailLayout.BODY_CONTENT_TOP_DP` drift apart, the rail
+     * default will silently misalign. Pin them as a single source.
+     */
+    @Test
+    fun navRailBodyContentTopMatchesListContentPaddingTop() {
+        assertEquals(
+            "NavigationRailLayout.BODY_CONTENT_TOP_DP must match " +
+                "Spacing.ListContentPadding.top so the derived rail " +
+                "default keeps the selected indicator pill aligned " +
+                "with body content. See NavigationRailLayout KDoc.",
+            Spacing.ListContentPadding.calculateTopPadding(),
+            NavigationRailLayout.BODY_CONTENT_TOP_DP.dp,
+        )
     }
 }

--- a/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/DataStoreAppSettings.kt
+++ b/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/DataStoreAppSettings.kt
@@ -24,6 +24,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.chriscartland.garage.domain.model.NavigationRailItemPosition
+import com.chriscartland.garage.domain.model.NavigationRailLayout
 import com.chriscartland.garage.domain.repository.AppSettingsRepository
 import com.chriscartland.garage.domain.repository.Setting
 import kotlinx.coroutines.flow.Flow
@@ -57,7 +58,11 @@ class DataStoreAppSettings(
             valueOf = NavigationRailItemPosition::valueOf,
         )
     override val navigationRailTopPaddingDp: Setting<Int> =
-        DataStoreIntSetting(dataStore, "NAVIGATION_RAIL_TOP_PADDING_DP", 8)
+        DataStoreIntSetting(
+            dataStore,
+            "NAVIGATION_RAIL_TOP_PADDING_DP",
+            NavigationRailLayout.DEFAULT_TOP_PADDING_DP,
+        )
 }
 
 private class DataStoreStringSetting(

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/NavigationRailLayout.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/NavigationRailLayout.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.domain.model
+
+/**
+ * Constants for aligning the Wide-mode `NavigationRail` selected-item
+ * indicator pill with the body's first content row.
+ *
+ * The default value for the user's "Nav rail top padding" setting is
+ * **derived** from these two named constants rather than hardcoded.
+ * The user can still override the value via Settings → Developer →
+ * Nav rail; the derivation only affects the default returned when no
+ * override exists.
+ *
+ * ## Why this exists
+ *
+ * Pre-derivation the default was a magic `8` in three places
+ * (`DataStoreAppSettings`, `FakeAppSettingsRepository`,
+ * `ProfileViewModel`). The relationship between `8` and the body's
+ * `safeListContentPadding.top` (currently 16 dp) was implicit and
+ * fragile — a future bump of `Spacing.ListContentPadding.top` (e.g.
+ * 16 → 24 dp to make sections feel more spacious) would silently
+ * break rail alignment until someone smoke-tested on hardware.
+ *
+ * Now the relationship is explicit:
+ * `DEFAULT_TOP_PADDING_DP = BODY_CONTENT_TOP_DP - RAIL_INTRINSIC_PILL_OFFSET_DP`.
+ * `BODY_CONTENT_TOP_DP` must match `Spacing.ListContentPadding.top`
+ * in `:androidApp` — pinned by `NavigationRailLayoutTest` so a
+ * mismatch fails the build.
+ *
+ * ## The math
+ *
+ * ```
+ * body's first content row top  =  BODY_CONTENT_TOP_DP  (from safeListContentPadding.top)
+ *
+ * rail's selected pill top      =  M3 NavigationRailVerticalPadding (4 dp)
+ *                                + user-configurable extra padding (N dp)
+ *                                + M3 NavigationRailItem internal pad before pill (~4 dp)
+ *                                =  RAIL_INTRINSIC_PILL_OFFSET_DP + N
+ *
+ * Setting them equal:           BODY_CONTENT_TOP_DP = RAIL_INTRINSIC_PILL_OFFSET_DP + N
+ * Solving for N (the default):  N = BODY_CONTENT_TOP_DP - RAIL_INTRINSIC_PILL_OFFSET_DP
+ * ```
+ *
+ * ## Drift risk
+ *
+ * `RAIL_INTRINSIC_PILL_OFFSET_DP` is empirical — it captures two M3
+ * internal padding constants (`NavigationRailVerticalPadding` plus
+ * `NavigationRailItem`'s own pre-indicator padding) that are NOT
+ * exposed by `androidx.compose.material3`. If a future M3 update
+ * changes either, this constant must be updated to keep alignment.
+ * Verified empirically through 2.16.30 (Material 3 1.4.x).
+ */
+object NavigationRailLayout {
+    /**
+     * Body's first content row top, in dp. Must match
+     * `Spacing.ListContentPadding.top` in `:androidApp`.
+     * Pinned by `NavigationRailLayoutTest`.
+     */
+    const val BODY_CONTENT_TOP_DP: Int = 16
+
+    /**
+     * Sum of M3 NavigationRail's internal vertical padding above the
+     * first item (`NavigationRailVerticalPadding` = 4 dp) and the
+     * NavigationRailItem's own internal padding above the
+     * selected-indicator pill (~4 dp; undocumented in M3 source).
+     * Empirical. See class KDoc for drift risk.
+     */
+    const val RAIL_INTRINSIC_PILL_OFFSET_DP: Int = 8
+
+    /**
+     * Default user-configurable extra padding above the rail items so
+     * the selected pill aligns with body content. Derived; not magic.
+     * User can override via Settings → Developer → Nav rail.
+     */
+    const val DEFAULT_TOP_PADDING_DP: Int = BODY_CONTENT_TOP_DP - RAIL_INTRINSIC_PILL_OFFSET_DP
+}

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAppSettingsRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAppSettingsRepository.kt
@@ -1,6 +1,7 @@
 package com.chriscartland.garage.testcommon
 
 import com.chriscartland.garage.domain.model.NavigationRailItemPosition
+import com.chriscartland.garage.domain.model.NavigationRailLayout
 import com.chriscartland.garage.domain.repository.AppSettingsRepository
 import com.chriscartland.garage.domain.repository.Setting
 import kotlinx.coroutines.flow.Flow
@@ -14,7 +15,8 @@ class FakeAppSettingsRepository : AppSettingsRepository {
     override val layoutDebugEnabled: Setting<Boolean> = InMemorySetting(false)
     override val navigationRailItemPosition: Setting<NavigationRailItemPosition> =
         InMemorySetting(NavigationRailItemPosition.TopAligned)
-    override val navigationRailTopPaddingDp: Setting<Int> = InMemorySetting(8)
+    override val navigationRailTopPaddingDp: Setting<Int> =
+        InMemorySetting(NavigationRailLayout.DEFAULT_TOP_PADDING_DP)
 }
 
 class InMemorySetting<T>(

--- a/AndroidGarage/version.properties
+++ b/AndroidGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.16.30
+versionName=2.16.31

--- a/AndroidGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/ProfileViewModel.kt
+++ b/AndroidGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/ProfileViewModel.kt
@@ -28,6 +28,7 @@ import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.GoogleIdToken
 import com.chriscartland.garage.domain.model.NavigationRailItemPosition
+import com.chriscartland.garage.domain.model.NavigationRailLayout
 import com.chriscartland.garage.domain.model.SnoozeAction
 import com.chriscartland.garage.domain.model.SnoozeDurationUIOption
 import com.chriscartland.garage.domain.model.SnoozeState
@@ -160,7 +161,8 @@ class DefaultProfileViewModel(
     override val navigationRailItemPosition: StateFlow<NavigationRailItemPosition> =
         _navigationRailItemPosition
 
-    private val _navigationRailTopPaddingDp = MutableStateFlow(8)
+    private val _navigationRailTopPaddingDp =
+        MutableStateFlow(NavigationRailLayout.DEFAULT_TOP_PADDING_DP)
     override val navigationRailTopPaddingDp: StateFlow<Int> = _navigationRailTopPaddingDp
 
     // Cached so the snooze action can attach the latest door change time


### PR DESCRIPTION
## Summary

Pre-2.16.31 the value `8` for `navigationRailTopPaddingDp` was a literal in 8 places. The relationship between `8` and `Spacing.ListContentPadding.top` (16 dp) was implicit — a future bump of the body content padding would silently misalign the rail until someone smoke-tested on hardware.

Now the default is **derived** from a single named relationship.

## The math, made explicit

New domain object `NavigationRailLayout`:

\`\`\`kotlin
const val BODY_CONTENT_TOP_DP = 16              // matches Spacing.ListContentPadding.top
const val RAIL_INTRINSIC_PILL_OFFSET_DP = 8     // M3 internals: NavigationRailVerticalPadding (4) + NavigationRailItem pre-pill pad (4)
const val DEFAULT_TOP_PADDING_DP = BODY_CONTENT_TOP_DP - RAIL_INTRINSIC_PILL_OFFSET_DP   // = 8
\`\`\`

## User-facing behavior

**No change.** Default is still 8 dp. Users can still override via Settings → Developer → Nav rail.

## Build-time pin

New `SpacingTest.navRailBodyContentTopMatchesListContentPaddingTop` asserts that `NavigationRailLayout.BODY_CONTENT_TOP_DP` equals `Spacing.ListContentPadding.top` in dp. If a future PR bumps the body content padding without updating the domain constant, the test fails the build with a message pointing at `NavigationRailLayout` KDoc.

## Files

- **NEW**: `domain/.../NavigationRailLayout.kt` — three named constants + KDoc explaining the math and M3-internals drift risk
- **3 source-of-truth defaults** updated to derive: `DataStoreAppSettings`, `FakeAppSettingsRepository`, `ProfileViewModel`
- **7 preview call sites** in `:androidApp` updated from `8` → `NavigationRailLayout.DEFAULT_TOP_PADDING_DP`
- **`SpacingTest`** new test pinning the relationship

## Drift risk

`RAIL_INTRINSIC_PILL_OFFSET_DP` (the `8` measured from M3 internals) remains empirical — neither M3 constant it sums (`NavigationRailVerticalPadding` and `NavigationRailItem`'s pre-pill padding) is exposed by `androidx.compose.material3`. If a future M3 update changes either, recovery is to measure on hardware and update the constant. KDoc spells this out.

## Test plan
- [x] `validate.sh` — all 220 tests passed including new pin
- [ ] Smoke: open app on Wide layout (≥600dp, <1200dp), confirm rail's selected indicator pill top still aligns with body's first content row top with default 8 dp setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)