### PR TITLE
ci(android): migrate upload-google-play `track` → `tracks` input

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -86,7 +86,7 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.chriscartland.garage
           releaseFiles: AndroidGarage/androidApp/build/outputs/bundle/release/*.aab
-          track: internal
+          tracks: internal
           whatsNewDirectory: AndroidGarage/distribution/whatsnew
 
       - name: Release summary


### PR DESCRIPTION
Follow-up to the v1.1.5 bump (#879). The v1.1.5 upgrade cleared the Node 20 warning but the `android/249` release surfaced a new one:

> WARNING!! 'track' is deprecated and will be removed in a future release. Please migrate to 'tracks'

The singular `track` still worked (the upload to internal track succeeded), but switch to the plural **`tracks: internal`** to clear it.

**Safe:** same shape as `releaseFiles` (plural), which this workflow already uses successfully — so plural inputs are proven in this action. Validates on the next release's upload step (the deploy path isn't exercised by pre-merge CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)