### PR TITLE
ci(android): Fix first-run race in Play track snapshot issue creation

### DIFF
--- a/.github/workflows/play-track-snapshot.yml
+++ b/.github/workflows/play-track-snapshot.yml
@@ -69,9 +69,17 @@ jobs:
           # Find the single long-lived log issue (open or closed); create it once.
           ISSUE=$(gh issue list --label "$LABEL" --state all --json number --jq '.[0].number' 2>/dev/null)
           if [ -z "$ISSUE" ]; then
-            gh issue create --title "$TITLE" --label "$LABEL" \
-              --body "Append-only history of Play Store release-track state. Each comment is one snapshot from \`edits.tracks.list\`, written by the Play Track Snapshot workflow (manual run, or after an Android release). Comments are never edited or deleted — scroll for history; newest is at the bottom."
-            ISSUE=$(gh issue list --label "$LABEL" --state all --json number --jq '.[0].number')
+            # Capture the number straight from create — `gh issue list` is
+            # eventually consistent and won't surface a just-created issue yet
+            # (the first-run race that produced an empty number before).
+            ISSUE_URL=$(gh issue create --title "$TITLE" --label "$LABEL" \
+              --body "Append-only history of Play Store release-track state. Each comment is one snapshot from \`edits.tracks.list\`, written by the Play Track Snapshot workflow (manual run, or after an Android release). Comments are never edited or deleted — scroll for history; newest is at the bottom.")
+            ISSUE="${ISSUE_URL##*/}"
+          fi
+
+          if [ -z "$ISSUE" ]; then
+            echo "::error::Could not resolve the track-state log issue number"
+            exit 1
           fi
 
           gh issue comment "$ISSUE" --body-file snapshot-comment.md


### PR DESCRIPTION
## Problem

The first dispatch of the Play Track Snapshot workflow ([run](https://github.com/cartland/SmartGarageDoor/actions/runs/27212841315)) failed at the append step with `invalid issue format: ""`.

- ✅ The Play API read succeeded — service account **has read access**, API shape matches.
- ✅ `gh issue create` succeeded → created issue #861 (label + body correct).
- ❌ The append failed: after creating the issue, the script re-queried `gh issue list` to get its number, but GitHub's issue list/search is **eventually consistent** and didn't surface the just-created issue yet → empty number → `gh issue comment ""` failed.

Net: #861 exists but got no snapshot comment.

## Fix

Capture the issue number directly from `gh issue create`'s output URL (`${URL##*/}`) instead of re-querying the eventually-consistent list, plus a guard that hard-fails with a clear message if the number can't be resolved. Only the first-ever run hit this; subsequent runs find the existing issue via the initial `gh issue list`.

## Verification

After merge, re-dispatch the workflow — it will find existing #861 and append the first real snapshot (capturing current internal + alpha state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)