### PR TITLE
chore(android): Set Kermit MinSeverity=Warn in release builds

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/GarageApplication.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/GarageApplication.kt
@@ -18,6 +18,8 @@
 package com.chriscartland.garage
 
 import android.app.Application
+import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
 import com.chriscartland.garage.di.AppComponent
 import com.chriscartland.garage.di.create
 
@@ -29,9 +31,30 @@ class GarageApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        configureLogging()
         // Warm the DataStore cache so settings are available before first composition.
         // DataStore reads are local file I/O — typically <10ms.
         // This ensures card expand/collapse state is correct on first render.
         component
+    }
+
+    /**
+     * Set a Kermit MinSeverity floor for release builds.
+     *
+     * Kermit defaults to Verbose, meaning every `Logger.v/d/i` call reaches
+     * logcat in release builds. Several of those calls in this codebase
+     * render `data class.toString()` for ServerConfig (carries
+     * `remoteButtonPushKey`), AuthState (carries user email), and FCM
+     * tokens — sensitive material that should not be readable via
+     * `adb logcat` on a production install. See the 2026-05-14 security
+     * audit, finding H1.
+     *
+     * Debug builds keep the full Verbose firehose so developers can see
+     * every log line during local iteration.
+     */
+    private fun configureLogging() {
+        if (!BuildConfig.DEBUG) {
+            Logger.setMinSeverity(Severity.Warn)
+        }
     }
 }


### PR DESCRIPTION
## Summary
In `GarageApplication.onCreate()`, gate Kermit to `MinSeverity = Warn` when `!BuildConfig.DEBUG`. Release builds drop `Logger.v/d/i` calls; debug builds keep the full verbose firehose.

## Why
Kermit defaults to Verbose in this codebase — no `MinSeverity` is set anywhere. Several `Logger.i/d` call sites render `data class.toString()` containing sensitive material:

| File | What leaks |
|---|---|
| `CachedServerConfigRepository.kt:82` | `Logger.i { "serverConfig <- $config" }` — includes `remoteButtonPushKey` |
| `FirebaseAuthRepository.kt:82, :107` | `Logger.i { "authState <- $newState" }` — includes user email |
| `FCMService.kt:42` + `FirebaseMessagingBridge.kt:60` | `Logger.d { "FCM Instance Token: $token" }` |

All of these reach logcat in release. Anything with `READ_LOGS` (rare on stock Android 4.1+, available on rooted devices, and `adb logcat` on USB-connected devices) can lift the push key, user email, and FCM token.

Security audit reference: H1 (sensitive data in Android logs).

## Defense-in-depth note
This is a coarse fix that protects across all current and future `Logger.d/i` calls. The more surgical fix — overriding `ServerConfig.toString()` to mask `remoteButtonPushKey` specifically — ships as the audit-item-5 PR per user instruction (after this PR + the other 5 in the bundle land first).

## Test plan
- [x] `./scripts/validate.sh` — all 47 checks pass
- [x] Debug build of `GarageApplication.kt` — Severity import + `Logger.setMinSeverity(Severity.Warn)` call resolve correctly
- [ ] Real device smoke test (post-merge): `adb logcat` on a release-installed APK should NOT show the push key or auth state lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)