### PR TITLE
chore(ios): SKIE + NativeComponent DI graph for :iosFramework (PR 5/N)

### DIFF
--- a/AndroidGarage/build.gradle.kts
+++ b/AndroidGarage/build.gradle.kts
@@ -29,6 +29,7 @@ plugins {
     alias(libs.plugins.baselineprofile) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.android.kotlin.multiplatform.library) apply false
+    alias(libs.plugins.skie) apply false
     alias(libs.plugins.spotless)
     alias(libs.plugins.detekt) apply false
 }

--- a/AndroidGarage/gradle/libs.versions.toml
+++ b/AndroidGarage/gradle/libs.versions.toml
@@ -33,11 +33,12 @@ credentialsGoogleId = "1.1.1"
 espressoCore = "3.6.1"
 firebase-bom = "33.15.0"
 gms = "4.4.2"
-kotlinInject = "0.9.0"
+kotlinInject = "0.8.0"
 kotlinxSerialization = "1.8.1"
 ktor = "3.1.3"
 kermit = "2.0.4"
 kotlinxDatetime = "0.6.2"
+skie = "0.10.9"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 kotlin = "2.1.20"
@@ -140,3 +141,4 @@ android-test = { id = "com.android.test", version.ref = "agp" }
 baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineprofile" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 android-kotlin-multiplatform-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
+skie = { id = "co.touchlab.skie", version.ref = "skie" }

--- a/AndroidGarage/iosFramework/build.gradle.kts
+++ b/AndroidGarage/iosFramework/build.gradle.kts
@@ -1,34 +1,29 @@
-/*
- * Copyright 2024 Chris Cartland. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
-
 // `:iosFramework` — Gradle module that produces the iOS `.framework`
 // binary consumed by the SwiftUI app at `AndroidGarage/iosApp/`. iOS-only;
 // no Android target. Mirrors battery-butler's `:ios-swift-di` module.
 //
-// Future PRs will add:
-//  - SKIE plugin (StateFlow → AsyncSequence + Combine, sealed → Swift enum)
-//  - kotlin-inject KSP wiring for the iOS `NativeComponent` DI graph
-//  - Framework exports of :domain, :viewmodel, :presentation-model,
-//    and androidx.lifecycle.viewmodel (so Swift can name those types)
-//  - `implementation` deps on :data, :data-local, :usecase (pulled into
-//    the framework binary but not exposed as public types to Swift)
+// Plugin stack:
+//  - SKIE (co.touchlab.skie): bridges Kotlin StateFlow → Swift
+//    AsyncSequence / Combine Publisher, sealed → Swift enum
+//  - kotlin-inject KSP: generates `InjectNativeComponent` (the iOS DI
+//    graph subclass of `NativeComponent`)
+//
+// Framework exports:
+//  - :domain, :viewmodel, :presentation-model (Swift names these types)
+//  - androidx.lifecycle.viewmodel (Swift sees ViewModel / ViewModelStore)
+//  - kermit (Swift may call Logger for parity with Kotlin diagnostics)
+//
+// Internal deps (not exported — types stay opaque to Swift):
+//  - :data, :data-local, :usecase (pulled into the framework binary)
+//
+// The framework is dynamic (isStatic = false) because static frameworks
+// can't re-export imported dependency symbols — required for the
+// `androidx.lifecycle.viewmodel` export.
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.google.devtools.ksp)
+    alias(libs.plugins.skie)
 }
 
 kotlin {
@@ -37,12 +32,40 @@ kotlin {
     listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach {
         it.binaries.framework {
             baseName = "shared"
+            isStatic = false
+            export(project(":domain"))
+            export(project(":viewmodel"))
+            export(project(":presentation-model"))
+            export(libs.androidx.lifecycle.viewmodel)
+            export(libs.kermit)
         }
     }
 
     sourceSets {
         commonMain.dependencies {
-            implementation(libs.kotlin.stdlib)
+            api(project(":domain"))
+            api(project(":viewmodel"))
+            api(project(":presentation-model"))
+            implementation(project(":data"))
+            implementation(project(":data-local"))
+            implementation(project(":usecase"))
+            implementation(libs.kotlin.inject.runtime)
+            implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kermit)
         }
+
+        // Shared source code for all 3 iOS targets — lets `IosNativeHelper`
+        // access the per-target KSP-generated `InjectNativeComponent` class
+        // without duplicating the helper file.
+        val iosShared = "src/iosShared/kotlin"
+        val iosArm64Main by getting { kotlin.srcDir(iosShared) }
+        val iosSimulatorArm64Main by getting { kotlin.srcDir(iosShared) }
+        val iosX64Main by getting { kotlin.srcDir(iosShared) }
     }
+}
+
+dependencies {
+    add("kspIosX64", libs.kotlin.inject.compiler)
+    add("kspIosArm64", libs.kotlin.inject.compiler)
+    add("kspIosSimulatorArm64", libs.kotlin.inject.compiler)
 }

--- a/AndroidGarage/iosFramework/src/commonMain/kotlin/com/chriscartland/garage/iosframework/NativeComponent.kt
+++ b/AndroidGarage/iosFramework/src/commonMain/kotlin/com/chriscartland/garage/iosframework/NativeComponent.kt
@@ -1,0 +1,728 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.iosframework
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import com.chriscartland.garage.data.AuthBridge
+import com.chriscartland.garage.data.LocalDoorDataSource
+import com.chriscartland.garage.data.MessagingBridge
+import com.chriscartland.garage.data.NetworkButtonDataSource
+import com.chriscartland.garage.data.NetworkButtonHealthDataSource
+import com.chriscartland.garage.data.NetworkConfigDataSource
+import com.chriscartland.garage.data.NetworkDoorDataSource
+import com.chriscartland.garage.data.NetworkFeatureAllowlistDataSource
+import com.chriscartland.garage.data.coroutines.DefaultDispatcherProvider
+import com.chriscartland.garage.data.ktor.KtorHttpClientFactory
+import com.chriscartland.garage.data.ktor.KtorNetworkButtonDataSource
+import com.chriscartland.garage.data.ktor.KtorNetworkButtonHealthDataSource
+import com.chriscartland.garage.data.ktor.KtorNetworkConfigDataSource
+import com.chriscartland.garage.data.ktor.KtorNetworkDoorDataSource
+import com.chriscartland.garage.data.ktor.KtorNetworkFeatureAllowlistDataSource
+import com.chriscartland.garage.data.repository.CachedFeatureAllowlistRepository
+import com.chriscartland.garage.data.repository.CachedServerConfigRepository
+import com.chriscartland.garage.data.repository.FirebaseAuthRepository
+import com.chriscartland.garage.data.repository.FirebaseButtonHealthFcmRepository
+import com.chriscartland.garage.data.repository.FirebaseDoorFcmRepository
+import com.chriscartland.garage.data.repository.NetworkButtonHealthRepository
+import com.chriscartland.garage.data.repository.NetworkDoorRepository
+import com.chriscartland.garage.data.repository.NetworkRemoteButtonRepository
+import com.chriscartland.garage.data.repository.NetworkSnoozeRepository
+import com.chriscartland.garage.datalocal.AppDatabase
+import com.chriscartland.garage.datalocal.DataStoreAppSettings
+import com.chriscartland.garage.datalocal.DataStoreDiagnosticsCounters
+import com.chriscartland.garage.datalocal.DataStoreFactory
+import com.chriscartland.garage.datalocal.DatabaseFactory
+import com.chriscartland.garage.datalocal.DatabaseLocalDoorDataSource
+import com.chriscartland.garage.datalocal.RoomAppLoggerRepository
+import com.chriscartland.garage.domain.coroutines.AppClock
+import com.chriscartland.garage.domain.coroutines.DispatcherProvider
+import com.chriscartland.garage.domain.model.AppConfig
+import com.chriscartland.garage.domain.repository.AppLoggerRepository
+import com.chriscartland.garage.domain.repository.AppSettingsRepository
+import com.chriscartland.garage.domain.repository.AuthRepository
+import com.chriscartland.garage.domain.repository.ButtonHealthFcmRepository
+import com.chriscartland.garage.domain.repository.ButtonHealthRepository
+import com.chriscartland.garage.domain.repository.DiagnosticsCountersRepository
+import com.chriscartland.garage.domain.repository.DoorFcmRepository
+import com.chriscartland.garage.domain.repository.DoorRepository
+import com.chriscartland.garage.domain.repository.FeatureAllowlistRepository
+import com.chriscartland.garage.domain.repository.RemoteButtonRepository
+import com.chriscartland.garage.domain.repository.ServerConfigRepository
+import com.chriscartland.garage.domain.repository.SnoozeRepository
+import com.chriscartland.garage.usecase.AppSettingsUseCase
+import com.chriscartland.garage.usecase.AppStartup
+import com.chriscartland.garage.usecase.ApplyButtonHealthFcmUseCase
+import com.chriscartland.garage.usecase.ButtonHealthFcmSubscriptionManager
+import com.chriscartland.garage.usecase.CheckInStalenessManager
+import com.chriscartland.garage.usecase.ClearDiagnosticsUseCase
+import com.chriscartland.garage.usecase.ComputeButtonHealthDisplayUseCase
+import com.chriscartland.garage.usecase.DefaultLiveClock
+import com.chriscartland.garage.usecase.DefaultReceiveFcmDoorEventUseCase
+import com.chriscartland.garage.usecase.DefaultRegisterFcmUseCase
+import com.chriscartland.garage.usecase.DeregisterFcmUseCase
+import com.chriscartland.garage.usecase.FcmRegistrationManager
+import com.chriscartland.garage.usecase.FetchButtonHealthUseCase
+import com.chriscartland.garage.usecase.FetchCurrentDoorEventUseCase
+import com.chriscartland.garage.usecase.FetchFcmStatusUseCase
+import com.chriscartland.garage.usecase.FetchRecentDoorEventsUseCase
+import com.chriscartland.garage.usecase.FetchSnoozeStatusUseCase
+import com.chriscartland.garage.usecase.GetAuthTokenForCopyUseCase
+import com.chriscartland.garage.usecase.InitialDoorFetchManager
+import com.chriscartland.garage.usecase.LiveClock
+import com.chriscartland.garage.usecase.LogAppEventUseCase
+import com.chriscartland.garage.usecase.ObserveAuthStateUseCase
+import com.chriscartland.garage.usecase.ObserveDiagnosticsCountUseCase
+import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
+import com.chriscartland.garage.usecase.ObserveFeatureAccessUseCase
+import com.chriscartland.garage.usecase.ObserveSnoozeStateUseCase
+import com.chriscartland.garage.usecase.PruneDiagnosticsLogUseCase
+import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
+import com.chriscartland.garage.usecase.ReceiveFcmDoorEventUseCase
+import com.chriscartland.garage.usecase.RegisterFcmUseCase
+import com.chriscartland.garage.usecase.RunStartupDiagnosticsMaintenanceUseCase
+import com.chriscartland.garage.usecase.SeedDiagnosticsCountersFromRoomUseCase
+import com.chriscartland.garage.usecase.SignInWithGoogleUseCase
+import com.chriscartland.garage.usecase.SignOutUseCase
+import com.chriscartland.garage.usecase.SnoozeNotificationsUseCase
+import com.chriscartland.garage.viewmodel.DefaultDiagnosticsViewModel
+import com.chriscartland.garage.viewmodel.DefaultDoorHistoryViewModel
+import com.chriscartland.garage.viewmodel.DefaultFunctionListViewModel
+import com.chriscartland.garage.viewmodel.DefaultHomeViewModel
+import com.chriscartland.garage.viewmodel.DefaultProfileViewModel
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.datetime.Clock
+import me.tatarka.inject.annotations.Component
+import me.tatarka.inject.annotations.Provides
+import me.tatarka.inject.annotations.Scope
+
+@Scope
+annotation class SharedSingleton
+
+/**
+ * Root kotlin-inject component for iOS.
+ *
+ * Mirrors the Android `:androidApp`'s `AppComponent` shape — same
+ * dependency graph, same `@SharedSingleton`-scoped repositories /
+ * managers — but with platform deps (`AuthBridge`, `MessagingBridge`,
+ * `DatabaseFactory`, `DataStoreFactory`, `AppConfig`, `appVersion`)
+ * supplied via constructor instead of read from `Application` +
+ * `BuildConfig`.
+ *
+ * Construction happens in [IosNativeHelper] (iosShared), which is the
+ * single entry point Swift calls to materialize the DI graph.
+ *
+ * **Singleton discipline (mirrors `AppComponent.kt` rules):**
+ *   1. Every `@SharedSingleton` provider must be reachable via an
+ *      abstract entry point — otherwise kotlin-inject skips the cache
+ *      and constructs fresh instances per access (the android/170
+ *      regression class of bug).
+ *   2. Every `@Provides fun` body declares its deps as parameters —
+ *      never call sibling `provide*()` inside the body.
+ *   3. ViewModels are non-singleton (per-screen-instance by design).
+ */
+@Component
+@SharedSingleton
+abstract class NativeComponent(
+    @get:Provides val authBridge: AuthBridge,
+    @get:Provides val messagingBridge: MessagingBridge,
+    @get:Provides val databaseFactory: DatabaseFactory,
+    @get:Provides val dataStoreFactory: DataStoreFactory,
+    @get:Provides val appConfig: AppConfig,
+    @get:Provides val appVersion: String,
+) {
+    // --- Entry points: ViewModels (per-screen, NOT singleton) ---
+    abstract val diagnosticsViewModel: DefaultDiagnosticsViewModel
+    abstract val functionListViewModel: DefaultFunctionListViewModel
+    abstract val homeViewModel: DefaultHomeViewModel
+    abstract val doorHistoryViewModel: DefaultDoorHistoryViewModel
+    abstract val profileViewModel: DefaultProfileViewModel
+
+    // --- Entry points: @SharedSingleton state owners ---
+    abstract val appStartup: AppStartup
+    abstract val applicationScope: CoroutineScope
+    abstract val httpClient: HttpClient
+    abstract val appDatabase: AppDatabase
+    abstract val appSettings: AppSettingsRepository
+    abstract val appLoggerRepository: AppLoggerRepository
+    abstract val diagnosticsCountersRepository: DiagnosticsCountersRepository
+    abstract val authRepository: AuthRepository
+    abstract val doorRepository: DoorRepository
+    abstract val serverConfigRepository: ServerConfigRepository
+    abstract val snoozeRepository: SnoozeRepository
+    abstract val remoteButtonRepository: RemoteButtonRepository
+    abstract val doorFcmRepository: DoorFcmRepository
+    abstract val featureAllowlistRepository: FeatureAllowlistRepository
+    abstract val fcmRegistrationManager: FcmRegistrationManager
+    abstract val checkInStalenessManager: CheckInStalenessManager
+    abstract val liveClock: LiveClock
+    abstract val receiveFcmDoorEventUseCase: ReceiveFcmDoorEventUseCase
+    abstract val appClock: AppClock
+    abstract val dispatcherProvider: DispatcherProvider
+    abstract val networkButtonDataSource: NetworkButtonDataSource
+    abstract val networkButtonHealthDataSource: NetworkButtonHealthDataSource
+    abstract val networkConfigDataSource: NetworkConfigDataSource
+    abstract val networkDoorDataSource: NetworkDoorDataSource
+    abstract val networkFeatureAllowlistDataSource: NetworkFeatureAllowlistDataSource
+    abstract val localDoorDataSource: LocalDoorDataSource
+    abstract val buttonHealthRepository: ButtonHealthRepository
+    abstract val buttonHealthFcmRepository: ButtonHealthFcmRepository
+    abstract val buttonHealthFcmSubscriptionManager: ButtonHealthFcmSubscriptionManager
+    abstract val applyButtonHealthFcmUseCase: ApplyButtonHealthFcmUseCase
+    abstract val initialDoorFetchManager: InitialDoorFetchManager
+    abstract val computeButtonHealthDisplayUseCase: ComputeButtonHealthDisplayUseCase
+    abstract val getAuthTokenForCopyUseCase: GetAuthTokenForCopyUseCase
+
+    // --- ViewModels ---
+
+    @Provides
+    fun provideDiagnosticsViewModel(
+        observeAppLogCount: ObserveDiagnosticsCountUseCase,
+        clearDiagnostics: ClearDiagnosticsUseCase,
+        dispatchers: DispatcherProvider,
+    ): DefaultDiagnosticsViewModel = DefaultDiagnosticsViewModel(observeAppLogCount, clearDiagnostics, dispatchers)
+
+    @Provides
+    fun provideFunctionListViewModel(
+        pushRemoteButton: PushRemoteButtonUseCase,
+        fetchCurrentDoorEvent: FetchCurrentDoorEventUseCase,
+        fetchRecentDoorEvents: FetchRecentDoorEventsUseCase,
+        fetchSnoozeStatus: FetchSnoozeStatusUseCase,
+        fetchButtonHealth: FetchButtonHealthUseCase,
+        snoozeNotifications: SnoozeNotificationsUseCase,
+        signInWithGoogle: SignInWithGoogleUseCase,
+        signOut: SignOutUseCase,
+        observeDoorEvents: ObserveDoorEventsUseCase,
+        observeFeatureAccess: ObserveFeatureAccessUseCase,
+        clearDiagnostics: ClearDiagnosticsUseCase,
+        pruneDiagnosticsLog: PruneDiagnosticsLogUseCase,
+        registerFcm: RegisterFcmUseCase,
+        deregisterFcm: DeregisterFcmUseCase,
+        dispatchers: DispatcherProvider,
+        appVersion: String,
+    ): DefaultFunctionListViewModel =
+        DefaultFunctionListViewModel(
+            pushRemoteButtonUseCase = pushRemoteButton,
+            fetchCurrentDoorEventUseCase = fetchCurrentDoorEvent,
+            fetchRecentDoorEventsUseCase = fetchRecentDoorEvents,
+            fetchSnoozeStatusUseCase = fetchSnoozeStatus,
+            fetchButtonHealthUseCase = fetchButtonHealth,
+            snoozeNotificationsUseCase = snoozeNotifications,
+            signInWithGoogleUseCase = signInWithGoogle,
+            signOutUseCase = signOut,
+            observeDoorEventsUseCase = observeDoorEvents,
+            observeFeatureAccessUseCase = observeFeatureAccess,
+            clearDiagnosticsUseCase = clearDiagnostics,
+            pruneDiagnosticsLogUseCase = pruneDiagnosticsLog,
+            registerFcmUseCase = registerFcm,
+            deregisterFcmUseCase = deregisterFcm,
+            dispatchers = dispatchers,
+            appVersion = appVersion,
+        )
+
+    @Provides
+    fun provideHomeViewModel(
+        observeDoorEvents: ObserveDoorEventsUseCase,
+        observeAuthState: ObserveAuthStateUseCase,
+        logAppEvent: LogAppEventUseCase,
+        dispatchers: DispatcherProvider,
+        fetchCurrentDoorEvent: FetchCurrentDoorEventUseCase,
+        fetchButtonHealth: FetchButtonHealthUseCase,
+        deregisterFcm: DeregisterFcmUseCase,
+        signInWithGoogle: SignInWithGoogleUseCase,
+        pushRemoteButton: PushRemoteButtonUseCase,
+        checkInStalenessManager: CheckInStalenessManager,
+        liveClock: LiveClock,
+        computeButtonHealthDisplay: ComputeButtonHealthDisplayUseCase,
+        appVersion: String,
+    ): DefaultHomeViewModel =
+        DefaultHomeViewModel(
+            observeDoorEvents = observeDoorEvents,
+            observeAuthState = observeAuthState,
+            logAppEvent = logAppEvent,
+            dispatchers = dispatchers,
+            fetchCurrentDoorEventUseCase = fetchCurrentDoorEvent,
+            fetchButtonHealthUseCase = fetchButtonHealth,
+            deregisterFcmUseCase = deregisterFcm,
+            signInWithGoogleUseCase = signInWithGoogle,
+            pushRemoteButtonUseCase = pushRemoteButton,
+            checkInStalenessManager = checkInStalenessManager,
+            liveClock = liveClock,
+            buttonHealthDisplay = computeButtonHealthDisplay(),
+            appVersion = appVersion,
+        )
+
+    @Provides
+    fun provideProfileViewModel(
+        observeAuthState: ObserveAuthStateUseCase,
+        observeSnoozeState: ObserveSnoozeStateUseCase,
+        observeDoorEvents: ObserveDoorEventsUseCase,
+        observeFeatureAccess: ObserveFeatureAccessUseCase,
+        signInWithGoogle: SignInWithGoogleUseCase,
+        signOut: SignOutUseCase,
+        fetchSnoozeStatus: FetchSnoozeStatusUseCase,
+        snoozeNotifications: SnoozeNotificationsUseCase,
+        logAppEvent: LogAppEventUseCase,
+        appSettings: AppSettingsUseCase,
+        dispatchers: DispatcherProvider,
+    ): DefaultProfileViewModel =
+        DefaultProfileViewModel(
+            observeAuthState = observeAuthState,
+            observeSnoozeState = observeSnoozeState,
+            observeDoorEvents = observeDoorEvents,
+            observeFeatureAccessUseCase = observeFeatureAccess,
+            signInWithGoogleUseCase = signInWithGoogle,
+            signOutUseCase = signOut,
+            fetchSnoozeStatusUseCase = fetchSnoozeStatus,
+            snoozeNotificationsUseCase = snoozeNotifications,
+            logAppEvent = logAppEvent,
+            appSettings = appSettings,
+            dispatchers = dispatchers,
+        )
+
+    @Provides
+    fun provideDoorHistoryViewModel(
+        observeDoorEvents: ObserveDoorEventsUseCase,
+        logAppEvent: LogAppEventUseCase,
+        dispatchers: DispatcherProvider,
+        fetchRecentDoorEvents: FetchRecentDoorEventsUseCase,
+        deregisterFcm: DeregisterFcmUseCase,
+        checkInStalenessManager: CheckInStalenessManager,
+        liveClock: LiveClock,
+    ): DefaultDoorHistoryViewModel =
+        DefaultDoorHistoryViewModel(
+            observeDoorEvents = observeDoorEvents,
+            logAppEvent = logAppEvent,
+            dispatchers = dispatchers,
+            fetchRecentDoorEventsUseCase = fetchRecentDoorEvents,
+            deregisterFcmUseCase = deregisterFcm,
+            checkInStalenessManager = checkInStalenessManager,
+            liveClock = liveClock,
+        )
+
+    // --- UseCases ---
+
+    @Provides
+    fun providePruneDiagnosticsLogUseCase(appLoggerRepository: AppLoggerRepository): PruneDiagnosticsLogUseCase =
+        PruneDiagnosticsLogUseCase(appLoggerRepository)
+
+    @Provides
+    fun provideRunStartupDiagnosticsMaintenanceUseCase(
+        seed: SeedDiagnosticsCountersFromRoomUseCase,
+        prune: PruneDiagnosticsLogUseCase,
+    ): RunStartupDiagnosticsMaintenanceUseCase = RunStartupDiagnosticsMaintenanceUseCase(seed, prune)
+
+    @Provides
+    fun provideGetAuthTokenForCopyUseCase(authRepository: AuthRepository): GetAuthTokenForCopyUseCase =
+        GetAuthTokenForCopyUseCase(authRepository)
+
+    @Provides
+    fun provideClearDiagnosticsUseCase(
+        appLoggerRepository: AppLoggerRepository,
+        diagnosticsCounters: DiagnosticsCountersRepository,
+    ): ClearDiagnosticsUseCase = ClearDiagnosticsUseCase(appLoggerRepository, diagnosticsCounters)
+
+    @Provides
+    fun provideSeedDiagnosticsCountersFromRoomUseCase(
+        appLoggerRepository: AppLoggerRepository,
+        diagnosticsCounters: DiagnosticsCountersRepository,
+    ): SeedDiagnosticsCountersFromRoomUseCase = SeedDiagnosticsCountersFromRoomUseCase(appLoggerRepository, diagnosticsCounters)
+
+    @Provides
+    fun provideObserveAuthStateUseCase(authRepository: AuthRepository): ObserveAuthStateUseCase = ObserveAuthStateUseCase(authRepository)
+
+    @Provides
+    fun provideSignInWithGoogleUseCase(authRepository: AuthRepository): SignInWithGoogleUseCase = SignInWithGoogleUseCase(authRepository)
+
+    @Provides
+    fun provideSignOutUseCase(authRepository: AuthRepository): SignOutUseCase = SignOutUseCase(authRepository)
+
+    @Provides
+    fun provideLogAppEventUseCase(
+        appLoggerRepository: AppLoggerRepository,
+        diagnosticsCounters: DiagnosticsCountersRepository,
+    ): LogAppEventUseCase = LogAppEventUseCase(appLoggerRepository, diagnosticsCounters)
+
+    @Provides
+    fun provideObserveDiagnosticsCountUseCase(diagnosticsCounters: DiagnosticsCountersRepository): ObserveDiagnosticsCountUseCase =
+        ObserveDiagnosticsCountUseCase(diagnosticsCounters)
+
+    @Provides
+    fun provideObserveDoorEventsUseCase(doorRepository: DoorRepository): ObserveDoorEventsUseCase = ObserveDoorEventsUseCase(doorRepository)
+
+    @Provides
+    fun provideAppSettingsUseCase(appSettings: AppSettingsRepository): AppSettingsUseCase = AppSettingsUseCase(appSettings)
+
+    @Provides
+    fun provideFetchCurrentDoorEventUseCase(doorRepository: DoorRepository): FetchCurrentDoorEventUseCase =
+        FetchCurrentDoorEventUseCase(doorRepository)
+
+    @Provides
+    fun provideFetchRecentDoorEventsUseCase(doorRepository: DoorRepository): FetchRecentDoorEventsUseCase =
+        FetchRecentDoorEventsUseCase(doorRepository)
+
+    @Provides
+    fun provideFetchFcmStatusUseCase(doorFcmRepository: DoorFcmRepository): FetchFcmStatusUseCase = FetchFcmStatusUseCase(doorFcmRepository)
+
+    @Provides
+    fun provideRegisterFcmUseCase(
+        doorRepository: DoorRepository,
+        doorFcmRepository: DoorFcmRepository,
+    ): RegisterFcmUseCase = DefaultRegisterFcmUseCase(doorRepository, doorFcmRepository)
+
+    @Provides
+    fun provideReceiveFcmDoorEventUseCase(
+        doorRepository: DoorRepository,
+        appLoggerRepository: AppLoggerRepository,
+        applicationScope: CoroutineScope,
+    ): ReceiveFcmDoorEventUseCase =
+        DefaultReceiveFcmDoorEventUseCase(
+            doorRepository = doorRepository,
+            appLoggerRepository = appLoggerRepository,
+            externalScope = applicationScope,
+        )
+
+    @Provides
+    fun provideDeregisterFcmUseCase(doorFcmRepository: DoorFcmRepository): DeregisterFcmUseCase = DeregisterFcmUseCase(doorFcmRepository)
+
+    @Provides
+    fun providePushRemoteButtonUseCase(
+        authRepository: AuthRepository,
+        remoteButtonRepository: RemoteButtonRepository,
+    ): PushRemoteButtonUseCase = PushRemoteButtonUseCase(authRepository, remoteButtonRepository)
+
+    @Provides
+    fun provideSnoozeNotificationsUseCase(
+        authRepository: AuthRepository,
+        snoozeRepository: SnoozeRepository,
+    ): SnoozeNotificationsUseCase = SnoozeNotificationsUseCase(authRepository, snoozeRepository)
+
+    @Provides
+    fun provideFetchSnoozeStatusUseCase(snoozeRepository: SnoozeRepository): FetchSnoozeStatusUseCase =
+        FetchSnoozeStatusUseCase(snoozeRepository)
+
+    @Provides
+    fun provideObserveSnoozeStateUseCase(snoozeRepository: SnoozeRepository): ObserveSnoozeStateUseCase =
+        ObserveSnoozeStateUseCase(snoozeRepository)
+
+    @Provides
+    fun provideObserveFeatureAccessUseCase(featureAllowlistRepository: FeatureAllowlistRepository): ObserveFeatureAccessUseCase =
+        ObserveFeatureAccessUseCase(featureAllowlistRepository)
+
+    @Provides
+    fun provideFetchButtonHealthUseCase(
+        authRepository: AuthRepository,
+        buttonHealthRepository: ButtonHealthRepository,
+    ): FetchButtonHealthUseCase = FetchButtonHealthUseCase(authRepository, buttonHealthRepository)
+
+    @Provides
+    fun provideApplyButtonHealthFcmUseCase(buttonHealthRepository: ButtonHealthRepository): ApplyButtonHealthFcmUseCase =
+        ApplyButtonHealthFcmUseCase(buttonHealthRepository)
+
+    @Provides
+    @SharedSingleton
+    fun provideComputeButtonHealthDisplayUseCase(
+        authRepository: AuthRepository,
+        buttonHealthRepository: ButtonHealthRepository,
+        liveClock: LiveClock,
+        applicationScope: CoroutineScope,
+    ): ComputeButtonHealthDisplayUseCase =
+        ComputeButtonHealthDisplayUseCase(
+            authRepository = authRepository,
+            buttonHealthRepository = buttonHealthRepository,
+            liveClock = liveClock,
+            applicationScope = applicationScope,
+        )
+
+    // --- @SharedSingleton providers (bodies take parameters so caching is honored) ---
+
+    @Provides
+    @SharedSingleton
+    fun providePreferencesDataStore(factory: DataStoreFactory): DataStore<Preferences> = factory.createPreferencesDataStore()
+
+    @Provides
+    @SharedSingleton
+    fun provideAppSettings(dataStore: DataStore<Preferences>): AppSettingsRepository = DataStoreAppSettings(dataStore)
+
+    @Provides
+    @SharedSingleton
+    fun provideDiagnosticsCountersRepository(factory: DataStoreFactory): DiagnosticsCountersRepository =
+        DataStoreDiagnosticsCounters(factory.createDiagnosticsCountersDataStore())
+
+    @Provides
+    @SharedSingleton
+    fun provideAppDatabase(factory: DatabaseFactory): AppDatabase = factory.createDatabase()
+
+    @Provides
+    @SharedSingleton
+    fun provideHttpClient(appConfig: AppConfig): HttpClient = KtorHttpClientFactory.create(baseUrl = appConfig.baseUrl, debug = false)
+
+    @Provides
+    @SharedSingleton
+    fun provideNetworkDoorDataSource(httpClient: HttpClient): NetworkDoorDataSource = KtorNetworkDoorDataSource(httpClient)
+
+    @Provides
+    @SharedSingleton
+    fun provideNetworkConfigDataSource(httpClient: HttpClient): NetworkConfigDataSource = KtorNetworkConfigDataSource(httpClient)
+
+    @Provides
+    @SharedSingleton
+    fun provideNetworkButtonDataSource(httpClient: HttpClient): NetworkButtonDataSource = KtorNetworkButtonDataSource(httpClient)
+
+    @Provides
+    @SharedSingleton
+    fun provideNetworkButtonHealthDataSource(httpClient: HttpClient): NetworkButtonHealthDataSource =
+        KtorNetworkButtonHealthDataSource(httpClient)
+
+    @Provides
+    @SharedSingleton
+    fun provideNetworkFeatureAllowlistDataSource(httpClient: HttpClient): NetworkFeatureAllowlistDataSource =
+        KtorNetworkFeatureAllowlistDataSource(httpClient)
+
+    @Provides
+    @SharedSingleton
+    fun provideLocalDoorDataSource(appDatabase: AppDatabase): LocalDoorDataSource = DatabaseLocalDoorDataSource(appDatabase)
+
+    @Provides
+    @SharedSingleton
+    fun provideApplicationScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @Provides
+    @SharedSingleton
+    fun provideDispatcherProvider(): DispatcherProvider = DefaultDispatcherProvider()
+
+    @Provides
+    @SharedSingleton
+    fun provideAppClock(): AppClock = AppClock { Clock.System.now().toEpochMilliseconds() / 1000 }
+
+    @Provides
+    @SharedSingleton
+    fun provideAppLoggerRepository(
+        appDatabase: AppDatabase,
+        appVersion: String,
+    ): AppLoggerRepository = RoomAppLoggerRepository(appDatabase, appVersion)
+
+    @Provides
+    @SharedSingleton
+    fun provideAuthRepository(
+        authBridge: AuthBridge,
+        appLoggerRepository: AppLoggerRepository,
+        applicationScope: CoroutineScope,
+    ): AuthRepository = FirebaseAuthRepository(authBridge, appLoggerRepository, applicationScope)
+
+    @Provides
+    @SharedSingleton
+    fun provideServerConfigRepository(
+        networkConfigDataSource: NetworkConfigDataSource,
+        appConfig: AppConfig,
+        applicationScope: CoroutineScope,
+    ): ServerConfigRepository = CachedServerConfigRepository(networkConfigDataSource, appConfig.serverConfigKey, applicationScope)
+
+    @Provides
+    @SharedSingleton
+    fun provideFeatureAllowlistRepository(
+        networkFeatureAllowlistDataSource: NetworkFeatureAllowlistDataSource,
+        authRepository: AuthRepository,
+        applicationScope: CoroutineScope,
+    ): FeatureAllowlistRepository =
+        CachedFeatureAllowlistRepository(
+            networkDataSource = networkFeatureAllowlistDataSource,
+            authRepository = authRepository,
+            externalScope = applicationScope,
+        )
+
+    @Provides
+    @SharedSingleton
+    fun provideDoorRepository(
+        localDoorDataSource: LocalDoorDataSource,
+        networkDoorDataSource: NetworkDoorDataSource,
+        serverConfigRepository: ServerConfigRepository,
+        appConfig: AppConfig,
+        applicationScope: CoroutineScope,
+    ): DoorRepository =
+        NetworkDoorRepository(
+            localDoorDataSource,
+            networkDoorDataSource,
+            serverConfigRepository,
+            appConfig.recentEventCount,
+            applicationScope,
+        )
+
+    @Provides
+    @SharedSingleton
+    fun provideRemoteButtonRepository(
+        networkButtonDataSource: NetworkButtonDataSource,
+        serverConfigRepository: ServerConfigRepository,
+        authRepository: AuthRepository,
+        appConfig: AppConfig,
+    ): RemoteButtonRepository =
+        NetworkRemoteButtonRepository(
+            networkButtonDataSource = networkButtonDataSource,
+            serverConfigRepository = serverConfigRepository,
+            authRepository = authRepository,
+            remoteButtonPushEnabled = appConfig.remoteButtonPushEnabled,
+        )
+
+    @Provides
+    @SharedSingleton
+    fun provideSnoozeRepository(
+        networkButtonDataSource: NetworkButtonDataSource,
+        serverConfigRepository: ServerConfigRepository,
+        authRepository: AuthRepository,
+        appConfig: AppConfig,
+        applicationScope: CoroutineScope,
+    ): SnoozeRepository =
+        NetworkSnoozeRepository(
+            networkButtonDataSource = networkButtonDataSource,
+            serverConfigRepository = serverConfigRepository,
+            authRepository = authRepository,
+            snoozeNotificationsOption = appConfig.snoozeNotificationsOption,
+            currentTimeSeconds = { Clock.System.now().toEpochMilliseconds() / 1000 },
+            externalScope = applicationScope,
+        )
+
+    @Provides
+    @SharedSingleton
+    fun provideDoorFcmRepository(
+        messagingBridge: MessagingBridge,
+        appSettings: AppSettingsRepository,
+        appLoggerRepository: AppLoggerRepository,
+    ): DoorFcmRepository = FirebaseDoorFcmRepository(messagingBridge, appSettings, appLoggerRepository)
+
+    @Provides
+    @SharedSingleton
+    fun provideButtonHealthRepository(
+        networkButtonHealthDataSource: NetworkButtonHealthDataSource,
+        serverConfigRepository: ServerConfigRepository,
+        authRepository: AuthRepository,
+        applicationScope: CoroutineScope,
+    ): ButtonHealthRepository =
+        NetworkButtonHealthRepository(
+            networkButtonHealthDataSource = networkButtonHealthDataSource,
+            serverConfigRepository = serverConfigRepository,
+            authRepository = authRepository,
+            externalScope = applicationScope,
+        )
+
+    @Provides
+    @SharedSingleton
+    fun provideButtonHealthFcmRepository(messagingBridge: MessagingBridge): ButtonHealthFcmRepository =
+        FirebaseButtonHealthFcmRepository(messagingBridge)
+
+    @Provides
+    @SharedSingleton
+    fun provideButtonHealthFcmSubscriptionManager(
+        authRepository: AuthRepository,
+        serverConfigRepository: ServerConfigRepository,
+        buttonHealthFcmRepository: ButtonHealthFcmRepository,
+        fetchButtonHealthUseCase: FetchButtonHealthUseCase,
+        applicationScope: CoroutineScope,
+        dispatchers: DispatcherProvider,
+    ): ButtonHealthFcmSubscriptionManager =
+        ButtonHealthFcmSubscriptionManager(
+            authRepository = authRepository,
+            serverConfigRepository = serverConfigRepository,
+            fcmRepository = buttonHealthFcmRepository,
+            fetchButtonHealthUseCase = fetchButtonHealthUseCase,
+            scope = applicationScope,
+            dispatcher = dispatchers.io,
+        )
+
+    @Provides
+    @SharedSingleton
+    fun provideFcmRegistrationManager(
+        registerFcm: RegisterFcmUseCase,
+        applicationScope: CoroutineScope,
+        dispatchers: DispatcherProvider,
+    ): FcmRegistrationManager = FcmRegistrationManager(registerFcm, applicationScope, dispatchers.io)
+
+    @Provides
+    @SharedSingleton
+    fun provideCheckInStalenessManager(
+        observeDoorEvents: ObserveDoorEventsUseCase,
+        logAppEvent: LogAppEventUseCase,
+        applicationScope: CoroutineScope,
+        dispatchers: DispatcherProvider,
+        appClock: AppClock,
+    ): CheckInStalenessManager =
+        CheckInStalenessManager(
+            observeDoorEvents = observeDoorEvents,
+            logAppEvent = logAppEvent,
+            scope = applicationScope,
+            dispatcher = dispatchers.io,
+            clock = appClock,
+        )
+
+    @Provides
+    @SharedSingleton
+    fun provideLiveClock(
+        appClock: AppClock,
+        applicationScope: CoroutineScope,
+        dispatchers: DispatcherProvider,
+    ): LiveClock =
+        DefaultLiveClock(
+            clock = appClock,
+            scope = applicationScope,
+            dispatcher = dispatchers.io,
+        )
+
+    @Provides
+    @SharedSingleton
+    fun provideInitialDoorFetchManager(
+        fetchCurrentDoorEvent: FetchCurrentDoorEventUseCase,
+        fetchRecentDoorEvents: FetchRecentDoorEventsUseCase,
+        logAppEvent: LogAppEventUseCase,
+        applicationScope: CoroutineScope,
+        dispatchers: DispatcherProvider,
+    ): InitialDoorFetchManager =
+        InitialDoorFetchManager(
+            fetchCurrentDoorEvent = fetchCurrentDoorEvent,
+            fetchRecentDoorEvents = fetchRecentDoorEvents,
+            logAppEvent = logAppEvent,
+            scope = applicationScope,
+            dispatcher = dispatchers.io,
+        )
+
+    @Provides
+    fun provideAppStartup(
+        fcmRegistrationManager: FcmRegistrationManager,
+        checkInStalenessManager: CheckInStalenessManager,
+        liveClock: LiveClock,
+        logAppEvent: LogAppEventUseCase,
+        runStartupDiagnosticsMaintenance: RunStartupDiagnosticsMaintenanceUseCase,
+        buttonHealthFcmSubscriptionManager: ButtonHealthFcmSubscriptionManager,
+        initialDoorFetchManager: InitialDoorFetchManager,
+        applicationScope: CoroutineScope,
+        dispatchers: DispatcherProvider,
+    ): AppStartup =
+        AppStartup(
+            fcmRegistrationManager = fcmRegistrationManager,
+            checkInStalenessManager = checkInStalenessManager,
+            liveClock = liveClock,
+            logAppEvent = logAppEvent,
+            runStartupDiagnosticsMaintenance = runStartupDiagnosticsMaintenance,
+            buttonHealthFcmSubscriptionManager = buttonHealthFcmSubscriptionManager,
+            initialDoorFetchManager = initialDoorFetchManager,
+            externalScope = applicationScope,
+            dispatchers = dispatchers,
+        )
+}

--- a/AndroidGarage/iosFramework/src/iosShared/kotlin/com/chriscartland/garage/iosframework/IosNativeHelper.kt
+++ b/AndroidGarage/iosFramework/src/iosShared/kotlin/com/chriscartland/garage/iosframework/IosNativeHelper.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.iosframework
+
+import com.chriscartland.garage.data.AuthBridge
+import com.chriscartland.garage.data.MessagingBridge
+import com.chriscartland.garage.datalocal.DataStoreFactory
+import com.chriscartland.garage.datalocal.DatabaseFactory
+import com.chriscartland.garage.domain.model.AppConfig
+import platform.Foundation.NSBundle
+
+/**
+ * Single Swift-callable entry point that builds the iOS DI graph.
+ *
+ * Pattern matches battery-butler's `IosNativeHelper` — Swift calls
+ * `IosNativeHelper().createComponent(...)` once at app launch and
+ * passes the result through the view tree.
+ *
+ * The Swift side supplies platform-specific bridges
+ * ([authBridge] = `FirebaseAuthBridge.swift`,
+ *  [messagingBridge] = `FirebaseMessagingBridge.swift`). When Swift
+ * impls are not yet wired (PR 5 baseline), pass [NoOpAuthBridge] /
+ * [NoOpMessagingBridge] — the framework still builds and the DI
+ * graph instantiates; only auth/push are inert.
+ *
+ * [DatabaseFactory] and [DataStoreFactory] are pure-Kotlin iOS
+ * actuals (NSDocumentDirectory path resolution); constructed here.
+ *
+ * [appConfig] is supplied by Swift, typically read from `Info.plist`
+ * (`Bundle.main.object(forInfoDictionaryKey:)`). For PR 5 baseline
+ * the Swift side can pass [defaultDevAppConfig] as a placeholder.
+ */
+class IosNativeHelper {
+    fun createComponent(
+        authBridge: AuthBridge,
+        messagingBridge: MessagingBridge,
+        appConfig: AppConfig,
+    ): NativeComponent =
+        NativeComponent::class.create(
+            authBridge = authBridge,
+            messagingBridge = messagingBridge,
+            databaseFactory = DatabaseFactory(),
+            dataStoreFactory = DataStoreFactory(),
+            appConfig = appConfig,
+            appVersion = currentAppVersion(),
+        )
+
+    private fun currentAppVersion(): String {
+        val bundle = NSBundle.mainBundle
+        val version =
+            bundle.objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
+                ?: "Unknown"
+        val build = bundle.objectForInfoDictionaryKey("CFBundleVersion") as? String ?: "0"
+        return "$version ($build)"
+    }
+
+    companion object {
+        /**
+         * Placeholder [AppConfig] for early-iteration iOS builds.
+         * Real values must come from `Info.plist` keys in the iOS app
+         * before any production-track release.
+         */
+        val defaultDevAppConfig: AppConfig = AppConfig(
+            baseUrl = "https://example.invalid",
+            recentEventCount = 50,
+            serverConfigKey = "",
+            snoozeNotificationsOption = true,
+            remoteButtonPushEnabled = true,
+        )
+    }
+}

--- a/AndroidGarage/iosFramework/src/iosShared/kotlin/com/chriscartland/garage/iosframework/NoOpAuthBridge.kt
+++ b/AndroidGarage/iosFramework/src/iosShared/kotlin/com/chriscartland/garage/iosframework/NoOpAuthBridge.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.iosframework
+
+import com.chriscartland.garage.data.AuthBridge
+import com.chriscartland.garage.data.AuthUserInfo
+import com.chriscartland.garage.domain.model.FirebaseIdToken
+import com.chriscartland.garage.domain.model.GoogleIdToken
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+/**
+ * NoOp `AuthBridge` for the iOS framework. Always signed out.
+ *
+ * Placeholder pending the Swift implementation in the iOS app
+ * (`FirebaseAuthBridge.swift`), which will use Firebase Auth iOS SDK
+ * + Google Sign-In iOS. The iOS app will construct its `NativeComponent`
+ * with the Swift implementation instead of this NoOp.
+ *
+ * Pattern matches battery-butler's `NoOpAuthRepository` constant —
+ * keeps the DI graph constructable + buildable without a real Firebase
+ * iOS config (`GoogleService-Info.plist`).
+ */
+object NoOpAuthBridge : AuthBridge {
+    override fun observeAuthUser(): Flow<AuthUserInfo?> = flowOf(null)
+
+    override suspend fun signInWithGoogleToken(idToken: GoogleIdToken): Boolean = false
+
+    override fun getCurrentUser(): AuthUserInfo? = null
+
+    override suspend fun getIdToken(forceRefresh: Boolean): FirebaseIdToken? = null
+
+    override suspend fun signOut() = Unit
+}

--- a/AndroidGarage/iosFramework/src/iosShared/kotlin/com/chriscartland/garage/iosframework/NoOpMessagingBridge.kt
+++ b/AndroidGarage/iosFramework/src/iosShared/kotlin/com/chriscartland/garage/iosframework/NoOpMessagingBridge.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.iosframework
+
+import com.chriscartland.garage.data.MessagingBridge
+
+/**
+ * NoOp `MessagingBridge` for the iOS framework. No subscriptions,
+ * no tokens. Placeholder pending the Swift implementation
+ * (`FirebaseMessagingBridge.swift`), which will use FCM iOS SDK
+ * + APNs registration via the iOS AppDelegate.
+ */
+object NoOpMessagingBridge : MessagingBridge {
+    override suspend fun subscribeToTopic(topic: String): Boolean = false
+
+    override suspend fun unsubscribeFromTopic(topic: String) = Unit
+
+    override suspend fun getToken(): String? = null
+}


### PR DESCRIPTION
## Summary
- SKIE 0.10.9 plugin wiring (Kotlin StateFlow → Swift AsyncSequence + Combine; sealed → Swift enum)
- Full kotlin-inject `NativeComponent` for iOS that mirrors `AppComponent.kt` with iOS-friendly platform deps
- `IosNativeHelper` — single Swift-callable entry point to materialize the DI graph
- `NoOpAuthBridge` + `NoOpMessagingBridge` placeholders so the framework builds without a real Firebase iOS config
- **kotlin-inject downgrade 0.9.0 → 0.8.0** — 0.9.0's KLIBs require Kotlin 2.2+; this project is on Kotlin 2.1.20

## Why this is the last \"Kotlin only\" PR
After this lands, the iOS framework builds end-to-end with the full DI graph + all 5 ViewModels accessible from Swift. The next PR (Xcode project + Swift bridge implementations + first SwiftUI screen) requires user setup that's outside this PR's scope:
- Apple Developer account + signing
- Firebase iOS app registration + `GoogleService-Info.plist`
- Xcode project at `AndroidGarage/iosApp/` consuming the framework
- Swift Firebase Auth iOS + FCM iOS bridge implementations
- SwiftUI screens consuming the 5 ViewModels via `SharedViewModel<VM>`

## kotlin-inject downgrade — why
0.9.0's klibs were built with Kotlin 2.2.20. This project is on Kotlin 2.1.20. The Kotlin/Native KLIB resolver requires the consumer to be ≥ the klib's compile-time Kotlin version. With 0.9.0:
```
e: KLIB resolver: Could not find ".../kotlin-inject-runtime-iosSimulatorArm64Main-0.9.0.klib"
   in [<konan paths only>, no Gradle cache]
```
Confirmed by reproducing on this commit before the downgrade. 0.8.0 is the youngest pre-2.2 release on Maven Central — Android side unaffected (validated via full `validate.sh` run). A future Kotlin bump to 2.2+ should re-bump kotlin-inject back to 0.9+.

## `:iosFramework/build.gradle.kts`
- `baseName = \"shared\"`, `isStatic = false` (dynamic required because the framework `export`s other dependency symbols)
- Exports: `:domain`, `:viewmodel`, `:presentation-model`, `androidx.lifecycle.viewmodel`, `kermit`
- Implementation deps (pulled into binary, opaque to Swift): `:data`, `:data-local`, `:usecase`, kotlinx-coroutines-core, kermit, kotlin-inject
- KSP iOS targets for all 3 architectures

## `NativeComponent` (commonMain)
- Mirrors `AppComponent.kt` — same dependency graph, same `@SharedSingleton`-scoped state owners, same singleton-discipline rules in the KDoc
- Constructor takes iOS-friendly platform deps: `AuthBridge`, `MessagingBridge`, `DatabaseFactory`, `DataStoreFactory`, `AppConfig`, `appVersion`
- All 5 ViewModels exposed as abstract entry points
- `provideHttpClient(...)` uses `debug = false` (no `BuildConfig.DEBUG` on iOS; iOS app can flip this via `AppConfig` later)
- `provideAppClock(...)` and `provideSnoozeRepository(...)` use `kotlinx.datetime.Clock.System.now()` instead of `System.currentTimeMillis()`

## `IosNativeHelper` (iosShared)
- `createComponent(authBridge, messagingBridge, appConfig)` builds the KSP-generated `InjectNativeComponent`
- `currentAppVersion()` reads `CFBundleShortVersionString` + `CFBundleVersion` from `NSBundle.mainBundle`
- `defaultDevAppConfig` constant for early-iteration iOS builds (real Info.plist values must come before production)

## NoOp bridges
- `NoOpAuthBridge` — always signed-out
- `NoOpMessagingBridge` — no FCM subscriptions
- Pattern matches battery-butler's `NoOpAuthRepository` / `NoOpRemoteDataSource` constants

## Test plan
- [x] `validate.sh` — all 47 checks PASS (Android side unaffected by kotlin-inject downgrade)
- [x] `./gradlew :iosFramework:linkDebugFrameworkIosSimulatorArm64` — BUILD SUCCESSFUL
- [x] `shared.framework` produced at `iosFramework/build/bin/iosSimulatorArm64/debugFramework/shared.framework`
- [x] KSP-generated `InjectNativeComponent.kt` confirmed at `iosFramework/build/generated/ksp/iosSimulatorArm64/iosSimulatorArm64Main/kotlin/.../InjectNativeComponent.kt`

## Notes
- PR #822 (PR 3 from this stack) was bundled into PR #823's squash-merge and closed manually — its content (DAO suspend refactor, kotlinx-datetime, DatabaseFactory expect/actual) is on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)