### PR TITLE
feat(android-data): door history pagination plumbing (data layer)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/config/AppConfigFactory.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/config/AppConfigFactory.kt
@@ -30,7 +30,8 @@ object AppConfigFactory {
     fun create(): AppConfig =
         AppConfig(
             baseUrl = BuildConfig.BASE_URL,
-            recentEventCount = 30,
+            // First-page size for door history; the server caps this at 50.
+            recentEventCount = 50,
             serverConfigKey = BuildConfig.SERVER_CONFIG_KEY,
             snoozeNotificationsOption = true,
             remoteButtonPushEnabled = true,

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -85,6 +85,7 @@ import com.chriscartland.garage.usecase.FcmRegistrationManager
 import com.chriscartland.garage.usecase.FetchButtonHealthUseCase
 import com.chriscartland.garage.usecase.FetchCurrentDoorEventUseCase
 import com.chriscartland.garage.usecase.FetchFcmStatusUseCase
+import com.chriscartland.garage.usecase.FetchOlderDoorEventsUseCase
 import com.chriscartland.garage.usecase.FetchRecentDoorEventsUseCase
 import com.chriscartland.garage.usecase.FetchSnoozeStatusUseCase
 import com.chriscartland.garage.usecase.GetAuthTokenForCopyUseCase
@@ -385,6 +386,10 @@ abstract class AppComponent(
     @Provides
     fun provideFetchRecentDoorEventsUseCase(doorRepository: DoorRepository): FetchRecentDoorEventsUseCase =
         FetchRecentDoorEventsUseCase(doorRepository)
+
+    @Provides
+    fun provideFetchOlderDoorEventsUseCase(doorRepository: DoorRepository): FetchOlderDoorEventsUseCase =
+        FetchOlderDoorEventsUseCase(doorRepository)
 
     @Provides
     fun provideFetchFcmStatusUseCase(doorFcmRepository: DoorFcmRepository): FetchFcmStatusUseCase = FetchFcmStatusUseCase(doorFcmRepository)

--- a/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/DatabaseLocalDoorDataSource.kt
+++ b/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/DatabaseLocalDoorDataSource.kt
@@ -42,4 +42,10 @@ class DatabaseLocalDoorDataSource(
         Logger.d { "Replacing DoorEvents: $doorEvents" }
         appDatabase.doorEventDao().replaceAll(doorEvents.map { it.toEntity() })
     }
+
+    override suspend fun appendDoorEvents(doorEvents: List<DoorEvent>) {
+        Logger.d { "Appending DoorEvents: ${doorEvents.size}" }
+        // insertList uses REPLACE-on-conflict, so overlapping page rows dedupe by PK.
+        appDatabase.doorEventDao().insertList(doorEvents.map { it.toEntity() })
+    }
 }

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/LocalDoorDataSource.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/LocalDoorDataSource.kt
@@ -15,5 +15,12 @@ interface LocalDoorDataSource {
 
     suspend fun insertDoorEvent(doorEvent: DoorEvent)
 
+    /** Replace the whole cache (initial load / pull-to-refresh). */
     suspend fun replaceDoorEvents(doorEvents: List<DoorEvent>)
+
+    /**
+     * Append older events to the cache without clearing it (pagination load-more).
+     * Page-boundary overlap is de-duplicated by primary key.
+     */
+    suspend fun appendDoorEvents(doorEvents: List<DoorEvent>)
 }

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/NetworkDoorDataSource.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/NetworkDoorDataSource.kt
@@ -1,6 +1,7 @@
 package com.chriscartland.garage.data
 
 import com.chriscartland.garage.domain.model.DoorEvent
+import com.chriscartland.garage.domain.model.DoorEventPage
 
 /**
  * Data source interface for fetching door events from the network.
@@ -11,8 +12,14 @@ import com.chriscartland.garage.domain.model.DoorEvent
 interface NetworkDoorDataSource {
     suspend fun fetchCurrentDoorEvent(buildTimestamp: String): NetworkResult<DoorEvent>
 
-    suspend fun fetchRecentDoorEvents(
+    /**
+     * Fetch one page of door history. [pageToken] null = the windowed first page
+     * (last 7 days, server-capped at 50); a non-null token pages further into the
+     * past. Returns the events plus the opaque next/prev tokens.
+     */
+    suspend fun fetchDoorEventPage(
         buildTimestamp: String,
-        count: Int,
-    ): NetworkResult<List<DoorEvent>>
+        pageSize: Int,
+        pageToken: String?,
+    ): NetworkResult<DoorEventPage>
 }

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/ktor/KtorNetworkDoorDataSource.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/ktor/KtorNetworkDoorDataSource.kt
@@ -21,6 +21,7 @@ import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.NetworkDoorDataSource
 import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.domain.model.DoorEvent
+import com.chriscartland.garage.domain.model.DoorEventPage
 import com.chriscartland.garage.domain.model.DoorPosition
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -58,35 +59,43 @@ class KtorNetworkDoorDataSource(
         }
     }
 
-    override suspend fun fetchRecentDoorEvents(
+    override suspend fun fetchDoorEventPage(
         buildTimestamp: String,
-        count: Int,
-    ): NetworkResult<List<DoorEvent>> {
+        pageSize: Int,
+        pageToken: String?,
+    ): NetworkResult<DoorEventPage> {
         return try {
             val response = client.get("eventHistory") {
                 parameter("buildTimestamp", buildTimestamp)
-                parameter("eventHistoryMaxCount", count)
+                parameter("pageSize", pageSize)
+                // Legacy alias: lets a pre-pagination server still apply the limit
+                // (keeps this client safe to ship before the server deploys).
+                parameter("eventHistoryMaxCount", pageSize)
+                if (pageToken != null) {
+                    parameter("pageToken", pageToken)
+                }
             }
             if (!response.status.isSuccess()) {
                 Logger.e { "Response code is ${response.status.value}" }
                 return NetworkResult.HttpError(response.status.value)
             }
             val body = response.body<KtorRecentEventDataResponse>()
-            if (body.eventHistory.isNullOrEmpty()) {
-                Logger.i { "recentEventData is empty" }
-                return NetworkResult.Success(emptyList())
-            }
-            val doorEvents = body.eventHistory.mapNotNull {
+            val doorEvents = body.eventHistory.orEmpty().mapNotNull {
                 it.currentEvent?.toDoorEvent()
             }
-            if (doorEvents.size != body.eventHistory.size) {
-                Logger.e { "Door events size ${doorEvents.size} does not match response size ${body.eventHistory.size}" }
-            }
-            NetworkResult.Success(doorEvents)
+            NetworkResult.Success(
+                DoorEventPage(
+                    events = doorEvents,
+                    nextPageToken = body.nextPageToken,
+                    prevPageToken = body.prevPageToken,
+                    // Old server omits hasMore — derive it from the older-direction token.
+                    hasMore = body.hasMore ?: (body.nextPageToken != null),
+                ),
+            )
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
-            Logger.e { "Error fetching recent door events: $e" }
+            Logger.e { "Error fetching door event page: $e" }
             NetworkResult.ConnectionFailed
         }
     }
@@ -102,6 +111,9 @@ private data class KtorCurrentEventDataResponse(
 @Serializable
 private data class KtorRecentEventDataResponse(
     val eventHistory: List<KtorEventData>? = null,
+    val nextPageToken: String? = null,
+    val prevPageToken: String? = null,
+    val hasMore: Boolean? = null,
 )
 
 @Serializable

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepository.kt
@@ -23,8 +23,10 @@ import com.chriscartland.garage.data.NetworkDoorDataSource
 import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.DoorEvent
+import com.chriscartland.garage.domain.model.DoorEventPage
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.model.FetchError
+import com.chriscartland.garage.domain.model.PaginationState
 import com.chriscartland.garage.domain.repository.DoorRepository
 import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import kotlinx.coroutines.CoroutineScope
@@ -63,6 +65,11 @@ class NetworkDoorRepository(
     // every fresh screen entry.
     private val _recentDoorEvents = MutableStateFlow<List<DoorEvent>>(emptyList())
     override val recentDoorEvents: StateFlow<List<DoorEvent>> = _recentDoorEvents
+
+    // ADR-022: repo-owned state-y pagination cursor. The token is server state
+    // tied to the cache contents, so it lives next to the cache (not the VM).
+    private val _paginationState = MutableStateFlow(PaginationState.Initial)
+    override val paginationState: StateFlow<PaginationState> = _paginationState
 
     init {
         externalScope.launch {
@@ -119,15 +126,18 @@ class NetworkDoorRepository(
             return AppResult.Error(FetchError.NotReady)
         }
         return when (
-            val result = networkDoorDataSource.fetchRecentDoorEvents(
+            val result = networkDoorDataSource.fetchDoorEventPage(
                 buildTimestamp = buildTimestamp,
-                count = recentEventCount,
+                pageSize = recentEventCount,
+                pageToken = null,
             )
         ) {
             is NetworkResult.Success -> {
-                Logger.d { "Success: ${result.data}" }
-                localDoorDataSource.replaceDoorEvents(result.data)
-                AppResult.Success(result.data)
+                Logger.d { "Success: ${result.data.events.size} events" }
+                // First page / pull-to-refresh: replace the cache and reset paging.
+                localDoorDataSource.replaceDoorEvents(result.data.events)
+                _paginationState.value = result.data.toPaginationState()
+                AppResult.Success(result.data.events)
             }
             is NetworkResult.HttpError -> {
                 Logger.e { "HTTP ${result.code} fetching recent door events" }
@@ -139,4 +149,51 @@ class NetworkDoorRepository(
             }
         }
     }
+
+    override suspend fun fetchOlderDoorEvents(): AppResult<List<DoorEvent>, FetchError> {
+        val current = _paginationState.value
+        val token = current.nextPageToken
+        if (token == null || current.isLoadingMore) {
+            // Nothing more to load, or a load is already in flight (reentrancy guard).
+            return AppResult.Success(emptyList())
+        }
+        val buildTimestamp = fetchBuildTimestampCached()
+        if (buildTimestamp == null) {
+            Logger.e { "Server config is null" }
+            return AppResult.Error(FetchError.NotReady)
+        }
+        _paginationState.value = current.copy(isLoadingMore = true)
+        Logger.i { "paginationState <- isLoadingMore=true (loadMore)" }
+        return when (
+            val result = networkDoorDataSource.fetchDoorEventPage(
+                buildTimestamp = buildTimestamp,
+                pageSize = recentEventCount,
+                pageToken = token,
+            )
+        ) {
+            is NetworkResult.Success -> {
+                Logger.d { "Older page: ${result.data.events.size} events" }
+                localDoorDataSource.appendDoorEvents(result.data.events)
+                _paginationState.value = result.data.toPaginationState()
+                AppResult.Success(result.data.events)
+            }
+            is NetworkResult.HttpError -> {
+                Logger.e { "HTTP ${result.code} fetching older door events" }
+                _paginationState.value = current.copy(isLoadingMore = false)
+                AppResult.Error(FetchError.NetworkFailed)
+            }
+            NetworkResult.ConnectionFailed -> {
+                Logger.e { "Connection failed fetching older door events" }
+                _paginationState.value = current.copy(isLoadingMore = false)
+                AppResult.Error(FetchError.NetworkFailed)
+            }
+        }
+    }
+
+    private fun DoorEventPage.toPaginationState(): PaginationState =
+        PaginationState(
+            nextPageToken = nextPageToken,
+            canLoadMore = hasMore && nextPageToken != null,
+            isLoadingMore = false,
+        )
 }

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/ktor/KtorNetworkDoorDataSourceTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/ktor/KtorNetworkDoorDataSourceTest.kt
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.data.ktor
+
+import com.chriscartland.garage.data.NetworkResult
+import com.chriscartland.garage.domain.model.DoorEventPage
+import com.chriscartland.garage.domain.model.DoorPosition
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.URLBuilder
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+/**
+ * Wire-contract tests for [KtorNetworkDoorDataSource]'s `GET /eventHistory`.
+ *
+ * The Android half of the wire-contract lock: the canonical bytes come from
+ * `wire-contracts/eventHistory/` (also loaded by the server's `HttpEventsTest.ts`
+ * via `deep.equal`). This test feeds the same bytes into a Ktor [MockEngine] and
+ * asserts the decoded [DoorEventPage]. A unilateral server rename (e.g.
+ * `nextPageToken` → `cursor`) flips a decoded value here and fails the test.
+ *
+ * The eventHistory response carries echo fields (queryParams, session, …) the
+ * client intentionally ignores, so this uses production-shape lenient decoding
+ * and asserts the meaningful fields rather than a strict whole-object decode.
+ */
+class KtorNetworkDoorDataSourceTest {
+    private val fixtureDir = File("../../wire-contracts/eventHistory")
+
+    private fun readFixture(name: String): String = File(fixtureDir, name).readText()
+
+    private val firstPageNextToken =
+        "eyJ2IjoxLCJidCI6IlNhdCBNYXIgMTMgMTQ6NDU6MDAgMjAyMSIsInMiOjE2OTk5OTgwMDAsIm4iOjAsImQiOiJvbGRlciJ9"
+    private val lastPagePrevToken =
+        "eyJ2IjoxLCJidCI6IlNhdCBNYXIgMTMgMTQ6NDU6MDAgMjAyMSIsInMiOjE2OTkwMDAwMDAsIm4iOjAsImQiOiJuZXdlciJ9"
+
+    private fun mockClient(
+        statusCode: HttpStatusCode,
+        responseBody: String,
+        capturedRequests: MutableList<RecordedRequest> = mutableListOf(),
+    ): HttpClient =
+        HttpClient(
+            MockEngine { request ->
+                capturedRequests.add(
+                    RecordedRequest(
+                        method = request.method,
+                        urlPath = request.url.encodedPath,
+                        urlQuery = request.url.parameters
+                            .entries()
+                            .associate { it.key to it.value },
+                    ),
+                )
+                respond(
+                    content = ByteReadChannel(responseBody),
+                    status = statusCode,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            },
+        ) {
+            install(ContentNegotiation) {
+                json(
+                    Json {
+                        ignoreUnknownKeys = true
+                        isLenient = true
+                    },
+                )
+            }
+            defaultRequest {
+                url(URLBuilder("https://example.invalid/").build().toString())
+            }
+        }
+
+    private data class RecordedRequest(
+        val method: HttpMethod,
+        val urlPath: String,
+        val urlQuery: Map<String, List<String>>,
+    )
+
+    @Test
+    fun decodesFirstPageWithNextToken() =
+        runTest {
+            val client = mockClient(HttpStatusCode.OK, readFixture("response_first_page.json"))
+            val ds = KtorNetworkDoorDataSource(client)
+
+            val result = ds.fetchDoorEventPage(buildTimestamp = "bt", pageSize = 50, pageToken = null)
+
+            val success = assertIs<NetworkResult.Success<DoorEventPage>>(result)
+            assertEquals(2, success.data.events.size)
+            assertEquals(DoorPosition.OPEN, success.data.events[0].doorPosition)
+            assertEquals(1699999000L, success.data.events[0].lastChangeTimeSeconds)
+            assertEquals(DoorPosition.CLOSED, success.data.events[1].doorPosition)
+            assertEquals(firstPageNextToken, success.data.nextPageToken)
+            assertNull(success.data.prevPageToken)
+            assertEquals(true, success.data.hasMore)
+        }
+
+    @Test
+    fun decodesLastPageWithNoNextToken() =
+        runTest {
+            val client = mockClient(HttpStatusCode.OK, readFixture("response_last_page.json"))
+            val ds = KtorNetworkDoorDataSource(client)
+
+            val result = ds.fetchDoorEventPage(buildTimestamp = "bt", pageSize = 50, pageToken = firstPageNextToken)
+
+            val success = assertIs<NetworkResult.Success<DoorEventPage>>(result)
+            assertEquals(1, success.data.events.size)
+            assertEquals(DoorPosition.OPENING, success.data.events[0].doorPosition)
+            assertNull(success.data.nextPageToken)
+            assertEquals(lastPagePrevToken, success.data.prevPageToken)
+            assertEquals(false, success.data.hasMore)
+        }
+
+    @Test
+    fun decodesEmptyPage() =
+        runTest {
+            val client = mockClient(HttpStatusCode.OK, readFixture("response_empty.json"))
+            val ds = KtorNetworkDoorDataSource(client)
+
+            val result = ds.fetchDoorEventPage(buildTimestamp = "bt", pageSize = 50, pageToken = null)
+
+            val success = assertIs<NetworkResult.Success<DoorEventPage>>(result)
+            assertEquals(0, success.data.events.size)
+            assertNull(success.data.nextPageToken)
+            assertNull(success.data.prevPageToken)
+            assertEquals(false, success.data.hasMore)
+        }
+
+    @Test
+    fun sendsGetWithPageSizeLegacyCountAndToken() =
+        runTest {
+            val captured = mutableListOf<RecordedRequest>()
+            val client = mockClient(HttpStatusCode.OK, readFixture("response_first_page.json"), captured)
+            val ds = KtorNetworkDoorDataSource(client)
+
+            ds.fetchDoorEventPage(buildTimestamp = "build-123", pageSize = 50, pageToken = "tok-abc")
+
+            assertEquals(1, captured.size)
+            assertEquals(HttpMethod.Get, captured[0].method)
+            assertEquals("/eventHistory", captured[0].urlPath)
+            assertEquals(listOf("build-123"), captured[0].urlQuery["buildTimestamp"])
+            assertEquals(listOf("50"), captured[0].urlQuery["pageSize"])
+            // Legacy alias so a pre-pagination server still applies the limit.
+            assertEquals(listOf("50"), captured[0].urlQuery["eventHistoryMaxCount"])
+            assertEquals(listOf("tok-abc"), captured[0].urlQuery["pageToken"])
+        }
+
+    @Test
+    fun omitsPageTokenOnFirstPage() =
+        runTest {
+            val captured = mutableListOf<RecordedRequest>()
+            val client = mockClient(HttpStatusCode.OK, readFixture("response_first_page.json"), captured)
+            val ds = KtorNetworkDoorDataSource(client)
+
+            ds.fetchDoorEventPage(buildTimestamp = "build-123", pageSize = 50, pageToken = null)
+
+            assertNull(captured[0].urlQuery["pageToken"])
+        }
+
+    @Test
+    fun mapsHttp500ToHttpError() =
+        runTest {
+            val client = mockClient(HttpStatusCode.InternalServerError, "{}")
+            val ds = KtorNetworkDoorDataSource(client)
+
+            val result = ds.fetchDoorEventPage(buildTimestamp = "bt", pageSize = 50, pageToken = null)
+
+            val httpError = assertIs<NetworkResult.HttpError>(result)
+            assertEquals(500, httpError.code)
+        }
+}

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepositoryIntegrationTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepositoryIntegrationTest.kt
@@ -20,6 +20,7 @@ package com.chriscartland.garage.data.repository
 import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.DoorEvent
+import com.chriscartland.garage.domain.model.DoorEventPage
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.model.FetchError
 import com.chriscartland.garage.domain.model.ServerConfig
@@ -144,18 +145,21 @@ class NetworkDoorRepositoryIntegrationTest {
             assertNull(repo.currentDoorEvent.first())
         }
 
-    // --- fetchRecentDoorEvents ---
+    // --- fetchRecentDoorEvents (first page) ---
 
     @Test
-    fun fetchRecentDoorEventsStoresInLocal() =
+    fun fetchRecentDoorEventsReplacesCacheAndSetsPagination() =
         runTest {
             configDataSource.setServerConfigResult(successConfig())
             val events = listOf(
                 DoorEvent(doorPosition = DoorPosition.OPEN, lastChangeTimeSeconds = 300L),
                 DoorEvent(doorPosition = DoorPosition.CLOSED, lastChangeTimeSeconds = 200L),
-                DoorEvent(doorPosition = DoorPosition.OPENING, lastChangeTimeSeconds = 100L),
             )
-            networkDataSource.setRecentDoorEventsResult(NetworkResult.Success(events))
+            networkDataSource.setDoorEventPageResult(
+                NetworkResult.Success(
+                    DoorEventPage(events = events, nextPageToken = "older-1", prevPageToken = null, hasMore = true),
+                ),
+            )
 
             val repo = createRepository()
             val result = repo.fetchRecentDoorEvents()
@@ -163,6 +167,13 @@ class NetworkDoorRepositoryIntegrationTest {
             assertIs<AppResult.Success<*>>(result)
             assertEquals(events, repo.recentDoorEvents.first())
             assertEquals(1, localDataSource.replaceCount)
+            assertEquals(0, localDataSource.appendCount)
+            // First page sends no token; pageSize comes from config (10 in this test).
+            assertEquals(1, networkDataSource.fetchPageCount)
+            assertNull(networkDataSource.fetchPageCalls[0].pageToken)
+            assertEquals(10, networkDataSource.fetchPageCalls[0].pageSize)
+            assertEquals("older-1", repo.paginationState.value.nextPageToken)
+            assertEquals(true, repo.paginationState.value.canLoadMore)
         }
 
     @Test
@@ -175,7 +186,7 @@ class NetworkDoorRepositoryIntegrationTest {
 
             assertIs<AppResult.Error<*>>(result)
             assertEquals(FetchError.NotReady, result.error)
-            assertEquals(0, networkDataSource.fetchRecentCount)
+            assertEquals(0, networkDataSource.fetchPageCount)
             assertEquals(0, localDataSource.replaceCount)
         }
 
@@ -183,15 +194,70 @@ class NetworkDoorRepositoryIntegrationTest {
     fun fetchRecentDoorEventsWithNullNetworkResponseReturnsNetworkFailed() =
         runTest {
             configDataSource.setServerConfigResult(successConfig())
-            networkDataSource.setRecentDoorEventsResult(NetworkResult.ConnectionFailed)
+            networkDataSource.setDoorEventPageResult(NetworkResult.ConnectionFailed)
 
             val repo = createRepository()
             val result = repo.fetchRecentDoorEvents()
 
             assertIs<AppResult.Error<*>>(result)
             assertEquals(FetchError.NetworkFailed, result.error)
-            assertEquals(1, networkDataSource.fetchRecentCount)
+            assertEquals(1, networkDataSource.fetchPageCount)
             assertEquals(0, localDataSource.replaceCount)
+        }
+
+    // --- fetchOlderDoorEvents (pagination) ---
+
+    @Test
+    fun fetchOlderDoorEventsAppendsAndAdvancesToken() =
+        runTest {
+            configDataSource.setServerConfigResult(successConfig())
+            val firstPage = listOf(
+                DoorEvent(doorPosition = DoorPosition.OPEN, lastChangeTimeSeconds = 300L),
+                DoorEvent(doorPosition = DoorPosition.CLOSED, lastChangeTimeSeconds = 200L),
+            )
+            networkDataSource.setDoorEventPageResult(
+                NetworkResult.Success(
+                    DoorEventPage(firstPage, nextPageToken = "older-1", prevPageToken = null, hasMore = true),
+                ),
+            )
+            val repo = createRepository()
+            repo.fetchRecentDoorEvents()
+
+            // The older page reaches the oldest event (hasMore = false).
+            val olderPage = listOf(DoorEvent(doorPosition = DoorPosition.OPENING, lastChangeTimeSeconds = 100L))
+            networkDataSource.setNextDoorEventPageResult(
+                NetworkResult.Success(
+                    DoorEventPage(olderPage, nextPageToken = null, prevPageToken = "newer-1", hasMore = false),
+                ),
+            )
+
+            val result = repo.fetchOlderDoorEvents()
+
+            assertIs<AppResult.Success<*>>(result)
+            assertEquals(olderPage, result.data)
+            assertEquals(1, localDataSource.appendCount)
+            // The older page used the stored token from the first page.
+            assertEquals("older-1", networkDataSource.fetchPageCalls[1].pageToken)
+            // Cache grew (newest-first), not replaced.
+            assertEquals(firstPage + olderPage, repo.recentDoorEvents.first())
+            assertEquals(1, localDataSource.replaceCount)
+            // Reached the oldest → no more.
+            assertNull(repo.paginationState.value.nextPageToken)
+            assertEquals(false, repo.paginationState.value.canLoadMore)
+        }
+
+    @Test
+    fun fetchOlderDoorEventsWithNoTokenIsNoOpWithNoNetwork() =
+        runTest {
+            configDataSource.setServerConfigResult(successConfig())
+            val repo = createRepository() // pagination starts Initial (no token)
+
+            val result = repo.fetchOlderDoorEvents()
+
+            assertIs<AppResult.Success<*>>(result)
+            assertEquals(emptyList<DoorEvent>(), result.data)
+            assertEquals(0, networkDataSource.fetchPageCount)
+            assertEquals(0, localDataSource.appendCount)
         }
 
     // --- insertDoorEvent ---

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/DoorEventPage.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/DoorEventPage.kt
@@ -1,0 +1,17 @@
+package com.chriscartland.garage.domain.model
+
+/**
+ * A page of door history events plus the opaque pagination tokens that bound it.
+ *
+ * Tokens are server state — the client treats them as opaque strings and passes
+ * them back to fetch adjacent pages. [nextPageToken] pages OLDER (into the past),
+ * [prevPageToken] pages NEWER (toward the present); a null token means there is
+ * nothing more in that direction. [hasMore] mirrors `nextPageToken != null` (the
+ * older direction the history UI consumes).
+ */
+data class DoorEventPage(
+    val events: List<DoorEvent>,
+    val nextPageToken: String?,
+    val prevPageToken: String?,
+    val hasMore: Boolean,
+)

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/PaginationState.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/PaginationState.kt
@@ -1,0 +1,23 @@
+package com.chriscartland.garage.domain.model
+
+/**
+ * In-memory pagination cursor for the recent-events list (ADR-022 — state-y).
+ *
+ * Owned by the door repository (a `@Singleton`) and exposed as a [StateFlow] so
+ * the history screen can drive "load more". Never persisted — on cold start the
+ * first-page fetch re-establishes it.
+ *
+ * - [nextPageToken] opaque cursor for the next OLDER page (null = at the oldest)
+ * - [canLoadMore] true once a page reported more older events are available
+ * - [isLoadingMore] an older-page fetch is in flight (single source of truth +
+ *   reentrancy guard against double-fetch on a scroll fling)
+ */
+data class PaginationState(
+    val nextPageToken: String? = null,
+    val canLoadMore: Boolean = false,
+    val isLoadingMore: Boolean = false,
+) {
+    companion object {
+        val Initial = PaginationState()
+    }
+}

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/DoorRepository.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/DoorRepository.kt
@@ -4,6 +4,7 @@ import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.model.FetchError
+import com.chriscartland.garage.domain.model.PaginationState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -27,6 +28,12 @@ interface DoorRepository {
      */
     val recentDoorEvents: StateFlow<List<DoorEvent>>
 
+    /**
+     * Observation: pagination cursor for [recentDoorEvents] (ADR-022 — state-y,
+     * repo-owned). Drives the history screen's "load more" affordance.
+     */
+    val paginationState: StateFlow<PaginationState>
+
     suspend fun fetchBuildTimestampCached(): String?
 
     suspend fun insertDoorEvent(doorEvent: DoorEvent)
@@ -34,6 +41,16 @@ interface DoorRepository {
     /** One-time request: fetch current door event from server and cache locally. */
     suspend fun fetchCurrentDoorEvent(): AppResult<DoorEvent, FetchError>
 
-    /** One-time request: fetch recent door events from server and cache locally. */
+    /**
+     * One-time request: fetch the first page of recent door events (windowed,
+     * server-capped) and REPLACE the cache. Resets pagination state.
+     */
     suspend fun fetchRecentDoorEvents(): AppResult<List<DoorEvent>, FetchError>
+
+    /**
+     * One-time request: fetch the next OLDER page using the stored token and
+     * APPEND to the cache. No-op (Success with empty list) when there is nothing
+     * more to load or a load is already in flight.
+     */
+    suspend fun fetchOlderDoorEvents(): AppResult<List<DoorEvent>, FetchError>
 }

--- a/AndroidGarage/iosFramework/src/commonMain/kotlin/com/chriscartland/garage/iosframework/NativeComponent.kt
+++ b/AndroidGarage/iosFramework/src/commonMain/kotlin/com/chriscartland/garage/iosframework/NativeComponent.kt
@@ -80,6 +80,7 @@ import com.chriscartland.garage.usecase.FcmRegistrationManager
 import com.chriscartland.garage.usecase.FetchButtonHealthUseCase
 import com.chriscartland.garage.usecase.FetchCurrentDoorEventUseCase
 import com.chriscartland.garage.usecase.FetchFcmStatusUseCase
+import com.chriscartland.garage.usecase.FetchOlderDoorEventsUseCase
 import com.chriscartland.garage.usecase.FetchRecentDoorEventsUseCase
 import com.chriscartland.garage.usecase.FetchSnoozeStatusUseCase
 import com.chriscartland.garage.usecase.GetAuthTokenForCopyUseCase
@@ -379,6 +380,10 @@ abstract class NativeComponent(
     @Provides
     fun provideFetchRecentDoorEventsUseCase(doorRepository: DoorRepository): FetchRecentDoorEventsUseCase =
         FetchRecentDoorEventsUseCase(doorRepository)
+
+    @Provides
+    fun provideFetchOlderDoorEventsUseCase(doorRepository: DoorRepository): FetchOlderDoorEventsUseCase =
+        FetchOlderDoorEventsUseCase(doorRepository)
 
     @Provides
     fun provideFetchFcmStatusUseCase(doorFcmRepository: DoorFcmRepository): FetchFcmStatusUseCase = FetchFcmStatusUseCase(doorFcmRepository)

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeDoorRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeDoorRepository.kt
@@ -21,6 +21,7 @@ import com.chriscartland.garage.domain.model.AppResult
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.model.FetchError
+import com.chriscartland.garage.domain.model.PaginationState
 import com.chriscartland.garage.domain.repository.DoorRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -30,16 +31,24 @@ class FakeDoorRepository : DoorRepository {
     private val _currentDoorEvent = MutableStateFlow<DoorEvent?>(DoorEvent())
     private val _recentDoorEvents = MutableStateFlow<List<DoorEvent>>(emptyList())
     private val _currentDoorPosition = MutableStateFlow(DoorPosition.UNKNOWN)
+    private val _paginationState = MutableStateFlow(PaginationState.Initial)
 
     override val currentDoorPosition: Flow<DoorPosition> = _currentDoorPosition
     override val currentDoorEvent: StateFlow<DoorEvent?> = _currentDoorEvent
     override val recentDoorEvents: StateFlow<List<DoorEvent>> = _recentDoorEvents
+    override val paginationState: StateFlow<PaginationState> = _paginationState
 
     var fetchCurrentDoorEventCount = 0
         private set
     var fetchRecentDoorEventsCount = 0
         private set
+    var fetchOlderDoorEventsCount = 0
+        private set
     private var buildTimestamp: String? = "2024-01-15T00:00:00Z"
+
+    // Configurable older page returned by fetchOlderDoorEvents().
+    private var olderPage: List<DoorEvent> = emptyList()
+    private var olderPageState: PaginationState = PaginationState.Initial
 
     fun setBuildTimestamp(value: String?) {
         buildTimestamp = value
@@ -52,6 +61,19 @@ class FakeDoorRepository : DoorRepository {
 
     fun setRecentDoorEvents(events: List<DoorEvent>) {
         _recentDoorEvents.value = events
+    }
+
+    fun setPaginationState(state: PaginationState) {
+        _paginationState.value = state
+    }
+
+    /** Configure the events appended and the resulting pagination state on the next load-more. */
+    fun setOlderPage(
+        events: List<DoorEvent>,
+        resultingState: PaginationState,
+    ) {
+        olderPage = events
+        olderPageState = resultingState
     }
 
     override suspend fun fetchBuildTimestampCached(): String? = buildTimestamp
@@ -70,5 +92,15 @@ class FakeDoorRepository : DoorRepository {
     override suspend fun fetchRecentDoorEvents(): AppResult<List<DoorEvent>, FetchError> {
         fetchRecentDoorEventsCount++
         return AppResult.Success(_recentDoorEvents.value)
+    }
+
+    override suspend fun fetchOlderDoorEvents(): AppResult<List<DoorEvent>, FetchError> {
+        fetchOlderDoorEventsCount++
+        if (_paginationState.value.nextPageToken == null) {
+            return AppResult.Success(emptyList())
+        }
+        _recentDoorEvents.value = _recentDoorEvents.value + olderPage
+        _paginationState.value = olderPageState
+        return AppResult.Success(olderPage)
     }
 }

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeNetworkDoorDataSource.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeNetworkDoorDataSource.kt
@@ -20,38 +20,48 @@ package com.chriscartland.garage.testcommon
 import com.chriscartland.garage.data.NetworkDoorDataSource
 import com.chriscartland.garage.data.NetworkResult
 import com.chriscartland.garage.domain.model.DoorEvent
+import com.chriscartland.garage.domain.model.DoorEventPage
 
 /**
  * Fake [NetworkDoorDataSource] for unit testing.
  *
  * Configure responses with `setX()` methods. Tracks each call via `*Calls`
  * lists (ADR-017 Rule 5 — call-list pattern), so tests can assert on the
- * exact arguments passed (build timestamps, page sizes). The `*Count`
+ * exact arguments passed (build timestamps, page sizes, tokens). The `*Count`
  * accessors are convenience reads backed by the lists.
  */
 class FakeNetworkDoorDataSource : NetworkDoorDataSource {
-    data class FetchRecentCall(
+    data class FetchPageCall(
         val buildTimestamp: String,
-        val count: Int,
+        val pageSize: Int,
+        val pageToken: String?,
     )
 
     private var currentDoorEventResult: NetworkResult<DoorEvent> = NetworkResult.ConnectionFailed
-    private var recentDoorEventsResult: NetworkResult<List<DoorEvent>> = NetworkResult.ConnectionFailed
+    private var doorEventPageResult: NetworkResult<DoorEventPage> = NetworkResult.ConnectionFailed
+
+    // When set, the next fetchDoorEventPage call returns this instead, then clears.
+    private var nextDoorEventPageResult: NetworkResult<DoorEventPage>? = null
 
     private val _fetchCurrentBuildTimestamps = mutableListOf<String>()
     val fetchCurrentBuildTimestamps: List<String> get() = _fetchCurrentBuildTimestamps
     val fetchCurrentCount: Int get() = _fetchCurrentBuildTimestamps.size
 
-    private val _fetchRecentCalls = mutableListOf<FetchRecentCall>()
-    val fetchRecentCalls: List<FetchRecentCall> get() = _fetchRecentCalls
-    val fetchRecentCount: Int get() = _fetchRecentCalls.size
+    private val _fetchPageCalls = mutableListOf<FetchPageCall>()
+    val fetchPageCalls: List<FetchPageCall> get() = _fetchPageCalls
+    val fetchPageCount: Int get() = _fetchPageCalls.size
 
     fun setCurrentDoorEventResult(value: NetworkResult<DoorEvent>) {
         currentDoorEventResult = value
     }
 
-    fun setRecentDoorEventsResult(value: NetworkResult<List<DoorEvent>>) {
-        recentDoorEventsResult = value
+    fun setDoorEventPageResult(value: NetworkResult<DoorEventPage>) {
+        doorEventPageResult = value
+    }
+
+    /** Arm the NEXT fetchDoorEventPage call to return [value] (e.g. an older page). */
+    fun setNextDoorEventPageResult(value: NetworkResult<DoorEventPage>) {
+        nextDoorEventPageResult = value
     }
 
     override suspend fun fetchCurrentDoorEvent(buildTimestamp: String): NetworkResult<DoorEvent> {
@@ -59,11 +69,16 @@ class FakeNetworkDoorDataSource : NetworkDoorDataSource {
         return currentDoorEventResult
     }
 
-    override suspend fun fetchRecentDoorEvents(
+    override suspend fun fetchDoorEventPage(
         buildTimestamp: String,
-        count: Int,
-    ): NetworkResult<List<DoorEvent>> {
-        _fetchRecentCalls.add(FetchRecentCall(buildTimestamp = buildTimestamp, count = count))
-        return recentDoorEventsResult
+        pageSize: Int,
+        pageToken: String?,
+    ): NetworkResult<DoorEventPage> {
+        _fetchPageCalls.add(FetchPageCall(buildTimestamp = buildTimestamp, pageSize = pageSize, pageToken = pageToken))
+        nextDoorEventPageResult?.let {
+            nextDoorEventPageResult = null
+            return it
+        }
+        return doorEventPageResult
     }
 }

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/InMemoryLocalDoorDataSource.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/InMemoryLocalDoorDataSource.kt
@@ -45,6 +45,10 @@ class InMemoryLocalDoorDataSource : LocalDoorDataSource {
     val replaceCalls: List<List<DoorEvent>> get() = _replaceCalls
     val replaceCount: Int get() = _replaceCalls.size
 
+    private val _appendCalls = mutableListOf<List<DoorEvent>>()
+    val appendCalls: List<List<DoorEvent>> get() = _appendCalls
+    val appendCount: Int get() = _appendCalls.size
+
     override suspend fun insertDoorEvent(doorEvent: DoorEvent) {
         _insertCalls.add(doorEvent)
         _currentDoorEvent.value = doorEvent
@@ -56,5 +60,14 @@ class InMemoryLocalDoorDataSource : LocalDoorDataSource {
         if (doorEvents.isNotEmpty()) {
             _currentDoorEvent.value = doorEvents.first()
         }
+    }
+
+    override suspend fun appendDoorEvents(doorEvents: List<DoorEvent>) {
+        _appendCalls.add(doorEvents)
+        // Mirror Room: dedupe by the entity PK (lastChangeTimeSeconds + doorPosition),
+        // keep the list newest-first.
+        _recentDoorEvents.value = (_recentDoorEvents.value + doorEvents)
+            .distinctBy { it.lastChangeTimeSeconds to it.doorPosition }
+            .sortedByDescending { it.lastChangeTimeSeconds ?: Long.MIN_VALUE }
     }
 }

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/FetchDoorEventsUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/FetchDoorEventsUseCase.kt
@@ -45,3 +45,16 @@ class FetchRecentDoorEventsUseCase(
 ) {
     suspend operator fun invoke(): AppResult<List<DoorEvent>, FetchError> = doorRepository.fetchRecentDoorEvents()
 }
+
+/**
+ * Fetches the next OLDER page of door events (pagination "load more") and
+ * appends it to the cache. No-op when there is nothing more to load.
+ *
+ * Returns [AppResult] so callers can handle [FetchError.NotReady] and
+ * [FetchError.NetworkFailed] explicitly with exhaustive `when`.
+ */
+class FetchOlderDoorEventsUseCase(
+    private val doorRepository: DoorRepository,
+) {
+    suspend operator fun invoke(): AppResult<List<DoorEvent>, FetchError> = doorRepository.fetchOlderDoorEvents()
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveDoorEventsUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveDoorEventsUseCase.kt
@@ -19,6 +19,7 @@ package com.chriscartland.garage.usecase
 
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
+import com.chriscartland.garage.domain.model.PaginationState
 import com.chriscartland.garage.domain.repository.DoorRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
@@ -46,6 +47,12 @@ class ObserveDoorEventsUseCase(
     fun current(): StateFlow<DoorEvent?> = doorRepository.currentDoorEvent
 
     fun recent(): StateFlow<List<DoorEvent>> = doorRepository.recentDoorEvents
+
+    /**
+     * Pagination cursor for [recent] (ADR-022 pass-through — the repo owns the
+     * StateFlow; do NOT wrap). Drives the history screen's "load more".
+     */
+    fun paginationState(): StateFlow<PaginationState> = doorRepository.paginationState
 
     /** Stream of door position changes — needed by ButtonStateMachine. */
     fun position(): Flow<DoorPosition> = doorRepository.currentDoorPosition


### PR DESCRIPTION
PR 2 of the door-history pagination stack (Android data layer). **No UI change** — pure plumbing, safe to ship/deploy on its own.

## What
- **New domain types:** `DoorEventPage` (events + opaque next/prev tokens + `hasMore`) and `PaginationState` (token + `canLoadMore` + `isLoadingMore`).
- **Network:** `NetworkDoorDataSource.fetchDoorEventPage(buildTimestamp, pageSize, pageToken)` replaces `fetchRecentDoorEvents`. The Ktor impl sends **both** `pageSize` and the legacy `eventHistoryMaxCount`, plus `pageToken` when paging older, and decodes the new token fields.
- **Local:** `LocalDoorDataSource.appendDoorEvents` (Room `insertList`, REPLACE-dedups page overlap) for the growing list. Refresh still replaces. **No Room schema migration** (append rows; token is in-memory).
- **Repository:** owns `paginationState: StateFlow<PaginationState>` (ADR-022) + `fetchOlderDoorEvents()`. First page replaces the cache and resets the token; older pages append and advance it, with a reentrancy guard. Exposed via `ObserveDoorEventsUseCase.paginationState()` + new `FetchOlderDoorEventsUseCase`.
- First-page size **30 → 50** (server caps at 50). DI providers added to `AppComponent` + `NativeComponent`; iOS framework kept compiling.

## Compatibility (your "each PR safe in any order" requirement)
The client sends both `pageSize` and `eventHistoryMaxCount`, and the token DTO fields are nullable with `ignoreUnknownKeys = true`:
- **Old server + new client** → no tokens in the response → `hasMore=false` → no load-more (graceful; behaves like today).
- **New server + this client** → windowed first page; tokens captured.

## Tests
- New Ktor **wire-contract test** loading the shared `wire-contracts/eventHistory/` fixtures (same files the server deep-equals) — a server key rename flips a decoded value and fails here.
- Repo integration tests: replace-resets-token, append-advances-token, no-token no-op.
- `validate.sh`: all lints + all unit tests (every module/variant) + assembleDebug + screenshot/instrumented compile **pass**. (The only `FAIL` is the pre-existing `iosApp/README.md` front-matter gap on `main` — unrelated, not touched here, not CI-gated; fixing separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)