### PR TITLE
test(android): RoomSchemaTest — assert migration declared for every schema version pair

### DIFF
--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/db/RoomSchemaTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/db/RoomSchemaTest.kt
@@ -65,6 +65,14 @@ class RoomSchemaTest {
 
     private val schemaDir = File("../data-local/schemas/com.chriscartland.garage.datalocal.AppDatabase")
 
+    private val appDatabaseSource = File(
+        "../data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/AppDatabase.kt",
+    )
+
+    private val databaseFactorySource = File(
+        "../data-local/src/androidMain/kotlin/com/chriscartland/garage/datalocal/DatabaseFactory.android.kt",
+    )
+
     private val json = Json { ignoreUnknownKeys = true }
 
     private fun latestSchemaVersion(): Int {
@@ -151,5 +159,178 @@ class RoomSchemaTest {
             latestFile,
             jsonVersion,
         )
+    }
+
+    /**
+     * Every consecutive schema version pair must have a migration path —
+     * either an `@AutoMigration` declared in `AppDatabase.kt` or an
+     * explicit `Migration` registered on the database builder.
+     *
+     * Why this matters: `DatabaseFactory.android.kt` uses
+     * `fallbackToDestructiveMigration(false)`, which **drops every
+     * Room-managed table** on any version mismatch with no declared
+     * migration — not just the changed one. Adding a column with a
+     * default value to `AppEvent` without declaring an `@AutoMigration`
+     * would silently wipe the user's `DoorEvent` history too. PR #660
+     * caught this in review; this test catches it in CI.
+     *
+     * This is a structural check, not a runtime migration test. It
+     * verifies the developer remembered to declare the migration; it
+     * does NOT execute the migration. For non-trivial migrations
+     * (column renames, type changes), Room rejects auto-migration at
+     * build time and forces an explicit `Migration` class — which this
+     * test also accepts.
+     */
+    @Test
+    fun everyVersionPairHasDeclaredMigration() {
+        require(appDatabaseSource.exists()) {
+            "Cannot find AppDatabase.kt at ${appDatabaseSource.absolutePath}. " +
+                "If the file moved, update RoomSchemaTest.appDatabaseSource."
+        }
+        require(databaseFactorySource.exists()) {
+            "Cannot find DatabaseFactory.android.kt at ${databaseFactorySource.absolutePath}. " +
+                "If the file moved, update RoomSchemaTest.databaseFactorySource."
+        }
+
+        val declaredAutoMigrations = parseDeclaredAutoMigrations(appDatabaseSource.readText())
+        val declaredCustomMigrations =
+            parseCustomMigrationPairs(databaseFactorySource.readText())
+        val declared = declaredAutoMigrations + declaredCustomMigrations
+
+        val versions = schemaDir
+            .listFiles { f -> f.extension == "json" }
+            ?.mapNotNull { it.nameWithoutExtension.toIntOrNull() }
+            ?.sorted()
+            ?: emptyList()
+        assertTrue("Need at least one schema file in $schemaDir", versions.isNotEmpty())
+
+        // Verify the chain is continuous from the lowest known schema
+        // to the latest. Gaps mean a schema version was deleted in the
+        // wrong order (e.g., removed v10 before all users upgraded past
+        // it) — the chain would never reach `version = 12` from a
+        // device still on v10.
+        val gaps = (versions.first()..versions.last()).filterNot { it in versions }
+        assertTrue(
+            "Schema files form a non-contiguous chain. Missing version JSONs: $gaps. " +
+                "Schema files present: $versions. Either restore the missing schemas " +
+                "or update the floor (delete older schemas in order from lowest).",
+            gaps.isEmpty(),
+        )
+
+        // For every consecutive pair, require a declared migration.
+        val missing = mutableListOf<Pair<Int, Int>>()
+        for (i in 0 until versions.size - 1) {
+            val from = versions[i]
+            val to = versions[i + 1]
+            if ((from to to) !in declared) {
+                missing += from to to
+            }
+        }
+        assertTrue(
+            buildString {
+                appendLine("No migration declared for version pair(s): $missing.")
+                appendLine()
+                appendLine(
+                    "DatabaseFactory.android.kt uses fallbackToDestructiveMigration(false), " +
+                        "which drops every table on any version mismatch with no migration. " +
+                        "Add one of:",
+                )
+                appendLine("  1. @AutoMigration(from = N, to = N+1) to AppDatabase.autoMigrations")
+                appendLine("     (works for additive, schema-preserving changes — adding columns")
+                appendLine("     with defaults, adding tables, adding/removing indexes).")
+                appendLine("  2. A Migration class registered via .addMigrations(...) in")
+                appendLine("     DatabaseFactory.android.kt (needed for renames, type changes).")
+                appendLine()
+                appendLine("Schemas found: $versions")
+                appendLine("Declared auto-migrations: $declaredAutoMigrations")
+                appendLine("Declared custom migrations: $declaredCustomMigrations")
+            },
+            missing.isEmpty(),
+        )
+    }
+
+    /**
+     * Parses `autoMigrations = [AutoMigration(from = X, to = Y), ...]`
+     * out of `AppDatabase.kt`. Tolerant of whitespace and trailing
+     * commas; rejects spec-class variants (those carry user-written
+     * code, which this test cannot inspect).
+     */
+    internal fun parseDeclaredAutoMigrations(source: String): Set<Pair<Int, Int>> {
+        // Match `AutoMigration(from = N, to = M)` — order-sensitive
+        // for now. Room also accepts `AutoMigration(from = N, to = M, spec = SomeSpec::class)`;
+        // the regex covers that case by allowing extra args.
+        val regex = Regex(
+            """AutoMigration\s*\(\s*from\s*=\s*(\d+)\s*,\s*to\s*=\s*(\d+)""",
+        )
+        return regex
+            .findAll(stripKotlinComments(source))
+            .map { it.groupValues[1].toInt() to it.groupValues[2].toInt() }
+            .toSet()
+    }
+
+    /**
+     * Parses pairs from `.addMigrations(MIGRATION_X_Y, ...)` calls in
+     * `DatabaseFactory.android.kt`. By convention, custom Migrations
+     * use the `MIGRATION_<from>_<to>` name pattern.
+     */
+    internal fun parseCustomMigrationPairs(source: String): Set<Pair<Int, Int>> {
+        val regex = Regex("""MIGRATION_(\d+)_(\d+)""")
+        return regex
+            .findAll(stripKotlinComments(source))
+            .map { it.groupValues[1].toInt() to it.groupValues[2].toInt() }
+            .toSet()
+    }
+
+    // Removes Kotlin block and line comments from [source]. Required
+    // because a commented-out `AutoMigration(...)` declaration must
+    // not be treated as a real declaration — that's the exact bug
+    // class this test exists to catch.
+    //
+    // Block comments use a non-greedy match. Kotlin block comments
+    // don't nest — the first close terminates — and this stripper
+    // matches that behavior.
+    internal fun stripKotlinComments(source: String): String =
+        source
+            .replace(Regex("""/\*[\s\S]*?\*/"""), "")
+            .replace(Regex("""//[^\n]*"""), "")
+
+    @Test
+    fun parserIgnoresCommentedOutAutoMigrations() {
+        // Lock down the comment-stripping behavior. Without this,
+        // a future "simplify the parser" refactor could silently
+        // reintroduce the bug where `// AutoMigration(from = X, to = Y)`
+        // counts as a declaration.
+        val source =
+            """
+            autoMigrations = [
+                AutoMigration(from = 1, to = 2),
+                // AutoMigration(from = 2, to = 3), // commented out!
+                /* AutoMigration(from = 3, to = 4), */
+            ],
+            """.trimIndent()
+        val parsed = parseDeclaredAutoMigrations(source)
+        assertEquals(setOf(1 to 2), parsed)
+    }
+
+    @Test
+    fun parserHandlesAutoMigrationWithSpec() {
+        // Room supports `AutoMigration(from = X, to = Y, spec = MySpec::class)`.
+        // The pair (X, Y) should still parse correctly.
+        val source = "AutoMigration(from = 5, to = 6, spec = MyAutoMigrationSpec::class)"
+        assertEquals(setOf(5 to 6), parseDeclaredAutoMigrations(source))
+    }
+
+    @Test
+    fun parserHandlesCustomMigrationConstantNames() {
+        val source =
+            """
+            .addMigrations(
+                MIGRATION_3_4,
+                MIGRATION_4_5,
+                // MIGRATION_5_6 disabled while we figure out the column type
+            )
+            """.trimIndent()
+        val parsed = parseCustomMigrationPairs(source)
+        assertEquals(setOf(3 to 4, 4 to 5), parsed)
     }
 }


### PR DESCRIPTION
## Summary

Adds a structural check that catches the PR #660 data-loss class at PR time. `DatabaseFactory.android.kt` uses `fallbackToDestructiveMigration(false)`, which drops every Room-managed table on any version mismatch with no declared migration. Bumping `@Database(version = N+1)` while forgetting to declare the matching `@AutoMigration` (or `Migration` class) would silently wipe ALL user data — not just the changed table.

The new `RoomSchemaTest.everyVersionPairHasDeclaredMigration` parses `AppDatabase.kt` for declared `AutoMigration(from = X, to = Y)` entries and `DatabaseFactory.android.kt` for `MIGRATION_X_Y` constants, then asserts coverage against the schema JSON files. Comment-stripping pass means commented-out declarations don't count.

## Why this design (vs runtime MigrationTestHelper)

Tried Room KMP's `MigrationTestHelper` first — the KMP API isn't visible from the Android JVM unit-test source set (the Android `Instrumentation`-coupled API shadows it). The instrumented variant works but requires a device, so it runs only in post-merge CI / `run-instrumented-tests.sh` — not at PR time.

A static check catches the actual bug class (forgetting the annotation) at PR time without any device or emulator. Trade-off: doesn't catch "AutoMigration declared but doesn't preserve data," but for additive changes Room's auto-migration is correct by construction, and non-trivial changes (renames, type changes) are rejected by Room at build time anyway.

## Empirical verification

Commented out the existing `AutoMigration(from = 11, to = 12)` declaration → test failed with this message:
```
No migration declared for version pair(s): [(11, 12)].

DatabaseFactory.android.kt uses fallbackToDestructiveMigration(false), which drops every table on any version mismatch with no migration. Add one of:
  1. @AutoMigration(from = N, to = N+1) to AppDatabase.autoMigrations
     (works for additive, schema-preserving changes — adding columns
     with defaults, adding tables, adding/removing indexes).
  2. A Migration class registered via .addMigrations(...) in
     DatabaseFactory.android.kt (needed for renames, type changes).

Schemas found: [11, 12]
Declared auto-migrations: []
Declared custom migrations: []
```
Restored the declaration → test passes. Three small parser unit tests lock in the comment-stripping and `spec = X::class` handling for future refactors.

## Test plan

- [x] `./scripts/validate.sh` passes locally
- [x] All 9 `RoomSchemaTest` cases pass (6 existing + 3 new parser tests + the coverage check)
- [x] Empirically verified test fails when AutoMigration is removed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)