### PR TITLE
docs: front-matter contract for store-asset docs (unblocks 2.17.1 release)

### DIFF
--- a/AndroidGarage/distribution/playstore/README.md
+++ b/AndroidGarage/distribution/playstore/README.md
@@ -1,3 +1,9 @@
+---
+category: reference
+status: active
+last_verified: 2026-06-11
+---
+
 # Play Store listing assets
 
 Garage-door identity for the Google Play listing and the on-device launcher

--- a/scripts/check-doc-frontmatter.sh
+++ b/scripts/check-doc-frontmatter.sh
@@ -65,6 +65,9 @@ should_skip() {
         */android-screenshot-tests/*SCREENSHOT_GALLERY.md) return 0 ;;
         */android-screenshot-tests/*PREVIEW_COVERAGE.md) return 0 ;;
         */android-screenshot-tests/collections/*) return 0 ;;
+        # Generated Play Store asset gallery (screenshots/store/README.md) — same
+        # generated-artifact class as the screenshot galleries above.
+        */screenshots/store/*) return 0 ;;
         */detekt.md) return 0 ;;
         */GarageFirmware_ESP32/*) return 0 ;;
         */Arduino_ESP32/*) return 0 ;;


### PR DESCRIPTION
`validate.sh`'s AGENTS.md doc front-matter check (not run in PR CI, so latent since #882/#883) flagged two files:

- **`distribution/playstore/README.md`** — added `reference`/`active` front-matter (it's a maintained doc, matching the other READMEs).
- **`screenshots/store/README.md`** — excluded in `check-doc-frontmatter.sh`; it's a **generated** gallery, same artifact class as the already-excluded `SCREENSHOT_GALLERY.md` / `collections/`.

Verified: `./scripts/check-doc-frontmatter.sh` passes. Unblocks the 2.17.1 release validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)