### PR TITLE
feat(server): raise eventHistory page size 50 → 100 (server/29)

### DIFF
--- a/FirebaseServer/CHANGELOG.md
+++ b/FirebaseServer/CHANGELOG.md
@@ -29,6 +29,9 @@ Example (placeholder tag numbers — the gate looks for exact `server/<real numb
 
 ---
 
+## server/29
+- **`eventHistory` page size raised 50 → 100.** Both the default (no `pageSize`) and the maximum cap are now 100, so each page returns up to twice as many events. The 7-day window is unchanged. Purely a larger cap — wire-compatible, no client change required; a client that requests a smaller `pageSize`/`eventHistoryMaxCount` is unaffected. PR #TBD.
+
 ## server/28
 - **`eventHistory` pagination + windowed default.** The endpoint now returns the **last 7 days of events, capped at 50** (newest first) by default, and supports **cursor pagination** into the past via an opaque `nextPageToken`. The response adds `nextPageToken` (older), `prevPageToken` (newer), and `hasMore`; a null `nextPageToken` is the end-of-history signal (covers both "no events" and "reached the oldest"). All legacy keys (`eventHistory`, `eventHistoryCount`, …) are preserved, so the change is **wire-compatible** — the live client ignores the new keys.
 - **Universal default (behavior change):** the 7-day window applies to *every* non-cursor request, including the current app, the moment this deploys. A quiet door will show fewer events until the user updates to the paginating client. No wire break.

--- a/FirebaseServer/CHANGELOG.md
+++ b/FirebaseServer/CHANGELOG.md
@@ -30,7 +30,7 @@ Example (placeholder tag numbers — the gate looks for exact `server/<real numb
 ---
 
 ## server/29
-- **`eventHistory` page size raised 50 → 100.** Both the default (no `pageSize`) and the maximum cap are now 100, so each page returns up to twice as many events. The 7-day window is unchanged. Purely a larger cap — wire-compatible, no client change required; a client that requests a smaller `pageSize`/`eventHistoryMaxCount` is unaffected. PR #TBD.
+- **`eventHistory` page size raised 50 → 100.** Both the default (no `pageSize`) and the maximum cap are now 100, so each page returns up to twice as many events. The 7-day window is unchanged. Purely a larger cap — wire-compatible, no client change required; a client that requests a smaller `pageSize`/`eventHistoryMaxCount` is unaffected. PR #875.
 
 ## server/28
 - **`eventHistory` pagination + windowed default.** The endpoint now returns the **last 7 days of events, capped at 50** (newest first) by default, and supports **cursor pagination** into the past via an opaque `nextPageToken`. The response adds `nextPageToken` (older), `prevPageToken` (newer), and `hasMore`; a null `nextPageToken` is the end-of-history signal (covers both "no events" and "reached the oldest"). All legacy keys (`eventHistory`, `eventHistoryCount`, …) are preserved, so the change is **wire-compatible** — the live client ignores the new keys.

--- a/FirebaseServer/src/functions/http/Events.ts
+++ b/FirebaseServer/src/functions/http/Events.ts
@@ -48,8 +48,8 @@ const NEXT_PAGE_TOKEN_KEY = "nextPageToken";
 const PREV_PAGE_TOKEN_KEY = "prevPageToken";
 const HAS_MORE_KEY = "hasMore";
 
-const PAGE_SIZE_MAX = 50;
-const PAGE_SIZE_DEFAULT = 50;
+const PAGE_SIZE_MAX = 100;
+const PAGE_SIZE_DEFAULT = 100;
 const WINDOW_SECONDS = 7 * 24 * 60 * 60; // default first-page window: last 7 days
 const PAGE_TOKEN_VERSION = 1;
 

--- a/FirebaseServer/test/functions/http/HttpEventsTest.ts
+++ b/FirebaseServer/test/functions/http/HttpEventsTest.ts
@@ -188,7 +188,7 @@ describe('handleEventHistory (pure handler core)', () => {
     expect(result).to.deep.equal({ kind: 'ok', data: EMPTY_FIXTURE });
   });
 
-  it('clamps pageSize to the 50 maximum', async () => {
+  it('clamps pageSize to the 100 maximum', async () => {
     const result = await handleEventHistory({
       query: { buildTimestamp: BUILD_TIMESTAMP, pageSize: '999' },
       body: {},
@@ -196,7 +196,16 @@ describe('handleEventHistory (pure handler core)', () => {
     });
     expect(result.kind).to.equal('ok');
     expect(fakeDB.pageCalls).to.have.lengthOf(1);
-    expect(fakeDB.pageCalls[0].limit).to.equal(50);
+    expect(fakeDB.pageCalls[0].limit).to.equal(100);
+  });
+
+  it('uses the 100 default page size when none is given', async () => {
+    await handleEventHistory({
+      query: { buildTimestamp: BUILD_TIMESTAMP },
+      body: {},
+      nowMillis: NOW_MILLIS,
+    });
+    expect(fakeDB.pageCalls[0].limit).to.equal(100);
   });
 
   it('decodes the page token into a startAfter cursor and drops the time window', async () => {


### PR DESCRIPTION
Raise the `eventHistory` page size from 50 to 100 so each page returns up to twice as many events.

## What
- `PAGE_SIZE_DEFAULT` and `PAGE_SIZE_MAX` → **100** (both must move — raising only the default would clamp back to the 50 cap).
- 7-day window **unchanged**.
- Updated the clamp test (`999 → 100`) + added a default-page-size test.
- `CHANGELOG.md`: `## server/29` (appended — server/28 worked, not a bug-chase).

## Compatibility
Raising a cap never breaks an existing client. The live 2.16.37 app (sends `eventHistoryMaxCount=30`) and any client requesting a smaller page are unaffected. Wire shape unchanged.

## Deploy
User-run: `./scripts/release-firebase.sh --check` → `server/29`. Takes effect (default 100) on deploy. `validate-firebase.sh` green (334 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)