### PR TITLE
feat(ios): SwiftUI app foundation building on shared.framework

### DIFF
--- a/AndroidGarage/docs/PENDING_FOLLOWUPS.md
+++ b/AndroidGarage/docs/PENDING_FOLLOWUPS.md
@@ -64,7 +64,15 @@ Currently pinned at 0.8.0 deliberately. Tripwire conditions in § 2 below — no
 | [#823](https://github.com/cartland/SmartGarageDoor/pull/823) | `:data-local` Room KMP + DataStore-Okio; DAO suspend refactor; kotlinx-datetime for `currentTimeMillis`; `DatabaseFactory` expect/actual; iOS targets on `:usecase`/`:viewmodel`/`:presentation-model`/`:test-common`; `AppStartup` moved to `:usecase/commonMain` |
 | [#824](https://github.com/cartland/SmartGarageDoor/pull/824) | SKIE 0.10.9 plugin; `NativeComponent` DI graph (mirrors `AppComponent` with iOS deps); `IosNativeHelper`; `NoOpAuthBridge` + `NoOpMessagingBridge` placeholders; kotlin-inject 0.8.0 downgrade (see follow-up #2 below) |
 
-**Remaining work** — each requires user setup that the Kotlin side can't supply:
+**Progress (2026-05-31):** Phase B/D foundation landed — `AndroidGarage/iosApp/`
+(XcodeGen `project.yml`, `iOSApp.swift` building the `NativeComponent` graph with
+NoOp bridges + `defaultDevAppConfig`, `SharedViewModel`, theme tokens, 5-tab shell)
+plus `KmpViewModelStore` in `:viewmodel`. **Verified: builds and links against
+`shared.framework` on the iOS simulator** (`** BUILD SUCCEEDED **`, no Firebase /
+Apple account needed). Next: Phase F (iOS CI on `macos-latest`), then Phase E
+(the 5 real screens). Phases A/C/G remain gated on the user setup below.
+
+**Remaining work** — Phases A, C, F, G; some require user setup the Kotlin side can't supply:
 
 #### A. Firebase iOS configuration (one-time, user)
 - Create iOS app in the existing Firebase project (bundle ID `com.chriscartland.garage` per the iOS plan)

--- a/AndroidGarage/iosApp/.gitignore
+++ b/AndroidGarage/iosApp/.gitignore
@@ -1,0 +1,12 @@
+# The Xcode project is generated from project.yml by XcodeGen — never commit it.
+*.xcodeproj/
+
+# Build output
+build/
+DerivedData/
+
+# Xcode user state
+*.xcuserstate
+**/xcuserdata/
+
+.DS_Store

--- a/AndroidGarage/iosApp/Core/SharedViewModel.swift
+++ b/AndroidGarage/iosApp/Core/SharedViewModel.swift
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import SwiftUI
+@preconcurrency import shared
+
+/// Ties a Kotlin `ViewModel`'s lifetime to a SwiftUI view.
+///
+/// On Android, a `ViewModelStore` (owned by the `NavBackStackEntry`) clears
+/// stored ViewModels — cancelling their `viewModelScope` — when the owner is
+/// destroyed. iOS has no such host, so a screen holds its ViewModel through a
+/// `SharedViewModel` declared as `@StateObject`. When SwiftUI releases the
+/// `@StateObject` (the view leaves the tree for good), `deinit` calls
+/// `KmpViewModelStore.clear()`, which runs `ViewModel.onCleared()` and cancels
+/// the Kotlin `viewModelScope` — so screen coroutines tear down instead of
+/// leaking for the life of the process.
+///
+/// `instance` is the concrete `Default*ViewModel`; screens read its
+/// `StateFlow`s (bridged by SKIE) and call its action methods directly.
+///
+/// Mirrors battery-butler's `*ViewModelWrapper` ownership pattern, generalized
+/// to one wrapper because this app's ViewModels expose several `StateFlow`s
+/// rather than a single `uiState`.
+final class SharedViewModel<VM: ViewModel>: ObservableObject {
+    let instance: VM
+    private let store = KmpViewModelStore()
+
+    init(_ instance: VM) {
+        self.instance = instance
+        store.put(key: "vm", viewModel: instance)
+    }
+
+    deinit {
+        store.clear()
+    }
+}

--- a/AndroidGarage/iosApp/Core/Theme/GarageColors.swift
+++ b/AndroidGarage/iosApp/Core/Theme/GarageColors.swift
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import SwiftUI
+
+/// Semantic colors for the app. Light/dark follow the system appearance.
+///
+/// Baseline mirrors the Android door-status palette at a high level; the full
+/// per-state `DoorStatusColorScheme.kt` translation lands with the Home screen
+/// (the only screen that renders the colored door-status surfaces).
+enum GarageColors {
+    /// Surface that reads "everything is fine" (door closed).
+    static let statusOk = Color.green
+    /// Surface that reads "door is open / in motion".
+    static let statusOpen = Color.orange
+    /// Surface that reads "warning / unknown / error".
+    static let statusWarning = Color.red
+    /// Neutral container background for cards.
+    static let cardBackground = Color(uiColor: .secondarySystemBackground)
+}

--- a/AndroidGarage/iosApp/Core/Theme/GarageSpacing.swift
+++ b/AndroidGarage/iosApp/Core/Theme/GarageSpacing.swift
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import CoreGraphics
+
+/// Spacing tokens mirroring Android's `ui/theme/Spacing.kt`. Names describe
+/// role, not value — reach for a token before a raw literal.
+enum GarageSpacing {
+    /// Horizontal padding between screen content and the device edges.
+    static let screen: CGFloat = 16
+    /// Spacing between items in a screen-level list.
+    static let betweenItems: CGFloat = 16
+    /// Vertical breathing room above the first / below the last list item.
+    static let listVertical: CGFloat = 16
+    /// Tight grouping inside a single visual unit (icon ↔ text, label ↔ control).
+    static let tight: CGFloat = 4
+    /// Padding inside a card.
+    static let card: CGFloat = 16
+    /// Max readable content width on wide screens.
+    static let contentWidth: CGFloat = 640
+}

--- a/AndroidGarage/iosApp/Features/Main/MainScreen.swift
+++ b/AndroidGarage/iosApp/Features/Main/MainScreen.swift
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import SwiftUI
+@preconcurrency import shared
+
+/// Root tab shell. Holds the DI `component` and routes each tab to its screen.
+///
+/// **Phase B baseline:** tab bodies are placeholders. Each screen
+/// (Home / History / Profile / Functions / Diagnostics) is wired to its real
+/// `Default*ViewModel` from `component` in the screens PR; the placeholder
+/// names the ViewModel that will back it so the wiring target is explicit.
+struct MainScreen: View {
+    let component: NativeComponent
+
+    var body: some View {
+        TabView {
+            ForEach(MainTab.allCases) { tab in
+                NavigationStack {
+                    TabPlaceholder(tab: tab)
+                        .navigationTitle(tab.title)
+                }
+                .tabItem {
+                    Label(tab.title, systemImage: tab.systemImage)
+                }
+            }
+        }
+    }
+}
+
+/// Temporary per-tab body for the Phase B foundation. Replaced screen-by-screen.
+private struct TabPlaceholder: View {
+    let tab: MainTab
+
+    var body: some View {
+        VStack(spacing: GarageSpacing.betweenItems) {
+            Image(systemName: tab.systemImage)
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+            Text(tab.title)
+                .font(.title2.weight(.semibold))
+            Text("Screen coming soon")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .padding(GarageSpacing.screen)
+    }
+}

--- a/AndroidGarage/iosApp/Features/Main/MainTab.swift
+++ b/AndroidGarage/iosApp/Features/Main/MainTab.swift
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import Foundation
+
+/// The five top-level tabs, mirroring the Android nav chrome
+/// (`AppLayoutMode.visibleTabs`): Home / History / Profile / Functions /
+/// Diagnostics.
+enum MainTab: String, CaseIterable, Identifiable {
+    case home
+    case history
+    case profile
+    case functions
+    case diagnostics
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .home: return "Home"
+        case .history: return "History"
+        case .profile: return "Profile"
+        case .functions: return "Functions"
+        case .diagnostics: return "Diagnostics"
+        }
+    }
+
+    /// SF Symbol for the tab item.
+    var systemImage: String {
+        switch self {
+        case .home: return "house"
+        case .history: return "clock.arrow.circlepath"
+        case .profile: return "person.crop.circle"
+        case .functions: return "square.grid.2x2"
+        case .diagnostics: return "stethoscope"
+        }
+    }
+}

--- a/AndroidGarage/iosApp/README.md
+++ b/AndroidGarage/iosApp/README.md
@@ -1,0 +1,53 @@
+# iosApp — SwiftUI client
+
+SwiftUI front-end for the Smart Garage Door system. Consumes the shared
+Kotlin business logic via the `:iosFramework` Gradle module (`shared.framework`),
+mirroring the Android app's clean architecture. See the iOS construction plan in
+[`../docs/PENDING_FOLLOWUPS.md`](../docs/PENDING_FOLLOWUPS.md) § "iOS app construction".
+
+## Layout
+
+```
+iosApp/
+├── project.yml              # XcodeGen spec — source of truth for the .xcodeproj
+├── iosApp/                  # App entry + Info.plist + asset catalog
+│   └── iOSApp.swift         # @main; builds the NativeComponent DI graph
+├── Core/                    # Cross-screen infrastructure
+│   ├── SharedViewModel.swift   # Ties a Kotlin viewModelScope to a SwiftUI view
+│   └── Theme/               # Colors + spacing tokens mirroring Android
+└── Features/                # One folder per screen
+    └── Main/                # Tab shell (Home/History/Profile/Functions/Diagnostics)
+```
+
+The `.xcodeproj` is **generated, never committed** (see `.gitignore`). `project.yml`
+is the reviewable source of truth.
+
+## Build (simulator)
+
+```bash
+brew install xcodegen                 # one-time
+cd AndroidGarage/iosApp
+xcodegen generate
+xcodebuild -project iosApp.xcodeproj -scheme iosApp \
+  -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' \
+  CODE_SIGNING_ALLOWED=NO build
+```
+
+A pre-build Run Script invokes `:iosFramework:embedAndSignAppleFrameworkForXcode`,
+which compiles `shared.framework` for the active SDK/arch and embeds + signs it
+into the app. `FRAMEWORK_SEARCH_PATHS` points at that task's output.
+
+## Status
+
+**Phase B/D foundation (current).** The app builds and launches on the simulator
+with `NoOpAuthBridge` / `NoOpMessagingBridge` (inert auth + push) and
+`defaultDevAppConfig` (placeholder backend) — no Firebase or Apple Developer
+account required. This proves the framework + DI graph integrate.
+
+**Pending (gated on user setup):**
+- Real screens bound to the `Default*ViewModel`s (Phase E).
+- iOS CI on `macos-latest` (Phase F).
+- `FirebaseAuthBridge` / `FirebaseMessagingBridge`, `GoogleService-Info.plist`,
+  and `AppConfig` read from `Info.plist` (Phase C) — needs the Firebase iOS app +
+  APNs key.
+- TestFlight + App Store (Phases F/G) — needs the Apple Developer account.

--- a/AndroidGarage/iosApp/iosApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/AndroidGarage/iosApp/iosApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AndroidGarage/iosApp/iosApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/AndroidGarage/iosApp/iosApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AndroidGarage/iosApp/iosApp/Assets.xcassets/Contents.json
+++ b/AndroidGarage/iosApp/iosApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AndroidGarage/iosApp/iosApp/Info.plist
+++ b/AndroidGarage/iosApp/iosApp/Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Custom keys only; GENERATE_INFOPLIST_FILE=YES synthesizes the rest. -->
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<!-- Encryption export compliance: app uses only standard TLS. -->
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+</dict>
+</plist>

--- a/AndroidGarage/iosApp/iosApp/iOSApp.swift
+++ b/AndroidGarage/iosApp/iosApp/iOSApp.swift
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import SwiftUI
+@preconcurrency import shared
+
+/// SwiftUI entry point.
+///
+/// Builds the Kotlin DI graph (`NativeComponent`) exactly once at launch and
+/// hands it to the view tree, mirroring battery-butler's `iOSApp.swift` and
+/// the Android `AppComponent` lifetime.
+///
+/// **Phase B baseline:** the graph is built with `NoOpAuthBridge` /
+/// `NoOpMessagingBridge` (inert auth + push) and `defaultDevAppConfig`
+/// (placeholder backend). No Firebase, no Apple Developer account required —
+/// this proves the framework + DI graph integrate and the app launches on the
+/// simulator. The real Firebase bridges (`FirebaseAuthBridge`,
+/// `FirebaseMessagingBridge`) and `AppConfig` read from `Info.plist` land in
+/// later PRs once the iOS Firebase config (`GoogleService-Info.plist`) exists.
+@main
+struct GarageApp: App {
+    let component: NativeComponent
+
+    init() {
+        component = IosNativeHelper().createComponent(
+            authBridge: NoOpAuthBridge.shared,
+            messagingBridge: NoOpMessagingBridge.shared,
+            appConfig: IosNativeHelper.companion.defaultDevAppConfig
+        )
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            MainScreen(component: component)
+        }
+    }
+}

--- a/AndroidGarage/iosApp/project.yml
+++ b/AndroidGarage/iosApp/project.yml
@@ -1,0 +1,76 @@
+# XcodeGen spec — source of truth for iosApp.xcodeproj.
+#
+# The .xcodeproj is GENERATED, not committed (see .gitignore). Regenerate
+# after editing this file or adding/removing Swift sources:
+#
+#     brew install xcodegen        # one-time
+#     cd AndroidGarage/iosApp && xcodegen generate
+#
+# Build for the simulator from the CLI:
+#
+#     cd AndroidGarage/iosApp && xcodegen generate
+#     xcodebuild -project iosApp.xcodeproj -scheme iosApp \
+#       -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' \
+#       CODE_SIGNING_ALLOWED=NO build
+#
+# The Kotlin `shared.framework` is produced by a pre-build Run Script that
+# invokes `:iosFramework:embedAndSignAppleFrameworkForXcode` (mirrors
+# battery-butler's wiring). FRAMEWORK_SEARCH_PATHS points at the task's
+# output dir; the task also embeds + signs the framework into the app.
+
+name: iosApp
+options:
+  bundleIdPrefix: com.chriscartland.garage
+  deploymentTarget:
+    iOS: "16.0"
+  createIntermediateGroups: true
+  generateEmptyDirectories: true
+
+settings:
+  base:
+    SWIFT_VERSION: "5.0"
+    # Kotlin/Native types lack Swift `Sendable` info; keep strict concurrency
+    # at `minimal` and `@preconcurrency import shared` where needed.
+    SWIFT_STRICT_CONCURRENCY: minimal
+    # KMP gradle Run Script writes outside the Xcode sandbox.
+    ENABLE_USER_SCRIPT_SANDBOXING: NO
+    MARKETING_VERSION: "0.1.0"
+    CURRENT_PROJECT_VERSION: "1"
+
+targets:
+  iosApp:
+    type: application
+    platform: iOS
+    sources:
+      - path: iosApp
+      - path: Core
+      - path: Features
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.chriscartland.garage
+        GENERATE_INFOPLIST_FILE: YES
+        INFOPLIST_FILE: iosApp/Info.plist
+        INFOPLIST_KEY_UILaunchScreen_Generation: YES
+        INFOPLIST_KEY_CFBundleDisplayName: Garage
+        INFOPLIST_KEY_UISupportedInterfaceOrientations: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
+        TARGETED_DEVICE_FAMILY: "1,2"
+        FRAMEWORK_SEARCH_PATHS:
+          - $(inherited)
+          - $(SRCROOT)/../iosFramework/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)
+        OTHER_LDFLAGS:
+          - $(inherited)
+          - -framework
+          - shared
+    preBuildScripts:
+      - name: "Build Kotlin shared.framework (embedAndSign)"
+        basedOnDependencyAnalysis: false
+        script: |
+          if [ "YES" = "$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED" ]; then
+            echo "Skipping Gradle build (OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED=YES)"
+            exit 0
+          fi
+          cd "$SRCROOT/.."
+          ./gradlew :iosFramework:embedAndSignAppleFrameworkForXcode

--- a/AndroidGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/KmpViewModelStore.kt
+++ b/AndroidGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/KmpViewModelStore.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStore
+
+/**
+ * Swift-callable owner of a [ViewModel]'s lifetime on iOS.
+ *
+ * On Android, `ViewModelStore` is owned by the `NavBackStackEntry` /
+ * `Activity` and clears the stored ViewModels (cancelling their
+ * `viewModelScope`) when the owner is destroyed. iOS has no such host, so
+ * the SwiftUI `*ViewModelWrapper` (an `ObservableObject`) creates one of
+ * these, [put]s its Kotlin ViewModel in it, and calls [clear] from `deinit`.
+ * `clear()` invokes `ViewModel.onCleared()`, which cancels `viewModelScope`
+ * — so a screen leaving the view tree tears down its coroutines instead of
+ * leaking them for the life of the process.
+ *
+ * Mirrors battery-butler's `KmpViewModelStore`. Lives in `:viewmodel`
+ * commonMain so it rides the framework's `export(project(":viewmodel"))`
+ * and is visible to Swift as `KmpViewModelStore`.
+ */
+class KmpViewModelStore {
+    private val store = ViewModelStore()
+
+    fun put(
+        key: String,
+        viewModel: ViewModel,
+    ) {
+        store.put(key, viewModel)
+    }
+
+    fun clear() {
+        store.clear()
+    }
+}


### PR DESCRIPTION
## What

Stands up `AndroidGarage/iosApp/` — the SwiftUI client skeleton — and verifies it **builds and links against the Kotlin `shared.framework` on the iOS simulator** (`** BUILD SUCCEEDED **`). This is the Phase B/D foundation from the iOS construction plan.

**No Firebase or Apple Developer account required.** The `NativeComponent` DI graph is built with `NoOpAuthBridge` / `NoOpMessagingBridge` and `defaultDevAppConfig` (inert auth/push, placeholder backend) — which proves the KMP↔Swift integration end-to-end without any of the user-gated setup.

## Changes

**Kotlin**
- `KmpViewModelStore` in `:viewmodel` commonMain — lets the Swift `SharedViewModel` tie a Kotlin `viewModelScope` to a SwiftUI view's lifetime (`clear()` on `deinit` → `onCleared()` → scope cancel). Rides the framework's `export(project(":viewmodel"))`. Mirrors battery-butler.

**iOS (`AndroidGarage/iosApp/`)**
- `project.yml` — XcodeGen spec is the reviewable source of truth; the `.xcodeproj` is **generated, never committed** (`.gitignore`). Wires the `embedAndSign` gradle Run Script + `FRAMEWORK_SEARCH_PATHS` exactly as battery-butler does, plus `ENABLE_USER_SCRIPT_SANDBOXING=NO` for the KMP gradle script.
- `iOSApp.swift` — `@main`; builds `NativeComponent` once at launch.
- `SharedViewModel.swift` — generic Kotlin-ViewModel lifetime wrapper.
- `GarageColors` / `GarageSpacing` — theme tokens mirroring Android.
- `MainScreen` / `MainTab` — 5-tab shell (Home/History/Profile/Functions/Diagnostics) with placeholder bodies; real screens wired to the `Default*ViewModel`s in the next PR.
- `Info.plist` + asset catalog + `README.md`.

## Verification

- `./scripts/validate.sh` — **All checks passed** (covers the `:viewmodel` Kotlin change).
- `xcodegen generate && xcodebuild -sdk iphonesimulator … build` — **`** BUILD SUCCEEDED **`** (compiles + links against `shared.framework`, embeds it, produces `iosApp.app`).
- No iOS CI yet — that's the next PR (Phase F, `macos-latest`). Local `xcodebuild` is the gate for this PR.

## Follow-ups (this stack)
1. **This PR** — foundation (B/D)
2. iOS CI on `macos-latest` (F)
3. The 5 real screens bound to the ViewModels (E)

Still gated on user setup: Firebase iOS app + `GoogleService-Info.plist` + APNs key (A/C), Apple Developer account for TestFlight (F/G).

🤖 Generated with [Claude Code](https://claude.com/claude-code)