### PR TITLE
docs(ios): add required front-matter to iosApp/README.md

### DIFF
--- a/AndroidGarage/iosApp/README.md
+++ b/AndroidGarage/iosApp/README.md
@@ -1,3 +1,9 @@
+---
+category: reference
+status: active
+last_verified: 2026-06-10
+---
+
 # iosApp — SwiftUI client
 
 SwiftUI front-end for the Smart Garage Door system. Consumes the shared


### PR DESCRIPTION
`AndroidGarage/iosApp/README.md` was added (iOS app PRs) without the YAML front-matter that `check-doc-frontmatter.sh` requires, so `validate.sh` fails on it locally. CI doesn't run this check, which is why it slipped through.

Adds the standard `reference` / `active` front-matter. No content change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)