### PR TITLE
fix(release): refresh git stat-cache before the clean-tree gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,12 +301,11 @@ The script computes the next tag as `android/<highest + 1>`. The `--confirm-tag`
 
 The changelog and the Play Store whatsnew are different files: `CHANGELOG.md` is the permanent internal history (every version, patches included); `distribution/whatsnew/` is rolling and only covers the current minor/major. Missing changelog entries silently went unnoticed through 2.5.0 (added in #548) — the gate closes that gap.
 
-**Stat-cache stale after `validate.sh`** (recurring — observed in `android/193`, `android/194`, and `server/24` releases). When the release script reports `Working tree has uncommitted changes` but `git status --short` is empty, it's git's stat-cache holding stale `lstat` info from files validate.sh touched (Gradle build outputs, marker file write). The release script's quick check uses timestamps; when they look new but content is identical, it falsely flags dirty. Fix:
+**Stat-cache stale after `validate.sh`** (was recurring — `android/193`, `android/194`, `android/248`, `server/24`). When the release script reported `Working tree has uncommitted changes` but `git status --short` was empty, it was git's stat-cache holding stale `lstat` info from files validate.sh touched (Gradle build outputs, marker file write): the quick dirty check uses timestamps; when they look new but content is identical, it falsely flagged dirty. **Both release scripts now run `git update-index -q --refresh` inside the clean-tree gate (before the `diff-index`/`diff` check), so this false positive should no longer occur** — the refresh re-stats every file and clears mtime-only false positives, and it can NEVER mask a real change (a file whose content differs from HEAD stays flagged). If you somehow still hit it (e.g. running an older script version), the manual fix is the same operation:
 ```bash
 git update-index --refresh > /dev/null 2>&1   # forces git to re-stat everything
 ./scripts/release-android.sh --confirm-tag android/N    # then retry
 ```
-Same pattern works for `release-firebase.sh`. The stat-cache refresh is harmless either way; safe to run before every release-script retry. (Both Android and Firebase release scripts share the same `git diff-index --quiet HEAD --` check pattern.)
 
 **Rollback requires two steps** (intentionally hard to do accidentally):
 ```bash

--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -402,6 +402,14 @@ echo ""
 
 # === Gate: Clean working tree (only when tagging HEAD) ===
 if [ -z "$CONFIRM_HASH" ]; then
+    # Reconcile git's stat-cache before the fast dirty check. validate.sh touches
+    # tracked files (Gradle outputs, the validation marker), bumping their mtime
+    # without changing content; the stale cached lstat then makes diff-index report
+    # a false "dirty" even though `git status` is clean. --refresh re-stats every
+    # file and clears mtime-only false positives. It NEVER masks a real change: a
+    # file whose content differs from HEAD stays flagged. (CLAUDE.md § "Stat-cache
+    # stale after validate.sh" — hit on android/193, /194, /248, server/24.)
+    git update-index -q --refresh > /dev/null 2>&1 || true
     if ! git diff-index --quiet HEAD --; then
         echo -e "${RED}Error: Working tree has uncommitted changes.${RESET}"
         echo "Commit or stash changes before releasing."

--- a/scripts/release-firebase.sh
+++ b/scripts/release-firebase.sh
@@ -372,6 +372,14 @@ echo ""
 
 # === Gate: Clean working tree (only when tagging HEAD) ===
 if [ -z "$CONFIRM_HASH" ]; then
+    # Reconcile git's stat-cache before the dirty check. validate-firebase.sh
+    # touches tracked files (the validation marker), bumping their mtime without
+    # changing content; the stale cached lstat then makes this check report a false
+    # "dirty" even though `git status` is clean. --refresh re-stats every file and
+    # clears mtime-only false positives. It NEVER masks a real change: a file whose
+    # content differs from HEAD stays flagged. (CLAUDE.md § "Stat-cache stale after
+    # validate.sh" — hit on server/24, android/193, /194, /248.)
+    git update-index -q --refresh > /dev/null 2>&1 || true
     if ! git diff --quiet HEAD 2>/dev/null; then
         echo -e "${RED}Error: Working tree has uncommitted changes.${RESET}"
         echo "Commit or stash changes before releasing."


### PR DESCRIPTION
Retires the recurring "Working tree has uncommitted changes" false positive on release.

## Problem
Both release scripts run their fast dirty-tree check (`git diff-index`/`git diff --quiet HEAD`) immediately after `validate.sh`. Validation **touches** tracked files (Gradle outputs, the validation marker), bumping their mtime without changing content. git's stale **stat-cache** then reports the tree dirty even though `git status` is clean — forcing a manual `git update-index --refresh` + retry on essentially every release (android/193, /194, /248, server/24).

## Fix
Add `git update-index -q --refresh > /dev/null 2>&1 || true` inside the clean-tree gate, **before** the check, in both `release-android.sh` and `release-firebase.sh`. It re-stats every file and clears mtime-only false positives.

**Safety:** this can never mask a real change — a file whose content differs from HEAD stays flagged, so the gate keeps its full safety value. It only reconciles mtime-vs-content.

Also updates the CLAUDE.md note to reflect the scripts now self-refresh (manual fix kept as a fallback).

Verified: `bash -n` parses both scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)