### PR TITLE
fix(server): retry open-door notification on send failure (R5)

### DIFF
--- a/FirebaseServer/src/controller/fcm/OldDataFCM.ts
+++ b/FirebaseServer/src/controller/fcm/OldDataFCM.ts
@@ -74,16 +74,35 @@ export async function sendFCMForOldData(buildTimestamp: string, eventData): Prom
   const data = {};
   data[NOTIFICATION_CURRENT_EVENT_KEY] = currentEvent;
   data[NOTIFICATION_MESSAGE_KEY] = message;
-  await NotificationsDatabase.save(buildTimestamp, data);
   console.log('Sending notification', JSON.stringify(message));
-  await firebase.messaging().send(message)
-    .then((response) => {
-      // Response is a message ID string.
-      console.log('Successfully sent message:', JSON.stringify(response));
-    })
-    .catch((error) => {
-      console.log('Error sending message:', JSON.stringify(error));
-    });
+  // Send BEFORE recording the dedup marker. If the send fails we must NOT
+  // persist "already notified for this event" — otherwise the duplicate-
+  // suppression check above would block every future retry and the user
+  // would never be told the door is open. Leaving the marker unsaved lets
+  // the next pubsubCheckForOpenDoorsJob tick (every 5 min) re-send while the
+  // door stays open: at-most-once becomes at-least-once. Note that "success"
+  // here means FCM *accepted* the message, not that the device received it.
+  // Full rationale + tradeoffs: docs/NOTIFICATION_RELIABILITY.md (R5).
+  try {
+    const response = await firebase.messaging().send(message);
+    // Response is a message ID string.
+    console.log('Successfully sent message:', JSON.stringify(response));
+  } catch (error) {
+    console.error('Error sending message:', JSON.stringify(error));
+    return null; // No dedup marker written → the next tick retries.
+  }
+  // Record the dedup marker only AFTER a confirmed send. A failure here is
+  // rare (a Firestore write) but means the next tick re-sends a duplicate,
+  // coalesced by collapse_key 'door_not_closed'. Log loudly so a persistent
+  // failure is noticed rather than silently re-notifying every 5 minutes.
+  try {
+    await NotificationsDatabase.save(buildTimestamp, data);
+  } catch (error) {
+    console.error(
+      'Sent notification but failed to persist dedup marker; may re-send next tick:',
+      JSON.stringify(error),
+    );
+  }
   return message;
 }
 

--- a/FirebaseServer/test/controller/fcm/OldDataFCMFakeTest.ts
+++ b/FirebaseServer/test/controller/fcm/OldDataFCMFakeTest.ts
@@ -287,42 +287,14 @@ describe('sendFCMForOldData (via fakes)', () => {
     expect(sendStub.calledOnce).to.be.true;
   });
 
-  // --- Failure modes ---
+  // --- Failure modes (R5: docs/NOTIFICATION_RELIABILITY.md) ---
 
   describe('failure modes', () => {
-    async function assertRejects(fn: () => Promise<any>): Promise<Error> {
-      try {
-        await fn();
-      } catch (e) {
-        return e as Error;
-      }
-      throw new Error('expected promise to reject, but it resolved');
-    }
-
-    it('propagates NotificationsDatabase.save failure; FCM is NOT called', async () => {
-      const staleOpen: SensorEvent = {
-        type: SensorEventType.Open,
-        timestampSeconds: STALE_EVENT_TS,
-        message: '',
-        checkInTimestampSeconds: 0,
-      };
-      fakeSensorEvents.seed(BUILD_TIMESTAMP, { currentEvent: staleOpen });
-      fakeNotifications.failNextSave(new Error('Firestore down: notifications.save'));
-
-      const err = await assertRejects(() => sendFCMForOldData(BUILD_TIMESTAMP, { currentEvent: staleOpen }));
-      expect(err.message).to.equal('Firestore down: notifications.save');
-
-      // save() was attempted (captured in audit log even when it threw).
-      expect(fakeNotifications.saved).to.have.length(1);
-      // FCM must NOT have been called — proves the save error short-circuits.
-      expect(sendStub.called).to.be.false;
-    });
-
-    it('FCM send() failure is swallowed internally; message still returned', async () => {
-      // Pin current behavior: sendFCMForOldData wraps firebase.messaging().send()
-      // in a `.catch()` that logs. Callers do not see the failure. This test
-      // documents and locks that contract — changing it (to propagate) is a
-      // behavior change, not a refactor.
+    it('FCM send() failure: returns null and does NOT persist the dedup marker (so the next tick retries)', async () => {
+      // R5 fix: the dedup marker is committed only AFTER a confirmed send. A
+      // failed send must leave no marker, so the every-5-min pubsub job
+      // re-sends while the door stays open instead of silently giving up
+      // (the old swallowed-error behavior locked in "already notified").
       const staleOpen: SensorEvent = {
         type: SensorEventType.Open,
         timestampSeconds: STALE_EVENT_TS,
@@ -334,11 +306,34 @@ describe('sendFCMForOldData (via fakes)', () => {
 
       const result = await sendFCMForOldData(BUILD_TIMESTAMP, { currentEvent: staleOpen });
 
-      // Result is the built message even though FCM send threw — swallowed.
-      expect(result).to.not.be.null;
-      // DB save committed before FCM attempt.
-      expect(fakeNotifications.saved).to.have.length(1);
+      // Send was attempted but failed → no message returned, no marker saved.
+      expect(result).to.be.null;
       expect(sendStub.calledOnce).to.be.true;
+      expect(fakeNotifications.saved).to.be.empty;
+    });
+
+    it('save() failure AFTER a successful send: message still returned, error swallowed+logged', async () => {
+      // The deliberate tradeoff of the R5 reorder: if the dedup-marker save
+      // fails after FCM already accepted the message, we do NOT reject (which
+      // would noise up the pubsub job) — we log loudly and return the message.
+      // The marker is absent, so the next tick may re-send a duplicate
+      // (coalesced by collapse_key). Strictly preferred over a silent miss.
+      const staleOpen: SensorEvent = {
+        type: SensorEventType.Open,
+        timestampSeconds: STALE_EVENT_TS,
+        message: '',
+        checkInTimestampSeconds: 0,
+      };
+      fakeSensorEvents.seed(BUILD_TIMESTAMP, { currentEvent: staleOpen });
+      fakeNotifications.failNextSave(new Error('Firestore down: notifications.save'));
+
+      const result = await sendFCMForOldData(BUILD_TIMESTAMP, { currentEvent: staleOpen });
+
+      // Send happened first and succeeded → message returned despite save failure.
+      expect(result).to.not.be.null;
+      expect(sendStub.calledOnce).to.be.true;
+      // save() was attempted (the fake records the attempt even when it throws).
+      expect(fakeNotifications.saved).to.have.length(1);
     });
   });
 });

--- a/docs/NOTIFICATION_RELIABILITY.md
+++ b/docs/NOTIFICATION_RELIABILITY.md
@@ -19,8 +19,10 @@ keys, data-only vs notification-payload split) — that lives in `CLAUDE.md`
 § "Safety Rules → FCM Push Notifications" and the `wire-contracts/` fixtures.
 Read those first for *how it works*; this doc is *where it's fragile*.
 
-All fixes below are **proposed, not yet implemented**. When one ships, move its
-row to "Resolved" and bump `last_verified`.
+All fixes below are **proposed, not yet implemented** — except **R5**, whose
+reorder fix has landed in `OldDataFCM.ts` (live in `main`, pending a `server/N`
+deploy to reach production). When a fix ships, annotate its row and bump
+`last_verified`.
 
 ## Findings summary
 
@@ -30,7 +32,7 @@ where they affect *delivery/surfacing* reliability.
 
 | ID | Sev | Feature | Finding | Source |
 |----|-----|---------|---------|--------|
-| **R5** | High | Open-door notif | At-most-once: a single dropped/failed send is never retried (dedup marker saved before send; send error swallowed). | `FirebaseServer/src/controller/fcm/OldDataFCM.ts:63-87` |
+| **R5** ✅ | High | Open-door notif | **Fixed in code, pending deploy.** Was at-most-once: a single dropped/failed send was never retried (dedup marker saved before send; send error swallowed). Now: send-before-save, so a failed send leaves no marker and the next 5-min tick retries. | `FirebaseServer/src/controller/fcm/OldDataFCM.ts` |
 | **R6** | Med | Open-door notif | Foreground drop: a notification-payload message that arrives while the app is foregrounded is only logged, never shown. | `AndroidGarage/androidApp/.../fcm/FCMService.kt:62-64` |
 | **R1** | Med | Push data | Missed-push recovery is manual: staleness is auto-detected but only raises a banner; nothing auto-refetches. | `AndroidGarage/usecase/.../CheckInStalenessManager.kt:54-104` |
 | **R2** | Med | Push data | Runtime topic change unhandled: `FcmRegistrationManager.restart()` exists but nothing calls it (explicit `TODO`). | `AndroidGarage/usecase/.../FcmRegistrationManager.kt:78-90` |
@@ -119,6 +121,12 @@ try {
 The existing every-5-minute job then becomes a real retry loop: a failed send
 leaves no marker, so the next tick tries again until one succeeds — while still
 delivering only one notification per episode.
+
+**Status (2026-06-14):** implemented in `OldDataFCM.ts` — send-before-save
+reorder, `return null` on send failure, plus a loud-log guard on the post-send
+marker save (mitigation for tradeoff #1 below). Live in `main`; reaches
+production on the next `server/N` deploy. The two failure-mode tests in
+`OldDataFCMFakeTest.ts` now lock the new contract.
 
 ## R5 — tradeoff / risks of this fix
 


### PR DESCRIPTION
## What

Fixes **R5** from `docs/NOTIFICATION_RELIABILITY.md`: the open-door notification was delivered **at most once**, and a single dropped FCM permanently suppressed it for that open-door episode.

## Why

In `sendFCMForOldData` (`OldDataFCM.ts`), the dedup marker was committed to `NotificationsDatabase` **before** the send, and the `firebase.messaging().send()` error was swallowed by `.catch`. So on a transient send failure the marker still said "already notified for event T," and the every-5-minute `pubsubCheckForOpenDoorsJob` dedup-skipped forever. The 5-minute loop *looked* like a retry but the marker defeated it. See the worked timeline in the doc.

## The change

Reorder to **send-before-save**:

- Send first. On failure → `console.error` + `return null`, writing **no** marker, so the next tick retries. At-most-once becomes at-least-once.
- Persist the dedup marker only **after** a confirmed send.
- A post-send save failure (rare) is logged loudly and the message is still returned — the next tick may re-send a duplicate (coalesced by `collapse_key: 'door_not_closed'`), which is strictly preferred over a silent miss. This is the documented tradeoff #1 mitigation.

## Tradeoff (documented)

This is a deliberate behavior change: it trades "silent miss" for a small "duplicate alert" risk. "Success" here means FCM *accepted* the message, not that the device received it — so it recovers from send-acceptance failures, not best-effort delivery loss (that's R6). Full analysis in the doc's "R5 — tradeoff / risks" section.

## Tests

- Rewrote the two `OldDataFCMFakeTest.ts` failure-mode tests that explicitly pinned the old behavior (one was titled "FCM send() failure is swallowed internally"):
  - send fails → returns `null`, **no** marker saved.
  - save fails after a successful send → message still returned, error swallowed+logged.
- The HTTP and pubsub handler tests stub `sendFCMForOldData` wholesale, so they're unaffected.
- `./scripts/validate-firebase.sh`: build (lint + tsc) clean, **333 passing**.

## Docs

Syncs `docs/NOTIFICATION_RELIABILITY.md` — R5 marked **fixed in code, pending a `server/N` deploy** (not yet in production until released).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
