### PR TITLE
chore(ci): Reduce CI artifact retention to 1 day for signed builds

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -135,6 +135,9 @@ jobs:
         with:
           name: debug-apk
           path: AndroidGarage/androidApp/build/outputs/apk/debug/
+          # Short retention: debug builds embed BuildConfig.SERVER_CONFIG_KEY
+          # too. Same exposure window applies on a public repo.
+          retention-days: 1
 
   build_release:
     name: Build Release AAB
@@ -162,3 +165,5 @@ jobs:
         with:
           name: release-aab
           path: AndroidGarage/androidApp/build/outputs/bundle/release/
+          # Short retention because the signed AAB embeds BuildConfig.SERVER_CONFIG_KEY.
+          retention-days: 1

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -69,12 +69,16 @@ jobs:
           echo "Renamed AAB files:"
           ls "$AAB_DIR"/*.aab
 
+      # Short retention because the signed AAB embeds BuildConfig.SERVER_CONFIG_KEY
+      # and is publicly fetchable for the retention window via the GitHub Actions
+      # artifacts API on a public repo. Play Store is the source of truth for the
+      # binary; this 1-day artifact exists only for same-day release-debugging.
       - name: Upload release AAB artifact
         uses: actions/upload-artifact@v6
         with:
           name: release-aab-${{ steps.validate.outputs.version_code }}
           path: AndroidGarage/androidApp/build/outputs/bundle/release/
-          retention-days: 30
+          retention-days: 1
 
       - name: Deploy to Google Play (Internal Track)
         uses: r0adkll/upload-google-play@v1.1.3


### PR DESCRIPTION
## Summary
Reduces GitHub Actions artifact retention to 1 day for any artifact that embeds `BuildConfig.SERVER_CONFIG_KEY`:
- `release-android.yml` signed release AAB: 30 → 1 day
- `ci-checks.yml` debug-apk: default → 1 day
- `ci-checks.yml` release-aab (built on PR validation): default → 1 day

Test-reports artifact retains the default window (no secrets).

## Why
This repo is public; GitHub Actions artifacts are fetchable for the retention window via the actions/artifacts API by anonymous callers. The signed AAB embeds `SERVER_CONFIG_KEY` (used as the `X-ServerConfigKey` header for `httpServerConfig`), and debug builds embed it too. Play Store / Play Console is the source of truth for the binary; the CI artifact exists only for same-day release-debugging.

Security audit reference: finding H3 (signed AAB retention).

## Test plan
- [x] Workflow YAML syntax check (Edit-tool diff inspection)
- [ ] First post-merge run will exercise the new retention setting (visible in Actions run summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)