### PR TITLE
chore(android): Konsist pilot — additive ADR-026 check

### DIFF
--- a/AndroidGarage/androidApp/build.gradle.kts
+++ b/AndroidGarage/androidApp/build.gradle.kts
@@ -271,6 +271,9 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(project(":test-common"))
+    // Konsist pilot — see androidApp/src/test/.../konsist/. Additive to the
+    // existing buildSrc/ Gradle tasks; both checks coexist by design.
+    testImplementation(libs.konsist)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/konsist/ScreenViewModelCardinalityKonsistTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/konsist/ScreenViewModelCardinalityKonsistTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.chriscartland.garage.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import org.junit.Test
+
+/**
+ * Konsist pilot: ADR-026 "one ViewModel per screen" — Konsist version.
+ *
+ * Same rule as the existing `checkScreenViewModelCardinality` Gradle task
+ * (in `buildSrc/src/main/kotlin/architecture/ScreenViewModelCheckTask.kt`).
+ * Intentionally additive — both checks run; this test exists to evaluate
+ * Konsist as a complement to the bespoke `buildSrc/` tasks.
+ *
+ * Rule: each `*Content.kt` screen Composable file under
+ * `androidApp/src/main/.../ui/` may import at most one type from
+ * `com.chriscartland.garage.viewmodel.*` whose name ends in `ViewModel`.
+ * The `Default` prefix is stripped so `AuthViewModel` (interface) +
+ * `DefaultAuthViewModel` (impl) collapse to one logical VM.
+ *
+ * Tradeoff observations (left for future-PR judgment):
+ *  - Konsist's `file.imports` is typed/structural — no regex false-positive
+ *    surface (the legacy task could be fooled by `import ...ViewModelKt`
+ *    or `import ...ViewModelStore` if the project ever pulled those names
+ *    into scope; this check ignores them naturally because they don't end
+ *    in `ViewModel` literally — but the same regex defense in the legacy
+ *    task is reactive, not structural).
+ *  - The Konsist scope's per-test parse cost is ~5-15s; subsequent
+ *    assertions in the same test class amortize it. The legacy task
+ *    scans files at task-execution time with no parser — faster cold,
+ *    no amortization across other checks.
+ *  - Exemptions: the legacy task supports per-file exemption via
+ *    `screen-viewmodel-exemptions.txt` (currently empty as of android/213
+ *    / 2.15.3). The Konsist version below does NOT honor that file —
+ *    intentional, since the file has been empty for the entire pilot
+ *    window. If a future legacy multi-VM screen lands, add it to BOTH
+ *    enforcement points (legacy file + a Konsist `withoutNameMatching`
+ *    filter) or replace this test entirely.
+ */
+class ScreenViewModelCardinalityKonsistTest {
+    @Test
+    fun `each Content kt file imports at most one ViewModel`() {
+        val violations = Konsist
+            .scopeFromProduction()
+            .files
+            .filter { it.name.endsWith("Content.kt") }
+            .mapNotNull { file ->
+                val viewModels = file.imports
+                    .map { it.name }
+                    .filter { it.startsWith("com.chriscartland.garage.viewmodel.") }
+                    .map { it.substringAfterLast('.') }
+                    .filter { it.endsWith("ViewModel") }
+                    .map { it.removePrefix("Default") }
+                    .distinct()
+                if (viewModels.size > 1) {
+                    file.path to viewModels
+                } else {
+                    null
+                }
+            }
+
+        if (violations.isNotEmpty()) {
+            val message = buildString {
+                appendLine("ADR-026 violation: screen Composable file(s) import more than one ViewModel.")
+                appendLine()
+                violations.forEach { (path, vms) ->
+                    appendLine("  $path → ${vms.size} VMs: ${vms.sorted().joinToString(", ")}")
+                }
+                appendLine()
+                appendLine("Aggregate the UseCases this screen needs inside a single ViewModel.")
+                appendLine("Detected by Konsist; the legacy buildSrc check enforces the same rule.")
+            }
+            throw AssertionError(message)
+        }
+    }
+}

--- a/AndroidGarage/gradle/libs.versions.toml
+++ b/AndroidGarage/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ kotlinxDatetime = "0.6.2"
 skie = "0.10.9"
 junit = "4.13.2"
 junitVersion = "1.2.1"
+konsist = "0.17.3"
 kotlin = "2.1.20"
 ksp = "2.1.20-1.0.32"
 lifecycle = "2.9.1"
@@ -107,6 +108,7 @@ ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+konsist = { group = "com.lemonappdev", name = "konsist", version.ref = "konsist" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }
 mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }


### PR DESCRIPTION
## Summary
Adds [Konsist 0.17.3](https://github.com/LemonAppDev/konsist) as a `testImplementation` of `:androidApp` and a **single** test that mirrors the existing `checkScreenViewModelCardinality` Gradle task.

**Intentionally additive.** Both checks run on every PR. The legacy `checkScreenViewModelCardinality` Gradle task in `buildSrc/` stays in place. Goal: evaluate Konsist's ergonomics against the bespoke `buildSrc/` task suite without losing coverage.

## Why this rule for the pilot
Per the earlier audit discussion: of the ~25 architecture checks in `buildSrc/`, only ~5-7 map cleanly to Konsist's typed-PSI vocabulary. The "one ViewModel per `*Content.kt`" rule (ADR-026) is the cleanest fit — Konsist's `file.imports` API replaces ~80 lines of regex + file-walk in the legacy task with ~10 lines of typed inspection. If Konsist clicks here, it would justify migrating the other 5-7 candidates. If it doesn't, the cost is one test file + one library dep.

## What it does
```kotlin
Konsist.scopeFromProduction()
    .files
    .filter { it.name.endsWith("Content.kt") }
    .mapNotNull { file ->
        val vms = file.imports
            .map { it.name }
            .filter { it.startsWith("com.chriscartland.garage.viewmodel.") }
            .map { it.substringAfterLast('.') }
            .filter { it.endsWith("ViewModel") }
            .map { it.removePrefix("Default") }
            .distinct()
        if (vms.size > 1) file.path to vms else null
    }
```
Then throws `AssertionError` with the violating files + their VM imports if any have >1.

## Known gap vs. legacy task
The legacy `ScreenViewModelCheckTask` supports per-file exemption via `screen-viewmodel-exemptions.txt` (currently empty as of `android/213` / 2.15.3). The Konsist test does **not** honor that file. If a future legacy multi-VM screen lands, add it to BOTH places — or replace this pilot test entirely. Documented inline in the test KDoc.

## Verified locally
- `./gradlew :androidApp:testDebugUnitTest --tests '*KonsistTest'` → **1 passing in 0.624s** (after scope parse).
- `./scripts/validate.sh` → **all 47 checks pass** (including the legacy `Screen ↔ ViewModel check`).

## Files
- `gradle/libs.versions.toml`: `konsist = "0.17.3"` + library coordinate
- `androidApp/build.gradle.kts`: `testImplementation(libs.konsist)`
- `androidApp/src/test/.../konsist/ScreenViewModelCardinalityKonsistTest.kt`: the new test

## Test plan
- [x] Konsist test passes locally
- [x] validate.sh passes (legacy check + Konsist test both green)
- [ ] CI passes on this PR

## Out of scope
- Removing the legacy `checkScreenViewModelCardinality` Gradle task — explicitly NOT doing this per user instruction. Decision deferred until after the pilot's CI experience informs the call.
- Porting other `buildSrc/` checks to Konsist — pilot first, then decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)