### PR TITLE
chore(android): Stricter conformity — NamingConventionCheckTask + detekt enrichment (2.16.32)

### DIFF
--- a/AndroidGarage/CHANGELOG.md
+++ b/AndroidGarage/CHANGELOG.md
@@ -15,6 +15,13 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
 
+## 2.16.32
+- **Stricter conformity checks ported from battery-butler.** No user-facing change; new build-time enforcement.
+  - **`checkNamingConvention`** (NEW lint task in `:buildSrc`) — forbids `Ui` and `View` (except `*ViewModel`) in class/interface/object names. KMP guardrail: `Ui` collides with iOS UIKit naming; `View` is ambiguous between Android View system and Compose. Codebase is clean at port time. Suppress with `// @NamingExempt` for unavoidable cases. Wired into `validate.sh`.
+  - **`naming.InvalidPackageDeclaration`** (detekt rule, was off) — pins the root package to `com.chriscartland.garage`. Catches typos, misplaced files, and accidental drift to other roots when copy-pasting from sibling repos.
+  - **`style.ForbiddenMethodCall`** (detekt rule, was off) — blocks `print` and `println` outside test/script paths. Production code uses Kermit (`Logger.d/e`) so output is structured and routable. Currently zero violations; this prevents drift.
+- **Internal: ported from battery-butler 2026-05-12.** Pattern follows existing SmartGarageDoor Gradle task conventions (`abstract class ... : DefaultTask()`, `@get:Input var sourceDirs`, registered in root `build.gradle.kts`).
+
 ## 2.16.31
 - **Default Nav rail top padding is now derived, not hardcoded.** Pre-2.16.31 the value `8` appeared as a literal in 8 places (`DataStoreAppSettings`, `FakeAppSettingsRepository`, `ProfileViewModel` initial state, 5 preview call sites). The relationship between `8` and `Spacing.ListContentPadding.top` (16 dp) was implicit — a future bump of `Spacing.ListContentPadding.top` (e.g. for a more spacious section rhythm) would silently break rail-vs-content alignment until someone smoke-tested on hardware. Now the default is **derived** from a single named relationship: `DEFAULT_TOP_PADDING_DP = BODY_CONTENT_TOP_DP − RAIL_INTRINSIC_PILL_OFFSET_DP`.
   - **User-facing**: no behavior change. Default is still 8 dp; users can still override via Settings → Developer → Nav rail.

--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -212,6 +212,19 @@ tasks.register<architecture.LiteralStringsInComposeCheckTask>("checkNoLiteralStr
     exemptionsFile = "$rootDir/string-literal-exemptions.txt"
 }
 
+tasks.register<architecture.NamingConventionCheckTask>("checkNamingConvention") {
+    sourceDirs = listOf(
+        "$rootDir/androidApp/src/main/java",
+        "$rootDir/domain/src/commonMain/kotlin",
+        "$rootDir/data/src/commonMain/kotlin",
+        "$rootDir/data-local/src/commonMain/kotlin",
+        "$rootDir/usecase/src/commonMain/kotlin",
+        "$rootDir/viewmodel/src/commonMain/kotlin",
+        "$rootDir/presentation-model/src/commonMain/kotlin",
+        "$rootDir/test-common/src/commonMain/kotlin",
+    )
+}
+
 tasks.register<architecture.NoBareTopLevelFunctionsTask>("checkNoBareTopLevelFunctions") {
     sourceDirs = listOf(
         "$rootDir/androidApp/src/main/java",

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/NamingConventionCheckTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/NamingConventionCheckTask.kt
@@ -1,0 +1,119 @@
+package architecture
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Forbids two specific class-name patterns that cause friction in KMP
+ * codebases:
+ *
+ * 1. **`Ui` in class names** — collides with iOS UIKit naming when the
+ *    class is later moved to `commonMain` for KMP sharing. Prefer
+ *    `Screen` for state objects (`HomeUiState` → `HomeScreenState`) or
+ *    drop the prefix entirely (`UiMessage` → `Message`).
+ * 2. **`View` in class names** (excluding `*ViewModel`) — ambiguous
+ *    between Android's View system and Compose. Pick a more specific
+ *    name (`ViewState` → `ScreenState`, `ViewData` → `DisplayData`).
+ *
+ * Ported from battery-butler 2026-05-12. The codebase was clean at port
+ * time; this task prevents drift.
+ *
+ * Suppression: add `// @NamingExempt` to the line if a violation is
+ * deliberate (e.g. a pre-existing public API that can't be renamed).
+ */
+abstract class NamingConventionCheckTask : DefaultTask() {
+    /**
+     * Source directories to scan, e.g. `usecase/src/commonMain/kotlin`.
+     * The task walks each recursively for `*.kt` files; test source
+     * sets (paths containing `/test/`, `/androidTest/`, `/commonTest/`,
+     * `/screenshotTest/`) are skipped so test fixtures can use
+     * conventional `*UiState` / `*View` names if needed.
+     */
+    @get:Input
+    var sourceDirs: List<String> = emptyList()
+
+    private data class Rule(
+        val id: String,
+        val pattern: Regex,
+        val message: String,
+        val fix: String,
+    )
+
+    private val rules = listOf(
+        Rule(
+            id = "no-ui-in-class-name",
+            pattern = Regex("""(class|interface|object)\s+\w*[a-z]Ui[A-Z]\w*"""),
+            message = "Class names must not contain 'Ui' — collides with iOS UIKit naming.",
+            fix = "Use 'Screen' (for state objects) or drop the prefix. Examples: " +
+                "HomeUiState → HomeScreenState, ChatUiMessage → ChatMessage.",
+        ),
+        Rule(
+            id = "no-view-in-class-name",
+            pattern = Regex("""(class|interface|object)\s+\w*View(?!Model)\w*"""),
+            message = "Class names must not contain 'View' (except *ViewModel) — " +
+                "ambiguous between Android View system and Compose.",
+            fix = "Use a more specific name. Examples: ViewState → ScreenState, " +
+                "ViewData → DisplayData.",
+        ),
+    )
+
+    private val suppressionMarker = "@NamingExempt"
+
+    private val testPathFragments = listOf(
+        "/test/",
+        "/androidTest/",
+        "/commonTest/",
+        "/jvmTest/",
+        "/androidUnitTest/",
+        "/androidInstrumentedTest/",
+        "/screenshotTest/",
+    )
+
+    @TaskAction
+    fun check() {
+        val violations = mutableListOf<String>()
+        var scanned = 0
+
+        sourceDirs.forEach { dir ->
+            val rootFile = File(dir)
+            if (!rootFile.exists()) return@forEach
+
+            rootFile
+                .walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .filter { file -> testPathFragments.none { frag -> file.path.contains(frag) } }
+                .forEach { file ->
+                    scanned++
+                    val relativePath = file.relativeTo(rootFile).path
+                    file.readLines().forEachIndexed { index, line ->
+                        if (line.contains(suppressionMarker)) return@forEachIndexed
+                        for (rule in rules) {
+                            if (rule.pattern.containsMatchIn(line)) {
+                                violations.add(
+                                    "$relativePath:${index + 1} [${rule.id}] " +
+                                        "${rule.message}\n        Fix: ${rule.fix}",
+                                )
+                            }
+                        }
+                    }
+                }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    append("Naming Convention Check FAILED (${violations.size} violation(s)):\n\n")
+                    violations.forEach { append("  - $it\n\n") }
+                    append(
+                        "Suppress with `// @NamingExempt` on the line if the violation " +
+                            "is deliberate (rare).\n",
+                    )
+                },
+            )
+        }
+        logger.lifecycle("Naming Convention Check passed: $scanned file(s) scanned.")
+    }
+}

--- a/AndroidGarage/detekt.yml
+++ b/AndroidGarage/detekt.yml
@@ -37,6 +37,14 @@ naming:
     active: false
   MatchingDeclarationName:
     active: false
+  # Pin the root package — every file under main / commonMain must
+  # declare a package starting with `com.chriscartland.garage`.
+  # Catches typos, misplaced files, and accidental drift to other
+  # roots when copy-pasting from sibling repos.
+  InvalidPackageDeclaration:
+    active: true
+    rootPackage: 'com.chriscartland.garage'
+    requireRootInDeclaration: false
 
 potential-bugs:
   active: true
@@ -56,6 +64,26 @@ style:
         value: "FIXME:"
       - reason: "Must be removed before merging"
         value: "STOPSHIP:"
+  # Block `print` and `println` outside test/script paths — production
+  # code uses Kermit (Logger.d/e) so output is structured and routable.
+  # Test paths and `*.kts` are excluded so test fixtures and build
+  # scripts can still use println for diagnostics.
+  ForbiddenMethodCall:
+    active: true
+    methods:
+      - reason: "Use Logger.d/e (Kermit) instead — production logs must be structured."
+        value: "kotlin.io.print"
+      - reason: "Use Logger.d/e (Kermit) instead — production logs must be structured."
+        value: "kotlin.io.println"
+    excludes:
+      - "**/test/**"
+      - "**/androidTest/**"
+      - "**/commonTest/**"
+      - "**/jvmTest/**"
+      - "**/androidUnitTest/**"
+      - "**/androidInstrumentedTest/**"
+      - "**/screenshotTest/**"
+      - "**/*.kts"
   UnusedPrivateMember:
     active: false
   UnusedPrivateProperty:

--- a/AndroidGarage/version.properties
+++ b/AndroidGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.16.31
+versionName=2.16.32

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -58,6 +58,9 @@ $GRADLE checkNoLiteralStringsInCompose && pass "no literal Text() in Composable"
 step "No *Impl suffix on class names (ADR-008 — use descriptive prefix)"
 $GRADLE checkNoImplSuffix && pass "no *Impl suffix" || fail "no *Impl suffix"
 
+step "No 'Ui' / 'View' in class names (KMP collision; ported from battery-butler)"
+$GRADLE checkNamingConvention && pass "naming convention" || fail "naming convention"
+
 step "No idToken parameter on UseCases (ADR-027 — token internal to repos)"
 $GRADLE checkNoTokenInUseCase && pass "no token in UseCase" || fail "no token in UseCase"
 


### PR DESCRIPTION
## Summary

Three new build-time enforcements ported from battery-butler. Zero existing violations; pure drift-prevention.

### `checkNamingConvention` (NEW Gradle task in `:buildSrc`)
Forbids two class-name patterns:
- **`Ui` in class names** — collides with iOS UIKit naming when moved to `commonMain`. Use `Screen` (for state) or drop the prefix. Example: `HomeUiState` → `HomeScreenState`.
- **`View` in class names** (except `*ViewModel`) — ambiguous between Android View system and Compose. Use a more specific name. Example: `ViewState` → `ScreenState`.

Suppress with `// @NamingExempt` on the line. Wired into `validate.sh`.

### `naming.InvalidPackageDeclaration` (detekt rule, was off)
Pins the root package to `com.chriscartland.garage`. Catches misplaced files, typos, and accidental drift when copy-pasting from sibling repos.

### `style.ForbiddenMethodCall` (detekt rule, was off)
Blocks `print` and `println` outside test/script paths. Production code uses Kermit (`Logger.d/e`) so output is structured and routable.

## Test plan
- [x] `validate.sh` — all checks passed including new `checkNamingConvention` step
- [x] Confirmed zero existing violations across all source roots

🤖 Generated with [Claude Code](https://claude.com/claude-code)