### PR TITLE
chore(hooks): warn-command-substitution is warn-only, not a confirmation gate

### DIFF
--- a/.claude/hooks/warn-command-substitution.sh
+++ b/.claude/hooks/warn-command-substitution.sh
@@ -9,14 +9,13 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 # Strip heredoc bodies and quoted strings used for commit messages etc.
 STRIPPED=$(echo "$COMMAND" | sed '/<<.*EOF/,/^EOF/d')
 
-# Check for $(...) command substitution outside of simple variable assignments
+# Check for $(...) command substitution outside of simple variable assignments.
+# Warn-only: surface a non-blocking note and let the command proceed (do NOT
+# return permissionDecision "ask" — that forced a confirmation prompt on every
+# $(...), which was pure friction). Normal permission rules still apply.
 if echo "$STRIPPED" | grep -qE '\$\('; then
   jq -n '{
-    "hookSpecificOutput": {
-      "hookEventName": "PreToolUse",
-      "permissionDecision": "ask",
-      "permissionDecisionReason": "Contains command substitution $(...) — review before approving."
-    }
+    "systemMessage": "Note: command uses $(...) substitution (proceeding without confirmation)."
   }'
 fi
 


### PR DESCRIPTION
The `warn-command-substitution.sh` hook returned `permissionDecision: "ask"` on every `$(...)`, forcing a confirmation prompt even for allowlisted commands — pure friction during normal work.

Change it to emit a non-blocking `systemMessage` and let the command proceed (normal permission rules still apply). This matches the hook's documented intent ("Warns on `$(...)`") in CLAUDE.md.

Pipe-tested: `$(...)` → passive note + proceed; clean commands → no output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)