### PR TITLE
chore(android): Strict theme-detection isolation — ThemeDetectionCheckTask (2.16.34)

### DIFF
--- a/AndroidGarage/CHANGELOG.md
+++ b/AndroidGarage/CHANGELOG.md
@@ -15,6 +15,15 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
 
+## 2.16.34
+- **`checkThemeDetection` build-time check** ported from battery-butler's `ThemeLayerCheckTask`. Forbids `isSystemInDarkTheme()` calls outside `androidApp/.../ui/theme/`.
+  - **Why this matters**: Theme detection (light vs dark) is the theme module's responsibility. If a screen Composable reads `isSystemInDarkTheme()` directly, it's reimplementing what `AppTheme` already resolved and propagated via `MaterialTheme.colorScheme.*` — duplicating the decision and making future theme changes (dynamic-color opt-in, custom dark-color overrides) leak into screen code.
+  - **Allowed locations**: any file under any path containing `/ui/theme/`. Currently: `Theme.kt` (where `AppTheme` reads it as a default param) and `PreviewSurface.kt` (where the preview wrapper mirrors the inner `AppTheme`'s configuration).
+  - **Codebase clean at port time** (only the 2 theme-module files use it). Zero violations; this prevents drift.
+  - **Suppression**: add `// @ThemeDetectionExempt` on the line if a non-theme file legitimately needs it.
+  - The other 2 rules from battery-butler's `ThemeLayerCheckTask` were not ported: forbidden raw `Color(0x...)` literals are already covered by `HardcodedColorCheckTask` (with allowed-files list); forbidden `import androidx.compose.ui.graphics.Color` is too broad — canvas/drawing files like `GarageDoorCanvas.kt` and `AnimatableGarageDoor.kt` legitimately need `Color` for rendering primitives.
+  - Wired into `validate.sh`.
+
 ## 2.16.33
 - **`checkPreviewTime` build-time check** ported from battery-butler. Two-pass BFS that ensures `@Preview` Composables never transitively call a Composable whose default parameter value uses `Clock.System.now()` / `Instant.now()` / `System.currentTimeMillis()` etc. without explicitly passing the time parameter.
   - **Why this matters**: `@Preview` and screenshot tests render at preview-time. A default like `now: Instant = Instant.now()` reads wall-clock at render — screenshots flap, golden-image tests get false-positive diffs, framed README screenshot drifts on every regen.

--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -218,6 +218,16 @@ tasks.register<architecture.PreviewTimeCheckTask>("checkPreviewTime") {
     )
 }
 
+tasks.register<architecture.ThemeDetectionCheckTask>("checkThemeDetection") {
+    sourceDirs = listOf(
+        "$rootDir/androidApp/src/main/java",
+    )
+    // Files inside any directory containing this fragment may call
+    // `isSystemInDarkTheme()`; everything else must read theme values
+    // through `MaterialTheme.colorScheme.*` after `AppTheme` resolves.
+    themePathFragments = listOf("/ui/theme/")
+}
+
 tasks.register<architecture.NamingConventionCheckTask>("checkNamingConvention") {
     sourceDirs = listOf(
         "$rootDir/androidApp/src/main/java",

--- a/AndroidGarage/buildSrc/src/main/kotlin/architecture/ThemeDetectionCheckTask.kt
+++ b/AndroidGarage/buildSrc/src/main/kotlin/architecture/ThemeDetectionCheckTask.kt
@@ -1,0 +1,116 @@
+package architecture
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Forbids `isSystemInDarkTheme()` calls outside the theme module.
+ *
+ * Theme detection (light vs dark) is the theme module's responsibility.
+ * If a screen Composable reaches for `isSystemInDarkTheme()` directly,
+ * it's reimplementing what `AppTheme` already resolves and propagates
+ * via `MaterialTheme.colorScheme.*` — duplicating the decision and
+ * making future theme changes (e.g. dynamic-color opt-in, custom
+ * dark-color overrides) leak into screen code.
+ *
+ * Allowed locations: any file under `androidApp/src/main/.../ui/theme/`.
+ * That covers `Theme.kt` (where `AppTheme` reads it as a default
+ * parameter) and `PreviewSurface.kt` (where the preview wrapper reads
+ * it to mirror the inner `AppTheme`'s configuration).
+ *
+ * This is the most portable rule from battery-butler's
+ * `ThemeLayerCheckTask`. The other two rules — forbidden raw `Color(0x...)`
+ * literals and forbidden `import androidx.compose.ui.graphics.Color` —
+ * are already covered (the literals by [HardcodedColorCheckTask] with
+ * its allowed-files list; the import is too broad for SmartGarageDoor
+ * because canvas/drawing files like `GarageDoorCanvas.kt` legitimately
+ * need `Color` for rendering primitives).
+ *
+ * Ported from battery-butler 2026-05-12. Codebase clean at port time.
+ *
+ * Suppression: add `// @ThemeDetectionExempt` on the line if a
+ * non-theme file legitimately needs this (rare).
+ */
+abstract class ThemeDetectionCheckTask : DefaultTask() {
+    /**
+     * Source directories to scan, e.g. `androidApp/src/main/java`.
+     */
+    @get:Input
+    var sourceDirs: List<String> = emptyList()
+
+    /**
+     * Path-fragment substrings that mark a file as inside the theme
+     * module (and therefore allowed to call `isSystemInDarkTheme()`).
+     * For SmartGarageDoor, this is `/ui/theme/`.
+     */
+    @get:Input
+    var themePathFragments: List<String> = emptyList()
+
+    private val pattern = Regex("""\bisSystemInDarkTheme\s*\(\s*\)""")
+    private val exemptComment = "@ThemeDetectionExempt"
+
+    private val skipPathFragments = listOf(
+        "/build/",
+        "/test/",
+        "/androidTest/",
+        "/commonTest/",
+        "/jvmTest/",
+        "/androidUnitTest/",
+        "/androidInstrumentedTest/",
+        "/screenshotTest/",
+    )
+
+    @TaskAction
+    fun check() {
+        val violations = mutableListOf<String>()
+        var scanned = 0
+
+        sourceDirs.forEach { dir ->
+            val rootFile = File(dir)
+            if (!rootFile.exists()) return@forEach
+
+            rootFile
+                .walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .filter { f -> skipPathFragments.none { frag -> f.path.contains(frag) } }
+                .filter { f -> themePathFragments.none { frag -> f.path.contains(frag) } }
+                .forEach { file ->
+                    scanned++
+                    val relativePath = file.relativeTo(rootFile).path
+                    file.readLines().forEachIndexed { index, line ->
+                        if (line.contains(exemptComment)) return@forEachIndexed
+                        if (pattern.containsMatchIn(line)) {
+                            violations.add(
+                                "$relativePath:${index + 1}: ${line.trim()}",
+                            )
+                        }
+                    }
+                }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    append("Theme Detection Check FAILED: ")
+                    append(violations.size)
+                    append(" violation(s).\n\n")
+                    violations.forEach { append("  - $it\n") }
+                    append("\n")
+                    append("Theme detection (`isSystemInDarkTheme()`) is the theme module's job.\n")
+                    append("Read `MaterialTheme.colorScheme.*` from your screen instead — `AppTheme`\n")
+                    append("already resolved the decision when it set up the color scheme.\n\n")
+                    append("Allowed locations: files under any path containing one of:\n")
+                    themePathFragments.forEach { append("  - $it\n") }
+                    append("\nSuppress with `// $exemptComment` on the line if unavoidable.\n")
+                },
+            )
+        }
+
+        logger.lifecycle(
+            "Theme Detection Check passed: $scanned file(s) scanned outside theme module.",
+        )
+    }
+}

--- a/AndroidGarage/version.properties
+++ b/AndroidGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.16.33
+versionName=2.16.34

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -64,6 +64,9 @@ $GRADLE checkNamingConvention && pass "naming convention" || fail "naming conven
 step "Previews don't transitively use Clock.System.now() / Instant.now() (deterministic screenshots)"
 $GRADLE checkPreviewTime && pass "preview time determinism" || fail "preview time determinism"
 
+step "isSystemInDarkTheme() only inside theme module (theme-detection isolation)"
+$GRADLE checkThemeDetection && pass "theme detection isolation" || fail "theme detection isolation"
+
 step "No idToken parameter on UseCases (ADR-027 — token internal to repos)"
 $GRADLE checkNoTokenInUseCase && pass "no token in UseCase" || fail "no token in UseCase"
 


### PR DESCRIPTION
## Summary

Port battery-butler's `ThemeLayerCheckTask` `isSystemInDarkTheme()` rule. Forbids the call outside `androidApp/.../ui/theme/`.

## Why this matters

Theme detection (light vs dark) is the theme module's responsibility. If a screen Composable reads `isSystemInDarkTheme()` directly, it's reimplementing what `AppTheme` already resolved and propagated via `MaterialTheme.colorScheme.*` — duplicating the decision and making future theme changes (dynamic-color opt-in, custom dark-color overrides) leak into screen code.

## Allowed locations

Any file under any path containing `/ui/theme/`. Currently:
- `Theme.kt` (where `AppTheme` reads it as a default param)
- `PreviewSurface.kt` (where the preview wrapper mirrors the inner `AppTheme`'s configuration)

## What's NOT ported (and why)

The other 2 rules from battery-butler's `ThemeLayerCheckTask`:
- **Raw `Color(0x...)` literals** — already covered by our `HardcodedColorCheckTask` with allowed-files list.
- **`Color` import** — too broad: canvas/drawing files like `GarageDoorCanvas.kt` and `AnimatableGarageDoor.kt` legitimately need `Color` for rendering primitives.

## Codebase clean at port time

Zero violations; pure drift-prevention.

## Suppression

Add `// @ThemeDetectionExempt` on the line if a non-theme file legitimately needs it.

## Test plan
- [x] `validate.sh` — all checks passed including new `checkThemeDetection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)