### PR TITLE
ci(android): bump upload-google-play v1.1.3 → v1.1.5 (Node 24)

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -81,7 +81,7 @@ jobs:
           retention-days: 1
 
       - name: Deploy to Google Play (Internal Track)
-        uses: r0adkll/upload-google-play@v1.1.3
+        uses: r0adkll/upload-google-play@v1.1.5
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.chriscartland.garage


### PR DESCRIPTION
Clears the Node 20 deprecation warning seen on the `android/248` release.

## Why
`r0adkll/upload-google-play@v1.1.3` declares `using: node20` — GitHub deprecates Node 20 on Actions runners (forced to Node 24 by 2026-06-16, removed 2026-09-16). Every Android release logs the warning.

- **v1.1.4** (2026-04-20): "Upgrade to Node24."
- **v1.1.5** (2026-04-21): adds a fix for `track`/`releaseFile` deprecation handling.

Verified `v1.1.5` `action.yml` declares **`using: 'node24'`** (vs `node20` at v1.1.3).

## Compatibility
Our step uses `serviceAccountJsonPlainText`, `packageName`, `releaseFiles`, `track: internal`, `whatsNewDirectory` — all stable, unchanged across v1.1.3→v1.1.5. The newer releases are additive (multi-track, version-code retention, editId export) and don't affect our single-internal-track usage. **Same input contract.**

## Verification
YAML validates. The only true end-to-end test is the next Android release's Play upload — but since the input contract is identical and only the runtime + an additive fix changed, risk is low. If anything regressed, it'd surface on the next `release-android.yml` run (deploy step), not in pre-merge CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)