### PR TITLE
chore(ios): KMP-enable remaining shared modules; move AppStartup (PR 4/N)

### DIFF
--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/db/DatabaseSanityTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/db/DatabaseSanityTest.kt
@@ -75,104 +75,110 @@ class DatabaseSanityTest {
     }
 
     @Test
-    fun insertAndReadDoorEvent() = runBlocking {
-        val entity = DoorEventEntity(
-            doorPosition = DoorPosition.CLOSED,
-            message = "The door is closed.",
-            lastCheckInTimeSeconds = 1000L,
-            lastChangeTimeSeconds = 900L,
-        )
-        db.doorEventDao().insert(entity)
+    fun insertAndReadDoorEvent() =
+        runBlocking {
+            val entity = DoorEventEntity(
+                doorPosition = DoorPosition.CLOSED,
+                message = "The door is closed.",
+                lastCheckInTimeSeconds = 1000L,
+                lastChangeTimeSeconds = 900L,
+            )
+            db.doorEventDao().insert(entity)
 
-        val result = db.doorEventDao().recentDoorEvents().first()
-        assertEquals("Should have 1 door event", 1, result.size)
-        assertEquals(DoorPosition.CLOSED, result[0].doorPosition)
-        assertEquals("The door is closed.", result[0].message)
-        assertEquals(1000L, result[0].lastCheckInTimeSeconds)
-        assertEquals(900L, result[0].lastChangeTimeSeconds)
-    }
-
-    @Test
-    fun insertAndReadAppEvent() = runBlocking {
-        val event = AppEvent(
-            eventKey = "test_key",
-            timestamp = 12345L,
-        )
-        db.appLoggerDao().insert(event)
-
-        val result = db.appLoggerDao().getAll().first()
-        assertEquals("Should have 1 app event", 1, result.size)
-        assertEquals("test_key", result[0].eventKey)
-    }
+            val result = db.doorEventDao().recentDoorEvents().first()
+            assertEquals("Should have 1 door event", 1, result.size)
+            assertEquals(DoorPosition.CLOSED, result[0].doorPosition)
+            assertEquals("The door is closed.", result[0].message)
+            assertEquals(1000L, result[0].lastCheckInTimeSeconds)
+            assertEquals(900L, result[0].lastChangeTimeSeconds)
+        }
 
     @Test
-    fun insertAndPruneKey_keepsMostRecentRowsUpToLimit() = runBlocking {
-        // Insert 5 rows; cap to 3. Oldest 2 should be evicted; newest 3 retained.
-        for (i in 1..5) {
-            db.appLoggerDao().insertAndPruneKey(
-                appEvent = AppEvent(eventKey = "k", timestamp = i.toLong()),
-                limit = 3,
+    fun insertAndReadAppEvent() =
+        runBlocking {
+            val event = AppEvent(
+                eventKey = "test_key",
+                timestamp = 12345L,
+            )
+            db.appLoggerDao().insert(event)
+
+            val result = db.appLoggerDao().getAll().first()
+            assertEquals("Should have 1 app event", 1, result.size)
+            assertEquals("test_key", result[0].eventKey)
+        }
+
+    @Test
+    fun insertAndPruneKey_keepsMostRecentRowsUpToLimit() =
+        runBlocking {
+            // Insert 5 rows; cap to 3. Oldest 2 should be evicted; newest 3 retained.
+            for (i in 1..5) {
+                db.appLoggerDao().insertAndPruneKey(
+                    appEvent = AppEvent(eventKey = "k", timestamp = i.toLong()),
+                    limit = 3,
+                )
+            }
+
+            val rows = db.appLoggerDao().getAll().first()
+            assertEquals("Should keep at most 3 rows for the key", 3, rows.size)
+            assertEquals(
+                "Most recent timestamps retained",
+                listOf(3L, 4L, 5L),
+                rows.map { it.timestamp }.sorted(),
             )
         }
 
-        val rows = db.appLoggerDao().getAll().first()
-        assertEquals("Should keep at most 3 rows for the key", 3, rows.size)
-        assertEquals(
-            "Most recent timestamps retained",
-            listOf(3L, 4L, 5L),
-            rows.map { it.timestamp }.sorted(),
-        )
-    }
-
     @Test
-    fun insertAndPruneKey_doesNotAffectOtherKeys() = runBlocking {
-        // High-volume key + a single low-volume key. Cap each to 2.
-        for (i in 1..5) {
+    fun insertAndPruneKey_doesNotAffectOtherKeys() =
+        runBlocking {
+            // High-volume key + a single low-volume key. Cap each to 2.
+            for (i in 1..5) {
+                db.appLoggerDao().insertAndPruneKey(
+                    appEvent = AppEvent(eventKey = "noisy", timestamp = i.toLong()),
+                    limit = 2,
+                )
+            }
             db.appLoggerDao().insertAndPruneKey(
-                appEvent = AppEvent(eventKey = "noisy", timestamp = i.toLong()),
+                appEvent = AppEvent(eventKey = "quiet", timestamp = 100L),
                 limit = 2,
             )
-        }
-        db.appLoggerDao().insertAndPruneKey(
-            appEvent = AppEvent(eventKey = "quiet", timestamp = 100L),
-            limit = 2,
-        )
 
-        val all = db.appLoggerDao().getAll().first()
-        val noisy = all.filter { it.eventKey == "noisy" }
-        val quiet = all.filter { it.eventKey == "quiet" }
-        assertEquals("Noisy key capped at 2", 2, noisy.size)
-        assertEquals("Quiet key untouched", 1, quiet.size)
-    }
+            val all = db.appLoggerDao().getAll().first()
+            val noisy = all.filter { it.eventKey == "noisy" }
+            val quiet = all.filter { it.eventKey == "quiet" }
+            assertEquals("Noisy key capped at 2", 2, noisy.size)
+            assertEquals("Quiet key untouched", 1, quiet.size)
+        }
 
     @Test
-    fun pruneAllKeys_trimsLegacyRowsForEveryKey() = runBlocking {
-        // Simulate the migration case: many existing rows pre-cap.
-        for (i in 1..10) {
-            db.appLoggerDao().insert(AppEvent(eventKey = "a", timestamp = i.toLong()))
-        }
-        for (i in 1..7) {
-            db.appLoggerDao().insert(AppEvent(eventKey = "b", timestamp = i.toLong()))
-        }
+    fun pruneAllKeys_trimsLegacyRowsForEveryKey() =
+        runBlocking {
+            // Simulate the migration case: many existing rows pre-cap.
+            for (i in 1..10) {
+                db.appLoggerDao().insert(AppEvent(eventKey = "a", timestamp = i.toLong()))
+            }
+            for (i in 1..7) {
+                db.appLoggerDao().insert(AppEvent(eventKey = "b", timestamp = i.toLong()))
+            }
 
-        db.appLoggerDao().pruneAllKeys(limit = 4)
+            db.appLoggerDao().pruneAllKeys(limit = 4)
 
-        val all = db.appLoggerDao().getAll().first()
-        assertEquals("Both keys trimmed to limit", 8, all.size)
-        assertEquals(4, all.count { it.eventKey == "a" })
-        assertEquals(4, all.count { it.eventKey == "b" })
-    }
+            val all = db.appLoggerDao().getAll().first()
+            assertEquals("Both keys trimmed to limit", 8, all.size)
+            assertEquals(4, all.count { it.eventKey == "a" })
+            assertEquals(4, all.count { it.eventKey == "b" })
+        }
 
     @Test
-    fun deleteAllAppEvents_clearsTheTable() = runBlocking {
-        db.appLoggerDao().insert(AppEvent(eventKey = "k", timestamp = 1L))
-        db.appLoggerDao().insert(AppEvent(eventKey = "k", timestamp = 2L))
+    fun deleteAllAppEvents_clearsTheTable() =
+        runBlocking {
+            db.appLoggerDao().insert(AppEvent(eventKey = "k", timestamp = 1L))
+            db.appLoggerDao().insert(AppEvent(eventKey = "k", timestamp = 2L))
 
-        db.appLoggerDao().deleteAllAppEvents()
+            db.appLoggerDao().deleteAllAppEvents()
 
-        val rows = db.appLoggerDao().getAll().first()
-        assertEquals("Table should be empty", 0, rows.size)
-    }
+            val rows = db.appLoggerDao().getAll().first()
+            assertEquals("Table should be empty", 0, rows.size)
+        }
 
     /**
      * Wires through the actual [RoomAppLoggerRepository.log] (not the DAO
@@ -200,24 +206,25 @@ class DatabaseSanityTest {
     }
 
     @Test
-    fun doorEventReplaceAll() = runBlocking {
-        val events = listOf(
-            DoorEventEntity(
-                doorPosition = DoorPosition.OPEN,
-                message = "Open",
-                lastChangeTimeSeconds = 100L,
-            ),
-            DoorEventEntity(
-                doorPosition = DoorPosition.CLOSED,
-                message = "Closed",
-                lastChangeTimeSeconds = 200L,
-            ),
-        )
-        db.doorEventDao().replaceAll(events)
+    fun doorEventReplaceAll() =
+        runBlocking {
+            val events = listOf(
+                DoorEventEntity(
+                    doorPosition = DoorPosition.OPEN,
+                    message = "Open",
+                    lastChangeTimeSeconds = 100L,
+                ),
+                DoorEventEntity(
+                    doorPosition = DoorPosition.CLOSED,
+                    message = "Closed",
+                    lastChangeTimeSeconds = 200L,
+                ),
+            )
+            db.doorEventDao().replaceAll(events)
 
-        val result = db.doorEventDao().recentDoorEvents().first()
-        assertEquals("Should have 2 door events", 2, result.size)
-    }
+            val result = db.doorEventDao().recentDoorEvents().first()
+            assertEquals("Should have 2 door events", 2, result.size)
+        }
 
     /**
      * Wires the real [RoomAppLoggerRepository] through

--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/db/DatabaseSanityTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/db/DatabaseSanityTest.kt
@@ -75,7 +75,7 @@ class DatabaseSanityTest {
     }
 
     @Test
-    fun insertAndReadDoorEvent() {
+    fun insertAndReadDoorEvent() = runBlocking {
         val entity = DoorEventEntity(
             doorPosition = DoorPosition.CLOSED,
             message = "The door is closed.",
@@ -84,7 +84,7 @@ class DatabaseSanityTest {
         )
         db.doorEventDao().insert(entity)
 
-        val result = runBlocking { db.doorEventDao().recentDoorEvents().first() }
+        val result = db.doorEventDao().recentDoorEvents().first()
         assertEquals("Should have 1 door event", 1, result.size)
         assertEquals(DoorPosition.CLOSED, result[0].doorPosition)
         assertEquals("The door is closed.", result[0].message)
@@ -93,20 +93,20 @@ class DatabaseSanityTest {
     }
 
     @Test
-    fun insertAndReadAppEvent() {
+    fun insertAndReadAppEvent() = runBlocking {
         val event = AppEvent(
             eventKey = "test_key",
             timestamp = 12345L,
         )
         db.appLoggerDao().insert(event)
 
-        val result = runBlocking { db.appLoggerDao().getAll().first() }
+        val result = db.appLoggerDao().getAll().first()
         assertEquals("Should have 1 app event", 1, result.size)
         assertEquals("test_key", result[0].eventKey)
     }
 
     @Test
-    fun insertAndPruneKey_keepsMostRecentRowsUpToLimit() {
+    fun insertAndPruneKey_keepsMostRecentRowsUpToLimit() = runBlocking {
         // Insert 5 rows; cap to 3. Oldest 2 should be evicted; newest 3 retained.
         for (i in 1..5) {
             db.appLoggerDao().insertAndPruneKey(
@@ -115,7 +115,7 @@ class DatabaseSanityTest {
             )
         }
 
-        val rows = runBlocking { db.appLoggerDao().getAll().first() }
+        val rows = db.appLoggerDao().getAll().first()
         assertEquals("Should keep at most 3 rows for the key", 3, rows.size)
         assertEquals(
             "Most recent timestamps retained",
@@ -125,7 +125,7 @@ class DatabaseSanityTest {
     }
 
     @Test
-    fun insertAndPruneKey_doesNotAffectOtherKeys() {
+    fun insertAndPruneKey_doesNotAffectOtherKeys() = runBlocking {
         // High-volume key + a single low-volume key. Cap each to 2.
         for (i in 1..5) {
             db.appLoggerDao().insertAndPruneKey(
@@ -138,7 +138,7 @@ class DatabaseSanityTest {
             limit = 2,
         )
 
-        val all = runBlocking { db.appLoggerDao().getAll().first() }
+        val all = db.appLoggerDao().getAll().first()
         val noisy = all.filter { it.eventKey == "noisy" }
         val quiet = all.filter { it.eventKey == "quiet" }
         assertEquals("Noisy key capped at 2", 2, noisy.size)
@@ -146,7 +146,7 @@ class DatabaseSanityTest {
     }
 
     @Test
-    fun pruneAllKeys_trimsLegacyRowsForEveryKey() {
+    fun pruneAllKeys_trimsLegacyRowsForEveryKey() = runBlocking {
         // Simulate the migration case: many existing rows pre-cap.
         for (i in 1..10) {
             db.appLoggerDao().insert(AppEvent(eventKey = "a", timestamp = i.toLong()))
@@ -157,20 +157,20 @@ class DatabaseSanityTest {
 
         db.appLoggerDao().pruneAllKeys(limit = 4)
 
-        val all = runBlocking { db.appLoggerDao().getAll().first() }
+        val all = db.appLoggerDao().getAll().first()
         assertEquals("Both keys trimmed to limit", 8, all.size)
         assertEquals(4, all.count { it.eventKey == "a" })
         assertEquals(4, all.count { it.eventKey == "b" })
     }
 
     @Test
-    fun deleteAllAppEvents_clearsTheTable() {
+    fun deleteAllAppEvents_clearsTheTable() = runBlocking {
         db.appLoggerDao().insert(AppEvent(eventKey = "k", timestamp = 1L))
         db.appLoggerDao().insert(AppEvent(eventKey = "k", timestamp = 2L))
 
         db.appLoggerDao().deleteAllAppEvents()
 
-        val rows = runBlocking { db.appLoggerDao().getAll().first() }
+        val rows = db.appLoggerDao().getAll().first()
         assertEquals("Table should be empty", 0, rows.size)
     }
 
@@ -200,7 +200,7 @@ class DatabaseSanityTest {
     }
 
     @Test
-    fun doorEventReplaceAll() {
+    fun doorEventReplaceAll() = runBlocking {
         val events = listOf(
             DoorEventEntity(
                 doorPosition = DoorPosition.OPEN,
@@ -215,7 +215,7 @@ class DatabaseSanityTest {
         )
         db.doorEventDao().replaceAll(events)
 
-        val result = runBlocking { db.doorEventDao().recentDoorEvents().first() }
+        val result = db.doorEventDao().recentDoorEvents().first()
         assertEquals("Should have 2 door events", 2, result.size)
     }
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -493,7 +493,7 @@ abstract class AppComponent(
 
     @Provides
     @Singleton
-    fun provideAppDatabase(): AppDatabase = DatabaseFactory.getDatabase(application)
+    fun provideAppDatabase(): AppDatabase = DatabaseFactory(application).createDatabase()
 
     @Provides
     @Singleton

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -20,7 +20,6 @@ package com.chriscartland.garage.di
 import android.app.Application
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import com.chriscartland.garage.AppStartup
 import com.chriscartland.garage.BuildConfig
 import com.chriscartland.garage.auth.FirebaseAuthBridge
 import com.chriscartland.garage.config.AppConfigFactory
@@ -72,6 +71,7 @@ import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import com.chriscartland.garage.domain.repository.SnoozeRepository
 import com.chriscartland.garage.fcm.FirebaseMessagingBridge
 import com.chriscartland.garage.usecase.AppSettingsUseCase
+import com.chriscartland.garage.usecase.AppStartup
 import com.chriscartland.garage.usecase.ApplyButtonHealthFcmUseCase
 import com.chriscartland.garage.usecase.ButtonHealthFcmSubscriptionManager
 import com.chriscartland.garage.usecase.CheckInStalenessManager

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/AppStartupTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/AppStartupTest.kt
@@ -34,6 +34,7 @@ import com.chriscartland.garage.testcommon.FakeAuthRepository
 import com.chriscartland.garage.testcommon.FakeDiagnosticsCountersRepository
 import com.chriscartland.garage.testcommon.FakeDoorRepository
 import com.chriscartland.garage.testcommon.TestDispatcherProvider
+import com.chriscartland.garage.usecase.AppStartup
 import com.chriscartland.garage.usecase.ButtonHealthFcmSubscriptionManager
 import com.chriscartland.garage.usecase.CheckInStalenessManager
 import com.chriscartland.garage.usecase.DefaultLiveClock

--- a/AndroidGarage/data-local/build.gradle.kts
+++ b/AndroidGarage/data-local/build.gradle.kts
@@ -17,11 +17,16 @@ tasks.register<ImportBoundaryCheckTask>("checkImportBoundary") {
 }
 
 kotlin {
+    applyDefaultHierarchyTemplate()
+
     androidTarget {
         compilerOptions {
             jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
         }
     }
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
 
     sourceSets {
         commonMain.dependencies {
@@ -29,6 +34,7 @@ kotlin {
             implementation(project(":data"))
             implementation(libs.kermit)
             implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kotlinx.datetime)
             api(libs.androidx.room.runtime)
             implementation(libs.sqlite.bundled)
             // `api` (not `implementation`) because DataStoreFactory's public
@@ -60,4 +66,7 @@ room {
 
 dependencies {
     add("kspAndroid", libs.androidx.room.compiler)
+    add("kspIosX64", libs.androidx.room.compiler)
+    add("kspIosArm64", libs.androidx.room.compiler)
+    add("kspIosSimulatorArm64", libs.androidx.room.compiler)
 }

--- a/AndroidGarage/data-local/src/androidMain/kotlin/com/chriscartland/garage/datalocal/CurrentTimeMillis.android.kt
+++ b/AndroidGarage/data-local/src/androidMain/kotlin/com/chriscartland/garage/datalocal/CurrentTimeMillis.android.kt
@@ -1,3 +1,0 @@
-package com.chriscartland.garage.datalocal
-
-actual fun currentTimeMillis(): Long = System.currentTimeMillis()

--- a/AndroidGarage/data-local/src/androidMain/kotlin/com/chriscartland/garage/datalocal/DatabaseFactory.android.kt
+++ b/AndroidGarage/data-local/src/androidMain/kotlin/com/chriscartland/garage/datalocal/DatabaseFactory.android.kt
@@ -5,24 +5,20 @@ import androidx.room.Room
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 
 /**
- * Android-specific database factory.
- *
- * Uses Android [Context] for database file path.
- * iOS would use NSDocumentDirectory instead.
+ * Android `actual` for [DatabaseFactory]. Resolves the SQLite file
+ * path via `context.getDatabasePath("database")`. The kotlin-inject
+ * `@Singleton` provider in `AppComponent` is the singleton scope —
+ * no internal caching needed here.
  */
-object DatabaseFactory {
-    @Volatile
-    private var instance: AppDatabase? = null
-
-    fun getDatabase(context: Context): AppDatabase =
-        instance ?: synchronized(this) {
-            instance ?: Room
-                .databaseBuilder<AppDatabase>(
-                    context = context,
-                    name = context.getDatabasePath("database").absolutePath,
-                ).setDriver(BundledSQLiteDriver())
-                .fallbackToDestructiveMigration(false)
-                .build()
-                .also { instance = it }
-        }
+actual class DatabaseFactory(
+    private val context: Context,
+) {
+    actual fun createDatabase(): AppDatabase =
+        Room
+            .databaseBuilder<AppDatabase>(
+                context = context,
+                name = context.getDatabasePath("database").absolutePath,
+            ).setDriver(BundledSQLiteDriver())
+            .fallbackToDestructiveMigration(false)
+            .build()
 }

--- a/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/AppEvent.kt
+++ b/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/AppEvent.kt
@@ -3,17 +3,15 @@ package com.chriscartland.garage.datalocal
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import kotlinx.datetime.Clock
 
 @Entity(indices = [Index(value = ["eventKey"])])
 data class AppEvent(
     val eventKey: String,
     @PrimaryKey(autoGenerate = true) val id: Int = 0,
-    val timestamp: Long = currentTimeMillis(),
+    // `kotlinx.datetime.Clock.System.now().toEpochMilliseconds()` is the
+    // KMP equivalent of `System.currentTimeMillis()` — same wall-clock
+    // semantics on Android (delegates to System) and iOS (NSDate).
+    val timestamp: Long = Clock.System.now().toEpochMilliseconds(),
     val appVersion: String = "",
 )
-
-/**
- * KMP-compatible current time in milliseconds.
- * On JVM/Android this delegates to System.currentTimeMillis().
- */
-expect fun currentTimeMillis(): Long

--- a/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/AppLoggerDao.kt
+++ b/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/AppLoggerDao.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface AppLoggerDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insert(appEvent: AppEvent)
+    suspend fun insert(appEvent: AppEvent)
 
     @Query("SELECT * FROM appEvent ORDER BY timestamp ASC")
     fun getAll(): Flow<List<AppEvent>>
@@ -36,20 +36,20 @@ interface AppLoggerDao {
     fun countKey(key: String): Flow<Long>
 
     @Query("SELECT DISTINCT eventKey FROM appEvent")
-    fun distinctKeys(): List<String>
+    suspend fun distinctKeys(): List<String>
 
     @Query(
         "DELETE FROM appEvent WHERE eventKey = :key " +
             "AND id NOT IN (SELECT id FROM appEvent WHERE eventKey = :key " +
             "ORDER BY timestamp DESC, id DESC LIMIT :limit)",
     )
-    fun pruneKey(
+    suspend fun pruneKey(
         key: String,
         limit: Int,
     )
 
     @Transaction
-    fun insertAndPruneKey(
+    suspend fun insertAndPruneKey(
         appEvent: AppEvent,
         limit: Int,
     ) {
@@ -66,7 +66,7 @@ interface AppLoggerDao {
      * legacy table may have ~50K rows across many keys, and FCM /
      * staleness / auth code paths may be firing log() simultaneously.
      */
-    fun pruneAllKeys(limit: Int) {
+    suspend fun pruneAllKeys(limit: Int) {
         require(limit > 0) { "limit must be > 0; got $limit" }
         for (key in distinctKeys()) {
             pruneKey(key, limit)
@@ -74,5 +74,5 @@ interface AppLoggerDao {
     }
 
     @Query("DELETE FROM appEvent")
-    fun deleteAllAppEvents()
+    suspend fun deleteAllAppEvents()
 }

--- a/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/DatabaseFactory.kt
+++ b/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/DatabaseFactory.kt
@@ -1,0 +1,19 @@
+package com.chriscartland.garage.datalocal
+
+/**
+ * Platform-specific factory for the app's Room [AppDatabase].
+ *
+ * Android `actual` takes a `Context` constructor parameter to resolve
+ * the database file path via `context.getDatabasePath("database")`.
+ * iOS `actual` resolves the path via `NSDocumentDirectory` and takes
+ * no constructor arguments.
+ *
+ * Construction is cheap; cache the result of [createDatabase] via the
+ * DI provider's `@Singleton` scope (not inside the factory). Calling
+ * [createDatabase] twice on the same factory instance would build two
+ * Room databases for the same file — which is fine for SQLite but
+ * defeats Room's identity-map and write-conflict guarantees.
+ */
+expect class DatabaseFactory {
+    fun createDatabase(): AppDatabase
+}

--- a/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/DatabaseLocalDoorDataSource.kt
+++ b/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/DatabaseLocalDoorDataSource.kt
@@ -33,12 +33,12 @@ class DatabaseLocalDoorDataSource(
             entities.map { it.toDomain() }
         }
 
-    override fun insertDoorEvent(doorEvent: DoorEvent) {
+    override suspend fun insertDoorEvent(doorEvent: DoorEvent) {
         Logger.d { "Inserting DoorEvent: $doorEvent" }
         appDatabase.doorEventDao().insert(doorEvent.toEntity())
     }
 
-    override fun replaceDoorEvents(doorEvents: List<DoorEvent>) {
+    override suspend fun replaceDoorEvents(doorEvents: List<DoorEvent>) {
         Logger.d { "Replacing DoorEvents: $doorEvents" }
         appDatabase.doorEventDao().replaceAll(doorEvents.map { it.toEntity() })
     }

--- a/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/DoorEventDao.kt
+++ b/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/DoorEventDao.kt
@@ -33,17 +33,17 @@ interface DoorEventDao {
     fun recentDoorEvents(): Flow<List<DoorEventEntity>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insert(doorEvent: DoorEventEntity)
+    suspend fun insert(doorEvent: DoorEventEntity)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertList(doorEvents: List<DoorEventEntity>)
+    suspend fun insertList(doorEvents: List<DoorEventEntity>)
 
     @Transaction
-    fun replaceAll(doorEvents: List<DoorEventEntity>) {
+    suspend fun replaceAll(doorEvents: List<DoorEventEntity>) {
         deleteAll()
         insertList(doorEvents)
     }
 
     @Query("DELETE FROM DoorEvent")
-    fun deleteAll()
+    suspend fun deleteAll()
 }

--- a/AndroidGarage/data-local/src/iosMain/kotlin/com/chriscartland/garage/datalocal/DataStoreFactory.ios.kt
+++ b/AndroidGarage/data-local/src/iosMain/kotlin/com/chriscartland/garage/datalocal/DataStoreFactory.ios.kt
@@ -1,0 +1,51 @@
+package com.chriscartland.garage.datalocal
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.cinterop.ExperimentalForeignApi
+import okio.Path.Companion.toPath
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSURL
+import platform.Foundation.NSUserDomainMask
+
+/**
+ * iOS `actual` for [DataStoreFactory]. Resolves file paths via
+ * `NSDocumentDirectory`. Each canonical store is cached via `lazy`,
+ * mirroring the Android impl. The DI provider must scope this
+ * factory as `@Singleton` — a fresh factory has fresh `lazy` slots,
+ * which would create a second DataStore for the same file (crash).
+ */
+actual class DataStoreFactory {
+    private val appSettingsInstance: DataStore<Preferences> by lazy {
+        createPreferences(PREFERENCES_FILE_NAME)
+    }
+
+    private val diagnosticsCountersInstance: DataStore<Preferences> by lazy {
+        createPreferences(DIAGNOSTICS_COUNTERS_FILE_NAME)
+    }
+
+    actual fun createPreferencesDataStore(): DataStore<Preferences> = appSettingsInstance
+
+    actual fun createDiagnosticsCountersDataStore(): DataStore<Preferences> = diagnosticsCountersInstance
+
+    private fun createPreferences(fileName: String): DataStore<Preferences> =
+        PreferenceDataStoreFactory.createWithPath(
+            produceFile = {
+                "${iosDocumentsDirectory()}/$fileName".toPath()
+            },
+        )
+
+    @OptIn(ExperimentalForeignApi::class)
+    private fun iosDocumentsDirectory(): String {
+        val documentDirectory: NSURL = NSFileManager.defaultManager.URLForDirectory(
+            directory = NSDocumentDirectory,
+            inDomain = NSUserDomainMask,
+            appropriateForURL = null,
+            create = false,
+            error = null,
+        )!!
+        return requireNotNull(documentDirectory.path)
+    }
+}

--- a/AndroidGarage/data-local/src/iosMain/kotlin/com/chriscartland/garage/datalocal/DatabaseFactory.ios.kt
+++ b/AndroidGarage/data-local/src/iosMain/kotlin/com/chriscartland/garage/datalocal/DatabaseFactory.ios.kt
@@ -1,0 +1,40 @@
+package com.chriscartland.garage.datalocal
+
+import androidx.room.Room
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSURL
+import platform.Foundation.NSUserDomainMask
+
+/**
+ * iOS `actual` for [DatabaseFactory]. Resolves the SQLite file path
+ * via `NSDocumentDirectory`. The kotlin-inject `@Singleton` provider
+ * in the iOS `NativeComponent` is the singleton scope — no internal
+ * caching needed here.
+ */
+actual class DatabaseFactory {
+    actual fun createDatabase(): AppDatabase {
+        val dbPath = "${iosDocumentsDirectory()}/garage.db"
+        return Room
+            .databaseBuilder<AppDatabase>(
+                name = dbPath,
+                factory = { AppDatabaseConstructor.initialize() },
+            ).setDriver(BundledSQLiteDriver())
+            .fallbackToDestructiveMigration(false)
+            .build()
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    private fun iosDocumentsDirectory(): String {
+        val documentDirectory: NSURL = NSFileManager.defaultManager.URLForDirectory(
+            directory = NSDocumentDirectory,
+            inDomain = NSUserDomainMask,
+            appropriateForURL = null,
+            create = false,
+            error = null,
+        )!!
+        return requireNotNull(documentDirectory.path)
+    }
+}

--- a/AndroidGarage/data/build.gradle.kts
+++ b/AndroidGarage/data/build.gradle.kts
@@ -11,7 +11,12 @@ tasks.register<ImportBoundaryCheckTask>("checkImportBoundary") {
 }
 
 kotlin {
+    applyDefaultHierarchyTemplate()
+
     androidTarget()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
 
     sourceSets {
         commonMain.dependencies {
@@ -26,6 +31,9 @@ kotlin {
         }
         androidMain.dependencies {
             implementation(libs.ktor.client.okhttp)
+        }
+        iosMain.dependencies {
+            implementation(libs.ktor.client.darwin)
         }
         commonTest.dependencies {
             implementation(project(":test-common"))

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/LocalDoorDataSource.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/LocalDoorDataSource.kt
@@ -13,7 +13,7 @@ interface LocalDoorDataSource {
     val currentDoorEvent: Flow<DoorEvent?>
     val recentDoorEvents: Flow<List<DoorEvent>>
 
-    fun insertDoorEvent(doorEvent: DoorEvent)
+    suspend fun insertDoorEvent(doorEvent: DoorEvent)
 
-    fun replaceDoorEvents(doorEvents: List<DoorEvent>)
+    suspend fun replaceDoorEvents(doorEvents: List<DoorEvent>)
 }

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/coroutines/DefaultDispatcherProvider.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/coroutines/DefaultDispatcherProvider.kt
@@ -20,6 +20,7 @@ package com.chriscartland.garage.data.coroutines
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 
 class DefaultDispatcherProvider : DispatcherProvider {
     override val main: CoroutineDispatcher = Dispatchers.Main

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepository.kt
@@ -84,7 +84,7 @@ class NetworkDoorRepository(
         return cached?.buildTimestamp
     }
 
-    override fun insertDoorEvent(doorEvent: DoorEvent) {
+    override suspend fun insertDoorEvent(doorEvent: DoorEvent) {
         Logger.d { "Inserting DoorEvent: $doorEvent" }
         localDoorDataSource.insertDoorEvent(doorEvent)
     }

--- a/AndroidGarage/data/src/iosMain/kotlin/com/chriscartland/garage/data/ktor/PlatformHttpEngine.ios.kt
+++ b/AndroidGarage/data/src/iosMain/kotlin/com/chriscartland/garage/data/ktor/PlatformHttpEngine.ios.kt
@@ -1,0 +1,6 @@
+package com.chriscartland.garage.data.ktor
+
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.darwin.Darwin
+
+actual fun createPlatformHttpEngine(): HttpClientEngine = Darwin.create()

--- a/AndroidGarage/domain/build.gradle.kts
+++ b/AndroidGarage/domain/build.gradle.kts
@@ -10,7 +10,12 @@ tasks.register<ImportBoundaryCheckTask>("checkImportBoundary") {
 }
 
 kotlin {
+    applyDefaultHierarchyTemplate()
+
     androidTarget()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
 
     sourceSets {
         commonMain.dependencies {

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/AuthModel.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/AuthModel.kt
@@ -1,5 +1,7 @@
 package com.chriscartland.garage.domain.model
 
+import kotlin.jvm.JvmInline
+
 @JvmInline
 value class Email(
     private val s: String,

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/FcmModel.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/FcmModel.kt
@@ -1,5 +1,7 @@
 package com.chriscartland.garage.domain.model
 
+import kotlin.jvm.JvmInline
+
 sealed class DoorFcmState {
     data object Unknown : DoorFcmState()
 

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/DoorRepository.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/DoorRepository.kt
@@ -29,7 +29,7 @@ interface DoorRepository {
 
     suspend fun fetchBuildTimestampCached(): String?
 
-    fun insertDoorEvent(doorEvent: DoorEvent)
+    suspend fun insertDoorEvent(doorEvent: DoorEvent)
 
     /** One-time request: fetch current door event from server and cache locally. */
     suspend fun fetchCurrentDoorEvent(): AppResult<DoorEvent, FetchError>

--- a/AndroidGarage/gradle/libs.versions.toml
+++ b/AndroidGarage/gradle/libs.versions.toml
@@ -97,6 +97,7 @@ kotlin-inject-compiler = { module = "me.tatarka.inject:kotlin-inject-compiler-ks
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }

--- a/AndroidGarage/gradle/libs.versions.toml
+++ b/AndroidGarage/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ kotlinInject = "0.9.0"
 kotlinxSerialization = "1.8.1"
 ktor = "3.1.3"
 kermit = "2.0.4"
+kotlinxDatetime = "0.6.2"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 kotlin = "2.1.20"
@@ -103,6 +104,7 @@ ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }

--- a/AndroidGarage/presentation-model/build.gradle.kts
+++ b/AndroidGarage/presentation-model/build.gradle.kts
@@ -10,7 +10,12 @@ tasks.register<ImportBoundaryCheckTask>("checkImportBoundary") {
 }
 
 kotlin {
+    applyDefaultHierarchyTemplate()
+
     androidTarget()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
 
     sourceSets {
         commonMain.dependencies {

--- a/AndroidGarage/test-common/build.gradle.kts
+++ b/AndroidGarage/test-common/build.gradle.kts
@@ -4,7 +4,12 @@ plugins {
 }
 
 kotlin {
+    applyDefaultHierarchyTemplate()
+
     androidTarget()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
 
     sourceSets {
         commonMain.dependencies {

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeDoorRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeDoorRepository.kt
@@ -56,7 +56,7 @@ class FakeDoorRepository : DoorRepository {
 
     override suspend fun fetchBuildTimestampCached(): String? = buildTimestamp
 
-    override fun insertDoorEvent(doorEvent: DoorEvent) {
+    override suspend fun insertDoorEvent(doorEvent: DoorEvent) {
         _currentDoorEvent.value = doorEvent
         _currentDoorPosition.value = doorEvent.doorPosition ?: DoorPosition.UNKNOWN
     }

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/InMemoryLocalDoorDataSource.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/InMemoryLocalDoorDataSource.kt
@@ -45,12 +45,12 @@ class InMemoryLocalDoorDataSource : LocalDoorDataSource {
     val replaceCalls: List<List<DoorEvent>> get() = _replaceCalls
     val replaceCount: Int get() = _replaceCalls.size
 
-    override fun insertDoorEvent(doorEvent: DoorEvent) {
+    override suspend fun insertDoorEvent(doorEvent: DoorEvent) {
         _insertCalls.add(doorEvent)
         _currentDoorEvent.value = doorEvent
     }
 
-    override fun replaceDoorEvents(doorEvents: List<DoorEvent>) {
+    override suspend fun replaceDoorEvents(doorEvents: List<DoorEvent>) {
         _replaceCalls.add(doorEvents)
         _recentDoorEvents.value = doorEvents
         if (doorEvents.isNotEmpty()) {

--- a/AndroidGarage/usecase/build.gradle.kts
+++ b/AndroidGarage/usecase/build.gradle.kts
@@ -16,7 +16,12 @@ tasks.register<ImportBoundaryCheckTask>("checkImportBoundary") {
 }
 
 kotlin {
+    applyDefaultHierarchyTemplate()
+
     androidTarget()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
 
     sourceSets {
         commonMain.dependencies {

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppStartup.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppStartup.kt
@@ -15,18 +15,11 @@
  *
  */
 
-package com.chriscartland.garage
+package com.chriscartland.garage.usecase
 
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.AppLoggerKeys
-import com.chriscartland.garage.usecase.ButtonHealthFcmSubscriptionManager
-import com.chriscartland.garage.usecase.CheckInStalenessManager
-import com.chriscartland.garage.usecase.FcmRegistrationManager
-import com.chriscartland.garage.usecase.InitialDoorFetchManager
-import com.chriscartland.garage.usecase.LiveClock
-import com.chriscartland.garage.usecase.LogAppEventUseCase
-import com.chriscartland.garage.usecase.RunStartupDiagnosticsMaintenanceUseCase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 

--- a/AndroidGarage/viewmodel/build.gradle.kts
+++ b/AndroidGarage/viewmodel/build.gradle.kts
@@ -23,13 +23,19 @@ tasks.register<ImportBoundaryCheckTask>("checkImportBoundary") {
 }
 
 kotlin {
+    applyDefaultHierarchyTemplate()
+
     androidTarget()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
 
     sourceSets {
         commonMain.dependencies {
             implementation(project(":domain"))
             implementation(project(":usecase"))
             implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kotlinx.datetime)
             implementation(libs.kermit)
             implementation(libs.androidx.lifecycle.viewmodel)
         }

--- a/AndroidGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/FunctionListViewModel.kt
+++ b/AndroidGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/FunctionListViewModel.kt
@@ -132,7 +132,9 @@ class DefaultFunctionListViewModel(
         viewModelScope.launch(dispatchers.io) {
             pushRemoteButtonUseCase(
                 buttonAckToken = ButtonAckToken.create(
-                    currentTimeMillis = System.currentTimeMillis(),
+                    currentTimeMillis = kotlinx.datetime.Clock.System
+                        .now()
+                        .toEpochMilliseconds(),
                     appVersion = appVersion,
                 ),
             )

--- a/AndroidGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/HomeViewModel.kt
+++ b/AndroidGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/HomeViewModel.kt
@@ -239,7 +239,9 @@ class DefaultHomeViewModel(
             when (
                 val result = pushRemoteButtonUseCase(
                     buttonAckToken = ButtonAckToken.create(
-                        currentTimeMillis = System.currentTimeMillis(),
+                        currentTimeMillis = kotlinx.datetime.Clock.System
+                            .now()
+                            .toEpochMilliseconds(),
                         appVersion = appVersion,
                     ),
                 )


### PR DESCRIPTION
## Summary
- Add iOS targets to `:usecase`, `:viewmodel`, `:presentation-model`, `:test-common`
- Move `AppStartup.kt` from `:androidApp` to `:usecase/commonMain`
- Replace `System.currentTimeMillis()` with `kotlinx.datetime.Clock.System.now().toEpochMilliseconds()` in 2 ViewModels

## Merge order
**PR 4 of N**. Stacked on PR #822. GitHub will auto-rebase after PR #822 lands.

## Per-module iOS target adds
Each gets `applyDefaultHierarchyTemplate()` + `iosX64`/`iosArm64`/`iosSimulatorArm64`. Zero source changes in `:usecase`, `:presentation-model`, `:test-common`.

## `:viewmodel` portability fix
`System.currentTimeMillis()` is JVM-only. Replaced with `kotlinx.datetime` (same artifact PR 3 added to `:data-local`) in:
- `HomeViewModel.submitButtonPress` (line 242)
- `FunctionListViewModel.openOrCloseDoor` (line 135)

## `AppStartup` move
`AppStartup.kt` was already pure KMP (zero Android imports — constructor-injected UseCases + Managers + DispatcherProvider + CoroutineScope) but lived under `androidApp/src/main/java/`. Moved into `:usecase/commonMain` so the iOS `NativeComponent` (PR 5) can expose it the same way `AppComponent` does on Android.

Package: `com.chriscartland.garage` → `com.chriscartland.garage.usecase`. `AppComponent.kt` and `AppStartupTest.kt` updated for the new import. Git tracked this as a rename (88% similarity).

The test file (`AppStartupTest.kt`) stays in `androidApp/src/test/` — it uses JUnit 4, which is KMP-portable in spirit but moving it adds no value to this PR.

## Test plan
- [x] All 47 validate.sh checks PASS (including `:usecase:testDebugUnitTest`, `:viewmodel:testDebugUnitTest`, `AppStartupTest`)
- [x] Compiled `:usecase` + `:viewmodel` + `:presentation-model` + `:test-common` for all 3 iOS targets — BUILD SUCCESSFUL

## What's next
After PR 4 merges, all shared KMP modules build for iOS. PR 5 adds the SKIE plugin + kotlin-inject KSP to `:iosFramework` and wires the iOS `NativeComponent` (the actual DI graph that produces `shared.framework` for the SwiftUI app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)