### PR TITLE
chore(server): Stop logging ID tokens + emails; redact 500 error payloads

### DIFF
--- a/FirebaseServer/src/functions/http/ButtonHealth.ts
+++ b/FirebaseServer/src/functions/http/ButtonHealth.ts
@@ -125,6 +125,6 @@ export const httpButtonHealth = functions.https.onRequest(async (request, respon
     // Catches a propagated AuthService.verifyIdToken throw — yields 500,
     // matching handleAddRemoteButtonCommand's behavior.
     console.error(error);
-    response.status(500).send(error);
+    response.status(500).send({ error: 'Internal Server Error' });
   }
 });

--- a/FirebaseServer/src/functions/http/Echo.ts
+++ b/FirebaseServer/src/functions/http/Echo.ts
@@ -75,7 +75,7 @@ export const httpEcho = functions.https.onRequest(async (request, response) => {
     response.status(200).send(result);
   }
   catch (error) {
-    console.error(error)
-    response.status(500).send(error)
+    console.error(error);
+    response.status(500).send({ error: 'Internal Server Error' });
   }
 });

--- a/FirebaseServer/src/functions/http/Events.ts
+++ b/FirebaseServer/src/functions/http/Events.ts
@@ -182,7 +182,7 @@ export const httpCurrentEventData = functions.https.onRequest(async (request, re
     }
   } catch (error) {
     console.error(error);
-    response.status(500).send(error);
+    response.status(500).send({ error: 'Internal Server Error' });
   }
 });
 
@@ -199,7 +199,7 @@ export const httpEventHistory = functions.https.onRequest(async (request, respon
     }
   } catch (error) {
     console.error(error);
-    response.status(500).send(error);
+    response.status(500).send({ error: 'Internal Server Error' });
   }
 });
 
@@ -216,6 +216,6 @@ export const httpNextEvent = functions.https.onRequest(async (request, response)
     }
   } catch (error) {
     console.error(error);
-    response.status(500).send(error);
+    response.status(500).send({ error: 'Internal Server Error' });
   }
 });

--- a/FirebaseServer/src/functions/http/RemoteButton.ts
+++ b/FirebaseServer/src/functions/http/RemoteButton.ts
@@ -154,7 +154,7 @@ export const httpRemoteButton = functions.https.onRequest(async (request, respon
   }
   catch (error) {
     console.error(error);
-    response.status(500).send(error);
+    response.status(500).send({ error: 'Internal Server Error' });
   }
 });
 
@@ -206,7 +206,6 @@ export async function handleAddRemoteButtonCommand(input: {
     console.error(result);
     return err(403, result);
   }
-  console.log('googleIdToken:', input.googleIdTokenHeader);
   if (!input.googleIdTokenHeader || input.googleIdTokenHeader.length <= 0) {
     const result = { error: 'Unauthorized (token).' };
     console.error(result);
@@ -218,7 +217,6 @@ export async function handleAddRemoteButtonCommand(input: {
   // Snooze's handler wraps this call in try/catch and returns 401 instead.
   const decodedToken = await AuthService.verifyIdToken(input.googleIdTokenHeader);
   const email = decodedToken.email;
-  console.log('email:', email);
   const authorizedEmails = getRemoteButtonAuthorizedEmails(config);
   if (!isEmailInAllowlist(email, authorizedEmails)) {
     const result = { error: 'Forbidden (user).' };
@@ -304,6 +302,6 @@ export const httpAddRemoteButtonCommand = functions.https.onRequest(async (reque
     // escaped the function and Firebase runtime's own error handler
     // sent 500.
     console.error(error);
-    response.status(500).send(error);
+    response.status(500).send({ error: 'Internal Server Error' });
   }
 });

--- a/FirebaseServer/src/functions/http/ServerConfig.ts
+++ b/FirebaseServer/src/functions/http/ServerConfig.ts
@@ -143,6 +143,6 @@ export const httpServerConfigUpdate = functions.https.onRequest(async (request, 
     }
   } catch (error) {
     console.error(error);
-    response.status(500).send(error);
+    response.status(500).send({ error: 'Internal Server Error' });
   }
 });

--- a/FirebaseServer/src/functions/http/Snooze.ts
+++ b/FirebaseServer/src/functions/http/Snooze.ts
@@ -128,7 +128,6 @@ export async function handleSnoozeNotificationsRequest(input: {
         console.error(result);
         return err(403, result);
     }
-    console.log('googleIdToken:', input.googleIdTokenHeader);
     if (!input.googleIdTokenHeader || input.googleIdTokenHeader.length <= 0) {
         const result = { error: 'Unauthorized (token).' };
         console.error(result);
@@ -146,7 +145,6 @@ export async function handleSnoozeNotificationsRequest(input: {
         const result = { error: 'Unauthorized (token).' };
         return err(401, result);
     }
-    console.log('email:', email);
     const authorizedEmails = getRemoteButtonAuthorizedEmails(config);
     if (!isEmailInAllowlist(email, authorizedEmails)) {
         const result = { error: 'Forbidden (user).' };


### PR DESCRIPTION
## Summary
Three related server-side hardening fixes in one PR:

1. **Delete `console.log('googleIdToken:', ...)`** from `RemoteButton.ts:209` and `Snooze.ts:131`. The raw JWT bearer was written to Cloud Logs on every authenticated call.
2. **Delete `console.log('email:', email)`** from `RemoteButton.ts:221` and `Snooze.ts:149`. Email logged unhashed; other authenticated handlers (ButtonHealth, FunctionListAccess, DeveloperAccess) already didn't log it.
3. **Replace `.send(error)` → `.send({ error: 'Internal Server Error' })`** in 8 call sites across 7 handlers (Echo, Events×3, RemoteButton×2, ButtonHealth, ServerConfig). Raw `Error` objects were sending stack traces and internal Firestore paths back to clients. `console.error(error)` stays — server-side logs preserved.

OpenDoor.ts already showed the correct pattern; this brings the rest in line.

## Audit references
- **C1** — Firebase ID tokens logged in plaintext (Cloud Logs ~30d retention)
- **H4** — `response.status(500).send(error)` leaks stack traces
- Email logging was a sibling of C1 (not separately numbered)

## Test plan
- [x] `./scripts/firebase-npm.sh run build` — 0 errors (2 pre-existing warnings, unrelated)
- [x] `./scripts/firebase-npm.sh run tests` — 311 passing
- [ ] First deploy will require `firebase deploy --only functions` for the changes to reach prod

## Out of scope
- The other audit findings related to handler-side hardening (input validation, runWith caps, auth gates on debug endpoints) ship in separate PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)