### PR TITLE
ci(android): Append-only Play Store track-state snapshot workflow

### DIFF
--- a/.github/scripts/play-track-snapshot.mjs
+++ b/.github/scripts/play-track-snapshot.mjs
@@ -1,0 +1,135 @@
+// Reads the current Play Store release-track state (read-only) and writes a
+// Markdown snapshot to `snapshot-comment.md` for appending to the track-state
+// log issue. Never publishes or mutates the store — it inserts an edit, lists
+// tracks, and abandons the edit.
+//
+// Inputs (env):
+//   GOOGLE_PLAY_SERVICE_ACCOUNT_JSON  Service account JSON (same secret used to upload)
+//   PACKAGE_NAME                      App package, e.g. com.chriscartland.garage
+//   SNAPSHOT_TRIGGER                  Human label for what triggered this run
+//   SNAPSHOT_TIMESTAMP                Pre-formatted UTC timestamp for the header
+//
+// Output: writes ./snapshot-comment.md and echoes it to stdout.
+//
+// versionCode -> versionName mapping: each release is tagged `android/N` where
+// N == versionCode, so `git show android/N:AndroidGarage/version.properties`
+// yields the versionName for that build. Requires a full-history checkout
+// (fetch-depth: 0) so the tags are present.
+
+import pkg from 'googleapis'
+import { execFileSync } from 'node:child_process'
+import { writeFileSync } from 'node:fs'
+
+const { google } = pkg
+
+const packageName = process.env.PACKAGE_NAME || 'com.chriscartland.garage'
+const saJson = process.env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON
+const trigger = process.env.SNAPSHOT_TRIGGER || 'manual'
+const timestamp = process.env.SNAPSHOT_TIMESTAMP || new Date().toISOString()
+
+if (!saJson) {
+  console.error('Missing GOOGLE_PLAY_SERVICE_ACCOUNT_JSON')
+  process.exit(1)
+}
+
+// Tracks render in this order; any unknown/custom closed-testing tracks append after.
+const DISPLAY_ORDER = ['internal', 'alpha', 'beta', 'production']
+
+const versionNameCache = new Map()
+function versionNameForCode(vc) {
+  if (versionNameCache.has(vc)) return versionNameCache.get(vc)
+  let name
+  try {
+    const out = execFileSync('git', ['show', `android/${vc}:AndroidGarage/version.properties`], {
+      encoding: 'utf8',
+    })
+    const m = out.match(/versionName=(.+)/)
+    name = m ? m[1].trim() : '(unknown)'
+  } catch {
+    name = '(no tag)'
+  }
+  versionNameCache.set(vc, name)
+  return name
+}
+
+const auth = new google.auth.GoogleAuth({
+  credentials: JSON.parse(saJson),
+  scopes: ['https://www.googleapis.com/auth/androidpublisher'],
+})
+const publisher = google.androidpublisher({ version: 'v3', auth })
+
+const { data: edit } = await publisher.edits.insert({ packageName })
+const editId = edit.id
+
+let tracks = []
+try {
+  const res = await publisher.edits.tracks.list({ packageName, editId })
+  tracks = res.data.tracks || []
+} finally {
+  // Read-only: discard the edit so nothing is committed to the store.
+  try {
+    await publisher.edits.delete({ packageName, editId })
+  } catch {
+    // best effort; abandoned edits expire on their own
+  }
+}
+
+const byName = new Map(tracks.map((t) => [t.track, t]))
+const orderedNames = [
+  ...DISPLAY_ORDER.filter((n) => byName.has(n)),
+  ...tracks.map((t) => t.track).filter((n) => !DISPLAY_ORDER.includes(n)),
+]
+
+const rows = []
+const machine = { timestamp, trigger, packageName, tracks: {} }
+
+for (const name of orderedNames) {
+  const releases = byName.get(name)?.releases || []
+  if (releases.length === 0) {
+    rows.push(`| ${name} | — | — | — | — |`)
+    machine.tracks[name] = null
+    continue
+  }
+  for (const r of releases) {
+    const vcs = (r.versionCodes || []).map(String)
+    const names = vcs.map(versionNameForCode)
+    const status = r.status || '—'
+    const rollout =
+      r.userFraction != null
+        ? `${Math.round(r.userFraction * 100)}%`
+        : status === 'completed'
+          ? '100%'
+          : '—'
+    rows.push(`| ${name} | ${vcs.join(', ') || '—'} | ${names.join(', ') || '—'} | ${status} | ${rollout} |`)
+    machine.tracks[name] = {
+      versionCodes: vcs.map(Number),
+      versionNames: names,
+      status,
+      userFraction: r.userFraction ?? null,
+      releaseName: r.name ?? null,
+    }
+  }
+}
+
+const body = [
+  `### Play Store track state — ${timestamp}`,
+  ``,
+  `**Trigger:** ${trigger}`,
+  ``,
+  `| Track | versionCode | versionName | Status | Rollout |`,
+  `|-------|-------------|-------------|--------|---------|`,
+  ...rows,
+  ``,
+  `<details><summary>Raw snapshot (JSON)</summary>`,
+  ``,
+  '```json',
+  JSON.stringify(machine, null, 2),
+  '```',
+  ``,
+  `</details>`,
+  ``,
+  `<sub>Read-only via androidpublisher \`edits.tracks.list\` · package \`${packageName}\`</sub>`,
+].join('\n')
+
+writeFileSync('snapshot-comment.md', body)
+console.log(body)

--- a/.github/workflows/play-track-snapshot.yml
+++ b/.github/workflows/play-track-snapshot.yml
@@ -1,0 +1,78 @@
+name: Play Track Snapshot
+
+# Reads the current Play Store release-track state and appends a snapshot to a
+# single long-lived "Play Store track state log" issue. Append-only: every run
+# adds a comment, nothing is ever edited or deleted. Read-only against the
+# store (lists tracks via an edit that is then abandoned).
+#
+# Triggers:
+#   - workflow_dispatch: run manually after promoting a track in the Console
+#   - workflow_run:      after "Android Release" completes (captures the new
+#                        internal-track upload)
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ['Android Release']
+    types: [completed]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: play-track-snapshot
+  cancel-in-progress: false
+
+jobs:
+  snapshot:
+    # On workflow_run, only snapshot when the release actually succeeded.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # need tags to map versionCode N -> android/N -> versionName
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Install reader dependency
+        run: npm install --no-save googleapis
+
+      - name: Read tracks and build snapshot
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          PACKAGE_NAME: com.chriscartland.garage
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            TRIGGER="release (${{ github.event.workflow_run.head_branch }})"
+          else
+            TRIGGER="manual (@${{ github.actor }})"
+          fi
+          export SNAPSHOT_TRIGGER="$TRIGGER"
+          export SNAPSHOT_TIMESTAMP="$(date -u '+%Y-%m-%d %H:%M UTC')"
+          node .github/scripts/play-track-snapshot.mjs
+
+      - name: Append snapshot to track-state log issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          LABEL="play-track-log"
+          TITLE="Play Store track state log"
+
+          # Ensure the label exists (idempotent).
+          gh label create "$LABEL" --color "0e8a16" \
+            --description "Append-only Play Store track-state snapshots" 2>/dev/null || true
+
+          # Find the single long-lived log issue (open or closed); create it once.
+          ISSUE=$(gh issue list --label "$LABEL" --state all --json number --jq '.[0].number' 2>/dev/null)
+          if [ -z "$ISSUE" ]; then
+            gh issue create --title "$TITLE" --label "$LABEL" \
+              --body "Append-only history of Play Store release-track state. Each comment is one snapshot from \`edits.tracks.list\`, written by the Play Track Snapshot workflow (manual run, or after an Android release). Comments are never edited or deleted — scroll for history; newest is at the bottom."
+            ISSUE=$(gh issue list --label "$LABEL" --state all --json number --jq '.[0].number')
+          fi
+
+          gh issue comment "$ISSUE" --body-file snapshot-comment.md
+          echo "Appended snapshot to issue #$ISSUE"


### PR DESCRIPTION
## What

Adds a read-only workflow that snapshots the current **Play Store release-track state** and **appends** it as a comment to a single long-lived `Play Store track state log` issue. Append-only — every run adds a comment, nothing is edited or deleted — so manual Console promotions (e.g. internal → alpha) are remembered with history intact.

## Files

- **`.github/workflows/play-track-snapshot.yml`** — triggers:
  - `workflow_dispatch` — run manually after promoting a track in the Console
  - `workflow_run` after **Android Release** completes (guarded on `conclusion == success`) — captures the new internal-track upload
  - Finds-or-creates the `play-track-log` issue by label (mirrors the `ci-failure-tracker` pattern), then `gh issue comment`s the snapshot. `concurrency` group serializes runs so two snapshots can't create duplicate issues.
- **`.github/scripts/play-track-snapshot.mjs`** — read-only Play API (`edits.insert` → `edits.tracks.list` → `edits.delete`, never commits to the store). Maps each `versionCode N → android/N → versionName` via git tags (needs `fetch-depth: 0`), captures staged-rollout `userFraction`, renders a Markdown table + collapsed raw-JSON block.

Reuses the existing `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` secret (already used to upload to internal).

## Snapshot format (example)

| Track | versionCode | versionName | Status | Rollout |
|-------|-------------|-------------|--------|---------|
| internal | 247 | 2.16.37 | completed | 100% |
| alpha | 247 | 2.16.37 | completed | 100% |
| production | 245 | 2.16.35 | completed | 100% |

## Verification

- ✅ Local: `node --check` passes; workflow YAML validated.
- ⚠️ **Verification gap (post-merge):** `workflow_dispatch` only becomes runnable once the file is on `main`, and the live API call can't be exercised locally. First real test is a manual dispatch after merge — confirming the service account has read access (expected, since it already uploads) and the API response shape matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)