### PR TITLE
ci(android): Track-snapshot — latest in body, history in comments, rollover + unit tests

### DIFF
--- a/.github/scripts/lib/format-snapshot.mjs
+++ b/.github/scripts/lib/format-snapshot.mjs
@@ -1,0 +1,85 @@
+// Pure rendering for the Play Store track-state snapshot. No I/O, no API, no
+// git — everything it needs is passed in, so it is unit-testable in isolation.
+//
+// `tracks`            : array of androidpublisher Track objects
+//                       ({ track, releases: [{ status, versionCodes, userFraction, name }] })
+// `resolveVersionName`: (versionCode: string) => string  — maps a code to its
+//                       versionName (production uses git tags; tests pass a stub)
+// `timestamp`,`trigger`,`packageName`: header/footer metadata
+//
+// Returns { comment, body, machine }:
+//   comment  Markdown for the appended history comment
+//   body     Markdown for the issue description (comment + a "current state" preamble)
+//   machine  the structured object embedded as raw JSON (also handy for tests)
+
+// Tracks render in this order; any custom/closed-testing tracks append after.
+export const DISPLAY_ORDER = ['internal', 'alpha', 'beta', 'production']
+
+function rollout(release) {
+  if (release.userFraction != null) return `${Math.round(release.userFraction * 100)}%`
+  return release.status === 'completed' ? '100%' : '—'
+}
+
+export function renderSnapshot({ tracks, resolveVersionName, timestamp, trigger, packageName }) {
+  const byName = new Map(tracks.map((t) => [t.track, t]))
+  const orderedNames = [
+    ...DISPLAY_ORDER.filter((n) => byName.has(n)),
+    ...tracks.map((t) => t.track).filter((n) => !DISPLAY_ORDER.includes(n)),
+  ]
+
+  const rows = []
+  const machine = { timestamp, trigger, packageName, tracks: {} }
+
+  for (const name of orderedNames) {
+    const releases = byName.get(name)?.releases || []
+    if (releases.length === 0) {
+      rows.push(`| ${name} | — | — | — | — |`)
+      machine.tracks[name] = null
+      continue
+    }
+    for (const r of releases) {
+      const vcs = (r.versionCodes || []).map(String)
+      const names = vcs.map(resolveVersionName)
+      const status = r.status || '—'
+      rows.push(
+        `| ${name} | ${vcs.join(', ') || '—'} | ${names.join(', ') || '—'} | ${status} | ${rollout(r)} |`,
+      )
+      machine.tracks[name] = {
+        versionCodes: vcs.map(Number),
+        versionNames: names,
+        status,
+        userFraction: r.userFraction ?? null,
+        releaseName: r.name ?? null,
+      }
+    }
+  }
+
+  const comment = [
+    `### Play Store track state — ${timestamp}`,
+    ``,
+    `**Trigger:** ${trigger}`,
+    ``,
+    `| Track | versionCode | versionName | Status | Rollout |`,
+    `|-------|-------------|-------------|--------|---------|`,
+    ...rows,
+    ``,
+    `<details><summary>Raw snapshot (JSON)</summary>`,
+    ``,
+    '```json',
+    JSON.stringify(machine, null, 2),
+    '```',
+    ``,
+    `</details>`,
+    ``,
+    `<sub>Read-only via androidpublisher \`edits.tracks.list\` · package \`${packageName}\`</sub>`,
+  ].join('\n')
+
+  const body = [
+    `**Current Play Store track state** — this description is overwritten on each run.`,
+    `The full append-only history is in the comments below.`,
+    ``,
+    comment,
+  ].join('\n')
+
+  return { comment, body, machine }
+}

--- a/.github/scripts/play-track-snapshot.mjs
+++ b/.github/scripts/play-track-snapshot.mjs
@@ -1,7 +1,9 @@
-// Reads the current Play Store release-track state (read-only) and writes a
-// Markdown snapshot to `snapshot-comment.md` for appending to the track-state
-// log issue. Never publishes or mutates the store — it inserts an edit, lists
-// tracks, and abandons the edit.
+// Reads the current Play Store release-track state (read-only) and writes two
+// Markdown files for the track-state log issue:
+//   snapshot-comment.md  appended as a new comment (immutable history)
+//   snapshot-body.md     written to the issue description (latest state)
+// Never publishes or mutates the store — it inserts an edit, lists tracks, and
+// abandons the edit.
 //
 // Inputs (env):
 //   GOOGLE_PLAY_SERVICE_ACCOUNT_JSON  Service account JSON (same secret used to upload)
@@ -9,7 +11,8 @@
 //   SNAPSHOT_TRIGGER                  Human label for what triggered this run
 //   SNAPSHOT_TIMESTAMP                Pre-formatted UTC timestamp for the header
 //
-// Output: writes ./snapshot-comment.md and echoes it to stdout.
+// Rendering lives in lib/format-snapshot.mjs (pure, unit-tested). This entry
+// point only does auth + the API read + the git-tag versionName lookup.
 //
 // versionCode -> versionName mapping: each release is tagged `android/N` where
 // N == versionCode, so `git show android/N:AndroidGarage/version.properties`
@@ -19,6 +22,7 @@
 import pkg from 'googleapis'
 import { execFileSync } from 'node:child_process'
 import { writeFileSync } from 'node:fs'
+import { renderSnapshot } from './lib/format-snapshot.mjs'
 
 const { google } = pkg
 
@@ -32,11 +36,8 @@ if (!saJson) {
   process.exit(1)
 }
 
-// Tracks render in this order; any unknown/custom closed-testing tracks append after.
-const DISPLAY_ORDER = ['internal', 'alpha', 'beta', 'production']
-
 const versionNameCache = new Map()
-function versionNameForCode(vc) {
+function resolveVersionName(vc) {
   if (versionNameCache.has(vc)) return versionNameCache.get(vc)
   let name
   try {
@@ -74,62 +75,14 @@ try {
   }
 }
 
-const byName = new Map(tracks.map((t) => [t.track, t]))
-const orderedNames = [
-  ...DISPLAY_ORDER.filter((n) => byName.has(n)),
-  ...tracks.map((t) => t.track).filter((n) => !DISPLAY_ORDER.includes(n)),
-]
+const { comment, body } = renderSnapshot({
+  tracks,
+  resolveVersionName,
+  timestamp,
+  trigger,
+  packageName,
+})
 
-const rows = []
-const machine = { timestamp, trigger, packageName, tracks: {} }
-
-for (const name of orderedNames) {
-  const releases = byName.get(name)?.releases || []
-  if (releases.length === 0) {
-    rows.push(`| ${name} | — | — | — | — |`)
-    machine.tracks[name] = null
-    continue
-  }
-  for (const r of releases) {
-    const vcs = (r.versionCodes || []).map(String)
-    const names = vcs.map(versionNameForCode)
-    const status = r.status || '—'
-    const rollout =
-      r.userFraction != null
-        ? `${Math.round(r.userFraction * 100)}%`
-        : status === 'completed'
-          ? '100%'
-          : '—'
-    rows.push(`| ${name} | ${vcs.join(', ') || '—'} | ${names.join(', ') || '—'} | ${status} | ${rollout} |`)
-    machine.tracks[name] = {
-      versionCodes: vcs.map(Number),
-      versionNames: names,
-      status,
-      userFraction: r.userFraction ?? null,
-      releaseName: r.name ?? null,
-    }
-  }
-}
-
-const body = [
-  `### Play Store track state — ${timestamp}`,
-  ``,
-  `**Trigger:** ${trigger}`,
-  ``,
-  `| Track | versionCode | versionName | Status | Rollout |`,
-  `|-------|-------------|-------------|--------|---------|`,
-  ...rows,
-  ``,
-  `<details><summary>Raw snapshot (JSON)</summary>`,
-  ``,
-  '```json',
-  JSON.stringify(machine, null, 2),
-  '```',
-  ``,
-  `</details>`,
-  ``,
-  `<sub>Read-only via androidpublisher \`edits.tracks.list\` · package \`${packageName}\`</sub>`,
-].join('\n')
-
-writeFileSync('snapshot-comment.md', body)
-console.log(body)
+writeFileSync('snapshot-comment.md', comment)
+writeFileSync('snapshot-body.md', body)
+console.log(comment)

--- a/.github/scripts/play-track-snapshot.test.mjs
+++ b/.github/scripts/play-track-snapshot.test.mjs
@@ -1,0 +1,90 @@
+// Unit tests for the pure snapshot renderer. Run with: node --test .github/scripts
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { renderSnapshot, DISPLAY_ORDER } from './lib/format-snapshot.mjs'
+
+const VERSION_NAMES = { 247: '2.16.37', 245: '2.16.35' }
+const resolveVersionName = (vc) => VERSION_NAMES[vc] ?? '(no tag)'
+
+// internal/alpha = completed full rollout; production = staged 10%; beta = empty.
+// Deliberately out of display order in the input to prove the renderer sorts.
+const TRACKS = [
+  { track: 'production', releases: [{ status: 'inProgress', versionCodes: ['245'], userFraction: 0.1, name: '2.16.35' }] },
+  { track: 'beta', releases: [] },
+  { track: 'alpha', releases: [{ status: 'completed', versionCodes: ['247'], name: '2.16.37' }] },
+  { track: 'internal', releases: [{ status: 'completed', versionCodes: ['247'], name: '2.16.37' }] },
+]
+
+function render(tracks = TRACKS) {
+  return renderSnapshot({
+    tracks,
+    resolveVersionName,
+    timestamp: '2026-06-09 14:31 UTC',
+    trigger: 'manual (@tester)',
+    packageName: 'com.chriscartland.garage',
+  })
+}
+
+test('renders tracks in display order regardless of input order', () => {
+  const { comment } = render()
+  const positions = DISPLAY_ORDER.map((n) => comment.indexOf(`| ${n} |`))
+  assert.ok(
+    positions.every((p) => p >= 0),
+    'every known track is present',
+  )
+  const sorted = [...positions].sort((a, b) => a - b)
+  assert.deepEqual(positions, sorted, 'rows appear internal, alpha, beta, production')
+})
+
+test('maps versionCode to versionName via the resolver', () => {
+  const { comment, machine } = render()
+  assert.match(comment, /\| internal \| 247 \| 2\.16\.37 \|/)
+  assert.deepEqual(machine.tracks.internal.versionNames, ['2.16.37'])
+})
+
+test('completed release with null userFraction shows 100%', () => {
+  const { comment } = render()
+  assert.match(comment, /\| internal \| 247 \| 2\.16\.37 \| completed \| 100% \|/)
+})
+
+test('staged rollout shows userFraction as a percentage', () => {
+  const { comment, machine } = render()
+  assert.match(comment, /\| production \| 245 \| 2\.16\.35 \| inProgress \| 10% \|/)
+  assert.equal(machine.tracks.production.userFraction, 0.1)
+})
+
+test('empty track renders dashes and a null machine entry', () => {
+  const { comment, machine } = render()
+  assert.match(comment, /\| beta \| — \| — \| — \| — \|/)
+  assert.equal(machine.tracks.beta, null)
+})
+
+test('unknown/custom tracks sort after the known four', () => {
+  const withCustom = [...TRACKS, { track: 'qa-closed', releases: [{ status: 'completed', versionCodes: ['247'] }] }]
+  const { comment } = render(withCustom)
+  assert.ok(
+    comment.indexOf('| production |') < comment.indexOf('| qa-closed |'),
+    'custom track appears after production',
+  )
+})
+
+test('unresolved versionCode falls back to the resolver default', () => {
+  const tracks = [{ track: 'internal', releases: [{ status: 'completed', versionCodes: ['999'] }] }]
+  const { comment } = render(tracks)
+  assert.match(comment, /\| internal \| 999 \| \(no tag\) \| completed \| 100% \|/)
+})
+
+test('body carries the latest snapshot plus the "current state" preamble', () => {
+  const { body, comment } = render()
+  assert.match(body, /\*\*Current Play Store track state\*\*/)
+  assert.ok(body.includes(comment), 'body embeds the full snapshot')
+})
+
+test('embedded JSON is valid and reflects the tracks', () => {
+  const { comment } = render()
+  const json = comment.match(/```json\n([\s\S]*?)\n```/)[1]
+  const parsed = JSON.parse(json)
+  assert.equal(parsed.tracks.alpha.status, 'completed')
+  assert.equal(parsed.tracks.beta, null)
+  assert.equal(parsed.packageName, 'com.chriscartland.garage')
+})

--- a/.github/workflows/play-track-snapshot.yml
+++ b/.github/workflows/play-track-snapshot.yml
@@ -1,9 +1,11 @@
 name: Play Track Snapshot
 
-# Reads the current Play Store release-track state and appends a snapshot to a
-# single long-lived "Play Store track state log" issue. Append-only: every run
-# adds a comment, nothing is ever edited or deleted. Read-only against the
-# store (lists tracks via an edit that is then abandoned).
+# Reads the current Play Store release-track state and records it on a long-lived
+# "Play Store track state log" issue: the latest snapshot is written to the issue
+# BODY (overwritten each run, an at-a-glance dashboard) and ALSO appended as a
+# COMMENT (immutable, append-only history). Read-only against the store (lists
+# tracks via an edit that is then abandoned). When the active issue accumulates
+# many comments it rolls over to a fresh one (see MAX_COMMENTS below).
 #
 # Triggers:
 #   - workflow_dispatch: run manually after promoting a track in the Console
@@ -55,32 +57,51 @@ jobs:
           export SNAPSHOT_TIMESTAMP="$(date -u '+%Y-%m-%d %H:%M UTC')"
           node .github/scripts/play-track-snapshot.mjs
 
-      - name: Append snapshot to track-state log issue
+      - name: Update track-state log issue (latest in body, history in comments)
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
           LABEL="play-track-log"
           TITLE="Play Store track state log"
+          MAX_COMMENTS=1000 # roll over to a fresh issue past this (GitHub hard cap ~2500)
 
           # Ensure the label exists (idempotent).
           gh label create "$LABEL" --color "0e8a16" \
-            --description "Append-only Play Store track-state snapshots" 2>/dev/null || true
+            --description "Play Store track-state snapshots (body = latest, comments = history)" 2>/dev/null || true
 
-          # Find the single long-lived log issue (open or closed); create it once.
-          ISSUE=$(gh issue list --label "$LABEL" --state all --json number --jq '.[0].number' 2>/dev/null)
+          # Create a new log issue with the given initial body; echo its number.
+          # Read the number straight from create output — `gh issue list` is
+          # eventually consistent and won't surface a just-created issue yet.
+          create_issue() {
+            local url
+            url=$(gh issue create --title "$TITLE" --label "$LABEL" --body "$1")
+            echo "${url##*/}"
+          }
+
+          # The active log is the OPEN issue carrying the label; create one if none.
+          ISSUE=$(gh issue list --label "$LABEL" --state open --json number --jq '.[0].number' 2>/dev/null)
+          [ "$ISSUE" = "null" ] && ISSUE=""
           if [ -z "$ISSUE" ]; then
-            # Capture the number straight from create — `gh issue list` is
-            # eventually consistent and won't surface a just-created issue yet
-            # (the first-run race that produced an empty number before).
-            ISSUE_URL=$(gh issue create --title "$TITLE" --label "$LABEL" \
-              --body "Append-only history of Play Store release-track state. Each comment is one snapshot from \`edits.tracks.list\`, written by the Play Track Snapshot workflow (manual run, or after an Android release). Comments are never edited or deleted — scroll for history; newest is at the bottom.")
-            ISSUE="${ISSUE_URL##*/}"
+            ISSUE=$(create_issue "_Initializing… the latest snapshot will appear here on the next run._")
           fi
-
           if [ -z "$ISSUE" ]; then
             echo "::error::Could not resolve the track-state log issue number"
             exit 1
           fi
 
+          # Roll over to a fresh issue once the log gets large (keeps the page fast).
+          COUNT=$(gh api "repos/$REPO/issues/$ISSUE" --jq '.comments' 2>/dev/null || echo 0)
+          if [ "${COUNT:-0}" -ge "$MAX_COMMENTS" ]; then
+            gh issue comment "$ISSUE" --body "📦 Reached $COUNT snapshots — rolling over to a fresh log issue to keep this page fast."
+            NEW=$(create_issue "_Continued from #$ISSUE. The latest snapshot will appear here on the next run._")
+            gh issue comment "$NEW" --body "Continued from #$ISSUE."
+            gh issue comment "$ISSUE" --body "Continued in #$NEW."
+            gh issue close "$ISSUE"
+            ISSUE="$NEW"
+          fi
+
+          # Latest state -> issue body (overwritten); history -> a comment (append-only).
+          gh issue edit "$ISSUE" --body-file snapshot-body.md
           gh issue comment "$ISSUE" --body-file snapshot-comment.md
-          echo "Appended snapshot to issue #$ISSUE"
+          echo "Updated issue #$ISSUE (body refreshed; snapshot appended; $COUNT prior comments)"

--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -1,0 +1,34 @@
+name: Scripts Tests
+
+# Unit tests for standalone Node scripts under .github/scripts/ (e.g. the Play
+# Store track-state renderer). Runs on PRs and pushes that touch those scripts.
+# Uses Node's built-in test runner — no dependencies, no install step.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/scripts/**'
+      - '.github/workflows/scripts-tests.yml'
+  pull_request:
+    paths:
+      - '.github/scripts/**'
+      - '.github/workflows/scripts-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      # Glob targets only *.test.mjs so the API entry point (which imports
+      # googleapis) is never loaded during tests.
+      - name: Run script unit tests
+        run: node --test '.github/scripts/**/*.test.mjs'


### PR DESCRIPTION
Builds on the Play Track Snapshot workflow (#860, #862). Three things:

## 1. Latest state in the issue body
Each run now **overwrites the issue description** with the current snapshot (an at-a-glance dashboard) **and** appends it as a **comment** (immutable history). The body is the only mutable part; comments stay append-only, so nothing is lost. Find-logic targets the **open** labelled issue.

## 2. Rollover at 1,000 comments
GitHub hard-caps issues near ~2,500 comments and pages get slow well before that. When the active log reaches `MAX_COMMENTS=1000`, the workflow opens a fresh issue (same `play-track-log` label), cross-links them (`Continued in #X` ↔ `Continued from #Y`), and closes the old one. At our cadence that's roughly once a decade — it's hygiene, not necessity.

## 3. Refactor for testability + unit test + CI guard
- Rendering extracted into a pure `lib/format-snapshot.mjs` (no I/O; `versionName` resolver injected). The entry script is now just auth + the API read.
- `play-track-snapshot.test.mjs` — `node:test`, **9 cases**: track ordering, `versionCode→versionName` mapping, staged-rollout `userFraction → %`, `completed`+null → 100%, empty-track dashes, custom-track sorting, body preamble, embedded-JSON validity.
- `scripts-tests.yml` — runs `node --test` on PRs/pushes touching `.github/scripts/**`. Targets `*.test.mjs` by glob so the `googleapis` entry point is never imported during tests.

## Verification
- ✅ Local: `node --test` → 9/9 pass; both YAML files valid; entry + lib parse.
- ⚠️ The body-edit + rollover paths run against live GitHub, so they're exercised post-merge by re-dispatching the workflow (it'll refresh #861's body and add a comment). Rollover only fires at 1,000 comments; the logic is covered by review + the cross-link structure.

> Note: `scripts-tests.yml` runs as an informational check (not yet in branch-protection required contexts). The PR is still gated by `Android CI Complete` since it touches `.github/**`. Can promote it to required later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)