### PR TITLE
test: verify Script unit tests gate runs on a non-scripts PR (throwaway)

### DIFF
--- a/docs/verify-scripts-gate.md
+++ b/docs/verify-scripts-gate.md
@@ -1,0 +1,3 @@
+# Scripts-gate verification (throwaway)
+
+Temporary PR to confirm the `Script unit tests` required check runs on a PR that does NOT touch `.github/scripts/**`. Closed (never merged) once the check concludes.


### PR DESCRIPTION
Throwaway verification — confirms `Script unit tests` runs on a PR that touches only a docs file (no `.github/scripts/**`). Will be closed, not merged.