### PR TITLE
chore(esp32): Move sensitive logs from ESP_LOGI to ESP_LOGD

### DIFF
--- a/GarageFirmware_ESP32/components/button_token/src/button_token.c
+++ b/GarageFirmware_ESP32/components/button_token/src/button_token.c
@@ -15,20 +15,25 @@ static void button_init(button_token_t *token) {
 
 static bool is_button_press_requested(button_token_t *token, const char *new_token) {
     if (strcmp(*token, new_token) == 0) {
-        ESP_LOGI(TAG, "Button token is not changed");
+        ESP_LOGD(TAG, "Button token is not changed");
         return false;
     } else if (strlen(new_token) == 0) {
-        ESP_LOGI(TAG, "Button press not requested because button token is empty");
+        ESP_LOGD(TAG, "Button press not requested because button token is empty");
         return false;
     } else {
-        ESP_LOGI(TAG, "Push the button for %s", new_token);
+        // Button token is sensitive — anyone with a UART connection (USB cable
+        // to the dev board) can read INFO-level logs. Log at DEBUG so the
+        // token only appears in builds that explicitly raise the log level
+        // above the default INFO threshold. Security audit reference: C2.
+        ESP_LOGD(TAG, "Push the button for %s", new_token);
         return true;
     }
 }
 
 static void consume_button_token(button_token_t *token, const char *new_token) {
     snprintf(*token, MAX_BUTTON_TOKEN_LENGTH, "%s", new_token);
-    ESP_LOGI(TAG, "Button token is now %s", *token);
+    // Sensitive — see is_button_press_requested above.
+    ESP_LOGD(TAG, "Button token is now %s", *token);
 }
 
 button_token_manager_t token_manager = {

--- a/GarageFirmware_ESP32/components/button_token/src/fake_button_token.c
+++ b/GarageFirmware_ESP32/components/button_token/src/fake_button_token.c
@@ -23,7 +23,8 @@ static void consume_button_token(button_token_t *token, const char *new_token) {
     // Alternate between requesting a button press and not requesting a button press
     request_button_press = !request_button_press;
     snprintf(*token, MAX_BUTTON_TOKEN_LENGTH, "%s", new_token);
-    ESP_LOGI(TAG, "Button token is now %s", *token);
+    // Match real implementation: token is sensitive, log at DEBUG.
+    ESP_LOGD(TAG, "Button token is now %s", *token);
 }
 
 button_token_manager_t token_manager = {

--- a/GarageFirmware_ESP32/components/garage_http_client/src/garage_http_client.c
+++ b/GarageFirmware_ESP32/components/garage_http_client/src/garage_http_client.c
@@ -108,7 +108,11 @@ void real_garage_server_send_sensor_values(sensor_request_t *sensor_request, sen
 }
 
 void real_garage_server_send_button_token(button_request_t *button_request, button_response_t *button_response, http_receive_buffer_t *recv_buffer) {
-    ESP_LOGI(TAG, "Send button token to server: device_id: %s, button_token: %s",
+    // device_id + button_token are sensitive — anyone with a UART connection
+    // can read INFO-level logs. Log at DEBUG so they only appear when the
+    // build raises the log level above the default INFO threshold.
+    // Security audit reference: C2.
+    ESP_LOGD(TAG, "Send button token to server: device_id: %s, button_token: %s",
              button_request->device_id,
              button_request->button_token);
 

--- a/GarageFirmware_ESP32/components/garage_http_client/src/https_post_request.c
+++ b/GarageFirmware_ESP32/components/garage_http_client/src/https_post_request.c
@@ -49,11 +49,14 @@ static esp_err_t _http_event_handler(esp_http_client_event_t *evt) {
         break;
 
     case HTTP_EVENT_ON_HEADER:
-        ESP_LOGI(TAG, "HTTP_EVENT_ON_HEADER, key=%s, value=%s", evt->header_key, evt->header_value);
+        // Response headers + body can contain server-issued button-ack tokens
+        // and other sensitive material. Log at DEBUG so they only appear in
+        // builds that raise the log level above INFO. Security audit ref: C2.
+        ESP_LOGD(TAG, "HTTP_EVENT_ON_HEADER, key=%s, value=%s", evt->header_key, evt->header_value);
         break;
 
     case HTTP_EVENT_ON_DATA:
-        ESP_LOGI(TAG, "HTTP_EVENT_ON_DATA, len=%d", evt->data_len);
+        ESP_LOGD(TAG, "HTTP_EVENT_ON_DATA, len=%d", evt->data_len);
 
         // Check for buffer overflow
         if (recv_buffer->data_received_len + evt->data_len > recv_buffer->buffer_len) {
@@ -64,7 +67,8 @@ static esp_err_t _http_event_handler(esp_http_client_event_t *evt) {
         // Copy the new data into the buffer
         memcpy(recv_buffer->buffer + recv_buffer->data_received_len, evt->data, evt->data_len);
         recv_buffer->data_received_len += evt->data_len;
-        ESP_LOGI(TAG, "Current buffer content: %.*s", recv_buffer->data_received_len, recv_buffer->buffer);
+        // Sensitive — see HTTP_EVENT_ON_HEADER above.
+        ESP_LOGD(TAG, "Current buffer content: %.*s", recv_buffer->data_received_len, recv_buffer->buffer);
         break;
 
     case HTTP_EVENT_ON_FINISH:


### PR DESCRIPTION
## Summary
Button tokens (the server-issued auth credentials for relay activation), `device_id`, and HTTP response headers/bodies should not appear in default INFO-level UART output. ESP-IDF's default log level is INFO; `ESP_LOGD` calls are compiled out unless the build explicitly raises the log level above INFO via menuconfig.

## Files changed
- **`button_token.c`** — `is_button_press_requested` + `consume_button_token` token-content logs: 3× `ESP_LOGI` → `ESP_LOGD`
- **`fake_button_token.c`** — matches the real implementation's level
- **`garage_http_client.c`** — `real_garage_server_send_button_token` device_id + button_token log: 1× `ESP_LOGI` → `ESP_LOGD`
- **`https_post_request.c`** — `HTTP_EVENT_ON_HEADER` (header key/value) and `HTTP_EVENT_ON_DATA` (full response body dump): 2× `ESP_LOGI` → `ESP_LOGD`. `HTTP_EVENT_ON_CONNECTED` / `_ON_FINISH` / `_DISCONNECTED` left at INFO — those carry only event name + byte count, no sensitive content.

## NOT changed
**`wifi_connector.c`** — the existing ternary `(WIFI_PASS[0] == '\0') ? "<empty>" : "********"` already masks the password when non-empty. The security audit's claim that the mask fires only on empty passwords was a misread. No fix needed.

The audit's separate concern about flash containing the password unencrypted (no `CONFIG_SECURE_FLASH_ENC_ENABLED`) is a different fix and is tracked as Medium finding M11.

## Audit reference
- **C2** — sensitive content in UART logs

## Test plan
- [x] Diff review (changes are mechanical log-level swaps; no logic changes)
- [ ] Flash to a dev board and `idf.py monitor` to confirm the token + body lines no longer appear at default log level (requires user hardware access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)