### PR TITLE
chore(server): Add runWith caps to every HTTP function

### DIFF
--- a/FirebaseServer/src/functions/HttpRuntime.ts
+++ b/FirebaseServer/src/functions/HttpRuntime.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2026 Chris Cartland. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { RuntimeOptions } from 'firebase-functions/v1';
+
+/**
+ * Shared runtime caps for every HTTP Cloud Function in this project.
+ *
+ * Security audit reference: H1 (no body-size limit, maxInstances, or
+ * timeout configured anywhere — DoS / billing-amplification surface).
+ *
+ * Conservative values chosen so legitimate traffic is never throttled:
+ *
+ *   maxInstances: 50
+ *     Default is 3000 — effectively unbounded for billing purposes. This
+ *     app has one ESP32 device polling every ~5 s, one Android user
+ *     making rare door-control calls, and rare maintenance calls.
+ *     Realistic concurrent load is single-digit; 50 is ~10× headroom.
+ *
+ *   timeoutSeconds: 60
+ *     v1 default. Each handler's actual work is a few Firestore reads /
+ *     writes (sub-second). 60 s is generous; long enough to ride out
+ *     Firestore cold-start latency.
+ *
+ *   memory: '256MB'
+ *     v1 default. Handlers are stateless and call Firestore SDK + send
+ *     a response; no heavy allocations. Bump per-function only if
+ *     Cloud Logging shows OOM signals.
+ *
+ * If a future change adds a handler that legitimately exceeds these
+ * (e.g. a long-running batch endpoint), declare its own RuntimeOptions
+ * at the call site rather than relaxing the shared default.
+ */
+export const HTTP_RUNTIME_OPTS: RuntimeOptions = {
+  maxInstances: 50,
+  timeoutSeconds: 60,
+  memory: '256MB',
+};

--- a/FirebaseServer/src/functions/http/ButtonHealth.ts
+++ b/FirebaseServer/src/functions/http/ButtonHealth.ts
@@ -21,6 +21,7 @@ import {
 import { isEmailInAllowlist } from '../../controller/Auth';
 import { SERVICE as AuthService } from '../../controller/AuthService';
 import { HandlerResult, ok, err } from '../HandlerResult';
+import { HTTP_RUNTIME_OPTS } from '../HttpRuntime';
 
 const BUILD_TIMESTAMP_PARAM_KEY = 'buildTimestamp';
 const DATABASE_TIMESTAMP_SECONDS_KEY = 'FIRESTORE_databaseTimestampSeconds';
@@ -109,7 +110,7 @@ export async function handleButtonHealth(input: {
  * curl -H "X-RemoteButtonPushKey: <key>" -H "X-AuthTokenGoogle: <id-token>" \
  *   "https://.../buttonHealth?buildTimestamp=<bt>"
  */
-export const httpButtonHealth = functions.https.onRequest(async (request, response) => {
+export const httpButtonHealth = functions.runWith(HTTP_RUNTIME_OPTS).https.onRequest(async (request, response) => {
   try {
     const result = await handleButtonHealth({
       query: request.query,

--- a/FirebaseServer/src/functions/http/DeleteData.ts
+++ b/FirebaseServer/src/functions/http/DeleteData.ts
@@ -26,6 +26,7 @@ import { deleteOldData } from '../../controller/DatabaseCleaner';
 import { isEmailInAllowlist } from '../../controller/Auth';
 import { SERVICE as AuthService } from '../../controller/AuthService';
 import { HandlerResult, ok, err } from '../HandlerResult';
+import { HTTP_RUNTIME_OPTS } from '../HttpRuntime';
 
 export interface DeleteOldDataResult {
   dryRun: boolean;
@@ -98,7 +99,7 @@ export async function handleDeleteOldData(input: {
   });
 }
 
-export const httpDeleteOldData = functions.https.onRequest(async (request, response) => {
+export const httpDeleteOldData = functions.runWith(HTTP_RUNTIME_OPTS).https.onRequest(async (request, response) => {
   try {
     const result = await handleDeleteOldData({
       query: request.query,

--- a/FirebaseServer/src/functions/http/DeveloperAccess.ts
+++ b/FirebaseServer/src/functions/http/DeveloperAccess.ts
@@ -21,6 +21,7 @@ import { getDeveloperAuthorizedEmails } from '../../controller/config/ConfigAcce
 import { SERVICE as AuthService } from '../../controller/AuthService';
 import { isEmailInAllowlist } from '../../controller/Auth';
 import { HandlerResult, ok, err } from '../HandlerResult';
+import { HTTP_RUNTIME_OPTS } from '../HttpRuntime';
 
 export interface DeveloperAccessResponse {
   enabled: boolean;
@@ -80,7 +81,7 @@ export async function handleDeveloperAccess(input: {
  * curl -H "X-AuthTokenGoogle: <id_token>" \
  *      "http://localhost:5000/PROJECT-ID/us-central1/developerAccess"
  */
-export const httpDeveloperAccess = functions.https.onRequest(async (request, response) => {
+export const httpDeveloperAccess = functions.runWith(HTTP_RUNTIME_OPTS).https.onRequest(async (request, response) => {
   const result = await handleDeveloperAccess({
     method: request.method,
     googleIdTokenHeader: request.get('X-AuthTokenGoogle'),

--- a/FirebaseServer/src/functions/http/Echo.ts
+++ b/FirebaseServer/src/functions/http/Echo.ts
@@ -19,6 +19,7 @@ import { v4 as uuidv4 } from 'uuid';
 import * as functions from 'firebase-functions/v1';
 
 import { DATABASE as UpdateDatabase } from '../../database/UpdateDatabase';
+import { HTTP_RUNTIME_OPTS } from '../HttpRuntime';
 
 const SESSION_PARAM_KEY = "session";
 const BUILD_TIMESTAMP_PARAM_KEY = "buildTimestamp";
@@ -66,7 +67,7 @@ export async function handleEchoRequest(input: {
 /**
  * HTTP endpoint captures request parameters, stores them in the database, and returns the data.
  */
-export const httpEcho = functions.https.onRequest(async (request, response) => {
+export const httpEcho = functions.runWith(HTTP_RUNTIME_OPTS).https.onRequest(async (request, response) => {
   try {
     const result = await handleEchoRequest({
       query: request.query,

--- a/FirebaseServer/src/functions/http/Events.ts
+++ b/FirebaseServer/src/functions/http/Events.ts
@@ -24,6 +24,7 @@ import { SensorSnapshot } from '../../model/SensorSnapshot';
 
 import { getNewEventOrNull } from '../../controller/EventInterpreter';
 import { HandlerResult, ok, err } from '../HandlerResult';
+import { HTTP_RUNTIME_OPTS } from '../HttpRuntime';
 
 const SESSION_PARAM_KEY = "session";
 const BUILD_TIMESTAMP_PARAM_KEY = "buildTimestamp";
@@ -172,7 +173,7 @@ export async function handleNextEvent(input: {
 /**
  * curl -H "Content-Type: application/json" http://localhost:5001/PROJECT-ID/us-central1/currentEventData?session=ABC&buildTimestamp=123&eventHistoryMaxCount=12
  */
-export const httpCurrentEventData = functions.https.onRequest(async (request, response) => {
+export const httpCurrentEventData = functions.runWith(HTTP_RUNTIME_OPTS).https.onRequest(async (request, response) => {
   try {
     const result = await handleCurrentEventData({ query: request.query, body: request.body });
     if (result.kind === 'error') {
@@ -189,7 +190,7 @@ export const httpCurrentEventData = functions.https.onRequest(async (request, re
 /**
  * curl -H "Content-Type: application/json" http://localhost:5001/PROJECT-ID/us-central1/eventHistory?session=ABC&buildTimestamp=123&eventHistoryMaxCount=20
  */
-export const httpEventHistory = functions.https.onRequest(async (request, response) => {
+export const httpEventHistory = functions.runWith(HTTP_RUNTIME_OPTS).https.onRequest(async (request, response) => {
   try {
     const result = await handleEventHistory({ query: request.query, body: request.body });
     if (result.kind === 'error') {
@@ -206,7 +207,7 @@ export const httpEventHistory = functions.https.onRequest(async (request, respon
 /**
  * curl -H "Content-Type: application/json" http://localhost:5000/PROJECT-ID/us-central1/event?session=ABC
  */
-export const httpNextEvent = functions.https.onRequest(async (request, response) => {
+export const httpNextEvent = functions.runWith(HTTP_RUNTIME_OPTS).https.onRequest(async (request, response) => {
   try {
     const result = await handleNextEvent({ query: request.query, body: request.body });
     if (result.kind === 'error') {

--- a/FirebaseServer/src/functions/http/FunctionListAccess.ts
+++ b/FirebaseServer/src/functions/http/FunctionListAccess.ts
@@ -21,6 +21,7 @@ import { getFunctionListAuthorizedEmails } from '../../controller/config/ConfigA
 import { SERVICE as AuthService } from '../../controller/AuthService';
 import { isEmailInAllowlist } from '../../controller/Auth';
 import { HandlerResult, ok, err } from '../HandlerResult';
+import { HTTP_RUNTIME_OPTS } from '../HttpRuntime';
 
 export interface FunctionListAccessResponse {
   enabled: boolean;
@@ -79,7 +80,7 @@ export async function handleFunctionListAccess(input: {
  * curl -H "X-AuthTokenGoogle: <id_token>" \
  *      "http://localhost:5000/PROJECT-ID/us-central1/functionListAccess"
  */
-export const httpFunctionListAccess = functions.https.onRequest(async (request, response) => {
+export const httpFunctionListAccess = functions.runWith(HTTP_RUNTIME_OPTS).https.onRequest(async (request, response) => {
   const result = await handleFunctionListAccess({
     method: request.method,
     googleIdTokenHeader: request.get('X-AuthTokenGoogle'),

--- a/FirebaseServer/src/functions/http/OpenDoor.ts
+++ b/FirebaseServer/src/functions/http/OpenDoor.ts
@@ -28,6 +28,7 @@ import {
 import { isEmailInAllowlist } from '../../controller/Auth';
 import { SERVICE as AuthService } from '../../controller/AuthService';
 import { HandlerResult, ok, err } from '../HandlerResult';
+import { HTTP_RUNTIME_OPTS } from '../HttpRuntime';
 
 // History: a DOOR_SENSOR_BUILD_TIMESTAMP_FALLBACK = 'Sat Mar 13 14:45:00 2021'
 // constant lived here through server/16. Removed in A3 after
@@ -94,7 +95,7 @@ export async function handleCheckForOpenDoorsRequest(input: {
   return ok(await sendFCMForOldData(buildTimestamp, eventData));
 }
 
-export const httpCheckForOpenDoors = functions.https.onRequest(async (request, response) => {
+export const httpCheckForOpenDoors = functions.runWith(HTTP_RUNTIME_OPTS).https.onRequest(async (request, response) => {
   try {
     const result = await handleCheckForOpenDoorsRequest({
       pushKeyHeader: request.get('X-RemoteButtonPushKey'),

--- a/FirebaseServer/src/functions/http/RemoteButton.ts
+++ b/FirebaseServer/src/functions/http/RemoteButton.ts
@@ -28,6 +28,7 @@ import { SERVICE as AuthService } from '../../controller/AuthService';
 
 import { RemoteButtonCommand } from '../../model/RemoteButtonCommand';
 import { HandlerResult, ok, err } from '../HandlerResult';
+import { HTTP_RUNTIME_OPTS } from '../HttpRuntime';
 
 const DATABASE_TIMESTAMP_SECONDS_KEY = 'FIRESTORE_databaseTimestampSeconds';
 const SESSION_PARAM_KEY = "session";
@@ -140,7 +141,7 @@ export async function handleRemoteButtonPoll(input: {
 /**
  * curl -H "Content-Type: application/json" http://localhost:5000/PROJECT-ID/us-central1/remoteButton?buildTimestamp=buildTimestamp&buttonAckToken=buttonAckToken
  */
-export const httpRemoteButton = functions.https.onRequest(async (request, response) => {
+export const httpRemoteButton = functions.runWith(HTTP_RUNTIME_OPTS).https.onRequest(async (request, response) => {
   try {
     const result = await handleRemoteButtonPoll({
       query: request.query,
@@ -282,7 +283,7 @@ export async function handleAddRemoteButtonCommand(input: {
 /**
  * curl -H "Content-Type: application/json" http://localhost:5000/PROJECT-ID/us-central1/addRemoteButtonCommand?buildTimestamp=buildTimestamp&buttonAckToken=buttonAckToken
  */
-export const httpAddRemoteButtonCommand = functions.https.onRequest(async (request, response) => {
+export const httpAddRemoteButtonCommand = functions.runWith(HTTP_RUNTIME_OPTS).https.onRequest(async (request, response) => {
   try {
     const result = await handleAddRemoteButtonCommand({
       query: request.query,

--- a/FirebaseServer/src/functions/http/ServerConfig.ts
+++ b/FirebaseServer/src/functions/http/ServerConfig.ts
@@ -18,6 +18,7 @@ import * as functions from 'firebase-functions/v1';
 
 import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
 import { HandlerResult, ok, err } from '../HandlerResult';
+import { HTTP_RUNTIME_OPTS } from '../HttpRuntime';
 
 /**
  * Helper — navigate `functions.config()` to the `serverconfig.<field>`
@@ -112,7 +113,7 @@ export async function handleServerConfigUpdate(input: {
   return ok(config);
 }
 
-export const httpServerConfig = functions.https.onRequest(async (request, response) => {
+export const httpServerConfig = functions.runWith(HTTP_RUNTIME_OPTS).https.onRequest(async (request, response) => {
   const expectedKey = readServerConfigSecret(functions.config(), 'key');
   const result = await handleServerConfigRead({
     method: request.method,
@@ -126,7 +127,7 @@ export const httpServerConfig = functions.https.onRequest(async (request, respon
   }
 });
 
-export const httpServerConfigUpdate = functions.https.onRequest(async (request, response) => {
+export const httpServerConfigUpdate = functions.runWith(HTTP_RUNTIME_OPTS).https.onRequest(async (request, response) => {
   const expectedKey = readServerConfigSecret(functions.config(), 'updatekey');
   try {
     const result = await handleServerConfigUpdate({

--- a/FirebaseServer/src/functions/http/Snooze.ts
+++ b/FirebaseServer/src/functions/http/Snooze.ts
@@ -22,6 +22,7 @@ import { isEmailInAllowlist } from '../../controller/Auth';
 import { SERVICE as AuthService } from '../../controller/AuthService';
 import { getSnoozeStatus, SnoozeLatestParams, SnoozeLatestResponse, SubmitSnoozeParams, submitSnoozeNotificationsRequest, SubmitSnoozeResponse } from '../../controller/SnoozeNotifications';
 import { HandlerResult, ok, err } from '../HandlerResult';
+import { HTTP_RUNTIME_OPTS } from '../HttpRuntime';
 
 const BUILD_TIMESTAMP_PARAM_KEY = "buildTimestamp";
 const SNOOZE_DURATION_PARAM_KEY = 'snoozeDuration';
@@ -72,7 +73,7 @@ export async function handleSnoozeNotificationsLatest(input: {
  *    -H "Content-Type: application/json" \
  *    -d '{}' \ "http://localhost:5000/PROJECT-ID/us-central1/snoozeNotificationsLatest?buildTimestamp=Sat%20Mar%2013%2014%3A45%3A00%202021"
  */
-export const httpSnoozeNotificationsLatest = functions.https.onRequest(async (request, response) => {
+export const httpSnoozeNotificationsLatest = functions.runWith(HTTP_RUNTIME_OPTS).https.onRequest(async (request, response) => {
   const result = await handleSnoozeNotificationsLatest({
     method: request.method,
     query: request.query,
@@ -196,7 +197,7 @@ export async function handleSnoozeNotificationsRequest(input: {
 /**
  * curl -H "Content-Type: application/json" http://localhost:5000/PROJECT-ID/us-central1/snoozeNotificationsLatest?buildTimestamp=buildTimestamp
  */
-export const httpSnoozeNotificationsRequest = functions.https.onRequest(async (request, response) => {
+export const httpSnoozeNotificationsRequest = functions.runWith(HTTP_RUNTIME_OPTS).https.onRequest(async (request, response) => {
     const result = await handleSnoozeNotificationsRequest({
         method: request.method,
         query: request.query,


### PR DESCRIPTION
## Summary
Final security-audit PR (item 10). Adds `functions.runWith({maxInstances: 50, timeoutSeconds: 60, memory: '256MB'}).https.onRequest(...)` to all 15 HTTP function exports across 10 handler files. Replaces the un-capped `functions.https.onRequest(...)` pattern that left the project's billing exposure unbounded.

## Why
Pre-audit defaults were:
- `maxInstances: 3000` — effectively unbounded for billing
- `timeoutSeconds: 60` (= default; not pinned)
- `memory: 256MB` (= default; not pinned)

A single attacker hitting `httpEcho` (the ESP32 ingestion path, intentionally token-free per design) could drive a real Cloud Functions bill. Audit finding H1.

## Implementation
- New shared constant `HTTP_RUNTIME_OPTS` in `src/functions/HttpRuntime.ts` (single source of truth)
- All 15 HTTP exports wrap `functions.runWith(HTTP_RUNTIME_OPTS).https.onRequest(...)` instead of `functions.https.onRequest(...)`
- Pubsub functions intentionally NOT touched — externally unreachable (Cloud Scheduler + GCP pubsub identity), not a DoS surface

## Values chosen
| Knob | Value | Rationale |
|---|---|---|
| `maxInstances` | 50 | ~10× headroom over normal load (1 ESP32 + 1 user). Default was 3000; even at 50 the billing-runaway window shrinks 60×. |
| `timeoutSeconds` | 60 | = v1 default; pinned explicitly so a future Firebase default change doesn't widen the cap silently. |
| `memory` | `'256MB'` | = v1 default; same reason. Handlers are stateless Firestore calls — no heavy allocations. |

## Behavior change
- **Normal traffic**: no observable change. 50 instances >> realistic concurrent load.
- **Flood attack**: function plateaus at 50 concurrent instances instead of spiraling to 3000. Worst-case bill bounded by `50 × timeoutSeconds × memory/sec`.

## Rollout plan (post-merge)
1. Deploy. Watch Cloud Logging for `Concurrent invocation limit exceeded` errors for 7 days.
2. If no signal → tighten `maxInstances` to 10–20 per-function in a follow-up PR.
3. If legitimate throttling occurs → bump that specific function back up.

## Audit reference
- **H1** — no body-size limit, maxInstances, or timeout configured

## Test plan
- [x] `firebase-npm.sh run build` — 0 errors (2 pre-existing warnings unrelated)
- [x] `firebase-npm.sh run tests` — 319 passing
- [ ] Post-deploy: monitor Cloud Logging for throttling signals for ~7 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)