### PR TITLE
docs: ADR-028 + event-history pagination design note

### DIFF
--- a/AndroidGarage/docs/DECISIONS.md
+++ b/AndroidGarage/docs/DECISIONS.md
@@ -1590,3 +1590,49 @@ The 2.13.3 defensive `forceRefresh = false ?: forceRefresh = true` fallback in t
 - ADR-018 — reactive auth listener pattern (predecessor; this ADR sharpens the rule)
 - ADR-022 — `StateFlow` at the repository boundary (this ADR refines what's *in* that StateFlow)
 - 2.13.3 CHANGELOG entry — the defensive patch this refactor supersedes
+
+## ADR-028: Door-history pagination cursor lives in the `@Singleton` repository
+
+### Status
+
+Accepted — 2026-06-10.
+
+### Context
+
+The door-history endpoint evolved to return a windowed first page (last 7 days, max 50) plus cursor pagination — the client fetches older events with an opaque `nextPageToken` and a `hasMore`/end signal (server side: [`docs/EVENT_HISTORY_PAGINATION.md`](../../docs/EVENT_HISTORY_PAGINATION.md)). The Android side has to: (a) hold the current cursor token, (b) append older pages to the list rather than replacing it, and (c) drive a "load more on scroll-to-end" affordance with a loading + terminal state.
+
+The token is **server state tied to the cache contents** — it only makes sense alongside the events currently cached. The history list is already a repository-owned, Room-backed `StateFlow` with an always-on collector (ADR-022). Two placement questions follow: where does the token + load-more flags live, and how does the cache grow?
+
+### Decision
+
+1. **Pagination state lives in the `@Singleton` repository**, exposed as `paginationState: StateFlow<PaginationState>` (`nextPageToken`, `canLoadMore`, `isLoadingMore`) and passed through a UseCase and the ViewModel unchanged (ADR-022 — no `stateIn`, no mirror). The repo is the single source of truth; the VM and both wide-screen panes read the same instance, so they can't diverge across `NavBackStackEntry` churn.
+2. **The list grows by append, not replace.** `fetchRecentDoorEvents()` (initial / pull-to-refresh) replaces the cache and resets the token; `fetchOlderDoorEvents()` appends the next older page (`DoorEventDao.insertList`, REPLACE-on-PK dedups page-boundary overlap) and advances the token. `recentDoorEvents` stays the list-y Room `StateFlow` and re-emits the grown list automatically.
+3. **`isLoadingMore` is the repository's single source of truth + a reentrancy guard.** `fetchOlderDoorEvents()` no-ops (returns `Success(emptyList())`) when there's no token or a load is already in flight, so a scroll fling that fires the trigger twice can't double-append.
+4. **No Room schema migration.** Pagination only appends rows to the existing `DoorEvent` table; the token is in-memory and never persisted (re-established by the first-page fetch on cold start). `RoomSchemaTest` / the schema-drift check confirm the version is untouched.
+5. **No growth cap for v1.** The dataset is a single garage door; the list is bounded by how far the user scrolls. If profiling ever shows a problem, add a trim query after append — deferred, recorded here so the absence is a decision, not an oversight.
+
+### Rationale
+
+**Why the repo, not the VM.** Putting the token in the VM resurrects exactly the multi-instance divergence ADR-022 was written to kill: each fresh `NavBackStackEntry` VM would hold its own token, drifting from the shared Room cache (and from the other dashboard pane). The repo already owns the cache; the cursor that describes the cache belongs next to it.
+
+**Why append uses `insertList` (REPLACE), not a bespoke merge.** The entity PK is `lastChangeTimeSeconds + ":" + doorPosition`, so an overlapping page row replaces its duplicate for free; the `recentDoorEvents()` query already returns all rows newest-first, so appended older rows just extend the tail. No new DAO query, no manual de-dup.
+
+**Why `isLoadingMore` in the repo, not the VM.** The load-more fetch runs on the repo's external scope (ADR-019), and the scroll trigger must be debounced against the shared cache regardless of which VM is alive. One flag in the repo is the cleanest single source of truth; the VM passes it through.
+
+### Consequences
+
+- The history UI's "load more" footer distinguishes two terminal reasons: empty list = "no events at all"; non-empty + `!canLoadMore` = "reached the beginning" (matches the API's null-token semantics).
+- The scroll-to-end trigger lives in `HistoryContent` (`derivedStateOf` near-end + `LaunchedEffect`), gated on `canLoadMore && !isLoadingMore`, with the repo guard as a backstop.
+- Adding a different paged list later reuses the same shape: repo-owned `PaginationState` + append-vs-replace.
+
+### When this decision might change
+
+- Unbounded growth becomes a real problem (huge histories) → add a trim-after-append query + a cap constant; this ADR's point 5 flips.
+- A second paged surface appears → consider extracting a small reusable `PagedRepository<T>` rather than copying the pattern a third time.
+
+### References
+
+- [`PaginationState.kt`](../domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/PaginationState.kt), [`DoorEventPage.kt`](../domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/DoorEventPage.kt)
+- [`NetworkDoorRepository.kt`](../data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/NetworkDoorRepository.kt) — `fetchOlderDoorEvents` + the reentrancy guard
+- [`docs/EVENT_HISTORY_PAGINATION.md`](../../docs/EVENT_HISTORY_PAGINATION.md) — the server token contract this consumes
+- ADR-022 — `StateFlow` pass-through (this ADR applies it to the new `paginationState`)

--- a/docs/EVENT_HISTORY_PAGINATION.md
+++ b/docs/EVENT_HISTORY_PAGINATION.md
@@ -1,0 +1,111 @@
+---
+category: reference
+status: active
+last_verified: 2026-06-10
+---
+
+# Event-history pagination (server contract)
+
+How the `eventHistory` HTTP endpoint windows + paginates door events, and the
+two load-bearing design decisions behind it. The Android consumer's side is
+ADR-028 in [`AndroidGarage/docs/DECISIONS.md`](../AndroidGarage/docs/DECISIONS.md).
+
+Shipped in `server/28` (PR #867) + Android PRs #869 (data) / #871 (UI).
+
+## Behavior
+
+- **Universal default:** every non-cursor request returns the **last 7 days of
+  events, capped at 50** (newest first). This applies to *all* clients — on
+  deploy, an un-updated app's history view windows to ~1 week. Wire-compatible:
+  the response keeps every legacy key.
+- **Cursor pagination into the past:** the response carries `nextPageToken`
+  (older), `prevPageToken` (newer), and `hasMore`. The client passes
+  `nextPageToken` back to fetch the next older page. A **null `nextPageToken`**
+  is the end-of-history signal — it covers both "no events at all" and "you've
+  reached the oldest event."
+- **Page size:** `pageSize` (clamped to `[1, 50]`). The client also sends the
+  legacy `eventHistoryMaxCount` as an alias so an old server still applies the
+  limit (forward/backward-compatible deploy in any order).
+
+## Request decision tree
+
+In `handleEventHistory` (after the existing `buildTimestamp` 400 guard):
+
+```
+pageToken present + valid + scoped to this buildTimestamp
+    -> CURSOR PAGE: startAfter(token), no time window, direction from token
+pageSize / eventHistoryMaxCount present, no token
+    -> WINDOWED PAGE: sinceTimestamp = now - 7d, limit = clamp(.. ,1,50)
+else
+    -> WINDOWED PAGE with the default page size (50)
+```
+
+`now` is injected from the thin wrapper (`Date.now()`) so the window is
+deterministic in tests. Malformed or foreign-`buildTimestamp` tokens fall back
+**leniently** to a fresh windowed first page — never a 400/500.
+
+## Decision 1 — opaque token format
+
+`base64url(JSON)` of:
+
+```
+{ v: 1, bt: <buildTimestamp>, s: <seconds>, n: <nanoseconds>, d: "older" | "newer" }
+```
+
+- `s` + `n` are the boundary doc's `FIRESTORE_databaseTimestamp` (a Firestore
+  `Timestamp`, sub-second precision) — **not** the seconds-only field — so two
+  events written in the same wall-clock second are never skipped at a page edge.
+- `bt` scopes the token to one `buildTimestamp`; a token from another build is
+  ignored (lenient fallback).
+- `d` lets the same token mechanism page both directions. `nextPageToken`
+  encodes the oldest returned doc with `d:"older"`; `prevPageToken` encodes the
+  newest with `d:"newer"`.
+- The client treats the whole string as **opaque** — internals can change under
+  a version bump (`v`) without a client release.
+- **No doc-id tiebreaker for v1.** Nanosecond collisions within one build's
+  partition don't occur at this write rate. If they ever do, the fix is to add
+  `__name__` to the `orderBy` + a composite index + the token — documented in
+  `TimeSeriesDatabase.getPageForBuildTimestamp`.
+
+## Decision 2 — no new index for the core path (Option B)
+
+The 7-day window is expressed as a **range on the same field as the sort**:
+
+```
+where('buildTimestamp','==',bt)
+  .where('FIRESTORE_databaseTimestamp','>=', cutoff)   // the window
+  .orderBy('FIRESTORE_databaseTimestamp','desc')
+```
+
+Because the inequality field equals the first `orderBy` field, Firestore accepts
+it and the **existing** `eventsAll: buildTimestamp ASC + FIRESTORE_databaseTimestamp DESC`
+composite index serves the default + older-cursor + under-fill-probe queries.
+**No new index, no index-before-deploy hazard** for the shipped feature.
+
+`hasMore` is computed by fetching `limit + 1`; when a windowed first page
+under-fills (or is empty) a cheap 1-doc `< cutoff` probe decides whether older
+events exist beyond the window so the end signal is correct.
+
+### One index IS added — for the dormant `newer` direction
+
+The `newer` (backward-toward-present) direction orders **ascending**, which the
+DESC-only index doesn't cover. `firestore.indexes.json` adds
+`eventsAll: buildTimestamp ASC + FIRESTORE_databaseTimestamp ASC` for it. The UI
+doesn't page newer yet (only `prevPageToken` ships as contract), so this index is
+**dormant** — but **deploy it before any client uses the newer direction**:
+
+```
+firebase deploy --only firestore:indexes
+```
+
+Creating an index never breaks existing queries, so this deploy is safe at any
+time and independent of the functions deploy.
+
+## Tests + fixtures
+
+Shared wire-contract fixtures live in [`wire-contracts/eventHistory/`](../wire-contracts/eventHistory/)
+(`response_first_page`, `response_last_page`, `response_empty`). Both the server
+Mocha suite (`HttpEventsTest.ts`, `deep.equal`) and the Android Ktor test
+(`KtorNetworkDoorDataSourceTest.kt`) load the same files, so a unilateral
+key rename breaks at least one side. The fixture tokens are real
+`encodePageToken` output, so a token-format change must regenerate them.


### PR DESCRIPTION
PR 4 (final) of the door-history pagination stack — documentation.

- **ADR-028** (`AndroidGarage/docs/DECISIONS.md`): pagination cursor lives in the `@Singleton` repository (ADR-022 pass-through, not the VM); append-vs-replace cache growth; no Room migration; no growth cap for v1 (recorded as a deliberate decision, not an oversight).
- **`docs/EVENT_HISTORY_PAGINATION.md`** (server contract): the universal windowed default, the request decision tree, the opaque `base64url` token format (sec+nanos + direction, scoped to `buildTimestamp`, no doc-id tiebreaker), and the Option-B index reuse — no new index for the core path, plus the dormant ASC index for the `newer` direction that needs `firebase deploy --only firestore:indexes` before use.

Docs-only; relative links checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)