### PR TITLE
test(android): Audit door-animation trajectory (opening + closing)

### DIFF
--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/GarageDoorAnimationBehaviorTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/GarageDoorAnimationBehaviorTest.kt
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.dp
+import com.chriscartland.garage.domain.model.DoorPosition
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import java.time.Duration
+
+/**
+ * Audit of the live garage-door animation **trajectory** — the behavior the
+ * user actually sees, not just the static target mappings.
+ *
+ * `GarageDoorAnimationMappingTest` (a JVM unit test) pins the pure
+ * `DoorAnimation.*For` mappings. This test pins the *wiring* in
+ * [GarageIcon] / `AnimatedDoorIcon`: the `remember { Animatable(initial) }`
+ * seed plus the `LaunchedEffect(doorPosition)` that drives `animateTo`.
+ * That wiring is where "the animation sometimes plays, sometimes doesn't"
+ * lives, and it is unobservable from screenshot tests (they render
+ * `static = true` and Layoutlib can't advance a `LaunchedEffect`).
+ *
+ * Mechanism: drive `mainClock` manually (`autoAdvance = false`), flip
+ * `doorPosition`, advance virtual time in steps, and read the live offset
+ * back through the [DoorOffsetSemanticsKey] test-support semantics property.
+ *
+ * ## Behavior matrix this audit pins (see `docs/DOOR_ANIMATION.md`)
+ *
+ * | Entry scenario                         | OPENING                | CLOSING                |
+ * |----------------------------------------|------------------------|------------------------|
+ * | Fresh composition already in motion    | snap to OPEN, no move  | snap to CLOSED, no move|
+ * | Live transition while composed         | tween CLOSED→OPEN      | tween OPEN→CLOSED       |
+ *
+ * The "fresh composition" row is the documented 2.16.4 / ADR-025 behavior:
+ * `initialPositionFor == targetPositionFor`, so a cold-open / tab-switch /
+ * back-nav into an in-motion state renders at the target with only the arrow
+ * overlay as the motion cue — it does NOT replay the slide. The "live
+ * transition" row is the case where the slide is visible. This is why the
+ * animation "sometimes works": it depends entirely on whether the icon was
+ * already alive when the state changed.
+ *
+ * **Instrumented — requires a connected device/emulator.** Not part of
+ * `validate.sh`; runs via `./scripts/run-instrumented-tests.sh` and the
+ * post-merge instrumented job. (validate.sh DOES compile this source set, so
+ * a signature break is still caught pre-submit.)
+ */
+class GarageDoorAnimationBehaviorTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    // Short virtual duration keeps the audit fast; the curve shape is
+    // identical to the production 12s tween, just compressed.
+    private val testDuration: Duration = Duration.ofMillis(1000)
+    private val stepMs = 250L
+    private val steps = 6 // 6 * 250 = 1500ms > duration, so the tween completes
+
+    // --- Fresh composition in a motion state: snaps, no slide -----------------
+
+    @Test
+    fun freshComposition_opening_rendersAtTarget_withNoMotion() {
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            GarageIcon(
+                doorPosition = DoorPosition.OPENING,
+                modifier = Modifier.size(ICON_DP.dp),
+                duration = testDuration,
+            )
+        }
+        composeTestRule.mainClock.advanceTimeByFrame()
+
+        // Seeded at the target (OPEN) and stays there across the full window.
+        assertEquals(OPEN_POSITION, composeTestRule.doorOffset(), EPS)
+        val samples = composeTestRule.sampleOffsets()
+        assertNoMotion(samples, expected = OPEN_POSITION)
+    }
+
+    @Test
+    fun freshComposition_closing_rendersAtTarget_withNoMotion() {
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            GarageIcon(
+                doorPosition = DoorPosition.CLOSING,
+                modifier = Modifier.size(ICON_DP.dp),
+                duration = testDuration,
+            )
+        }
+        composeTestRule.mainClock.advanceTimeByFrame()
+
+        assertEquals(CLOSED_POSITION, composeTestRule.doorOffset(), EPS)
+        val samples = composeTestRule.sampleOffsets()
+        assertNoMotion(samples, expected = CLOSED_POSITION)
+    }
+
+    // --- Live transition while composed: slides ------------------------------
+
+    @Test
+    fun liveTransition_closedToOpening_slidesOpen() {
+        val state = mutableStateOf(DoorPosition.CLOSED)
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            GarageIcon(
+                doorPosition = state.value,
+                modifier = Modifier.size(ICON_DP.dp),
+                duration = testDuration,
+            )
+        }
+        composeTestRule.mainClock.advanceTimeByFrame()
+        // Settled closed before the transition.
+        assertEquals(CLOSED_POSITION, composeTestRule.doorOffset(), EPS)
+
+        composeTestRule.runOnUiThread { state.value = DoorPosition.OPENING }
+        composeTestRule.mainClock.advanceTimeByFrame() // relaunch LaunchedEffect
+
+        val samples = composeTestRule.sampleOffsets()
+        // Door slides up: offset decreases CLOSED(0.0) → OPEN(-0.75).
+        assertMonotonic(samples, decreasing = true)
+        assertMotionOccurred(samples)
+        assertEquals(OPEN_POSITION, samples.last(), EPS)
+    }
+
+    @Test
+    fun liveTransition_openToClosing_slidesClosed() {
+        val state = mutableStateOf(DoorPosition.OPEN)
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            GarageIcon(
+                doorPosition = state.value,
+                modifier = Modifier.size(ICON_DP.dp),
+                duration = testDuration,
+            )
+        }
+        composeTestRule.mainClock.advanceTimeByFrame()
+        assertEquals(OPEN_POSITION, composeTestRule.doorOffset(), EPS)
+
+        composeTestRule.runOnUiThread { state.value = DoorPosition.CLOSING }
+        composeTestRule.mainClock.advanceTimeByFrame()
+
+        val samples = composeTestRule.sampleOffsets()
+        // Door slides down: offset increases OPEN(-0.75) → CLOSED(0.0).
+        assertMonotonic(samples, decreasing = false)
+        assertMotionOccurred(samples)
+        assertEquals(CLOSED_POSITION, samples.last(), EPS)
+    }
+
+    // --- Direction flip mid-slide: reverses toward the new target ------------
+
+    @Test
+    fun liveTransition_openingThenClosing_reversesTowardClosed() {
+        val state = mutableStateOf(DoorPosition.CLOSED)
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            GarageIcon(
+                doorPosition = state.value,
+                modifier = Modifier.size(ICON_DP.dp),
+                duration = testDuration,
+            )
+        }
+        composeTestRule.mainClock.advanceTimeByFrame()
+
+        // Start opening, advance to roughly mid-slide.
+        composeTestRule.runOnUiThread { state.value = DoorPosition.OPENING }
+        composeTestRule.mainClock.advanceTimeByFrame()
+        composeTestRule.mainClock.advanceTimeBy(stepMs * 2) // ~halfway
+        val midway = composeTestRule.doorOffset()
+        assertTrue(
+            "expected mid-slide between OPEN and CLOSED, was $midway",
+            midway < CLOSED_POSITION - EPS && midway > OPEN_POSITION + EPS,
+        )
+
+        // Flip to closing — the tween reverses toward CLOSED.
+        composeTestRule.runOnUiThread { state.value = DoorPosition.CLOSING }
+        composeTestRule.mainClock.advanceTimeByFrame()
+        val samples = composeTestRule.sampleOffsets()
+        assertMonotonic(samples, decreasing = false) // heads back toward CLOSED(0.0)
+        assertEquals(CLOSED_POSITION, samples.last(), EPS)
+    }
+
+    // --- helpers --------------------------------------------------------------
+
+    private fun ComposeContentTestRule.doorOffset(): Float =
+        onNode(SemanticsMatcher.keyIsDefined(DoorOffsetSemanticsKey))
+            .fetchSemanticsNode()
+            .config[DoorOffsetSemanticsKey]
+
+    /** Advance the clock in [steps] of [stepMs], collecting the offset each tick. */
+    private fun ComposeContentTestRule.sampleOffsets(): List<Float> {
+        val out = mutableListOf(doorOffset())
+        repeat(steps) {
+            mainClock.advanceTimeBy(stepMs)
+            out += doorOffset()
+        }
+        return out
+    }
+
+    private fun assertNoMotion(
+        samples: List<Float>,
+        expected: Float,
+    ) {
+        samples.forEachIndexed { i, v ->
+            assertEquals("sample[$i] drifted from pinned target: $samples", expected, v, EPS)
+        }
+    }
+
+    private fun assertMonotonic(
+        samples: List<Float>,
+        decreasing: Boolean,
+    ) {
+        for (i in 1 until samples.size) {
+            val ok =
+                if (decreasing) {
+                    samples[i] <= samples[i - 1] + EPS
+                } else {
+                    samples[i] >= samples[i - 1] - EPS
+                }
+            assertTrue(
+                "non-monotonic (${if (decreasing) "decreasing" else "increasing"}) " +
+                    "at index $i: $samples",
+                ok,
+            )
+        }
+    }
+
+    private fun assertMotionOccurred(samples: List<Float>) {
+        val travel = kotlin.math.abs(samples.first() - samples.last())
+        assertTrue("expected visible travel, samples barely moved: $samples", travel > 0.1f)
+    }
+
+    private companion object {
+        const val EPS = 0.01f
+        const val ICON_DP = 200
+    }
+}

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/GarageIcon.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/GarageIcon.kt
@@ -32,6 +32,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.ui.theme.LocalDoorStatusColorScheme
@@ -120,6 +123,17 @@ private fun AnimatedDoorIcon(
     )
 }
 
+/**
+ * Test-support semantics: publishes the live door offset so the
+ * instrumented animation audit ([GarageDoorAnimationBehaviorTest]) can read
+ * the actual `Animatable` value the real wiring produces frame-by-frame.
+ * The trajectory is otherwise unobservable — screenshot tests render
+ * `static = true` and can't advance a `LaunchedEffect`. Production cost is
+ * one Float in the semantics tree per icon; nothing reads it at runtime.
+ */
+val DoorOffsetSemanticsKey = SemanticsPropertyKey<Float>("DoorOffset")
+private var SemanticsPropertyReceiver.doorOffsetSemantics by DoorOffsetSemanticsKey
+
 @Composable
 private fun DoorIconBox(
     doorOffset: Float,
@@ -128,7 +142,9 @@ private fun DoorIconBox(
     color: Color,
 ) {
     Box(
-        modifier = modifier.aspectRatio(GARAGE_DOOR_ASPECT_RATIO),
+        modifier = modifier
+            .aspectRatio(GARAGE_DOOR_ASPECT_RATIO)
+            .semantics { doorOffsetSemantics = doorOffset },
         contentAlignment = Alignment.Center,
     ) {
         GarageDoorCanvas(

--- a/AndroidGarage/docs/DOOR_ANIMATION.md
+++ b/AndroidGarage/docs/DOOR_ANIMATION.md
@@ -90,9 +90,10 @@ Linear easing matches the roughly constant-speed motion of a real garage door.
 |-------|------------------|-------|
 | Unit (mapping) | Each `DoorAnimation.*For` function returns the documented value for every `DoorPosition` | [`GarageDoorAnimationMappingTest`](../androidApp/src/test/java/com/chriscartland/garage/ui/GarageDoorAnimationMappingTest.kt) |
 | Compile-time | Every `DoorPosition` enum value is mapped (exhaustive `when`, no `else`) | The compiler — adding a new enum value breaks the build |
+| Instrumented (trajectory) | The live offset **curve**: fresh-composition motion states snap to target (no slide); live transitions tween CLOSED↔OPEN in the right direction; a mid-slide direction flip reverses | [`GarageDoorAnimationBehaviorTest`](../androidApp/src/androidTest/java/com/chriscartland/garage/ui/GarageDoorAnimationBehaviorTest.kt) (device required) |
 | Screenshot | The icon renders as expected for each state in light + dark themes | [`GarageDoorScreenshotTest`](../android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/GarageDoorScreenshotTest.kt), regenerate via `./scripts/generate-android-screenshots.sh` |
 
-Screenshot tests use `static = true` so they render deterministically (no `mainClock`-dependent animation frames). The current AGP `screenshot` plugin renders Compose previews and does not expose `mainClock`; adding intermediate-frame screenshots would require switching to Paparazzi/Roborazzi and is intentionally out of scope.
+Screenshot tests use `static = true` so they render deterministically (no `mainClock`-dependent animation frames). The current AGP `screenshot` plugin renders Compose previews and does not expose `mainClock`; capturing the *trajectory* (not just single frames) is instead done by the instrumented `GarageDoorAnimationBehaviorTest`, which drives `mainClock` manually and reads the live offset back through the `DoorOffsetSemanticsKey` test-support semantics property on `GarageIcon`. That is the layer that pins "the slide only plays on a live state change, not on fresh composition" — the behavior that otherwise looks like an intermittent bug. Adding intermediate-frame *screenshots* would still require Paparazzi/Roborazzi and remains out of scope; the trajectory assertions cover the motion correctness without pixel capture.
 
 ## Updating the contract
 


### PR DESCRIPTION
## Summary

Answers "the Home-tab door animation doesn't always resume — sometimes it works." Builds a deterministic, regression-locked **audit** of the live `GarageIcon` animation trajectory in both directions, and documents the root cause of the perceived inconsistency.

### Why it "sometimes works" (documented 2.16.4 / ADR-025 behavior)

`DoorAnimation.initialPositionFor == targetPositionFor` for every state. So:

- **Fresh composition already in a motion state** (cold-open, tab-switch, back-nav while the door is OPENING/CLOSING) → the `Animatable` is seeded at the target and `LaunchedEffect { animateTo(target) }` is a no-op. The door renders at the end position with only the arrow overlay — **no slide.**
- **Live transition while the icon is already alive** (state changes CLOSED→OPENING while you're watching Home) → `animateTo` runs from the current value → **the slide plays.**

The slide playing or not depends entirely on whether the icon was alive when the state changed. This is intentional (pre-2.16.4 replayed on every screen re-entry, which flickered and didn't sync with the physical door). This PR does **not** change that behavior — it audits and locks it.

### Why existing tests didn't catch this

- `GarageDoorAnimationMappingTest` (JVM unit) pins the pure target/initial/spec/overlay mappings — not the trajectory.
- Screenshot tests render `static = true`; Layoutlib can't advance a `LaunchedEffect`, so motion is invisible to them.

## What's added

- **`GarageDoorAnimationBehaviorTest`** (instrumented) — drives `mainClock` manually and reads the live door offset back through a new test-only `DoorOffsetSemanticsKey`. 5 tests pin the direction × entry-scenario matrix:

  | Entry scenario | OPENING | CLOSING |
  |---|---|---|
  | Fresh composition | snap to OPEN, no slide | snap to CLOSED, no slide |
  | Live transition | slide CLOSED→OPEN | slide OPEN→CLOSED |
  | Mid-slide direction flip | — | reverses toward CLOSED |

- **`GarageIcon.kt`** — one test-support semantics property (`DoorOffsetSemanticsKey`, ~13 lines). Nothing reads it at runtime; it's the only way to observe the `Animatable` value frame-by-frame.
- **`DOOR_ANIMATION.md`** — verification table gains the instrumented trajectory layer.

## Test plan

- [x] `validate.sh` green (compiles `compileDebugAndroidTestKotlin`; spotless/lints pass)
- [ ] **Instrumented run** (device required): `./scripts/run-instrumented-tests.sh` — produces the empirical pass/fail matrix. Expected all-pass (confirms current behavior matches the documented contract). Also runs in the post-merge instrumented job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)