### PR TITLE
chore(firestore): Make configCurrent unreadable to anonymous callers

### DIFF
--- a/FirebaseServer/firestore.rules
+++ b/FirebaseServer/firestore.rules
@@ -12,9 +12,13 @@ service cloud.firestore {
       allow write: if false;
       allow read: if true;
     }
+    // `configCurrent/` holds remoteButtonPushKey, all 4 allowlists, and the
+    // device buildTimestamp — none of which should be readable by anonymous
+    // Firestore REST callers. Clients (Android, ESP32) reach config through
+    // the `httpServerConfig` Cloud Function (gated by X-ServerConfigKey),
+    // which uses the Admin SDK and is unaffected by these rules.
     match /configCurrent/{document=**} {
-      allow write: if false;
-      allow read: if true;
+      allow read, write: if false;
     }
   }
 }


### PR DESCRIPTION
## Summary
Tightens `firestore.rules` for `/configCurrent/{document=**}`: read access removed (was `allow read: if true`).

## Why
Pre-change, any anonymous internet caller could hit Firestore REST and lift:
- `remoteButtonPushKey` (one half of door-control auth — the X-RemoteButtonPushKey header)
- All four email allowlists (`remoteButtonAuthorizedEmails`, `featureSnoozeAllowedEmails` if present, `featureFunctionListAllowedEmails`, `featureDeveloperAllowedEmails`)
- The device `buildTimestamp` (FCM topic seed + httpEcho event-forgery seed)

Reproduction (currently works on prod, will 403 after this PR deploys):
\`\`\`
curl 'https://firestore.googleapis.com/v1/projects/<PROJECT_ID>/databases/(default)/documents/configCurrent/current'
\`\`\`

Security audit reference: finding C3 (configCurrent publicly readable).

## Why this is safe
Android + ESP32 do NOT read Firestore directly — they reach config through the `httpServerConfig` Cloud Function (gated by the static `X-ServerConfigKey` header). Cloud Functions use the Admin SDK and bypass client-side rules. Firebase Console reads also use Admin SDK and are unaffected.

This is a defense-in-depth fix. The static `X-ServerConfigKey` exposure (audit finding C5) is a separate, larger architectural issue not covered by this PR.

## Out of scope
- `eventsCurrent` and `updateAll` remain `allow read: if true`. Door state is meant to be observable. Tightening those is a separate decision.

## Test plan
- [x] Diff inspection: single rule changed
- [ ] First deploy will require `firebase deploy --only firestore:rules` (or whatever the user's deploy flow is) — these rules don't auto-deploy on every PR merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)