### PR TITLE
docs+test: Snooze behavior audit — event-coupling, stuck-OPENING void

### DIFF
--- a/AndroidGarage/docs/ARCHITECTURE.md
+++ b/AndroidGarage/docs/ARCHITECTURE.md
@@ -186,8 +186,8 @@ Safety rails enforced by `validate.sh`:
 
 - **`LoadingResult<T>`** (sealed class): `Loading(data?)`, `Complete(data?)`, `Error(exception)`. Used by DoorViewModel to represent fetch state.
 - **`RemoteButtonState`** (sealed): `Ready`, `Preparing`, `AwaitingConfirmation`, `Cancelled`, `SendingToServer`, `SendingToDoor`, `Succeeded`, `ServerFailed`, `DoorFailed`. Unified state for the remote garage button — combines tap-to-confirm interaction with network/door request tracking. Owned by `ButtonStateMachine` in `usecase/`. See [`RemoteButtonState.kt`](../domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/RemoteButtonState.kt) for the full state diagram in KDoc.
-- **`SnoozeState`** (sealed): Loading, NotSnoozing, Snoozing(until). Always-visible current snooze status from server.
-- **`SnoozeAction`** (sealed): Idle, Sending, Succeeded.{Cleared, Set}, Failed.{NotAuthenticated, MissingData, NetworkError}. Overlay on top of SnoozeState; auto-resets to Idle after 10s.
+- **`SnoozeState`** (sealed): Loading, NotSnoozing, Snoozing(until). Always-visible current snooze status from server. **Note:** the server's snooze model is event-coupled — `Snoozing(until)` does NOT guarantee suppression across door state changes. See [`docs/SNOOZE_BEHAVIOR.md`](../../docs/SNOOZE_BEHAVIOR.md) for the full design, the 60s `Opening → OpeningTooLong` interaction that voids in-motion snoozes, and the practical "cannot meaningfully snooze a stuck-OPENING/CLOSING door" consequence.
+- **`SnoozeAction`** (sealed): Idle, Sending, Succeeded.{Cleared, Set}, Failed.{NotAuthenticated, MissingData, NetworkError}. Overlay on top of SnoozeState; auto-resets to Idle after 10s. `Failed.NetworkError` currently absorbs the server's HTTP 404 "snooze event timestamp does not match current event timestamp" path; a typed `SnoozeEventChanged` variant is a documented follow-up.
 - **`AuthState`** (sealed): Unknown, Unauthenticated, Authenticated(user). Drives sign-in UI.
 - **`DoorFcmState`** (sealed): Unknown, NotRegistered, Registered(topic). Tracks FCM subscription.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -501,6 +501,9 @@ Push notifications are the hardest feature to verify in production. If topic nam
 - Wire-contract fixtures pin the payload Map<String, String> shape across server + Android (PR #842, 2026-05-23): `wire-contracts/fcmDoorEvent/payload_{closed,open,opening}.json` and `wire-contracts/fcmButtonHealth/payload_{online,offline,online_with_lastpoll}.json`. Server tests (`EventFCMTest.ts`, `ButtonHealthFCMTest.ts`) `deep.equal` against the loaded fixture; Android `FcmPayloadParsingTest.fixturePayload*Parses` loads the same JSON as `Map<String, String>` and asserts the parse. A unilateral rename on either side breaks at least one half.
 - FCM-related code: `FCMService`, `DoorFcmRepository`, `FcmPayloadParser`, topic subscription flow
 
+### Snooze (event-coupled, do not "fix" without an ADR)
+The server's snooze model is bound to the door event timestamp that was current when the snooze was set (`SnoozeNotifications.ts:100`). Any subsequent door event silently voids it — including the ESP32-poll-triggered `Opening → OpeningTooLong` promotion at 60s (`EventInterpreter.ts:26, 194-197`). Practical consequence: **a stuck-`OPENING` or stuck-`CLOSING` door cannot meaningfully be snoozed** with the current model. Submit during a transition may also fail with HTTP 404 (`:152-158`), which the client currently surfaces as a generic `ActionError.NetworkFailed`. Not a regression — this has been the design since 2024-11-18 (`3e73f7384`). Full design + rationale + source pointers + verification table: [`docs/SNOOZE_BEHAVIOR.md`](docs/SNOOZE_BEHAVIOR.md). Don't unilaterally remove the timestamp check; if a redesign is wanted, write an ADR first.
+
 ### Code Patterns
 - No bare top-level functions — group in a named `object {}` for discoverability (Composables exempt). Enforced by `checkNoBareTopLevelFunctions` (in `validate.sh`). See ADR-009
 - No extension functions on generic types (e.g., `FcmPayloadParser.parse(data)` not `Map.asDoorEvent()`)

--- a/FirebaseServer/test/controller/SnoozeNotificationsTest.ts
+++ b/FirebaseServer/test/controller/SnoozeNotificationsTest.ts
@@ -69,6 +69,27 @@ describe('SnoozeNotifications', () => {
       const result = await getSnoozeStatus(params);
       expect(result.status).to.equal(SnoozeStatus.ACTIVE);
     });
+
+    // Pins the "auto-void on next door event" behavior — the dominant
+    // reason snooze "doesn't work" during opening/closing. The stored
+    // snooze record is still in the future (end-time +1h) AND the same
+    // user just set it, but the door event has advanced (e.g., the
+    // ESP32's next poll after 60s promoted Opening → OpeningTooLong,
+    // writing a new event with a new timestamp). getSnoozeStatus must
+    // return NONE so the notification check (OldDataFCM) falls through
+    // to the normal 15-min stuck-open path. See docs/SNOOZE_BEHAVIOR.md.
+    it('should return NONE when the snooze record is future-dated but the current event has advanced', async () => {
+      const currentEvent = { currentEvent: { timestampSeconds: '99999' } }; // newer event
+      const snoozeRequest = {
+        snoozeEndTimeSeconds: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now
+        currentEventTimestampSeconds: 12345,                         // older event
+      };
+      sinon.stub(SensorEventDatabase, 'getCurrent').resolves(currentEvent);
+      sinon.stub(SnoozeNotificationsDatabase, 'get').resolves(snoozeRequest);
+      const params = { buildTimestamp: 'test' };
+      const result = await getSnoozeStatus(params);
+      expect(result.status).to.equal(SnoozeStatus.NONE);
+    });
   });
 
   describe('submitSnoozeNotificationsRequest', () => {

--- a/docs/SNOOZE_BEHAVIOR.md
+++ b/docs/SNOOZE_BEHAVIOR.md
@@ -1,0 +1,116 @@
+---
+category: reference
+status: active
+last_verified: 2026-05-29
+---
+
+# Snooze Behavior
+
+Cross-component reference: how snooze actually works on the server, why it appears unreliable during `OPENING`/`CLOSING`, and what that means for what users can and can't expect.
+
+The active design **couples each snooze to a specific door event timestamp**. This file exists so future-you (and any new collaborator) doesn't have to re-derive that from `git blame` the next time someone asks "why didn't snooze suppress that notification?"
+
+## What snooze does
+
+Snooze suppresses the server's **"door open too long"** notification — `OldDataFCM.sendFCMForOldData` — for a window the user chooses (1h, 4h, 8h, 12h). That's the only user-visible notification path the app sends; `EventFCM` is data-only (no `notification` field), so there's no per-state-change notification for snooze to also suppress.
+
+## How a snooze is stored
+
+When the user picks a duration and taps Save, the client sends two key fields:
+
+- `snoozeDuration` (e.g. `"1h"`)
+- `snoozeEventTimestamp` — the `lastChangeTimeSeconds` of the door event the client is currently displaying (`ProfileViewModel.kt:224`, `FunctionListViewModel.kt:169`).
+
+Server (`SnoozeNotifications.ts:152-158`):
+
+1. Read the current door event from `SensorEventDatabase.getCurrent`.
+2. If `snoozeEventTimestamp` ≠ `currentEvent.timestampSeconds` → **reject with HTTP 404** `"Snooze event timestamp does not match current event timestamp"`.
+3. Otherwise store the snooze with `currentEventTimestampSeconds = currentEvent.timestampSeconds` and `snoozeEndTimeSeconds = now + duration`.
+
+## How a snooze is checked
+
+Server `getSnoozeStatus` (`SnoozeNotifications.ts:49-127`):
+
+1. Read the current door event.
+2. Read the latest snooze record.
+3. If `snoozeResult.currentEventTimestampSeconds !== currentEvent.timestampSeconds` → return **`NONE`** (`:100-107`). The snooze is effectively void from this moment on.
+4. Otherwise compare `now` vs `snoozeEndTimeSeconds`:
+   - `now > end` → `EXPIRED`
+   - else → `ACTIVE`
+
+`OldDataFCM.shouldSendFcmForOpenDoor` calls `getSnoozeStatus`:
+- `ACTIVE` → do not send.
+- `EXPIRED` or `NONE` → fall through to the normal 15-minute stuck-open check.
+
+## Why snooze appears to "not work" during `OPENING` / `CLOSING`
+
+Two coupled mechanisms collide and the result is deterministic, not random:
+
+### Mechanism 1 — Submit-time race (`:152-158`)
+
+The client reads `lastChangeTimeSeconds` when the snooze sheet opens and sends that exact value on Save. During a transition (CLOSED→OPENING→OPEN; OPEN→CLOSING→CLOSED), the event timestamp rolls over every few seconds. By the time the user picks a duration and taps Save, the door has probably advanced past it. Server rejects with 404. The client maps that to `ActionError.NetworkFailed` (a generic error) — the user sees a vague failure rather than "the door state changed before your snooze could apply."
+
+### Mechanism 2 — `EventInterpreter` 60-second promotion (`EventInterpreter.ts:26, 194-197`)
+
+```typescript
+const TOO_LONG_DURATION_SECONDS = 60;
+...
+case SensorEventType.Opening:
+  ...
+  if (oldEventDurationSeconds > TOO_LONG_DURATION_SECONDS) {
+    return OpeningTooLong(timestampSeconds);   // NEW event, NEW timestamp
+  }
+```
+
+The ESP32 polls sensor state every few seconds. The next poll after the 60-second threshold causes `getNewEventOrNull` to write a brand-new event of type `OpeningTooLong` (or `ClosingTooLong` from the closing branch) with a fresh timestamp. This happens with no user action and no UI indication — the door icon just changes from the up/down arrow to the warning glyph.
+
+If the user snoozed during the first 60 seconds of an `Opening` state that ends up stuck, the snooze record's `currentEventTimestampSeconds` is the original `Opening` timestamp. Within ~60 seconds, the `OpeningTooLong` promotion silently voids it (Mechanism 1's status check returns `NONE` from then on).
+
+### Combined consequence
+
+**There is no path by which a user can meaningfully snooze a stuck-`OPENING` or stuck-`CLOSING` door** with the current model. Either:
+
+- they snooze inside the first 60s and the promotion voids it shortly after, or
+- they snooze after the 60s mark and the submit fails with 404 because the client is still sending the pre-promotion timestamp.
+
+This is exactly the scenario reported in 2026-05-28 ("I was opening but the open signal never arrived, and snooze didn't hold"). Not a regression — the `currentEventTimestampSeconds` check has existed since `3e73f7384` (2024-11-18).
+
+## Practical guidance
+
+- **Snooze works reliably only when the door is in a stable state** (`OPEN`, `CLOSED`, `OPEN_MISALIGNED`) AND the door doesn't change state for the duration of the snooze.
+- **The first state change after a snooze voids it.** Snooze-while-OPEN, then close the door — the next CLOSED event invalidates the snooze. There is no carry-over.
+- **In-motion snooze (`OPENING`/`CLOSING`) is functionally broken** by the 60s `TooLong` promotion. The UI accepts the action; the resulting snooze is either rejected at submit or void within a minute.
+
+## Why the model exists (preserved-quirk note, do not "fix" without re-litigating)
+
+Original intent — snooze should apply to **this instance** of door-open, not to a blanket "next N hours regardless." Each open-then-close cycle should re-arm the "you should be aware" notification on the next cycle. Event-coupling is the implementation of that intent. Decoupling snooze from the event would be an architectural change with its own UX trade-offs (e.g., a snooze set hours ago could silently suppress a notification for an unrelated open cycle).
+
+Any redesign discussion belongs in a new ADR; don't unilaterally remove the timestamp check.
+
+## Source pointers
+
+| File | Line | What |
+|---|---|---|
+| `FirebaseServer/src/controller/SnoozeNotifications.ts` | `:100-107` | The timestamp-match check that returns `NONE` on mismatch. |
+| `FirebaseServer/src/controller/SnoozeNotifications.ts` | `:152-158` | Submit-time 404 when client timestamp doesn't match current event. |
+| `FirebaseServer/src/controller/EventInterpreter.ts` | `:26` | `TOO_LONG_DURATION_SECONDS = 60`. |
+| `FirebaseServer/src/controller/EventInterpreter.ts` | `:194-197` | `Opening → OpeningTooLong` promotion that writes a new event. |
+| `FirebaseServer/src/controller/fcm/OldDataFCM.ts` | `:93-117` | The single notification path snooze actually suppresses. |
+| `AndroidGarage/usecase/.../SnoozeNotificationsUseCase.kt` | `:54-60` | Client passes `lastChangeTimeSeconds` of the displayed event. |
+| `AndroidGarage/viewmodel/.../ProfileViewModel.kt` | `:222-225` | Snooze action call-site on the Settings page. |
+
+## Verification
+
+| Layer | Pins | Where |
+|---|---|---|
+| Server unit | `ACTIVE` / `EXPIRED` / `NONE` paths, including **NONE-when-event-advanced** (the "auto-void" case) | `FirebaseServer/test/controller/SnoozeNotificationsTest.ts` |
+| Server unit | Per-state `Opening → OpeningTooLong` promotion logic | `FirebaseServer/test/controller/EventInterpreterTest.ts` |
+| Server HTTP | 404 path when submit timestamp doesn't match current event | `FirebaseServer/test/functions/http/HttpSnoozeNotificationsRequestTest.ts` |
+| Cross-system | The interaction (60s promotion silently voids ACTIVE snooze) | **Not pinned by a single test.** Inferred from the two layers above + this doc. If this becomes load-bearing, add an integration test that wires `EventInterpreter` + `SnoozeNotificationsDatabase` + `getSnoozeStatus`. |
+
+## When to update this doc
+
+- Anyone touches `SnoozeNotifications.ts`, `EventInterpreter.ts:26`, or `OldDataFCM.ts:93-117`.
+- The client changes which event timestamp it sends as `snoozeEventTimestamp`.
+- A typed client error for "snooze rejected due to event change" replaces the generic `ActionError.NetworkFailed` mapping (would be the natural Tier 2 follow-up).
+- A redesign ADR lands that changes the event-coupling.


### PR DESCRIPTION
## Summary

Documents and locks the snooze behavior surfaced on 2026-05-28: **a stuck-`OPENING` (or stuck-`CLOSING`) door cannot meaningfully be snoozed** because the ESP32-poll-triggered `Opening → OpeningTooLong` promotion at 60s (`EventInterpreter.ts:26, 194-197`) writes a new event with a new timestamp, which silently voids any snooze (`SnoozeNotifications.ts:100`).

**Not a regression** — this design has been in place since 2024-11-18 (`3e73f7384`). The audit confirms behavior matches code and gives future-you (and any new collaborator) a single doc to read instead of re-deriving the bug class from `git blame`.

## What's in this PR — all purely additive, no production change

1. **Server test** in `SnoozeNotificationsTest.ts`: pins the "ACTIVE snooze record exists, end-time in future, but `currentEventTimestampSeconds` no longer matches → NONE" case — the exact auto-void semantics that were previously implied by the codepath but unwritten as a test.

2. **New cross-component doc** `docs/SNOOZE_BEHAVIOR.md`: storage model, the check semantics, the two failure modes during transitions (submit-time race + 60s promotion), practical guidance, original design intent (with a "preserved-quirk note, do not fix without an ADR" framing), source pointers, verification table.

3. **`CLAUDE.md` Safety Rules section**: one paragraph pointer next to the FCM warning so future agents don't re-derive it.

4. **`AndroidGarage/docs/ARCHITECTURE.md` State Management section**: clarifies that `SnoozeState.Snoozing(until)` is not a suppression guarantee across state changes, and notes that `Failed.NetworkError` currently absorbs the HTTP 404 "event timestamp mismatch" case.

## Test plan

- [x] `./scripts/validate-firebase.sh` green — 326 passing, including the new `should return NONE when the snooze record is future-dated but the current event has advanced`
- [x] Android side is docs-only (CLAUDE.md, ARCHITECTURE.md) → fast-path skip
- [x] Firebase side has the new `.ts` test → full Firebase CI

## What this PR does NOT do

- No change to the server snooze model. Event-coupling stays.
- No client error-mapping change. HTTP 404 still maps to generic `ActionError.NetworkFailed`. The typed `SnoozeEventChanged` variant is a documented follow-up (Tier 2), not in this PR.
- No `server/N` or `android/N` release needed (test + docs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)