### PR TITLE
ci: Make Scripts Tests always-run so it's safe as a required check

### DIFF
--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -1,26 +1,29 @@
 name: Scripts Tests
 
 # Unit tests for standalone Node scripts under .github/scripts/ (e.g. the Play
-# Store track-state renderer). Runs on PRs and pushes that touch those scripts.
-# Uses Node's built-in test runner — no dependencies, no install step.
+# Store track-state renderer). Uses Node's built-in test runner — no
+# dependencies, no install step (~6s).
+#
+# Deliberately NO `paths:` filter. The `Script unit tests` job is a REQUIRED
+# status check, and a path-filtered required check stays "Expected/pending"
+# forever on any PR that doesn't touch the filtered paths — which blocks the
+# merge. Running on every PR/push (the test is trivial) guarantees the check
+# always reports success or failure and never hangs or skips. `timeout-minutes`
+# bounds it so a stuck runner fails fast instead of blocking for hours.
 
 on:
   push:
     branches: [main]
-    paths:
-      - '.github/scripts/**'
-      - '.github/workflows/scripts-tests.yml'
   pull_request:
-    paths:
-      - '.github/scripts/**'
-      - '.github/workflows/scripts-tests.yml'
 
 permissions:
   contents: read
 
 jobs:
   test:
+    name: Script unit tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # never hang; the tests take ~6s
     steps:
       - uses: actions/checkout@v5
 
@@ -29,6 +32,7 @@ jobs:
           node-version: '22'
 
       # Glob targets only *.test.mjs so the API entry point (which imports
-      # googleapis) is never loaded during tests.
+      # googleapis) is never loaded during tests. `node --test` exits non-zero
+      # on failure and zero on success, so the check always concludes.
       - name: Run script unit tests
         run: node --test '.github/scripts/**/*.test.mjs'


### PR DESCRIPTION
Prep for promoting `Script unit tests` to a required status check.

## Why
A **path-filtered required check never runs** on PRs that don't touch the filtered paths. GitHub then leaves the required context in `Expected`/pending **forever**, which **blocks the merge**. So before making this check required, it must run on *every* PR.

## Change
- Remove the `paths:` filter → the workflow runs on every PR and every push to main. The test is dependency-free and ~6s, so always-running is cheap.
- Name the job `Script unit tests` → a stable, descriptive required-context name (renaming a required context later needs the branch-protection dance, so pin it now).
- Add `timeout-minutes: 10` → a stuck runner fails fast instead of blocking for the 6h default.

Net: the check always reports **success or failure**, never hangs, never skips in a way that blocks a merge.

## Plan
1. Merge this.
2. Verify on a PR that does **not** touch `.github/scripts/**` that `Script unit tests` still runs and concludes.
3. Promote `Script unit tests` to a required status check alongside `Android CI Complete` / `Firebase CI Complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)