### PR TITLE
chore(ios): KMP-enable :domain and :data for iOS targets (PR 2/N)

### DIFF
--- a/AndroidGarage/data/build.gradle.kts
+++ b/AndroidGarage/data/build.gradle.kts
@@ -11,7 +11,12 @@ tasks.register<ImportBoundaryCheckTask>("checkImportBoundary") {
 }
 
 kotlin {
+    applyDefaultHierarchyTemplate()
+
     androidTarget()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
 
     sourceSets {
         commonMain.dependencies {
@@ -26,6 +31,9 @@ kotlin {
         }
         androidMain.dependencies {
             implementation(libs.ktor.client.okhttp)
+        }
+        iosMain.dependencies {
+            implementation(libs.ktor.client.darwin)
         }
         commonTest.dependencies {
             implementation(project(":test-common"))

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/coroutines/DefaultDispatcherProvider.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/coroutines/DefaultDispatcherProvider.kt
@@ -20,6 +20,7 @@ package com.chriscartland.garage.data.coroutines
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 
 class DefaultDispatcherProvider : DispatcherProvider {
     override val main: CoroutineDispatcher = Dispatchers.Main

--- a/AndroidGarage/data/src/iosMain/kotlin/com/chriscartland/garage/data/ktor/PlatformHttpEngine.ios.kt
+++ b/AndroidGarage/data/src/iosMain/kotlin/com/chriscartland/garage/data/ktor/PlatformHttpEngine.ios.kt
@@ -1,0 +1,6 @@
+package com.chriscartland.garage.data.ktor
+
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.darwin.Darwin
+
+actual fun createPlatformHttpEngine(): HttpClientEngine = Darwin.create()

--- a/AndroidGarage/domain/build.gradle.kts
+++ b/AndroidGarage/domain/build.gradle.kts
@@ -10,7 +10,12 @@ tasks.register<ImportBoundaryCheckTask>("checkImportBoundary") {
 }
 
 kotlin {
+    applyDefaultHierarchyTemplate()
+
     androidTarget()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
 
     sourceSets {
         commonMain.dependencies {

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/AuthModel.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/AuthModel.kt
@@ -1,5 +1,7 @@
 package com.chriscartland.garage.domain.model
 
+import kotlin.jvm.JvmInline
+
 @JvmInline
 value class Email(
     private val s: String,

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/FcmModel.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/FcmModel.kt
@@ -1,5 +1,7 @@
 package com.chriscartland.garage.domain.model
 
+import kotlin.jvm.JvmInline
+
 sealed class DoorFcmState {
     data object Unknown : DoorFcmState()
 

--- a/AndroidGarage/gradle/libs.versions.toml
+++ b/AndroidGarage/gradle/libs.versions.toml
@@ -97,6 +97,7 @@ kotlin-inject-compiler = { module = "me.tatarka.inject:kotlin-inject-compiler-ks
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }


### PR DESCRIPTION
## Summary
- Add iOS targets (`iosX64`/`iosArm64`/`iosSimulatorArm64`) to `:domain` and `:data`
- New `data/src/iosMain/kotlin/.../PlatformHttpEngine.ios.kt` returning Ktor `Darwin` engine
- Add `ktor-client-darwin` to `libs.versions.toml` (same Ktor 3.1.3)
- 3 small commonMain portability fixes:
  - Explicit `import kotlin.jvm.JvmInline` on the two `@JvmInline` value classes (Native targets need the explicit import; JVM-only resolved it implicitly)
  - Explicit `import kotlinx.coroutines.IO` on `DefaultDispatcherProvider` (multiplatform extension property added in coroutines 1.7+, same pattern battery-butler uses)
  - No third fix — the Darwin actual is the third change

## Why
This is **PR 2** of the iOS migration. PR 1 added the empty `:iosFramework` skeleton; this PR makes the bottom of the dependency chain (`:domain` and `:data`) iOS-compatible end-to-end so future PRs can build on it. The `expect`/`actual` for `createPlatformHttpEngine()` was already in commonMain (KDoc said \"iOS: Darwin (to be added)\") — this provides the iOS actual.

## Scope
Tiny — 25 line additions, 0 deletions, 0 behavior change on Android. All Android tests pass identically.

## Test plan
- [x] `validate.sh` — all 47 checks PASS (spotless, lint, detekt, all custom architecture lints, unit tests across :data-local / :data / :domain / :usecase / :viewmodel / :androidApp Debug+Release, screenshot test compilation, instrumented test compilation, Room schema drift)
- [x] `./gradlew :data:compileKotlinIosX64 :data:compileKotlinIosArm64 :data:compileKotlinIosSimulatorArm64` — BUILD SUCCESSFUL
- [x] `./gradlew :domain:compileKotlinIosX64 :domain:compileKotlinIosArm64 :domain:compileKotlinIosSimulatorArm64` — BUILD SUCCESSFUL

## Next
PR 3: iOS targets on `:data-local` (Room KMP + DataStore Okio + `currentTimeMillis` + `DatabaseFactory` refactor to expect/actual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)