### PR TITLE
feat(ios): Wire all 5 screens to the shared ViewModels (Phase E)

### DIFF
--- a/AndroidGarage/docs/PENDING_FOLLOWUPS.md
+++ b/AndroidGarage/docs/PENDING_FOLLOWUPS.md
@@ -64,15 +64,25 @@ Currently pinned at 0.8.0 deliberately. Tripwire conditions in § 2 below — no
 | [#823](https://github.com/cartland/SmartGarageDoor/pull/823) | `:data-local` Room KMP + DataStore-Okio; DAO suspend refactor; kotlinx-datetime for `currentTimeMillis`; `DatabaseFactory` expect/actual; iOS targets on `:usecase`/`:viewmodel`/`:presentation-model`/`:test-common`; `AppStartup` moved to `:usecase/commonMain` |
 | [#824](https://github.com/cartland/SmartGarageDoor/pull/824) | SKIE 0.10.9 plugin; `NativeComponent` DI graph (mirrors `AppComponent` with iOS deps); `IosNativeHelper`; `NoOpAuthBridge` + `NoOpMessagingBridge` placeholders; kotlin-inject 0.8.0 downgrade (see follow-up #2 below) |
 
-**Progress (2026-05-31):** Phase B/D foundation landed — `AndroidGarage/iosApp/`
-(XcodeGen `project.yml`, `iOSApp.swift` building the `NativeComponent` graph with
-NoOp bridges + `defaultDevAppConfig`, `SharedViewModel`, theme tokens, 5-tab shell)
-plus `KmpViewModelStore` in `:viewmodel`. **Verified: builds and links against
-`shared.framework` on the iOS simulator** (`** BUILD SUCCEEDED **`, no Firebase /
-Apple account needed). Next: Phase F (iOS CI on `macos-latest`), then Phase E
-(the 5 real screens). Phases A/C/G remain gated on the user setup below.
+**Progress (2026-05-31 → 06-01):** Phases B/D/F/E landed (PRs #856, #857, + screens):
+- **B/D** — `AndroidGarage/iosApp/` foundation: XcodeGen `project.yml`, `iOSApp.swift`
+  building the `NativeComponent` graph with NoOp bridges + `defaultDevAppConfig`,
+  `SharedViewModel`, theme tokens, 5-tab shell; plus `KmpViewModelStore` in `:viewmodel`.
+- **F** — `.github/workflows/ios-ci.yml` (build app + `iosSimulatorArm64Test` on `macos-latest`).
+- **E** — all 5 screens (Home / History / Profile / Functions / Diagnostics) wired to the
+  real `Default*ViewModel`s via per-screen `*ViewModelWrapper`s (SKIE `onEnum(of:)` +
+  `for await` flow binding). Functional baseline — real data + primary actions; the
+  animated door canvas and pixel-level Android parity are deferred polish.
 
-**Remaining work** — Phases A, C, F, G; some require user setup the Kotlin side can't supply:
+**Verified: builds and links against `shared.framework` on the iOS simulator**
+(`** BUILD SUCCEEDED **`) with no Firebase / Apple account. The app currently runs
+against `defaultDevAppConfig` (placeholder backend) + NoOp auth/push, so screens render
+empty/signed-out until Phase A/C wire the real Firebase config + backend. SKIE binding
+notes for future screens: sealed Kotlin types use `onEnum(of:)`; `:usecase` types are
+module-prefixed in Swift (e.g. `UsecaseButtonHealthDisplay`); `StateFlow<Long>` values
+read via `.value.int64Value`.
+
+**Remaining work** — Phases A, C, G; all require user setup the Kotlin side can't supply:
 
 #### A. Firebase iOS configuration (one-time, user)
 - Create iOS app in the existing Firebase project (bundle ID `com.chriscartland.garage` per the iOS plan)

--- a/AndroidGarage/iosApp/Features/Diagnostics/DiagnosticsScreen.swift
+++ b/AndroidGarage/iosApp/Features/Diagnostics/DiagnosticsScreen.swift
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import SwiftUI
+@preconcurrency import shared
+
+/// Diagnostics tab — lifetime counters + "Clear all diagnostics".
+/// Mirrors Android's `DiagnosticsContent`.
+struct DiagnosticsScreen: View {
+    @StateObject private var wrapper: DiagnosticsViewModelWrapper
+    @State private var showClearConfirm = false
+
+    init(component: NativeComponent) {
+        _wrapper = StateObject(wrappedValue: DiagnosticsViewModelWrapper(component: component))
+    }
+
+    var body: some View {
+        List {
+            Section("Counters") {
+                ForEach(wrapper.counters) { counter in
+                    HStack {
+                        Text(counter.label)
+                        Spacer()
+                        Text("\(counter.value)")
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            Section {
+                Button(role: .destructive) {
+                    showClearConfirm = true
+                } label: {
+                    HStack(spacing: GarageSpacing.tight) {
+                        if wrapper.clearInFlight {
+                            ProgressView().controlSize(.small)
+                        }
+                        Text(wrapper.clearInFlight ? "Clearing…" : "Clear all diagnostics")
+                    }
+                }
+                .disabled(wrapper.clearInFlight)
+            }
+        }
+        .navigationTitle("Diagnostics")
+        .confirmationDialog(
+            "Clear all diagnostics?",
+            isPresented: $showClearConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Clear all", role: .destructive) { wrapper.clearDiagnostics() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Wipes the app-event log and lifetime counters.")
+        }
+    }
+}

--- a/AndroidGarage/iosApp/Features/Diagnostics/DiagnosticsViewModelWrapper.swift
+++ b/AndroidGarage/iosApp/Features/Diagnostics/DiagnosticsViewModelWrapper.swift
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import SwiftUI
+@preconcurrency import shared
+
+/// Bridges `DefaultDiagnosticsViewModel`'s `StateFlow`s to SwiftUI.
+///
+/// Pattern (shared by every `*ViewModelWrapper`): own a `SharedViewModel` for
+/// lifetime, seed each `@Published` synchronously from the flow's `.value`
+/// (no initial flicker), then spawn one `@MainActor` task per flow that
+/// republishes updates via `for await`. Tasks are cancelled in `deinit`.
+@MainActor
+final class DiagnosticsViewModelWrapper: ObservableObject {
+    struct Counter: Identifiable {
+        let id: String
+        let label: String
+        let value: Int64
+    }
+
+    @Published private(set) var counters: [Counter] = []
+    @Published private(set) var clearInFlight: Bool = false
+
+    private let shared: SharedViewModel<DefaultDiagnosticsViewModel>
+    private var tasks: [Task<Void, Never>] = []
+
+    private var vm: DefaultDiagnosticsViewModel { shared.instance }
+
+    init(component: NativeComponent) {
+        shared = SharedViewModel(component.diagnosticsViewModel)
+        rebuildCounters()
+        clearInFlight = vm.clearInFlight.value.boolValue
+
+        // Any counter emission re-derives the whole list from current `.value`s.
+        observeCounter(vm.initCurrentDoorCount)
+        observeCounter(vm.initRecentDoorCount)
+        observeCounter(vm.userFetchCurrentDoorCount)
+        observeCounter(vm.userFetchRecentDoorCount)
+        observeCounter(vm.fcmReceivedDoorCount)
+        observeCounter(vm.fcmSubscribeTopicCount)
+        observeCounter(vm.exceededExpectedTimeWithoutFcmCount)
+        observeCounter(vm.timeWithoutFcmInExpectedRangeCount)
+
+        tasks.append(Task { @MainActor [weak self] in
+            guard let self else { return }
+            for await value in self.vm.clearInFlight {
+                self.clearInFlight = value.boolValue
+            }
+        })
+    }
+
+    private func observeCounter(_ flow: SkieSwiftStateFlow<KotlinLong>) {
+        tasks.append(Task { @MainActor [weak self] in
+            for await _ in flow { self?.rebuildCounters() }
+        })
+    }
+
+    private func rebuildCounters() {
+        counters = [
+            Counter(id: "initCurrent", label: "Init current door", value: vm.initCurrentDoorCount.value.int64Value),
+            Counter(id: "initRecent", label: "Init recent door", value: vm.initRecentDoorCount.value.int64Value),
+            Counter(id: "userCurrent", label: "User fetch current", value: vm.userFetchCurrentDoorCount.value.int64Value),
+            Counter(id: "userRecent", label: "User fetch recent", value: vm.userFetchRecentDoorCount.value.int64Value),
+            Counter(id: "fcmReceived", label: "FCM door events received", value: vm.fcmReceivedDoorCount.value.int64Value),
+            Counter(id: "fcmSubscribe", label: "FCM topic subscribes", value: vm.fcmSubscribeTopicCount.value.int64Value),
+            Counter(id: "fcmExceeded", label: "Exceeded expected time without FCM", value: vm.exceededExpectedTimeWithoutFcmCount.value.int64Value),
+            Counter(id: "fcmInRange", label: "Time without FCM in range", value: vm.timeWithoutFcmInExpectedRangeCount.value.int64Value),
+        ]
+    }
+
+    func clearDiagnostics() {
+        vm.clearDiagnostics()
+    }
+
+    deinit {
+        tasks.forEach { $0.cancel() }
+    }
+}

--- a/AndroidGarage/iosApp/Features/FunctionList/FunctionListScreen.swift
+++ b/AndroidGarage/iosApp/Features/FunctionList/FunctionListScreen.swift
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import SwiftUI
+@preconcurrency import shared
+
+/// Functions tab — per-user-gated developer actions. Mirrors Android's
+/// `FunctionListContent`. Buttons show only when `accessGranted == true`.
+struct FunctionListScreen: View {
+    @StateObject private var wrapper: FunctionListViewModelWrapper
+
+    init(component: NativeComponent) {
+        _wrapper = StateObject(wrappedValue: FunctionListViewModelWrapper(component: component))
+    }
+
+    var body: some View {
+        List {
+            if wrapper.accessGranted == true {
+                Section("Door") {
+                    Button("Open / close door") { wrapper.openOrCloseDoor() }
+                    Button("Snooze 1 hour") { wrapper.snoozeForOneHour() }
+                }
+                Section("Refresh") {
+                    Button("Door status") { wrapper.refreshDoorStatus() }
+                    Button("Door history") { wrapper.refreshDoorHistory() }
+                    Button("Snooze status") { wrapper.refreshSnoozeStatus() }
+                    Button("Button health") { wrapper.refreshButtonHealth() }
+                }
+                Section("FCM") {
+                    Button("Register FCM") { wrapper.registerFcm() }
+                    Button("Deregister FCM") { wrapper.deregisterFcm() }
+                }
+                Section("Diagnostics") {
+                    Button("Prune diagnostics log") { wrapper.pruneDiagnosticsLog() }
+                    Button("Clear all diagnostics", role: .destructive) { wrapper.clearDiagnostics() }
+                }
+            } else {
+                VStack(spacing: GarageSpacing.betweenItems) {
+                    Image(systemName: "lock")
+                        .font(.system(size: 48))
+                        .foregroundStyle(.secondary)
+                    Text("Functions unavailable")
+                        .font(.title2.weight(.semibold))
+                    Text("This developer panel is gated to allowlisted accounts.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(GarageSpacing.screen)
+                .listRowBackground(Color.clear)
+            }
+        }
+        .navigationTitle("Functions")
+    }
+}

--- a/AndroidGarage/iosApp/Features/FunctionList/FunctionListViewModelWrapper.swift
+++ b/AndroidGarage/iosApp/Features/FunctionList/FunctionListViewModelWrapper.swift
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import SwiftUI
+@preconcurrency import shared
+
+/// Bridges `DefaultFunctionListViewModel` to SwiftUI.
+///
+/// `accessGranted` is tri-state (`Bool?`): gate the buttons on `== true` only —
+/// both `nil` (loading / denied) and `false` (server says no) keep the gate
+/// closed. See `docs/FEATURE_FLAGS.md`.
+@MainActor
+final class FunctionListViewModelWrapper: ObservableObject {
+    @Published private(set) var accessGranted: Bool?
+
+    private let shared: SharedViewModel<DefaultFunctionListViewModel>
+    private var tasks: [Task<Void, Never>] = []
+    private var vm: DefaultFunctionListViewModel { shared.instance }
+
+    init(component: NativeComponent) {
+        shared = SharedViewModel(component.functionListViewModel)
+        accessGranted = vm.accessGranted.value?.boolValue
+
+        tasks.append(Task { @MainActor [weak self] in
+            guard let self else { return }
+            for await v in self.vm.accessGranted { self.accessGranted = v?.boolValue }
+        })
+    }
+
+    func openOrCloseDoor() { vm.openOrCloseDoor() }
+    func refreshDoorStatus() { vm.refreshDoorStatus() }
+    func refreshDoorHistory() { vm.refreshDoorHistory() }
+    func refreshSnoozeStatus() { vm.refreshSnoozeStatus() }
+    func refreshButtonHealth() { vm.refreshButtonHealth() }
+    func snoozeForOneHour() { vm.snoozeNotificationsForOneHour() }
+    func registerFcm() { vm.registerFcm() }
+    func deregisterFcm() { vm.deregisterFcm() }
+    func clearDiagnostics() { vm.clearDiagnostics() }
+    func pruneDiagnosticsLog() { vm.pruneDiagnosticsLog() }
+
+    deinit { tasks.forEach { $0.cancel() } }
+}

--- a/AndroidGarage/iosApp/Features/History/HistoryScreen.swift
+++ b/AndroidGarage/iosApp/Features/History/HistoryScreen.swift
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import SwiftUI
+@preconcurrency import shared
+
+/// History tab — recent door events. Mirrors Android's `DoorHistoryContent`.
+struct HistoryScreen: View {
+    @StateObject private var wrapper: HistoryViewModelWrapper
+
+    init(component: NativeComponent) {
+        _wrapper = StateObject(wrappedValue: HistoryViewModelWrapper(component: component))
+    }
+
+    var body: some View {
+        List {
+            if wrapper.rows.isEmpty {
+                Text(wrapper.isLoading ? "Loading…" : "No recent events")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(wrapper.rows) { row in
+                    HStack {
+                        Text(row.position)
+                        Spacer()
+                        if let seconds = row.changeTimeSeconds {
+                            Text(Self.relative(seconds))
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("History")
+        .refreshable { wrapper.refresh() }
+    }
+
+    private static func relative(_ epochSeconds: Int64) -> String {
+        let date = Date(timeIntervalSince1970: TimeInterval(epochSeconds))
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}

--- a/AndroidGarage/iosApp/Features/History/HistoryViewModelWrapper.swift
+++ b/AndroidGarage/iosApp/Features/History/HistoryViewModelWrapper.swift
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import SwiftUI
+@preconcurrency import shared
+
+/// Bridges `DefaultDoorHistoryViewModel` to SwiftUI.
+@MainActor
+final class HistoryViewModelWrapper: ObservableObject {
+    struct Row: Identifiable {
+        let id: Int
+        let position: String
+        let changeTimeSeconds: Int64?
+    }
+
+    @Published private(set) var rows: [Row] = []
+    @Published private(set) var isLoading: Bool = false
+
+    private let shared: SharedViewModel<DefaultDoorHistoryViewModel>
+    private var tasks: [Task<Void, Never>] = []
+    private var vm: DefaultDoorHistoryViewModel { shared.instance }
+
+    init(component: NativeComponent) {
+        shared = SharedViewModel(component.doorHistoryViewModel)
+        apply(vm.recentDoorEvents.value)
+
+        tasks.append(Task { @MainActor [weak self] in
+            guard let self else { return }
+            for await result in self.vm.recentDoorEvents { self.apply(result) }
+        })
+    }
+
+    private func apply(_ result: LoadingResult<NSArray>) {
+        isLoading = result is LoadingResultLoading
+        let events = (result.data as? [DoorEvent]) ?? []
+        rows = events.enumerated().map { index, event in
+            Row(
+                id: index,
+                position: (event.doorPosition?.name ?? "UNKNOWN")
+                    .replacingOccurrences(of: "_", with: " ")
+                    .capitalized,
+                changeTimeSeconds: event.lastChangeTimeSeconds?.int64Value
+            )
+        }
+    }
+
+    func refresh() { vm.fetchRecentDoorEvents() }
+
+    deinit { tasks.forEach { $0.cancel() } }
+}

--- a/AndroidGarage/iosApp/Features/Home/HomeScreen.swift
+++ b/AndroidGarage/iosApp/Features/Home/HomeScreen.swift
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import SwiftUI
+@preconcurrency import shared
+
+/// Home tab — current door status, the open/close button, device health.
+/// Functional baseline; the animated door canvas is a later polish pass.
+struct HomeScreen: View {
+    @StateObject private var wrapper: HomeViewModelWrapper
+
+    init(component: NativeComponent) {
+        _wrapper = StateObject(wrappedValue: HomeViewModelWrapper(component: component))
+    }
+
+    var body: some View {
+        List {
+            Section("Status") {
+                VStack(alignment: .leading, spacing: GarageSpacing.tight) {
+                    Text(wrapper.doorPosition.replacingOccurrences(of: "_", with: " ").capitalized)
+                        .font(.largeTitle.weight(.bold))
+                    if let message = wrapper.doorMessage {
+                        Text(message).font(.subheadline).foregroundStyle(.secondary)
+                    }
+                    if wrapper.isCheckInStale {
+                        Label("Check-in is stale", systemImage: "exclamationmark.triangle")
+                            .font(.footnote)
+                            .foregroundStyle(GarageColors.statusWarning)
+                    }
+                }
+                .padding(.vertical, GarageSpacing.tight)
+            }
+
+            Section("Remote button") {
+                Button(action: { wrapper.onButtonTap() }) {
+                    Text(wrapper.buttonStateLabel)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .listRowInsets(EdgeInsets())
+                .padding(GarageSpacing.tight)
+            }
+
+            Section("Device health") {
+                Text(wrapper.buttonHealthLabel).foregroundStyle(.secondary)
+            }
+
+            Section("Account") {
+                Text(wrapper.signedIn ? "Signed in" : "Signed out")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .navigationTitle("Garage")
+        .refreshable { wrapper.refresh() }
+    }
+}

--- a/AndroidGarage/iosApp/Features/Home/HomeViewModelWrapper.swift
+++ b/AndroidGarage/iosApp/Features/Home/HomeViewModelWrapper.swift
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import SwiftUI
+@preconcurrency import shared
+
+/// Bridges `DefaultHomeViewModel` to SwiftUI. See `DiagnosticsViewModelWrapper`
+/// for the shared observe pattern.
+@MainActor
+final class HomeViewModelWrapper: ObservableObject {
+    @Published private(set) var signedIn: Bool = false
+    @Published private(set) var doorPosition: String = "UNKNOWN"
+    @Published private(set) var doorMessage: String?
+    @Published private(set) var lastChangeTimeSeconds: Int64?
+    @Published private(set) var isCheckInStale: Bool = false
+    @Published private(set) var buttonStateLabel: String = "Ready"
+    @Published private(set) var buttonHealthLabel: String = "Unknown"
+
+    private let shared: SharedViewModel<DefaultHomeViewModel>
+    private var tasks: [Task<Void, Never>] = []
+    private var vm: DefaultHomeViewModel { shared.instance }
+
+    init(component: NativeComponent) {
+        shared = SharedViewModel(component.homeViewModel)
+        applyAuth(vm.authState.value)
+        applyDoor(vm.currentDoorEvent.value)
+        applyButton(vm.buttonState.value)
+        applyHealth(vm.buttonHealthDisplay.value)
+        isCheckInStale = vm.isCheckInStale.value.boolValue
+
+        tasks.append(Task { @MainActor [weak self] in
+            for await v in self!.vm.authState { self?.applyAuth(v) }
+        })
+        tasks.append(Task { @MainActor [weak self] in
+            for await v in self!.vm.currentDoorEvent { self?.applyDoor(v) }
+        })
+        tasks.append(Task { @MainActor [weak self] in
+            for await v in self!.vm.buttonState { self?.applyButton(v) }
+        })
+        tasks.append(Task { @MainActor [weak self] in
+            for await v in self!.vm.buttonHealthDisplay { self?.applyHealth(v) }
+        })
+        tasks.append(Task { @MainActor [weak self] in
+            for await v in self!.vm.isCheckInStale { self?.isCheckInStale = v.boolValue }
+        })
+    }
+
+    private func applyAuth(_ state: AuthState) {
+        if case .authenticated = onEnum(of: state) {
+            signedIn = true
+        } else {
+            signedIn = false
+        }
+    }
+
+    private func applyDoor(_ result: LoadingResult<DoorEvent>) {
+        let event = result.data
+        doorPosition = event?.doorPosition?.name ?? "UNKNOWN"
+        doorMessage = event?.message
+        lastChangeTimeSeconds = event?.lastChangeTimeSeconds?.int64Value
+    }
+
+    private func applyButton(_ state: RemoteButtonState) {
+        buttonStateLabel = HomeViewModelWrapper.label(for: state)
+    }
+
+    private func applyHealth(_ display: UsecaseButtonHealthDisplay) {
+        switch onEnum(of: display) {
+        case .offline(let offline):
+            buttonHealthLabel = "Offline (\(offline.durationLabel))"
+        case .online:
+            buttonHealthLabel = "Online"
+        case .loading:
+            buttonHealthLabel = "Checking…"
+        case .unauthorized:
+            buttonHealthLabel = "Sign in to see device health"
+        case .unknown:
+            buttonHealthLabel = "Unknown"
+        }
+    }
+
+    private static func label(for state: RemoteButtonState) -> String {
+        switch onEnum(of: state) {
+        case .ready: return "Tap to open / close"
+        case .preparing: return "Preparing…"
+        case .awaitingConfirmation: return "Tap again to confirm"
+        case .cancelled: return "Cancelled"
+        case .sendingToServer: return "Sending…"
+        case .sendingToDoor: return "Waiting for door…"
+        case .succeeded: return "Done"
+        case .serverFailed: return "Server error"
+        case .doorFailed: return "Door did not move"
+        }
+    }
+
+    func onButtonTap() { vm.onButtonTap() }
+    func refresh() {
+        vm.fetchCurrentDoorEvent()
+        vm.refreshButtonHealth()
+    }
+
+    deinit { tasks.forEach { $0.cancel() } }
+}

--- a/AndroidGarage/iosApp/Features/Main/MainScreen.swift
+++ b/AndroidGarage/iosApp/Features/Main/MainScreen.swift
@@ -31,8 +31,7 @@ struct MainScreen: View {
         TabView {
             ForEach(MainTab.allCases) { tab in
                 NavigationStack {
-                    TabPlaceholder(tab: tab)
-                        .navigationTitle(tab.title)
+                    screen(for: tab)
                 }
                 .tabItem {
                     Label(tab.title, systemImage: tab.systemImage)
@@ -40,23 +39,20 @@ struct MainScreen: View {
             }
         }
     }
-}
 
-/// Temporary per-tab body for the Phase B foundation. Replaced screen-by-screen.
-private struct TabPlaceholder: View {
-    let tab: MainTab
-
-    var body: some View {
-        VStack(spacing: GarageSpacing.betweenItems) {
-            Image(systemName: tab.systemImage)
-                .font(.system(size: 48))
-                .foregroundStyle(.secondary)
-            Text(tab.title)
-                .font(.title2.weight(.semibold))
-            Text("Screen coming soon")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+    @ViewBuilder
+    private func screen(for tab: MainTab) -> some View {
+        switch tab {
+        case .home:
+            HomeScreen(component: component)
+        case .history:
+            HistoryScreen(component: component)
+        case .profile:
+            ProfileScreen(component: component)
+        case .functions:
+            FunctionListScreen(component: component)
+        case .diagnostics:
+            DiagnosticsScreen(component: component)
         }
-        .padding(GarageSpacing.screen)
     }
 }

--- a/AndroidGarage/iosApp/Features/Profile/ProfileScreen.swift
+++ b/AndroidGarage/iosApp/Features/Profile/ProfileScreen.swift
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import SwiftUI
+@preconcurrency import shared
+
+/// Profile tab — account + snooze. Mirrors Android's `ProfileContent`.
+/// Google Sign-In is wired once the Firebase iOS SDK lands (Phase C); for now
+/// the account row reflects the (NoOp) auth state.
+struct ProfileScreen: View {
+    @StateObject private var wrapper: ProfileViewModelWrapper
+
+    init(component: NativeComponent) {
+        _wrapper = StateObject(wrappedValue: ProfileViewModelWrapper(component: component))
+    }
+
+    var body: some View {
+        List {
+            Section("Account") {
+                Text(wrapper.signedIn ? "Signed in" : "Signed out")
+                    .foregroundStyle(.secondary)
+                if wrapper.signedIn {
+                    Button("Sign out", role: .destructive) { wrapper.signOut() }
+                }
+            }
+
+            Section("Snooze notifications") {
+                HStack {
+                    Text(wrapper.snoozeLabel)
+                    Spacer()
+                    if wrapper.snoozeSending { ProgressView().controlSize(.small) }
+                }
+                if let error = wrapper.snoozeError {
+                    Text(error).font(.footnote).foregroundStyle(GarageColors.statusWarning)
+                }
+                ForEach(wrapper.durations, id: \.label) { entry in
+                    Button(entry.label) { wrapper.snooze(entry.option) }
+                        .disabled(wrapper.snoozeSending)
+                }
+            }
+        }
+        .navigationTitle("Profile")
+        .refreshable { wrapper.refreshSnooze() }
+    }
+}

--- a/AndroidGarage/iosApp/Features/Profile/ProfileViewModelWrapper.swift
+++ b/AndroidGarage/iosApp/Features/Profile/ProfileViewModelWrapper.swift
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import SwiftUI
+@preconcurrency import shared
+
+/// Bridges `DefaultProfileViewModel` to SwiftUI.
+@MainActor
+final class ProfileViewModelWrapper: ObservableObject {
+    @Published private(set) var signedIn: Bool = false
+    @Published private(set) var snoozeLabel: String = "Not snoozing"
+    @Published private(set) var snoozeSending: Bool = false
+    @Published private(set) var snoozeError: String?
+
+    /// Duration options exposed to the UI, in display order.
+    let durations: [(label: String, option: SnoozeDurationUIOption)] = [
+        ("Do not snooze", .none),
+        ("1 hour", .oneHour),
+        ("4 hours", .fourHours),
+        ("8 hours", .eightHours),
+        ("12 hours", .twelveHours),
+    ]
+
+    private let shared: SharedViewModel<DefaultProfileViewModel>
+    private var tasks: [Task<Void, Never>] = []
+    private var vm: DefaultProfileViewModel { shared.instance }
+
+    init(component: NativeComponent) {
+        shared = SharedViewModel(component.profileViewModel)
+        applyAuth(vm.authState.value)
+        applySnooze(vm.snoozeState.value)
+        applyAction(vm.snoozeAction.value)
+
+        tasks.append(Task { @MainActor [weak self] in
+            guard let self else { return }
+            for await v in self.vm.authState { self.applyAuth(v) }
+        })
+        tasks.append(Task { @MainActor [weak self] in
+            guard let self else { return }
+            for await v in self.vm.snoozeState { self.applySnooze(v) }
+        })
+        tasks.append(Task { @MainActor [weak self] in
+            guard let self else { return }
+            for await v in self.vm.snoozeAction { self.applyAction(v) }
+        })
+    }
+
+    private func applyAuth(_ state: AuthState) {
+        if case .authenticated = onEnum(of: state) {
+            signedIn = true
+        } else {
+            signedIn = false
+        }
+    }
+
+    private func applySnooze(_ state: SnoozeState) {
+        switch onEnum(of: state) {
+        case .snoozing(let snoozing):
+            let date = Date(timeIntervalSince1970: TimeInterval(snoozing.untilEpochSeconds))
+            snoozeLabel = "Snoozing until \(date.formatted(date: .omitted, time: .shortened))"
+        case .loading:
+            snoozeLabel = "Loading…"
+        case .notSnoozing:
+            snoozeLabel = "Not snoozing"
+        }
+    }
+
+    private func applyAction(_ action: SnoozeAction) {
+        switch onEnum(of: action) {
+        case .sending:
+            snoozeSending = true
+            snoozeError = nil
+        case .failed:
+            snoozeSending = false
+            snoozeError = "Snooze failed, try again"
+        case .idle, .succeeded:
+            snoozeSending = false
+            snoozeError = nil
+        }
+    }
+
+    func signOut() { vm.signOut() }
+    func refreshSnooze() { vm.fetchSnoozeStatus() }
+    func snooze(_ option: SnoozeDurationUIOption) { vm.snoozeOpenDoorsNotifications(snoozeDuration: option) }
+
+    deinit { tasks.forEach { $0.cancel() } }
+}


### PR DESCRIPTION
## What

Replaces the placeholder tab bodies (from #856) with the five real screens, each bound to its `Default*ViewModel` from the `NativeComponent` DI graph through a per-screen `*ViewModelWrapper`. This is Phase E of the iOS construction plan.

| Screen | ViewModel | Binds | Actions |
|--------|-----------|-------|---------|
| Home | `DefaultHomeViewModel` | door status, button state, health label, auth | tap button, pull-to-refresh |
| History | `DefaultDoorHistoryViewModel` | recent door events | pull-to-refresh |
| Profile | `DefaultProfileViewModel` | account, snooze state | sign out, snooze (5 durations) |
| Functions | `DefaultFunctionListViewModel` | `accessGranted` (tri-state) | gated dev actions |
| Diagnostics | `DefaultDiagnosticsViewModel` | 8 lifetime counters | clear-all (in-flight spinner) |

## Binding pattern

`DiagnosticsViewModelWrapper` documents it: own a `SharedViewModel` for lifetime, seed each `@Published` synchronously from the flow's `.value`, then one `@MainActor` task per flow republishes updates via `for await`; tasks cancelled in `deinit`.

**SKIE specifics learned + applied** (useful for any future screen):
- Sealed Kotlin types matched via SKIE's `onEnum(of:)` → `.case(let x)`, not `is`-casts (SKIE hides the flattened subclass names).
- Non-exported `:usecase` types are **module-prefixed** in Swift (`UsecaseButtonHealthDisplay`); domain sealed subtypes keep nested swift_names (`AuthState.Authenticated`).
- `SnoozeDurationUIOption` bridges to a Swift enum (`.none`/`.oneHour`/…).
- `StateFlow<Long>` → `.value.int64Value`; `StateFlow<Boolean?>` → `.value?.boolValue`.

## Scope / honesty

Functional baseline — real data + primary actions, simple SwiftUI. The **animated door canvas** and pixel-level Android parity are deferred polish. Because auth/push are NoOp and the backend is `defaultDevAppConfig`, screens render **signed-out / empty** until Phase A/C wire real Firebase + the backend config. Snooze failure currently shows a generic message (the `Failed.*` sub-reasons are a follow-up).

## Verification
- `xcodegen generate && xcodebuild build -sdk iphonesimulator` — **`** BUILD SUCCEEDED **`**.
- `ios-ci.yml` (merged in #857) builds this on `macos-latest` + runs the framework DI test.

## Remaining iOS work (user-gated)
Phase A (Firebase iOS app + `GoogleService-Info.plist` + APNs key), Phase C (Firebase Swift bridges), Phase G (App Store). See `AndroidGarage/docs/PENDING_FOLLOWUPS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)