### PR TITLE
chore(android): Override ServerConfig.toString() to mask remoteButtonPushKey

### DIFF
--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/ServerConfig.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/ServerConfig.kt
@@ -1,7 +1,38 @@
 package com.chriscartland.garage.domain.model
 
+/**
+ * Server-derived config the device fetches at startup.
+ *
+ * `remoteButtonPushKey` is the shared secret sent in the
+ * `X-RemoteButtonPushKey` header on every door-control HTTP call —
+ * combined with the user's Firebase ID token + email allowlist it gates
+ * the relay-activation path. It must NOT appear in logs.
+ *
+ * Auto-generated `equals` / `hashCode` / `copy` / `componentN` keep the
+ * full field set as Kotlin data classes always do — only `toString` is
+ * overridden, because `toString` is the only path through which the
+ * push key leaked (audit finding H1 / C1: `Logger.i { "config <- $config" }`
+ * patterns rendered the auto-generated toString into logcat).
+ */
 data class ServerConfig(
     val buildTimestamp: String,
     val remoteButtonBuildTimestamp: String,
     val remoteButtonPushKey: String,
-)
+) {
+    /**
+     * Override the auto-generated toString to mask `remoteButtonPushKey`.
+     *
+     * Distinguishes empty from non-empty so a future "push key is empty
+     * in prod" bug stays diagnosable from logs:
+     *   - Empty   → `remoteButtonPushKey=<empty>`
+     *   - Present → `remoteButtonPushKey=***`
+     */
+    override fun toString(): String {
+        val maskedKey = if (remoteButtonPushKey.isEmpty()) "<empty>" else "***"
+        return "ServerConfig(" +
+            "buildTimestamp=$buildTimestamp, " +
+            "remoteButtonBuildTimestamp=$remoteButtonBuildTimestamp, " +
+            "remoteButtonPushKey=$maskedKey" +
+            ")"
+    }
+}

--- a/AndroidGarage/domain/src/commonTest/kotlin/com/chriscartland/garage/domain/model/ServerConfigTest.kt
+++ b/AndroidGarage/domain/src/commonTest/kotlin/com/chriscartland/garage/domain/model/ServerConfigTest.kt
@@ -1,0 +1,82 @@
+package com.chriscartland.garage.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins ServerConfig's `toString` behavior: the auto-generated
+ * data-class toString leaks `remoteButtonPushKey` (the X-RemoteButtonPushKey
+ * shared secret) via `Logger.i { "config <- $config" }` patterns. The
+ * custom toString masks it; these tests fail loudly if a future refactor
+ * "fixes" the override away.
+ *
+ * Security audit reference: H1 / C1.
+ */
+class ServerConfigTest {
+    @Test
+    fun toStringMasksPushKey() {
+        val config = ServerConfig(
+            buildTimestamp = "Sat Mar 13 14:45:00 2021",
+            remoteButtonBuildTimestamp = "Sat Apr 10 23:57:32 2021",
+            remoteButtonPushKey = "super-secret-shared-key-abc123",
+        )
+        val rendered = config.toString()
+        assertFalse(
+            "super-secret-shared-key-abc123" in rendered,
+            "toString must not expose the push key (audit H1/C1); got: $rendered",
+        )
+        assertTrue(
+            "remoteButtonPushKey=***" in rendered,
+            "Non-empty push key should render as '***'; got: $rendered",
+        )
+    }
+
+    @Test
+    fun toStringDistinguishesEmptyPushKey() {
+        val config = ServerConfig(
+            buildTimestamp = "x",
+            remoteButtonBuildTimestamp = "y",
+            remoteButtonPushKey = "",
+        )
+        val rendered = config.toString()
+        assertTrue(
+            "remoteButtonPushKey=<empty>" in rendered,
+            "Empty push key should render as '<empty>' for diagnostic clarity; got: $rendered",
+        )
+    }
+
+    @Test
+    fun toStringStillIncludesNonSecretFields() {
+        // buildTimestamp + remoteButtonBuildTimestamp are device identifiers
+        // (FCM topic seeds) but not credentials. They stay visible so the
+        // log line remains useful for diagnosing config issues.
+        val config = ServerConfig(
+            buildTimestamp = "build-1",
+            remoteButtonBuildTimestamp = "build-2",
+            remoteButtonPushKey = "secret",
+        )
+        val rendered = config.toString()
+        assertTrue("build-1" in rendered, "buildTimestamp should be visible; got: $rendered")
+        assertTrue(
+            "build-2" in rendered,
+            "remoteButtonBuildTimestamp should be visible; got: $rendered",
+        )
+    }
+
+    @Test
+    fun equalsAndHashCodeAreUnaffectedByToStringOverride() {
+        // The data-class auto-generated equals/hashCode/copy operate on
+        // the actual field values, not toString output. Override only
+        // touches toString. This test pins the contract so a future
+        // refactor doesn't accidentally break MutableStateFlow dedup.
+        val a = ServerConfig("b1", "b2", "secret")
+        val b = ServerConfig("b1", "b2", "secret")
+        val c = ServerConfig("b1", "b2", "different-secret")
+        assertEquals(a, b, "equals should compare actual values")
+        assertEquals(a.hashCode(), b.hashCode())
+        assertFalse(a == c, "equals should detect a different push key")
+        assertFalse(a.hashCode() == c.hashCode(), "hashCode should differ on different secret")
+    }
+}


### PR DESCRIPTION
## Summary
Surgical fix for audit item 5: override `data class ServerConfig`'s auto-generated `toString()` to mask `remoteButtonPushKey`. Wait until PRs #827–#832 (items 1–4 + 6–9) are merged first — this is the post-bundle precision fix.

## Why
The Kotlin `data class` auto-generated `toString` includes every field. `remoteButtonPushKey` is the shared secret in the X-RemoteButtonPushKey header. Several call sites passed `ServerConfig` through a string template (e.g. `Logger.i { "serverConfig <- $config" }` in `CachedServerConfigRepository.kt:82`), rendering the key into logcat.

PR #832 (Kermit `MinSeverity=Warn`) covers this broadly by silencing `Logger.i/d` in release builds. **This PR is the precision fix** — even if a future `Logger.w(...)` or exception message ever renders ServerConfig, the push key stays masked. Defense-in-depth; both fixes ship and both should be maintained.

## Mask policy
- Empty push key → `remoteButtonPushKey=<empty>` (diagnostic clarity — a future "key is empty in prod" bug stays diagnosable from logs)
- Non-empty key → `remoteButtonPushKey=***`

## What's NOT changed
Auto-generated `equals` / `hashCode` / `copy` / `componentN` are unaffected by the toString override. Pinned by a regression test (`equalsAndHashCodeAreUnaffectedByToStringOverride`) asserting:
- `equals` still returns `true` on identical secrets
- `equals` still returns `false` on different secrets
- `hashCode` differs on different secrets

This preserves the `MutableStateFlow` dedup behavior and any other equality-based logic.

## Tests
4 new tests in `ServerConfigTest.kt`:
- `toStringMasksPushKey` — push-key literal must not appear in toString
- `toStringDistinguishesEmptyPushKey`
- `toStringStillIncludesNonSecretFields` (`buildTimestamp` + `remoteButtonBuildTimestamp` remain visible — they're FCM topic seeds, not credentials)
- `equalsAndHashCodeAreUnaffectedByToStringOverride`

## Audit reference
- **H1** — sensitive data in Android logs (push key rendered via data-class toString)
- **C1** — sibling issue on the server side; closed by PR #829

Verified via `./scripts/validate.sh` (all 47 checks pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)