### PR TITLE
test(viewmodel): no-flicker initial-value tests for Home + DoorHistory VMs

### DIFF
--- a/AndroidGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/DoorHistoryViewModelTest.kt
+++ b/AndroidGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/DoorHistoryViewModelTest.kt
@@ -85,6 +85,14 @@ class DoorHistoryViewModelTest {
     private fun createViewModel(
         scope: CoroutineScope,
         fetchOnInit: Boolean = true,
+        // Default true to keep existing behavior. The no-flicker
+        // tests pass false so they can observe the VM's state
+        // immediately after construction, before the
+        // `viewModelScope.launch(dispatchers.io) { collect ... }`
+        // body has executed. That's the state a real Composable
+        // sees on first composition in production (where the IO
+        // launch races the first-frame read of .value).
+        runScheduler: Boolean = true,
     ): DefaultDoorHistoryViewModel {
         val stalenessManager = CheckInStalenessManager(
             observeDoorEvents = ObserveDoorEventsUseCase(doorRepository),
@@ -111,9 +119,49 @@ class DoorHistoryViewModelTest {
             liveClock = liveClock,
             fetchOnInit = fetchOnInit,
         )
-        testDispatcher.scheduler.runCurrent()
+        if (runScheduler) {
+            testDispatcher.scheduler.runCurrent()
+        }
         return vm
     }
+
+    /**
+     * Reads `viewModel.recentDoorEvents.value` BEFORE
+     * `runCurrent()` — simulates the production race where the
+     * Composable's first composition reads `.value` before the
+     * `viewModelScope.launch(dispatchers.io) { collect { ... } }`
+     * body has had a chance to fire on the IO thread.
+     *
+     * Bug class this guards (ADR-023 / PR #739): if
+     * `_recentDoorEvents` is seeded with `Loading(emptyList())`,
+     * the first-composition read returns the empty list, the
+     * history `LazyColumn` renders zero items for one frame, then
+     * the IO launch lands `Complete(actualList)` and the list
+     * pops in. Visible flicker on every fresh `NavBackStackEntry`.
+     *
+     * Correct: seed from `observeDoorEvents.recent().value` so
+     * the synchronous initial value is `Complete(cachedList)`.
+     */
+    @Test
+    fun initialRecentDoorEventsValueIsCompleteFromUpstreamCache() =
+        runTest {
+            // testDoorEvent is pre-seeded into the repo in setup().
+            val viewModel = createViewModel(
+                scope = backgroundScope,
+                fetchOnInit = false,
+                runScheduler = false,
+            )
+
+            val initial = viewModel.recentDoorEvents.value
+            assertTrue(
+                initial is LoadingResult.Complete,
+                "Expected Complete on construction (no flicker), was $initial. " +
+                    "If this fails, the VM's mirror MutableStateFlow is probably " +
+                    "seeded with Loading(...) instead of Complete(upstream.value). " +
+                    "See ADR-023 / PR #739.",
+            )
+            assertEquals(listOf(testDoorEvent), initial.data)
+        }
 
     @Test
     fun collectsRecentDoorEventsFromRepository() =

--- a/AndroidGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/HomeViewModelTest.kt
+++ b/AndroidGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/HomeViewModelTest.kt
@@ -110,6 +110,14 @@ class HomeViewModelTest {
         scope: CoroutineScope,
         authState: AuthState = AuthState.Unauthenticated,
         fetchOnInit: Boolean = true,
+        // Default true to keep existing behavior. The no-flicker
+        // tests pass false so they can observe the VM's state
+        // immediately after construction, before the
+        // `viewModelScope.launch(dispatchers.io) { collect ... }`
+        // body has executed. That's the state a real Composable
+        // sees on first composition in production (where the IO
+        // launch races the first-frame read of .value).
+        runScheduler: Boolean = true,
     ): DefaultHomeViewModel {
         authRepository.setAuthState(authState)
         val stalenessManager = CheckInStalenessManager(
@@ -152,7 +160,9 @@ class HomeViewModelTest {
             appVersion = "test",
             fetchOnInit = fetchOnInit,
         )
-        testDispatcher.scheduler.runCurrent()
+        if (runScheduler) {
+            testDispatcher.scheduler.runCurrent()
+        }
         return vm
     }
 
@@ -248,6 +258,46 @@ class HomeViewModelTest {
 
             // LiveClock backed by AppClock { 0L }: initial value is 0.
             assertEquals(0L, viewModel.nowEpochSeconds.value)
+        }
+
+    /**
+     * Reads `viewModel.currentDoorEvent.value` BEFORE
+     * `runCurrent()` — simulates the production race where the
+     * Composable's first composition reads `.value` before the
+     * `viewModelScope.launch(dispatchers.io) { collect { ... } }`
+     * body has had a chance to fire on the IO thread.
+     *
+     * Bug class this guards (ADR-023 / 2.4.4 Home-tab flicker;
+     * PR #738 mirror seed fix): if `_currentDoorEvent` is seeded
+     * with `Loading(null)`, the first-composition read returns
+     * `Loading(null)` → maps to UNKNOWN/MIDWAY door icon, then the
+     * IO launch lands `Complete(actualEvent)` → maps to OPEN/CLOSED,
+     * and `LaunchedEffect(doorPosition)` in `GarageIcon` visibly
+     * animates MIDWAY → actual on every fresh `NavBackStackEntry`.
+     *
+     * Correct: seed from `observeDoorEvents.current().value` so
+     * the synchronous initial value is `Complete(cachedValue)`,
+     * not `Loading(null)`.
+     */
+    @Test
+    fun initialCurrentDoorEventValueIsCompleteFromUpstreamCache() =
+        runTest {
+            // testDoorEvent is pre-seeded into the repo in setup().
+            val viewModel = createViewModel(
+                scope = backgroundScope,
+                fetchOnInit = false,
+                runScheduler = false,
+            )
+
+            val initial = viewModel.currentDoorEvent.value
+            assertTrue(
+                initial is LoadingResult.Complete,
+                "Expected Complete on construction (no flicker), was $initial. " +
+                    "If this fails, the VM's mirror MutableStateFlow is probably " +
+                    "seeded with Loading(...) instead of Complete(upstream.value). " +
+                    "See ADR-023 / 2.4.4 regression.",
+            )
+            assertEquals(testDoorEvent, initial.data)
         }
 
     @Test


### PR DESCRIPTION
## Summary

Catches the ADR-023 / 2.4.4 Home-tab `LoadingResult` flicker class (and the PR #738/#739 mirror-seed fix) at PR time.

**The bug class:** VMs that mirror a singleton repo's `StateFlow` into a `LoadingResult` need to seed the `MutableStateFlow` with `Complete(upstream.value)`, NOT `Loading(null)`. If seeded with Loading, the first-composition read returns Loading → maps to UNKNOWN/MIDWAY door icon (Home) or empty list (History), then the IO-launched `collect { ... }` body lands `Complete(actualValue)`, and `LaunchedEffect(doorPosition)` in `GarageIcon` visibly animates MIDWAY → actual on every fresh `NavBackStackEntry`.

**The new tests** construct the VM with `runScheduler = false` (no `runCurrent()`), simulating production where the Composable's first composition reads `.value` before the `viewModelScope.launch(IO) { collect { ... } }` body has fired on a background thread. They read `.value` immediately and assert it's `Complete(cachedValue)`, not `Loading(...)`.

## Empirical verification

- ✅ Tests pass on current correct code (seed = `Complete(upstream.value)`).
- ✅ Tests fail with helpful messages when both VMs are reverted to `Loading(null)` / `Loading(emptyList())`:
  ```
  Expected Complete on construction (no flicker), was Loading(d=null).
  If this fails, the VM's mirror MutableStateFlow is probably seeded
  with Loading(...) instead of Complete(upstream.value).
  See ADR-023 / 2.4.4 regression.
  ```

## Other changes

Added a `runScheduler: Boolean = true` parameter to each test's `createViewModel` helper. Existing tests pass the default and keep their `runCurrent()` behavior — only the new no-flicker tests skip it.

## Test plan

- [x] `./scripts/validate.sh` passes end-to-end
- [x] New tests catch the bug (verified by reverting both VMs)
- [x] Existing tests still pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)