### PR TITLE
feat: Test Notification Sandbox (diagnostic, additive)

### DIFF
--- a/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/di/ComponentGraphTest.kt
+++ b/AndroidGarage/androidApp/src/androidTest/java/com/chriscartland/garage/di/ComponentGraphTest.kt
@@ -118,6 +118,19 @@ class ComponentGraphTest {
     }
 
     @Test
+    fun testNotificationRepositoryIsSingleton() {
+        // Owns the max-one-subscription mutex + subscription record. Two
+        // instances would each track their own state and could leave the
+        // device subscribed to multiple test topics at once.
+        val c = component
+        assertSame(
+            "TestNotificationRepository must be singleton",
+            c.testNotificationRepository,
+            c.testNotificationRepository,
+        )
+    }
+
+    @Test
     fun remoteButtonRepositoryIsSingleton() {
         val c = component
         assertSame("RemoteButtonRepository must be singleton", c.remoteButtonRepository, c.remoteButtonRepository)

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -40,6 +40,7 @@ import com.chriscartland.garage.data.ktor.KtorNetworkDoorDataSource
 import com.chriscartland.garage.data.ktor.KtorNetworkFeatureAllowlistDataSource
 import com.chriscartland.garage.data.repository.CachedFeatureAllowlistRepository
 import com.chriscartland.garage.data.repository.CachedServerConfigRepository
+import com.chriscartland.garage.data.repository.DefaultTestNotificationRepository
 import com.chriscartland.garage.data.repository.FirebaseAuthRepository
 import com.chriscartland.garage.data.repository.FirebaseButtonHealthFcmRepository
 import com.chriscartland.garage.data.repository.FirebaseDoorFcmRepository
@@ -69,11 +70,13 @@ import com.chriscartland.garage.domain.repository.FeatureAllowlistRepository
 import com.chriscartland.garage.domain.repository.RemoteButtonRepository
 import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import com.chriscartland.garage.domain.repository.SnoozeRepository
+import com.chriscartland.garage.domain.repository.TestNotificationRepository
 import com.chriscartland.garage.fcm.FirebaseMessagingBridge
 import com.chriscartland.garage.usecase.AppSettingsUseCase
 import com.chriscartland.garage.usecase.AppStartup
 import com.chriscartland.garage.usecase.ApplyButtonHealthFcmUseCase
 import com.chriscartland.garage.usecase.ButtonHealthFcmSubscriptionManager
+import com.chriscartland.garage.usecase.ChangeTestNotificationTopicUseCase
 import com.chriscartland.garage.usecase.CheckInStalenessManager
 import com.chriscartland.garage.usecase.ClearDiagnosticsUseCase
 import com.chriscartland.garage.usecase.ComputeButtonHealthDisplayUseCase
@@ -89,6 +92,7 @@ import com.chriscartland.garage.usecase.FetchOlderDoorEventsUseCase
 import com.chriscartland.garage.usecase.FetchRecentDoorEventsUseCase
 import com.chriscartland.garage.usecase.FetchSnoozeStatusUseCase
 import com.chriscartland.garage.usecase.GetAuthTokenForCopyUseCase
+import com.chriscartland.garage.usecase.GetTestNotificationTopicUseCase
 import com.chriscartland.garage.usecase.InitialDoorFetchManager
 import com.chriscartland.garage.usecase.LiveClock
 import com.chriscartland.garage.usecase.LogAppEventUseCase
@@ -97,6 +101,7 @@ import com.chriscartland.garage.usecase.ObserveDiagnosticsCountUseCase
 import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
 import com.chriscartland.garage.usecase.ObserveFeatureAccessUseCase
 import com.chriscartland.garage.usecase.ObserveSnoozeStateUseCase
+import com.chriscartland.garage.usecase.ObserveTestNotificationStateUseCase
 import com.chriscartland.garage.usecase.PruneDiagnosticsLogUseCase
 import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
 import com.chriscartland.garage.usecase.ReceiveFcmDoorEventUseCase
@@ -106,6 +111,8 @@ import com.chriscartland.garage.usecase.SeedDiagnosticsCountersFromRoomUseCase
 import com.chriscartland.garage.usecase.SignInWithGoogleUseCase
 import com.chriscartland.garage.usecase.SignOutUseCase
 import com.chriscartland.garage.usecase.SnoozeNotificationsUseCase
+import com.chriscartland.garage.usecase.SubscribeTestNotificationUseCase
+import com.chriscartland.garage.usecase.UnsubscribeTestNotificationUseCase
 import com.chriscartland.garage.version.AppVersion
 import com.chriscartland.garage.viewmodel.DefaultDiagnosticsViewModel
 import com.chriscartland.garage.viewmodel.DefaultDoorHistoryViewModel
@@ -174,6 +181,7 @@ abstract class AppComponent(
     abstract val snoozeRepository: SnoozeRepository
     abstract val remoteButtonRepository: RemoteButtonRepository
     abstract val doorFcmRepository: DoorFcmRepository
+    abstract val testNotificationRepository: TestNotificationRepository
     abstract val featureAllowlistRepository: FeatureAllowlistRepository
     abstract val fcmRegistrationManager: FcmRegistrationManager
     abstract val checkInStalenessManager: CheckInStalenessManager
@@ -250,6 +258,11 @@ abstract class AppComponent(
         pruneDiagnosticsLog: PruneDiagnosticsLogUseCase,
         registerFcm: RegisterFcmUseCase,
         deregisterFcm: DeregisterFcmUseCase,
+        getTestNotificationTopic: GetTestNotificationTopicUseCase,
+        changeTestNotificationTopic: ChangeTestNotificationTopicUseCase,
+        subscribeTestNotification: SubscribeTestNotificationUseCase,
+        unsubscribeTestNotification: UnsubscribeTestNotificationUseCase,
+        observeTestNotificationState: ObserveTestNotificationStateUseCase,
         dispatchers: DispatcherProvider,
         appVersion: String,
     ): DefaultFunctionListViewModel =
@@ -268,6 +281,11 @@ abstract class AppComponent(
             pruneDiagnosticsLogUseCase = pruneDiagnosticsLog,
             registerFcmUseCase = registerFcm,
             deregisterFcmUseCase = deregisterFcm,
+            getTestNotificationTopicUseCase = getTestNotificationTopic,
+            changeTestNotificationTopicUseCase = changeTestNotificationTopic,
+            subscribeTestNotificationUseCase = subscribeTestNotification,
+            unsubscribeTestNotificationUseCase = unsubscribeTestNotification,
+            observeTestNotificationStateUseCase = observeTestNotificationState,
             dispatchers = dispatchers,
             appVersion = appVersion,
         )
@@ -416,6 +434,26 @@ abstract class AppComponent(
 
     @Provides
     fun provideDeregisterFcmUseCase(doorFcmRepository: DoorFcmRepository): DeregisterFcmUseCase = DeregisterFcmUseCase(doorFcmRepository)
+
+    @Provides
+    fun provideGetTestNotificationTopicUseCase(repository: TestNotificationRepository): GetTestNotificationTopicUseCase =
+        GetTestNotificationTopicUseCase(repository)
+
+    @Provides
+    fun provideChangeTestNotificationTopicUseCase(repository: TestNotificationRepository): ChangeTestNotificationTopicUseCase =
+        ChangeTestNotificationTopicUseCase(repository)
+
+    @Provides
+    fun provideSubscribeTestNotificationUseCase(repository: TestNotificationRepository): SubscribeTestNotificationUseCase =
+        SubscribeTestNotificationUseCase(repository)
+
+    @Provides
+    fun provideUnsubscribeTestNotificationUseCase(repository: TestNotificationRepository): UnsubscribeTestNotificationUseCase =
+        UnsubscribeTestNotificationUseCase(repository)
+
+    @Provides
+    fun provideObserveTestNotificationStateUseCase(repository: TestNotificationRepository): ObserveTestNotificationStateUseCase =
+        ObserveTestNotificationStateUseCase(repository)
 
     @Provides
     fun providePushRemoteButtonUseCase(
@@ -644,6 +682,14 @@ abstract class AppComponent(
         appSettings: AppSettingsRepository,
         appLoggerRepository: AppLoggerRepository,
     ): DoorFcmRepository = FirebaseDoorFcmRepository(messagingBridge, appSettings, appLoggerRepository)
+
+    // @Singleton: one instance owns the max-one-subscription mutex + record.
+    @Provides
+    @Singleton
+    fun provideTestNotificationRepository(
+        messagingBridge: MessagingBridge,
+        appSettings: AppSettingsRepository,
+    ): TestNotificationRepository = DefaultTestNotificationRepository(messagingBridge, appSettings)
 
     @Provides
     @Singleton

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
@@ -27,11 +27,16 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
 class FCMService : FirebaseMessagingService() {
+    private val testNotificationPresenter: TestNotificationPresenter by lazy {
+        TestNotificationPresenter(applicationContext)
+    }
+
     private val handler: FcmMessageHandler by lazy {
         val component = (application as GarageApplication).component
         FcmMessageHandler(
             receiveFcmDoorEvent = component.receiveFcmDoorEventUseCase,
             applyButtonHealthFcm = component.applyButtonHealthFcmUseCase,
+            showTestNotification = testNotificationPresenter::show,
         )
     }
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FcmMessageHandler.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FcmMessageHandler.kt
@@ -20,6 +20,7 @@ package com.chriscartland.garage.fcm
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.ButtonHealthFcmPayloadParser
 import com.chriscartland.garage.data.FcmPayloadParser
+import com.chriscartland.garage.data.repository.DefaultTestNotificationRepository
 import com.chriscartland.garage.usecase.ApplyButtonHealthFcmUseCase
 import com.chriscartland.garage.usecase.ReceiveFcmDoorEventUseCase
 
@@ -27,6 +28,8 @@ import com.chriscartland.garage.usecase.ReceiveFcmDoorEventUseCase
  * Handles FCM data messages. Extracted from FCMService for testability.
  *
  * Dispatches by topic prefix:
+ *  - `testNotification-*` → [showTestNotification] (diagnostic sandbox; an
+ *    app-built notification, fully isolated from the production door path)
  *  - `buttonHealth-*` → [ApplyButtonHealthFcmUseCase]
  *  - everything else → door-event parser (default-preserving — the
  *    existing door FCM path stays exactly as it was)
@@ -37,6 +40,7 @@ import com.chriscartland.garage.usecase.ReceiveFcmDoorEventUseCase
 class FcmMessageHandler(
     private val receiveFcmDoorEvent: ReceiveFcmDoorEventUseCase,
     private val applyButtonHealthFcm: ApplyButtonHealthFcmUseCase,
+    private val showTestNotification: (Map<String, String>) -> Unit,
 ) {
     /**
      * Process an FCM data message. Topic prefix determines which
@@ -56,10 +60,14 @@ class FcmMessageHandler(
             Logger.d { "Message data payload is empty" }
             return false
         }
-        return if (topic.startsWith("buttonHealth-")) {
-            handleButtonHealthMessage(data)
-        } else {
-            handleDoorMessage(data)
+        return when {
+            topic.startsWith(DefaultTestNotificationRepository.TEST_TOPIC_PREFIX) -> {
+                Logger.d { "Test notification FCM payload: $data" }
+                showTestNotification(data)
+                true
+            }
+            topic.startsWith("buttonHealth-") -> handleButtonHealthMessage(data)
+            else -> handleDoorMessage(data)
         }
     }
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/TestNotificationPayload.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/TestNotificationPayload.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.fcm
+
+/** Parsed content of a test-notification-sandbox FCM data payload. */
+data class TestNotificationContent(
+    val title: String,
+    val body: String,
+    val tag: String,
+)
+
+/**
+ * Pure parser for the test-notification sandbox data payload. Lenient by design
+ * — a minimal payload still renders something, so the sandbox always shows a
+ * notification. `tag` drives Android's inline replacement: sending a later
+ * message with the same `tag` replaces the existing notification in place
+ * (the mechanism the reliable "Resolved" feature will rely on).
+ */
+object TestNotificationPayload {
+    const val DEFAULT_TAG = "test"
+
+    fun parse(data: Map<String, String>): TestNotificationContent =
+        TestNotificationContent(
+            title = data["title"]?.ifEmpty { null } ?: "Test notification",
+            body = data["body"] ?: "",
+            tag = data["tag"]?.ifEmpty { null } ?: DEFAULT_TAG,
+        )
+}

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/TestNotificationPresenter.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/TestNotificationPresenter.kt
@@ -53,7 +53,8 @@ class TestNotificationPresenter(
         val content = TestNotificationPayload.parse(data)
         Logger.d { "TestNotification: posting tag=${content.tag} title=${content.title}" }
         val notification =
-            NotificationCompat.Builder(context, CHANNEL_ID)
+            NotificationCompat
+                .Builder(context, CHANNEL_ID)
                 .setSmallIcon(android.R.drawable.ic_dialog_info)
                 .setContentTitle(content.title)
                 .setContentText(content.body)
@@ -76,7 +77,8 @@ class TestNotificationPresenter(
                 ).apply {
                     description = "Sandbox channel for the test-notification diagnostic feature."
                 }
-            context.getSystemService(NotificationManager::class.java)
+            context
+                .getSystemService(NotificationManager::class.java)
                 ?.createNotificationChannel(channel)
         }
     }

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/TestNotificationPresenter.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/TestNotificationPresenter.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.fcm
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import co.touchlab.kermit.Logger
+
+/**
+ * Renders test-notification-sandbox messages as **app-owned** notifications.
+ *
+ * This is the isolated prototype of the app-built notification infrastructure
+ * the reliable open-door "Resolved" feature will later need: a dedicated
+ * channel, `tag`-based inline replacement, and uniform foreground/background
+ * rendering (a data message always reaches `onMessageReceived`). It is driven
+ * ONLY by the diagnostic `testNotification-*` topic and touches nothing in the
+ * production door-notification path.
+ */
+class TestNotificationPresenter(
+    private val context: Context,
+) {
+    fun show(data: Map<String, String>) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) !=
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            Logger.w { "TestNotification: POST_NOTIFICATIONS not granted; skipping notify" }
+            return
+        }
+        ensureChannel()
+        val content = TestNotificationPayload.parse(data)
+        Logger.d { "TestNotification: posting tag=${content.tag} title=${content.title}" }
+        val notification =
+            NotificationCompat.Builder(context, CHANNEL_ID)
+                .setSmallIcon(android.R.drawable.ic_dialog_info)
+                .setContentTitle(content.title)
+                .setContentText(content.body)
+                .setStyle(NotificationCompat.BigTextStyle().bigText(content.body))
+                .setAutoCancel(true)
+                .setOnlyAlertOnce(true)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .build()
+        // Same (tag, id) replaces the existing notification in place.
+        NotificationManagerCompat.from(context).notify(content.tag, NOTIFICATION_ID, notification)
+    }
+
+    private fun ensureChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel =
+                NotificationChannel(
+                    CHANNEL_ID,
+                    "Test notifications (diagnostic)",
+                    NotificationManager.IMPORTANCE_HIGH,
+                ).apply {
+                    description = "Sandbox channel for the test-notification diagnostic feature."
+                }
+            context.getSystemService(NotificationManager::class.java)
+                ?.createNotificationChannel(channel)
+        }
+    }
+
+    companion object {
+        const val CHANNEL_ID = "test_notification_sandbox"
+
+        /** Fixed id; the payload `tag` is what differentiates / replaces notifications. */
+        const val NOTIFICATION_ID = 4242
+    }
+}

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/FunctionListContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/FunctionListContent.kt
@@ -65,7 +65,7 @@ fun FunctionListContent(
     FunctionListContent(
         modifier = modifier,
         accessGranted = accessGranted,
-        testNotificationTopic = testNotificationState.topic?.string,
+        testNotificationTopic = testNotificationState.topic?.string ?: "",
         testNotificationSubscribed = testNotificationState.isSubscribed,
         onSubscribeTestNotification = resolved::subscribeTestNotification,
         onUnsubscribeTestNotification = resolved::unsubscribeTestNotification,
@@ -93,7 +93,7 @@ fun FunctionListContent(
 fun FunctionListContent(
     modifier: Modifier = Modifier,
     accessGranted: Boolean? = null,
-    testNotificationTopic: String? = null,
+    testNotificationTopic: String = "",
     testNotificationSubscribed: Boolean = false,
     onSubscribeTestNotification: () -> Unit = {},
     onUnsubscribeTestNotification: () -> Unit = {},
@@ -142,7 +142,7 @@ fun FunctionListContent(
             }
             // Test-notification sandbox (diagnostic). Hidden until the personal
             // topic is generated, so previews/screenshots are unaffected.
-            if (testNotificationTopic != null) {
+            if (testNotificationTopic.isNotEmpty()) {
                 item {
                     Text(
                         text = "Test notification topic:\n$testNotificationTopic",

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/FunctionListContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/FunctionListContent.kt
@@ -31,7 +31,9 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -57,10 +59,20 @@ fun FunctionListContent(
         onTokenReceived = { token -> resolved.signInWithGoogle(token) },
     )
     val copyAuthToken = rememberAuthTokenCopier()
+    val testNotificationState by resolved.testNotificationState.collectAsState()
+    val clipboard = LocalClipboardManager.current
 
     FunctionListContent(
         modifier = modifier,
         accessGranted = accessGranted,
+        testNotificationTopic = testNotificationState.topic?.string,
+        testNotificationSubscribed = testNotificationState.isSubscribed,
+        onSubscribeTestNotification = resolved::subscribeTestNotification,
+        onUnsubscribeTestNotification = resolved::unsubscribeTestNotification,
+        onChangeTestNotificationTopic = resolved::changeTestNotificationTopic,
+        onCopyTestNotificationTopic = {
+            testNotificationState.topic?.let { clipboard.setText(AnnotatedString(it.string)) }
+        },
         onOpenOrCloseDoor = resolved::openOrCloseDoor,
         onRefreshDoorStatus = resolved::refreshDoorStatus,
         onRefreshDoorHistory = resolved::refreshDoorHistory,
@@ -81,6 +93,12 @@ fun FunctionListContent(
 fun FunctionListContent(
     modifier: Modifier = Modifier,
     accessGranted: Boolean? = null,
+    testNotificationTopic: String? = null,
+    testNotificationSubscribed: Boolean = false,
+    onSubscribeTestNotification: () -> Unit = {},
+    onUnsubscribeTestNotification: () -> Unit = {},
+    onChangeTestNotificationTopic: () -> Unit = {},
+    onCopyTestNotificationTopic: () -> Unit = {},
     onOpenOrCloseDoor: () -> Unit = {},
     onRefreshDoorStatus: () -> Unit = {},
     onRefreshDoorHistory: () -> Unit = {},
@@ -121,6 +139,35 @@ fun FunctionListContent(
             // the verification property the user asked for.
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 item { FunctionButton(stringResource(R.string.function_list_copy_auth_token), onCopyAuthToken) }
+            }
+            // Test-notification sandbox (diagnostic). Hidden until the personal
+            // topic is generated, so previews/screenshots are unaffected.
+            if (testNotificationTopic != null) {
+                item {
+                    Text(
+                        text = "Test notification topic:\n$testNotificationTopic",
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 8.dp, vertical = 8.dp),
+                    )
+                }
+                item { FunctionButton("Copy test topic", onCopyTestNotificationTopic) }
+                item {
+                    FunctionButton(
+                        label = if (testNotificationSubscribed) {
+                            "Unsubscribe test notifications"
+                        } else {
+                            "Subscribe test notifications"
+                        },
+                        onClick = if (testNotificationSubscribed) {
+                            onUnsubscribeTestNotification
+                        } else {
+                            onSubscribeTestNotification
+                        },
+                    )
+                }
+                item { FunctionButton("Change test topic", onChangeTestNotificationTopic) }
             }
         }
     } else {

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/fcm/FcmMessageHandlerTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/fcm/FcmMessageHandlerTest.kt
@@ -40,7 +40,13 @@ class FcmMessageHandlerTest {
     private val receiveFcmDoorEvent = RecordingReceiveFcmDoorEventUseCase()
     private val buttonHealthRepo = RecordingButtonHealthRepository()
     private val applyButtonHealthFcm = ApplyButtonHealthFcmUseCase(buttonHealthRepo)
-    private val handler = FcmMessageHandler(receiveFcmDoorEvent, applyButtonHealthFcm)
+    private val testNotifications = mutableListOf<Map<String, String>>()
+    private val handler =
+        FcmMessageHandler(
+            receiveFcmDoorEvent,
+            applyButtonHealthFcm,
+            showTestNotification = { testNotifications.add(it) },
+        )
 
     private fun doorPayload(
         type: String? = "CLOSED",
@@ -151,6 +157,21 @@ class FcmMessageHandlerTest {
 
             assertFalse(result)
             assertNull(buttonHealthRepo.lastApplied)
+        }
+
+    // --- Test-notification sandbox branch (diagnostic; isolated from production) ---
+
+    @Test
+    fun testNotificationTopic_routesToPresenter_notDoorOrButtonHealth() =
+        runTest {
+            val data = mapOf("title" to "Hi", "body" to "There", "tag" to "t1")
+            val result = handler.handleMessage(topic = "testNotification-abc123", data = data)
+
+            assertTrue(result)
+            assertEquals(1, testNotifications.size)
+            assertEquals(data, testNotifications.single())
+            assertNull(receiveFcmDoorEvent.lastEvent) // Door branch NOT invoked.
+            assertNull(buttonHealthRepo.lastApplied) // Button-health branch NOT invoked.
         }
 }
 

--- a/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/fcm/TestNotificationPayloadTest.kt
+++ b/AndroidGarage/androidApp/src/test/java/com/chriscartland/garage/fcm/TestNotificationPayloadTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.fcm
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TestNotificationPayloadTest {
+    @Test
+    fun parsesAllFields() {
+        val content =
+            TestNotificationPayload.parse(
+                mapOf("title" to "Garage open", "body" to "Open 12 min", "tag" to "door-1"),
+            )
+        assertEquals("Garage open", content.title)
+        assertEquals("Open 12 min", content.body)
+        assertEquals("door-1", content.tag)
+    }
+
+    @Test
+    fun defaultsWhenFieldsMissing() {
+        val content = TestNotificationPayload.parse(emptyMap())
+        assertEquals("Test notification", content.title)
+        assertEquals("", content.body)
+        assertEquals(TestNotificationPayload.DEFAULT_TAG, content.tag)
+    }
+
+    @Test
+    fun emptyTitleAndTagFallBackToDefaults() {
+        val content = TestNotificationPayload.parse(mapOf("title" to "", "tag" to ""))
+        assertEquals("Test notification", content.title)
+        assertEquals(TestNotificationPayload.DEFAULT_TAG, content.tag)
+    }
+}

--- a/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/DataStoreAppSettings.kt
+++ b/AndroidGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/DataStoreAppSettings.kt
@@ -63,6 +63,12 @@ class DataStoreAppSettings(
             "NAVIGATION_RAIL_TOP_PADDING_DP",
             NavigationRailLayout.DEFAULT_TOP_PADDING_DP,
         )
+    override val testNotificationCurrentTopic: Setting<String> =
+        DataStoreStringSetting(dataStore, "TEST_NOTIFICATION_CURRENT_TOPIC", "")
+    override val testNotificationWantSubscribed: Setting<Boolean> =
+        DataStoreBooleanSetting(dataStore, "TEST_NOTIFICATION_WANT_SUBSCRIBED", false)
+    override val testNotificationSubscribedTopic: Setting<String> =
+        DataStoreStringSetting(dataStore, "TEST_NOTIFICATION_SUBSCRIBED_TOPIC", "")
 }
 
 private class DataStoreStringSetting(

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/DefaultTestNotificationRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/DefaultTestNotificationRepository.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.data.repository
+
+import co.touchlab.kermit.Logger
+import com.chriscartland.garage.data.MessagingBridge
+import com.chriscartland.garage.domain.model.TestNotificationSandboxState
+import com.chriscartland.garage.domain.model.TestNotificationTopic
+import com.chriscartland.garage.domain.repository.AppSettingsRepository
+import com.chriscartland.garage.domain.repository.TestNotificationRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Enforces the max-one-subscription invariant for the test-notification
+ * sandbox (see [TestNotificationRepository]).
+ *
+ * Persists three values in [AppSettingsRepository] and reconciles to them:
+ *  - `testNotificationCurrentTopic` — the topic the user has/copies.
+ *  - `testNotificationWantSubscribed` — user intent.
+ *  - `testNotificationSubscribedTopic` — what FCM is actually subscribed to
+ *    (`""` = none). The authoritative record, since the FCM SDK can't be queried.
+ *
+ * Every mutating method ends in [reconcile] under [mutex], so concurrent calls
+ * can't interleave into a double-subscribe, and the system converges to
+ * `subscribedTopic ∈ { currentTopic, none }` regardless of call order.
+ *
+ * MUST be a `@Singleton` — one instance owns the mutex + the subscription record.
+ *
+ * @param newTopicId produces the random id for a new topic. Injectable so tests
+ *   can use deterministic ids; production uses a 64-bit random hex.
+ */
+class DefaultTestNotificationRepository(
+    private val messagingBridge: MessagingBridge,
+    private val settings: AppSettingsRepository,
+    private val newTopicId: () -> String = {
+        kotlin.random.Random.nextLong().toULong().toString(16).padStart(16, '0')
+    },
+) : TestNotificationRepository {
+    private val mutex = Mutex()
+
+    private val _state = MutableStateFlow(TestNotificationSandboxState())
+    override val state: StateFlow<TestNotificationSandboxState> = _state
+
+    override suspend fun getTopic(): TestNotificationTopic =
+        mutex.withLock {
+            val topic = currentTopicOrGenerate()
+            publishState()
+            TestNotificationTopic(topic)
+        }
+
+    override suspend fun changeTopic(): TestNotificationTopic =
+        mutex.withLock {
+            val fresh = TEST_TOPIC_PREFIX + newTopicId()
+            settings.testNotificationCurrentTopic.set(fresh)
+            reconcile() // if subscribed, the subscription follows to `fresh`
+            publishState()
+            TestNotificationTopic(fresh)
+        }
+
+    override suspend fun subscribe() =
+        mutex.withLock {
+            currentTopicOrGenerate() // a subscribe with no topic yet generates one
+            settings.testNotificationWantSubscribed.set(true)
+            reconcile()
+            publishState()
+        }
+
+    override suspend fun unsubscribe() =
+        mutex.withLock {
+            settings.testNotificationWantSubscribed.set(false)
+            reconcile()
+            publishState()
+        }
+
+    // --- internals: all callers already hold `mutex` ---
+
+    /** Current topic string, generating + persisting one if none exists yet. */
+    private suspend fun currentTopicOrGenerate(): String {
+        val stored = settings.testNotificationCurrentTopic.flow.first()
+        if (stored.isNotEmpty()) return stored
+        val fresh = TEST_TOPIC_PREFIX + newTopicId()
+        settings.testNotificationCurrentTopic.set(fresh)
+        return fresh
+    }
+
+    /**
+     * The single enforcement point. Makes the real FCM subscription match
+     * intent. Guarantees `subscribedTopic ∈ { currentTopic, none }` and never
+     * touches a non-test topic.
+     */
+    private suspend fun reconcile() {
+        val want = settings.testNotificationWantSubscribed.flow.first()
+        val current = settings.testNotificationCurrentTopic.flow.first()
+        val target: String? = if (want && current.isNotEmpty()) current else null
+        val subscribed: String? =
+            settings.testNotificationSubscribedTopic.flow.first().ifEmpty { null }
+
+        if (subscribed == target) return
+
+        // Tear down the existing subscription FIRST → never two live at once.
+        if (subscribed != null) {
+            requireOwnTopic(subscribed)
+            messagingBridge.unsubscribeFromTopic(subscribed)
+            settings.testNotificationSubscribedTopic.set("")
+        }
+        // Establish the new subscription; record it ONLY on confirmed success
+        // (mirrors the M1 fix — never claim a subscription we don't have).
+        if (target != null) {
+            requireOwnTopic(target)
+            if (messagingBridge.subscribeToTopic(target)) {
+                settings.testNotificationSubscribedTopic.set(target)
+            } else {
+                Logger.w {
+                    "TestNotification: subscribe to $target failed; retry on next reconcile"
+                }
+            }
+        }
+    }
+
+    private suspend fun publishState() {
+        val current = settings.testNotificationCurrentTopic.flow.first()
+        val subscribed = settings.testNotificationSubscribedTopic.flow.first()
+        _state.value =
+            TestNotificationSandboxState(
+                topic = current.ifEmpty { null }?.let { TestNotificationTopic(it) },
+                isSubscribed = subscribed.isNotEmpty(),
+            )
+    }
+
+    /**
+     * Defense in depth: refuse to pass any non-`testNotification-` topic to the
+     * shared [MessagingBridge]. Even a corrupted persisted value can never
+     * unsubscribe a production (`door_open-*` / `buttonHealth-*`) topic — it
+     * throws here instead, failing safe.
+     */
+    private fun requireOwnTopic(topic: String) {
+        require(topic.startsWith(TEST_TOPIC_PREFIX)) {
+            "TestNotificationRepository refused to touch non-test topic: $topic"
+        }
+    }
+
+    companion object {
+        const val TEST_TOPIC_PREFIX = "testNotification-"
+    }
+}

--- a/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/DefaultTestNotificationRepository.kt
+++ b/AndroidGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/DefaultTestNotificationRepository.kt
@@ -52,7 +52,11 @@ class DefaultTestNotificationRepository(
     private val messagingBridge: MessagingBridge,
     private val settings: AppSettingsRepository,
     private val newTopicId: () -> String = {
-        kotlin.random.Random.nextLong().toULong().toString(16).padStart(16, '0')
+        kotlin.random.Random
+            .nextLong()
+            .toULong()
+            .toString(16)
+            .padStart(16, '0')
     },
 ) : TestNotificationRepository {
     private val mutex = Mutex()
@@ -112,7 +116,9 @@ class DefaultTestNotificationRepository(
         val current = settings.testNotificationCurrentTopic.flow.first()
         val target: String? = if (want && current.isNotEmpty()) current else null
         val subscribed: String? =
-            settings.testNotificationSubscribedTopic.flow.first().ifEmpty { null }
+            settings.testNotificationSubscribedTopic.flow
+                .first()
+                .ifEmpty { null }
 
         if (subscribed == target) return
 

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/DefaultTestNotificationRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/DefaultTestNotificationRepositoryTest.kt
@@ -49,8 +49,7 @@ class DefaultTestNotificationRepositoryTest {
         return net.filterValues { it > 0 }.keys.toList()
     }
 
-    private fun FakeMessagingBridge.allTouchedTopics(): List<String> =
-        subscribedTopics + unsubscribedTopics
+    private fun FakeMessagingBridge.allTouchedTopics(): List<String> = subscribedTopics + unsubscribedTopics
 
     // --- getTopic ---
 
@@ -82,7 +81,11 @@ class DefaultTestNotificationRepositoryTest {
             f.repo.subscribe()
 
             assertEquals(1, f.bridge.activeTopics().size)
-            assertEquals(f.repo.state.value.topic?.string, f.bridge.activeTopics().single())
+            assertEquals(
+                f.repo.state.value.topic
+                    ?.string,
+                f.bridge.activeTopics().single(),
+            )
             assertTrue(f.repo.state.value.isSubscribed)
         }
 
@@ -125,13 +128,18 @@ class DefaultTestNotificationRepositoryTest {
         runTest {
             val f = Fixture()
             f.repo.subscribe()
-            val old = f.repo.state.value.topic?.string
+            val old = f.repo.state.value.topic
+                ?.string
             val new = f.repo.changeTopic().string
 
             assertTrue(f.bridge.unsubscribedTopics.contains(old))
             assertTrue(f.bridge.subscribedTopics.contains(new))
             assertEquals(listOf(new), f.bridge.activeTopics())
-            assertEquals(new, f.repo.state.value.topic?.string)
+            assertEquals(
+                new,
+                f.repo.state.value.topic
+                    ?.string,
+            )
             assertTrue(f.repo.state.value.isSubscribed)
         }
 
@@ -143,7 +151,11 @@ class DefaultTestNotificationRepositoryTest {
             val new = f.repo.changeTopic().string
 
             assertTrue(f.bridge.allTouchedTopics().isEmpty())
-            assertEquals(new, f.repo.state.value.topic?.string)
+            assertEquals(
+                new,
+                f.repo.state.value.topic
+                    ?.string,
+            )
             assertEquals(false, f.repo.state.value.isSubscribed)
         }
 
@@ -179,7 +191,12 @@ class DefaultTestNotificationRepositoryTest {
                 val active = f.bridge.activeTopics()
                 assertEquals(active.isNotEmpty(), f.repo.state.value.isSubscribed, "seq=$seq")
                 if (active.isNotEmpty()) {
-                    assertEquals(f.repo.state.value.topic?.string, active.single(), "seq=$seq")
+                    assertEquals(
+                        f.repo.state.value.topic
+                            ?.string,
+                        active.single(),
+                        "seq=$seq",
+                    )
                 }
             }
         }

--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/DefaultTestNotificationRepositoryTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/DefaultTestNotificationRepositoryTest.kt
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.data.repository
+
+import com.chriscartland.garage.data.repository.DefaultTestNotificationRepository.Companion.TEST_TOPIC_PREFIX
+import com.chriscartland.garage.testcommon.FakeAppSettingsRepository
+import com.chriscartland.garage.testcommon.FakeMessagingBridge
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DefaultTestNotificationRepositoryTest {
+    private class Fixture {
+        val bridge = FakeMessagingBridge()
+        val settings = FakeAppSettingsRepository()
+        private var counter = 0
+        val repo =
+            DefaultTestNotificationRepository(
+                messagingBridge = bridge,
+                settings = settings,
+                newTopicId = { "id${counter++}" }, // deterministic topics: id0, id1, …
+            )
+    }
+
+    /** Net currently-subscribed topics derived from the fake's call records. */
+    private fun FakeMessagingBridge.activeTopics(): List<String> {
+        val net = mutableMapOf<String, Int>()
+        subscribedTopics.forEach { net[it] = (net[it] ?: 0) + 1 }
+        unsubscribedTopics.forEach { net[it] = (net[it] ?: 0) - 1 }
+        return net.filterValues { it > 0 }.keys.toList()
+    }
+
+    private fun FakeMessagingBridge.allTouchedTopics(): List<String> =
+        subscribedTopics + unsubscribedTopics
+
+    // --- getTopic ---
+
+    @Test
+    fun getTopicGeneratesTestTopicAndDoesNotSubscribe() =
+        runTest {
+            val f = Fixture()
+            val topic = f.repo.getTopic()
+
+            assertTrue(topic.string.startsWith(TEST_TOPIC_PREFIX))
+            assertTrue(f.bridge.subscribedTopics.isEmpty())
+            assertEquals(topic, f.repo.state.value.topic)
+            assertEquals(false, f.repo.state.value.isSubscribed)
+        }
+
+    @Test
+    fun getTopicIsStableAcrossCalls() =
+        runTest {
+            val f = Fixture()
+            assertEquals(f.repo.getTopic(), f.repo.getTopic())
+        }
+
+    // --- subscribe / unsubscribe ---
+
+    @Test
+    fun subscribeYieldsExactlyOneActiveSubscriptionToCurrentTopic() =
+        runTest {
+            val f = Fixture()
+            f.repo.subscribe()
+
+            assertEquals(1, f.bridge.activeTopics().size)
+            assertEquals(f.repo.state.value.topic?.string, f.bridge.activeTopics().single())
+            assertTrue(f.repo.state.value.isSubscribed)
+        }
+
+    @Test
+    fun subscribeIsIdempotent() =
+        runTest {
+            val f = Fixture()
+            f.repo.subscribe()
+            f.repo.subscribe()
+            f.repo.subscribe()
+
+            // Only one actual FCM subscribe call; one active subscription.
+            assertEquals(1, f.bridge.subscribedTopics.size)
+            assertEquals(1, f.bridge.activeTopics().size)
+        }
+
+    @Test
+    fun unsubscribeAfterSubscribeLeavesZeroActive() =
+        runTest {
+            val f = Fixture()
+            f.repo.subscribe()
+            f.repo.unsubscribe()
+
+            assertTrue(f.bridge.activeTopics().isEmpty())
+            assertEquals(false, f.repo.state.value.isSubscribed)
+        }
+
+    @Test
+    fun unsubscribeWithoutSubscribeIsNoOp() =
+        runTest {
+            val f = Fixture()
+            f.repo.unsubscribe()
+            assertTrue(f.bridge.allTouchedTopics().isEmpty())
+        }
+
+    // --- changeTopic ---
+
+    @Test
+    fun changeTopicWhileSubscribedMovesSubscriptionToNewTopic() =
+        runTest {
+            val f = Fixture()
+            f.repo.subscribe()
+            val old = f.repo.state.value.topic?.string
+            val new = f.repo.changeTopic().string
+
+            assertTrue(f.bridge.unsubscribedTopics.contains(old))
+            assertTrue(f.bridge.subscribedTopics.contains(new))
+            assertEquals(listOf(new), f.bridge.activeTopics())
+            assertEquals(new, f.repo.state.value.topic?.string)
+            assertTrue(f.repo.state.value.isSubscribed)
+        }
+
+    @Test
+    fun changeTopicWhileNotSubscribedDoesNotSubscribe() =
+        runTest {
+            val f = Fixture()
+            f.repo.getTopic()
+            val new = f.repo.changeTopic().string
+
+            assertTrue(f.bridge.allTouchedTopics().isEmpty())
+            assertEquals(new, f.repo.state.value.topic?.string)
+            assertEquals(false, f.repo.state.value.isSubscribed)
+        }
+
+    // --- invariant: at most one active subscription, any call order ---
+
+    @Test
+    fun atMostOneActiveSubscriptionForEveryCallOrder() =
+        runTest {
+            val sequences =
+                listOf(
+                    listOf("sub", "sub", "change", "sub", "unsub", "change", "sub"),
+                    listOf("change", "sub", "change", "change", "unsub", "sub"),
+                    listOf("sub", "unsub", "sub", "unsub", "sub"),
+                    listOf("get", "sub", "get", "change", "sub", "unsub"),
+                    listOf("unsub", "unsub", "sub", "sub", "change", "unsub", "change"),
+                )
+            for (seq in sequences) {
+                val f = Fixture()
+                for (op in seq) {
+                    when (op) {
+                        "sub" -> f.repo.subscribe()
+                        "unsub" -> f.repo.unsubscribe()
+                        "change" -> f.repo.changeTopic()
+                        "get" -> f.repo.getTopic()
+                    }
+                    // The invariant holds after EVERY operation, not just at the end.
+                    assertTrue(
+                        f.bridge.activeTopics().size <= 1,
+                        "More than one active subscription after $op in $seq: ${f.bridge.activeTopics()}",
+                    )
+                }
+                // Final state agrees with the fake's record.
+                val active = f.bridge.activeTopics()
+                assertEquals(active.isNotEmpty(), f.repo.state.value.isSubscribed, "seq=$seq")
+                if (active.isNotEmpty()) {
+                    assertEquals(f.repo.state.value.topic?.string, active.single(), "seq=$seq")
+                }
+            }
+        }
+
+    @Test
+    fun concurrentOperationsNeverExceedOneActiveSubscription() =
+        runTest {
+            val f = Fixture()
+            // Fire many operations concurrently; the repo's Mutex serializes them.
+            val ops = List(30) { i ->
+                launch {
+                    when (i % 3) {
+                        0 -> f.repo.subscribe()
+                        1 -> f.repo.unsubscribe()
+                        else -> f.repo.changeTopic()
+                    }
+                }
+            }
+            ops.forEach { it.join() }
+
+            assertTrue(
+                f.bridge.activeTopics().size <= 1,
+                "Concurrent ops left >1 active: ${f.bridge.activeTopics()}",
+            )
+            assertEquals(f.bridge.activeTopics().isNotEmpty(), f.repo.state.value.isSubscribed)
+        }
+
+    // --- safety: only ever touch own (testNotification-*) topics ---
+
+    @Test
+    fun onlyTestNotificationTopicsAreEverPassedToTheBridge() =
+        runTest {
+            val f = Fixture()
+            listOf("sub", "change", "sub", "unsub", "change", "sub", "unsub").forEach {
+                when (it) {
+                    "sub" -> f.repo.subscribe()
+                    "unsub" -> f.repo.unsubscribe()
+                    "change" -> f.repo.changeTopic()
+                }
+            }
+            assertTrue(f.bridge.allTouchedTopics().isNotEmpty())
+            assertTrue(
+                f.bridge.allTouchedTopics().all { it.startsWith(TEST_TOPIC_PREFIX) },
+                "A non-test topic reached the bridge: ${f.bridge.allTouchedTopics()}",
+            )
+            // Production namespaces are never touched.
+            assertTrue(f.bridge.allTouchedTopics().none { it.startsWith("door_open-") })
+            assertTrue(f.bridge.allTouchedTopics().none { it.startsWith("buttonHealth-") })
+        }
+
+    @Test
+    fun reconcileRefusesACorruptedNonTestSubscribedTopicAndNeverUnsubscribesProduction() =
+        runTest {
+            val f = Fixture()
+            // Simulate a corrupted persisted record pointing at a PRODUCTION topic.
+            f.settings.testNotificationSubscribedTopic.set("door_open-PRODUCTION_DEVICE")
+            f.settings.testNotificationCurrentTopic.set("${TEST_TOPIC_PREFIX}safe")
+            f.settings.testNotificationWantSubscribed.set(true)
+
+            // Any reconcile must refuse — the prefix guard throws BEFORE the bridge call.
+            assertFailsWith<IllegalArgumentException> { f.repo.subscribe() }
+
+            // The production topic was never handed to the bridge.
+            assertTrue(f.bridge.unsubscribedTopics.none { it == "door_open-PRODUCTION_DEVICE" })
+            assertTrue(f.bridge.allTouchedTopics().none { it.startsWith("door_open-") })
+        }
+
+    @Test
+    fun freshRepoStartsUnsubscribedWithNoTopic() =
+        runTest {
+            val f = Fixture()
+            assertNull(f.repo.state.value.topic)
+            assertEquals(false, f.repo.state.value.isSubscribed)
+        }
+}

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/TestNotification.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/TestNotification.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.domain.model
+
+import kotlin.jvm.JvmInline
+
+/**
+ * A personal FCM topic for the test-notification sandbox (a diagnostic
+ * feature). Always of the form `testNotification-<uuid>` — disjoint from the
+ * production `door_open-*` and `buttonHealth-*` namespaces, so the sandbox can
+ * never touch production subscriptions.
+ */
+@JvmInline
+value class TestNotificationTopic(
+    val string: String,
+)
+
+/**
+ * Observable state of the test-notification sandbox for the UI.
+ *
+ * @property topic the current personal topic, or null before it is generated.
+ * @property isSubscribed whether the device is currently subscribed to [topic].
+ */
+data class TestNotificationSandboxState(
+    val topic: TestNotificationTopic? = null,
+    val isSubscribed: Boolean = false,
+)

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/AppSettingsRepository.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/AppSettingsRepository.kt
@@ -60,4 +60,17 @@ interface AppSettingsRepository {
      * Settings → Developer → "Nav rail top padding". Default 0.
      */
     val navigationRailTopPaddingDp: Setting<Int>
+
+    // --- Test-notification sandbox (diagnostic feature) ---
+    // Three values the TestNotificationRepository reconciles to. Kept separate
+    // from fcmDoorTopic so the sandbox shares no state with production FCM.
+
+    /** The current personal test topic (`testNotification-<uuid>`); `""` until generated. */
+    val testNotificationCurrentTopic: Setting<String>
+
+    /** User intent: whether they want to be subscribed to the test topic. */
+    val testNotificationWantSubscribed: Setting<Boolean>
+
+    /** Authoritative record of the topic FCM is actually subscribed to; `""` = none. */
+    val testNotificationSubscribedTopic: Setting<String>
 }

--- a/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/TestNotificationRepository.kt
+++ b/AndroidGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/TestNotificationRepository.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.domain.repository
+
+import com.chriscartland.garage.domain.model.TestNotificationSandboxState
+import com.chriscartland.garage.domain.model.TestNotificationTopic
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Owns the test-notification sandbox subscription with a hard invariant:
+ *
+ * **At most ONE active FCM subscription at a time, regardless of the order the
+ * four UseCases (get / change / subscribe / unsubscribe) are called.**
+ *
+ * The invariant is enforced HERE, not in the UseCases — they are thin
+ * delegators. Internally a single `reconcile()` runs under a `Mutex`, so
+ * concurrent calls cannot interleave into a double-subscribe, and every
+ * mutating call converges to `subscribedTopic ∈ { currentTopic, none }`.
+ *
+ * **Safety:** the repository only ever touches its own `testNotification-*`
+ * topics. It never reads the production door topic, never enumerates
+ * subscriptions, and guards every bridge call with a prefix check — so it can
+ * never unsubscribe a production (`door_open-*` / `buttonHealth-*`) topic.
+ */
+interface TestNotificationRepository {
+    /** Observable sandbox state (current topic + whether currently subscribed). */
+    val state: StateFlow<TestNotificationSandboxState>
+
+    /** Get-or-generate the current personal topic. Does not change subscription. */
+    suspend fun getTopic(): TestNotificationTopic
+
+    /**
+     * Regenerate the personal topic. If currently subscribed, the subscription
+     * follows to the new topic (the old one is torn down first), preserving the
+     * max-one-subscription invariant.
+     */
+    suspend fun changeTopic(): TestNotificationTopic
+
+    /** Subscribe to the current topic. Idempotent; tears down any prior subscription first. */
+    suspend fun subscribe()
+
+    /** Unsubscribe from the current subscription. Idempotent. */
+    suspend fun unsubscribe()
+}

--- a/AndroidGarage/iosFramework/src/commonMain/kotlin/com/chriscartland/garage/iosframework/NativeComponent.kt
+++ b/AndroidGarage/iosFramework/src/commonMain/kotlin/com/chriscartland/garage/iosframework/NativeComponent.kt
@@ -36,6 +36,7 @@ import com.chriscartland.garage.data.ktor.KtorNetworkDoorDataSource
 import com.chriscartland.garage.data.ktor.KtorNetworkFeatureAllowlistDataSource
 import com.chriscartland.garage.data.repository.CachedFeatureAllowlistRepository
 import com.chriscartland.garage.data.repository.CachedServerConfigRepository
+import com.chriscartland.garage.data.repository.DefaultTestNotificationRepository
 import com.chriscartland.garage.data.repository.FirebaseAuthRepository
 import com.chriscartland.garage.data.repository.FirebaseButtonHealthFcmRepository
 import com.chriscartland.garage.data.repository.FirebaseDoorFcmRepository
@@ -65,10 +66,12 @@ import com.chriscartland.garage.domain.repository.FeatureAllowlistRepository
 import com.chriscartland.garage.domain.repository.RemoteButtonRepository
 import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import com.chriscartland.garage.domain.repository.SnoozeRepository
+import com.chriscartland.garage.domain.repository.TestNotificationRepository
 import com.chriscartland.garage.usecase.AppSettingsUseCase
 import com.chriscartland.garage.usecase.AppStartup
 import com.chriscartland.garage.usecase.ApplyButtonHealthFcmUseCase
 import com.chriscartland.garage.usecase.ButtonHealthFcmSubscriptionManager
+import com.chriscartland.garage.usecase.ChangeTestNotificationTopicUseCase
 import com.chriscartland.garage.usecase.CheckInStalenessManager
 import com.chriscartland.garage.usecase.ClearDiagnosticsUseCase
 import com.chriscartland.garage.usecase.ComputeButtonHealthDisplayUseCase
@@ -84,6 +87,7 @@ import com.chriscartland.garage.usecase.FetchOlderDoorEventsUseCase
 import com.chriscartland.garage.usecase.FetchRecentDoorEventsUseCase
 import com.chriscartland.garage.usecase.FetchSnoozeStatusUseCase
 import com.chriscartland.garage.usecase.GetAuthTokenForCopyUseCase
+import com.chriscartland.garage.usecase.GetTestNotificationTopicUseCase
 import com.chriscartland.garage.usecase.InitialDoorFetchManager
 import com.chriscartland.garage.usecase.LiveClock
 import com.chriscartland.garage.usecase.LogAppEventUseCase
@@ -92,6 +96,7 @@ import com.chriscartland.garage.usecase.ObserveDiagnosticsCountUseCase
 import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
 import com.chriscartland.garage.usecase.ObserveFeatureAccessUseCase
 import com.chriscartland.garage.usecase.ObserveSnoozeStateUseCase
+import com.chriscartland.garage.usecase.ObserveTestNotificationStateUseCase
 import com.chriscartland.garage.usecase.PruneDiagnosticsLogUseCase
 import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
 import com.chriscartland.garage.usecase.ReceiveFcmDoorEventUseCase
@@ -101,6 +106,8 @@ import com.chriscartland.garage.usecase.SeedDiagnosticsCountersFromRoomUseCase
 import com.chriscartland.garage.usecase.SignInWithGoogleUseCase
 import com.chriscartland.garage.usecase.SignOutUseCase
 import com.chriscartland.garage.usecase.SnoozeNotificationsUseCase
+import com.chriscartland.garage.usecase.SubscribeTestNotificationUseCase
+import com.chriscartland.garage.usecase.UnsubscribeTestNotificationUseCase
 import com.chriscartland.garage.viewmodel.DefaultDiagnosticsViewModel
 import com.chriscartland.garage.viewmodel.DefaultDoorHistoryViewModel
 import com.chriscartland.garage.viewmodel.DefaultFunctionListViewModel
@@ -172,6 +179,7 @@ abstract class NativeComponent(
     abstract val snoozeRepository: SnoozeRepository
     abstract val remoteButtonRepository: RemoteButtonRepository
     abstract val doorFcmRepository: DoorFcmRepository
+    abstract val testNotificationRepository: TestNotificationRepository
     abstract val featureAllowlistRepository: FeatureAllowlistRepository
     abstract val fcmRegistrationManager: FcmRegistrationManager
     abstract val checkInStalenessManager: CheckInStalenessManager
@@ -218,6 +226,11 @@ abstract class NativeComponent(
         pruneDiagnosticsLog: PruneDiagnosticsLogUseCase,
         registerFcm: RegisterFcmUseCase,
         deregisterFcm: DeregisterFcmUseCase,
+        getTestNotificationTopic: GetTestNotificationTopicUseCase,
+        changeTestNotificationTopic: ChangeTestNotificationTopicUseCase,
+        subscribeTestNotification: SubscribeTestNotificationUseCase,
+        unsubscribeTestNotification: UnsubscribeTestNotificationUseCase,
+        observeTestNotificationState: ObserveTestNotificationStateUseCase,
         dispatchers: DispatcherProvider,
         appVersion: String,
     ): DefaultFunctionListViewModel =
@@ -236,6 +249,11 @@ abstract class NativeComponent(
             pruneDiagnosticsLogUseCase = pruneDiagnosticsLog,
             registerFcmUseCase = registerFcm,
             deregisterFcmUseCase = deregisterFcm,
+            getTestNotificationTopicUseCase = getTestNotificationTopic,
+            changeTestNotificationTopicUseCase = changeTestNotificationTopic,
+            subscribeTestNotificationUseCase = subscribeTestNotification,
+            unsubscribeTestNotificationUseCase = unsubscribeTestNotification,
+            observeTestNotificationStateUseCase = observeTestNotificationState,
             dispatchers = dispatchers,
             appVersion = appVersion,
         )
@@ -410,6 +428,26 @@ abstract class NativeComponent(
 
     @Provides
     fun provideDeregisterFcmUseCase(doorFcmRepository: DoorFcmRepository): DeregisterFcmUseCase = DeregisterFcmUseCase(doorFcmRepository)
+
+    @Provides
+    fun provideGetTestNotificationTopicUseCase(repository: TestNotificationRepository): GetTestNotificationTopicUseCase =
+        GetTestNotificationTopicUseCase(repository)
+
+    @Provides
+    fun provideChangeTestNotificationTopicUseCase(repository: TestNotificationRepository): ChangeTestNotificationTopicUseCase =
+        ChangeTestNotificationTopicUseCase(repository)
+
+    @Provides
+    fun provideSubscribeTestNotificationUseCase(repository: TestNotificationRepository): SubscribeTestNotificationUseCase =
+        SubscribeTestNotificationUseCase(repository)
+
+    @Provides
+    fun provideUnsubscribeTestNotificationUseCase(repository: TestNotificationRepository): UnsubscribeTestNotificationUseCase =
+        UnsubscribeTestNotificationUseCase(repository)
+
+    @Provides
+    fun provideObserveTestNotificationStateUseCase(repository: TestNotificationRepository): ObserveTestNotificationStateUseCase =
+        ObserveTestNotificationStateUseCase(repository)
 
     @Provides
     fun providePushRemoteButtonUseCase(
@@ -614,6 +652,14 @@ abstract class NativeComponent(
         appSettings: AppSettingsRepository,
         appLoggerRepository: AppLoggerRepository,
     ): DoorFcmRepository = FirebaseDoorFcmRepository(messagingBridge, appSettings, appLoggerRepository)
+
+    // @SharedSingleton: one instance owns the max-one-subscription mutex + record.
+    @Provides
+    @SharedSingleton
+    fun provideTestNotificationRepository(
+        messagingBridge: MessagingBridge,
+        appSettings: AppSettingsRepository,
+    ): TestNotificationRepository = DefaultTestNotificationRepository(messagingBridge, appSettings)
 
     @Provides
     @SharedSingleton

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAppSettingsRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeAppSettingsRepository.kt
@@ -17,6 +17,9 @@ class FakeAppSettingsRepository : AppSettingsRepository {
         InMemorySetting(NavigationRailItemPosition.TopAligned)
     override val navigationRailTopPaddingDp: Setting<Int> =
         InMemorySetting(NavigationRailLayout.DEFAULT_TOP_PADDING_DP)
+    override val testNotificationCurrentTopic: Setting<String> = InMemorySetting("")
+    override val testNotificationWantSubscribed: Setting<Boolean> = InMemorySetting(false)
+    override val testNotificationSubscribedTopic: Setting<String> = InMemorySetting("")
 }
 
 class InMemorySetting<T>(

--- a/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeTestNotificationRepository.kt
+++ b/AndroidGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeTestNotificationRepository.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.testcommon
+
+import com.chriscartland.garage.domain.model.TestNotificationSandboxState
+import com.chriscartland.garage.domain.model.TestNotificationTopic
+import com.chriscartland.garage.domain.repository.TestNotificationRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Simple in-memory [TestNotificationRepository] for ViewModel tests. Does NOT
+ * reproduce the real max-one-subscription invariant — that is covered by
+ * `DefaultTestNotificationRepositoryTest`. This just tracks topic + subscribed
+ * so VM-level state wiring can be asserted.
+ */
+class FakeTestNotificationRepository : TestNotificationRepository {
+    private val _state = MutableStateFlow(TestNotificationSandboxState())
+    override val state: StateFlow<TestNotificationSandboxState> = _state
+
+    private var counter = 0
+
+    override suspend fun getTopic(): TestNotificationTopic {
+        val existing = _state.value.topic
+        if (existing != null) return existing
+        val fresh = TestNotificationTopic("testNotification-fake${counter++}")
+        _state.update { it.copy(topic = fresh) }
+        return fresh
+    }
+
+    override suspend fun changeTopic(): TestNotificationTopic {
+        val fresh = TestNotificationTopic("testNotification-fake${counter++}")
+        _state.update { it.copy(topic = fresh) }
+        return fresh
+    }
+
+    override suspend fun subscribe() {
+        _state.update { it.copy(isSubscribed = true) }
+    }
+
+    override suspend fun unsubscribe() {
+        _state.update { it.copy(isSubscribed = false) }
+    }
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ChangeTestNotificationTopicUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ChangeTestNotificationTopicUseCase.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.TestNotificationTopic
+import com.chriscartland.garage.domain.repository.TestNotificationRepository
+
+/**
+ * Regenerate the personal test-notification topic. If subscribed, the
+ * subscription follows to the new topic. Thin delegate — invariant lives in
+ * [TestNotificationRepository].
+ */
+class ChangeTestNotificationTopicUseCase(
+    private val repository: TestNotificationRepository,
+) {
+    suspend operator fun invoke(): TestNotificationTopic = repository.changeTopic()
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/GetTestNotificationTopicUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/GetTestNotificationTopicUseCase.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.TestNotificationTopic
+import com.chriscartland.garage.domain.repository.TestNotificationRepository
+
+/**
+ * Get-or-generate the personal test-notification topic. Thin delegate — the
+ * max-one-subscription invariant lives entirely in [TestNotificationRepository].
+ */
+class GetTestNotificationTopicUseCase(
+    private val repository: TestNotificationRepository,
+) {
+    suspend operator fun invoke(): TestNotificationTopic = repository.getTopic()
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveTestNotificationStateUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveTestNotificationStateUseCase.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.TestNotificationSandboxState
+import com.chriscartland.garage.domain.repository.TestNotificationRepository
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Observe the test-notification sandbox state (current topic + whether
+ * subscribed). The read-side counterpart to the four action UseCases — the VM
+ * can't inject the repository (layer-import lint), so this exposes the repo's
+ * `StateFlow` by reference (ADR-022 pass-through: no `stateIn`, no rewrap).
+ */
+class ObserveTestNotificationStateUseCase(
+    private val repository: TestNotificationRepository,
+) {
+    operator fun invoke(): StateFlow<TestNotificationSandboxState> = repository.state
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SubscribeTestNotificationUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SubscribeTestNotificationUseCase.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.repository.TestNotificationRepository
+
+/**
+ * Subscribe to the personal test-notification topic. Thin delegate — the
+ * repository guarantees at most one active subscription regardless of call order.
+ */
+class SubscribeTestNotificationUseCase(
+    private val repository: TestNotificationRepository,
+) {
+    suspend operator fun invoke() = repository.subscribe()
+}

--- a/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/UnsubscribeTestNotificationUseCase.kt
+++ b/AndroidGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/UnsubscribeTestNotificationUseCase.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.repository.TestNotificationRepository
+
+/**
+ * Unsubscribe from the personal test-notification topic. Thin delegate — only
+ * the repository's own topic is ever unsubscribed (never production topics).
+ */
+class UnsubscribeTestNotificationUseCase(
+    private val repository: TestNotificationRepository,
+) {
+    suspend operator fun invoke() = repository.unsubscribe()
+}

--- a/AndroidGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/FunctionListViewModel.kt
+++ b/AndroidGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/FunctionListViewModel.kt
@@ -25,22 +25,28 @@ import com.chriscartland.garage.domain.model.AppLoggerLimits
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.GoogleIdToken
 import com.chriscartland.garage.domain.model.SnoozeDurationUIOption
+import com.chriscartland.garage.domain.model.TestNotificationSandboxState
 import com.chriscartland.garage.domain.model.toServer
 import com.chriscartland.garage.usecase.ButtonAckToken
+import com.chriscartland.garage.usecase.ChangeTestNotificationTopicUseCase
 import com.chriscartland.garage.usecase.ClearDiagnosticsUseCase
 import com.chriscartland.garage.usecase.DeregisterFcmUseCase
 import com.chriscartland.garage.usecase.FetchButtonHealthUseCase
 import com.chriscartland.garage.usecase.FetchCurrentDoorEventUseCase
 import com.chriscartland.garage.usecase.FetchRecentDoorEventsUseCase
 import com.chriscartland.garage.usecase.FetchSnoozeStatusUseCase
+import com.chriscartland.garage.usecase.GetTestNotificationTopicUseCase
 import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
 import com.chriscartland.garage.usecase.ObserveFeatureAccessUseCase
+import com.chriscartland.garage.usecase.ObserveTestNotificationStateUseCase
 import com.chriscartland.garage.usecase.PruneDiagnosticsLogUseCase
 import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
 import com.chriscartland.garage.usecase.RegisterFcmUseCase
 import com.chriscartland.garage.usecase.SignInWithGoogleUseCase
 import com.chriscartland.garage.usecase.SignOutUseCase
 import com.chriscartland.garage.usecase.SnoozeNotificationsUseCase
+import com.chriscartland.garage.usecase.SubscribeTestNotificationUseCase
+import com.chriscartland.garage.usecase.UnsubscribeTestNotificationUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -90,6 +96,17 @@ interface FunctionListViewModel {
     fun registerFcm()
 
     fun deregisterFcm()
+
+    // --- Test-notification sandbox (diagnostic) ---
+
+    /** Current sandbox state: the personal topic + whether subscribed. */
+    val testNotificationState: StateFlow<TestNotificationSandboxState>
+
+    fun subscribeTestNotification()
+
+    fun unsubscribeTestNotification()
+
+    fun changeTestNotificationTopic()
 }
 
 class DefaultFunctionListViewModel(
@@ -107,6 +124,11 @@ class DefaultFunctionListViewModel(
     private val pruneDiagnosticsLogUseCase: PruneDiagnosticsLogUseCase,
     private val registerFcmUseCase: RegisterFcmUseCase,
     private val deregisterFcmUseCase: DeregisterFcmUseCase,
+    private val getTestNotificationTopicUseCase: GetTestNotificationTopicUseCase,
+    private val changeTestNotificationTopicUseCase: ChangeTestNotificationTopicUseCase,
+    private val subscribeTestNotificationUseCase: SubscribeTestNotificationUseCase,
+    private val unsubscribeTestNotificationUseCase: UnsubscribeTestNotificationUseCase,
+    private val observeTestNotificationStateUseCase: ObserveTestNotificationStateUseCase,
     private val dispatchers: DispatcherProvider,
     private val appVersion: String,
 ) : ViewModel(),
@@ -118,6 +140,9 @@ class DefaultFunctionListViewModel(
     private val _accessGranted = MutableStateFlow<Boolean?>(null)
     override val accessGranted: StateFlow<Boolean?> = _accessGranted
 
+    override val testNotificationState: StateFlow<TestNotificationSandboxState> =
+        observeTestNotificationStateUseCase()
+
     init {
         viewModelScope.launch(dispatchers.io) {
             observeDoorEventsUseCase.current().collect { currentDoorEvent.value = it }
@@ -125,6 +150,8 @@ class DefaultFunctionListViewModel(
         viewModelScope.launch(dispatchers.io) {
             observeFeatureAccessUseCase.functionList().collect { _accessGranted.value = it }
         }
+        // Ensure a personal test topic exists so the UI can show/copy it.
+        viewModelScope.launch(dispatchers.io) { getTestNotificationTopicUseCase() }
     }
 
     override fun openOrCloseDoor() {
@@ -211,5 +238,20 @@ class DefaultFunctionListViewModel(
         viewModelScope.launch(dispatchers.io) {
             deregisterFcmUseCase()
         }
+    }
+
+    override fun subscribeTestNotification() {
+        Logger.d { "subscribeTestNotification" }
+        viewModelScope.launch(dispatchers.io) { subscribeTestNotificationUseCase() }
+    }
+
+    override fun unsubscribeTestNotification() {
+        Logger.d { "unsubscribeTestNotification" }
+        viewModelScope.launch(dispatchers.io) { unsubscribeTestNotificationUseCase() }
+    }
+
+    override fun changeTestNotificationTopic() {
+        Logger.d { "changeTestNotificationTopic" }
+        viewModelScope.launch(dispatchers.io) { changeTestNotificationTopicUseCase() }
     }
 }

--- a/AndroidGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/DefaultFunctionListViewModelTest.kt
+++ b/AndroidGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/DefaultFunctionListViewModelTest.kt
@@ -37,7 +37,9 @@ import com.chriscartland.garage.testcommon.FakeDoorRepository
 import com.chriscartland.garage.testcommon.FakeFeatureAllowlistRepository
 import com.chriscartland.garage.testcommon.FakeRemoteButtonRepository
 import com.chriscartland.garage.testcommon.FakeSnoozeRepository
+import com.chriscartland.garage.testcommon.FakeTestNotificationRepository
 import com.chriscartland.garage.testcommon.TestDispatcherProvider
+import com.chriscartland.garage.usecase.ChangeTestNotificationTopicUseCase
 import com.chriscartland.garage.usecase.ClearDiagnosticsUseCase
 import com.chriscartland.garage.usecase.DefaultRegisterFcmUseCase
 import com.chriscartland.garage.usecase.DeregisterFcmUseCase
@@ -45,13 +47,17 @@ import com.chriscartland.garage.usecase.FetchButtonHealthUseCase
 import com.chriscartland.garage.usecase.FetchCurrentDoorEventUseCase
 import com.chriscartland.garage.usecase.FetchRecentDoorEventsUseCase
 import com.chriscartland.garage.usecase.FetchSnoozeStatusUseCase
+import com.chriscartland.garage.usecase.GetTestNotificationTopicUseCase
 import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
 import com.chriscartland.garage.usecase.ObserveFeatureAccessUseCase
+import com.chriscartland.garage.usecase.ObserveTestNotificationStateUseCase
 import com.chriscartland.garage.usecase.PruneDiagnosticsLogUseCase
 import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
 import com.chriscartland.garage.usecase.SignInWithGoogleUseCase
 import com.chriscartland.garage.usecase.SignOutUseCase
 import com.chriscartland.garage.usecase.SnoozeNotificationsUseCase
+import com.chriscartland.garage.usecase.SubscribeTestNotificationUseCase
+import com.chriscartland.garage.usecase.UnsubscribeTestNotificationUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -102,6 +108,7 @@ class DefaultFunctionListViewModelTest {
 
     private fun createViewModel(authState: AuthState = AuthState.Unauthenticated): DefaultFunctionListViewModel {
         authRepository.setAuthState(authState)
+        val testNotif = FakeTestNotificationRepository()
         return DefaultFunctionListViewModel(
             pushRemoteButtonUseCase = PushRemoteButtonUseCase(
                 authRepository,
@@ -129,6 +136,11 @@ class DefaultFunctionListViewModelTest {
             pruneDiagnosticsLogUseCase = PruneDiagnosticsLogUseCase(appLoggerRepository),
             registerFcmUseCase = DefaultRegisterFcmUseCase(doorRepository, doorFcmRepository),
             deregisterFcmUseCase = DeregisterFcmUseCase(doorFcmRepository),
+            getTestNotificationTopicUseCase = GetTestNotificationTopicUseCase(testNotif),
+            changeTestNotificationTopicUseCase = ChangeTestNotificationTopicUseCase(testNotif),
+            subscribeTestNotificationUseCase = SubscribeTestNotificationUseCase(testNotif),
+            unsubscribeTestNotificationUseCase = UnsubscribeTestNotificationUseCase(testNotif),
+            observeTestNotificationStateUseCase = ObserveTestNotificationStateUseCase(testNotif),
             dispatchers = TestDispatcherProvider(testDispatcher),
             appVersion = "test",
         )

--- a/docs/TEST_NOTIFICATION_SANDBOX_PLAN.md
+++ b/docs/TEST_NOTIFICATION_SANDBOX_PLAN.md
@@ -5,9 +5,9 @@ status: active
 
 # Test Notification Sandbox — implementation plan
 
-**Status: IN PROGRESS** (this doc is the resume point if the session is interrupted).
+**Status: v1 COMPLETE (in PR).**
 
-**Progress:** ✅ domain + data repo + 4 UseCases + invariant/safety test (committed). ✅ Android app-built display: presenter, parser, FcmMessageHandler branch, FCMService wiring + tests (committed). ⏳ Remaining: VM wiring (+ a read-side `ObserveTestNotificationStateUseCase`, since VMs can't inject repos), DI (AppComponent + NativeComponent), Function List UI, ComponentGraphTest assertSame, VM test, validate.sh.
+**Progress:** ✅ Engine (repo invariant + 4 UseCases + safety test). ✅ App-built display (presenter, parser, handler branch, FCMService). ✅ VM + read-side `ObserveTestNotificationStateUseCase` + DI (AppComponent + NativeComponent) + Function List UI + ComponentGraphTest singleton guard + VM test. ✅ `validate.sh` green (one fix: screen Composable used `String = ""` not `String? = null` per the Konsist nullable-default ban).
 
 A diagnostic-gated, **purely additive** Android feature to prototype app-owned
 notification infrastructure (app-built notifications, dedicated channel,

--- a/docs/TEST_NOTIFICATION_SANDBOX_PLAN.md
+++ b/docs/TEST_NOTIFICATION_SANDBOX_PLAN.md
@@ -1,0 +1,112 @@
+---
+category: plan
+status: active
+---
+
+# Test Notification Sandbox — implementation plan
+
+**Status: IN PROGRESS** (this doc is the resume point if the session is interrupted).
+
+A diagnostic-gated, **purely additive** Android feature to prototype app-owned
+notification infrastructure (app-built notifications, dedicated channel,
+`tag`-based inline replace, foreground handling) **in isolation** from the
+production door-notification path. Once proven here, the reliable "Resolved:
+door was open for X min" feature (and fixes R6/M4 in `NOTIFICATION_RELIABILITY.md`)
+can be refactored onto this foundation.
+
+## Scope (v1)
+
+- **Client-only.** No server code. Test notifications are sent **manually** from
+  the Firebase console / a script, targeting a personal topic the app displays.
+- **Gated** behind the existing `featureFunctionList` flag (lives in the Function
+  List screen — no new flag).
+- **Zero touch** to `OldDataFCM` / `EventFCM` / the door path.
+
+## Architecture
+
+### Repository owns the "≤1 subscription, any call order" invariant
+
+`TestNotificationRepository` persists three values and reconciles to them under a
+single `Mutex`:
+
+| Persisted (DataStore) | Meaning |
+|---|---|
+| `testNotificationCurrentTopic: String` | the topic shown/copied (generated on first use) |
+| `testNotificationWantSubscribed: Boolean` | user intent |
+| `testNotificationSubscribedTopic: String` | what FCM is actually subscribed to (`""` = none) — our authoritative record |
+
+Single enforcement point `reconcile()` (always under `withLock`):
+1. `target = wantSubscribed ? currentTopic : null`
+2. if `subscribedTopic == target` → return
+3. if `subscribedTopic != null` → `requireOwnTopic` + `bridge.unsubscribeFromTopic`, clear it (tear down old FIRST → never 2 live)
+4. if `target != null` → `requireOwnTopic` + `bridge.subscribeToTopic`; set `subscribedTopic = target` **only on confirmed success** (M1 lesson); on failure leave null so next reconcile retries.
+
+Guarantee: `subscribedTopic ∈ { currentTopic, none }` for any call order; `Mutex` serializes concurrent calls.
+
+### Safety — only ever touch own topics
+
+- Generated topics are `testNotification-<uuid>` (disjoint from `door_open-*` / `buttonHealth-*`).
+- `reconcile()` only ever unsubscribes its own tracked `subscribedTopic`; never reads `fcmDoorTopic`, never enumerates.
+- **Prefix guard** before every bridge call: `require(t.startsWith("testNotification-"))` → fails safe (throws, logged) rather than touching production.
+- Separate DataStore keys from production.
+
+### Four thin UseCases (zero logic — delegate to repo)
+
+- `GetTestNotificationTopicUseCase` → `repo.getTopic()`
+- `ChangeTestNotificationTopicUseCase` → `repo.changeTopic()` (regenerates; subscription **follows** to new topic)
+- `SubscribeTestNotificationUseCase` → `repo.subscribe()`
+- `UnsubscribeTestNotificationUseCase` → `repo.unsubscribe()`
+
+Repo also exposes `state: StateFlow<TestNotificationSandboxState>` (topic + isSubscribed) for the UI.
+
+### App-built display
+
+- `FcmMessageHandler` gains a `testNotification-*` branch → `TestNotificationPresenter` (androidApp, holds appContext): lazily creates a dedicated `NotificationChannel`, builds `NotificationCompat` from data payload (`title`/`body`/`tag`), posts `notify(tag, FIXED_ID, …)` so same-`tag` replaces; `setOnlyAlertOnce(true)` + `setAutoCancel(true)`. Data message → `onMessageReceived` always fires → foreground + background identical.
+
+### UI
+
+Section in `FunctionListContent` (inherits `featureFunctionList`): topic string + tap-to-copy, subscribe / unsubscribe / change controls, live status from the repo state. Wired through `FunctionListViewModel` (the screen's VM, ADR-026).
+
+## File checklist
+
+### domain/
+- [ ] `model/TestNotificationTopic.kt` — value class + `TestNotificationSandboxState`
+- [ ] `repository/TestNotificationRepository.kt` — interface (getTopic/changeTopic/subscribe/unsubscribe + state)
+- [ ] `repository/AppSettingsRepository.kt` — add 3 `Setting`s
+
+### data-local/
+- [ ] `DataStoreAppSettings.kt` — add 3 DataStore settings
+
+### data/
+- [ ] `repository/DefaultTestNotificationRepository.kt` — Mutex + reconcile + prefix guard
+
+### usecase/
+- [ ] `GetTestNotificationTopicUseCase.kt`
+- [ ] `ChangeTestNotificationTopicUseCase.kt`
+- [ ] `SubscribeTestNotificationUseCase.kt`
+- [ ] `UnsubscribeTestNotificationUseCase.kt`
+
+### viewmodel/
+- [ ] `FunctionListViewModel.kt` — inject the 4 UseCases + expose state/actions
+
+### androidApp/
+- [ ] `fcm/TestNotificationPresenter.kt` — channel + NotificationManager post
+- [ ] `fcm/FcmMessageHandler.kt` — add `testNotification-*` branch
+- [ ] `fcm/FCMService.kt` — wire presenter into handler
+- [ ] `ui/FunctionListContent.kt` — test-notification section
+- [ ] `di/AppComponent.kt` — `@Singleton` repo + entry point + 4 UseCases + presenter
+- [ ] `ComponentGraphTest` — assertSame for the singleton repo
+
+### iosFramework/
+- [ ] `NativeComponent.kt` — provide repo + 4 UseCases (VM ctor changed; iOS-DI rule). Presenter is Android-only.
+
+### tests
+- [ ] `DefaultTestNotificationRepositoryTest` — **every call-order permutation asserts ≤1 sub + correct target + only `testNotification-*` ever passed to the fake bridge + a "non-test value refused" test**
+- [ ] `FcmMessageHandlerTest` — `testNotification-*` routing branch
+- [ ] pure `payload → NotificationContent` mapper test
+- [ ] `validate.sh` green before push
+
+## Notes / decisions
+- Repo is `@Singleton` (the invariant requires one instance owning the state + Mutex).
+- changeTopic-follows-subscription = confirmed default.
+- Send is manual (console). To inline-replace test: send twice with the same `tag`.

--- a/docs/TEST_NOTIFICATION_SANDBOX_PLAN.md
+++ b/docs/TEST_NOTIFICATION_SANDBOX_PLAN.md
@@ -7,6 +7,8 @@ status: active
 
 **Status: IN PROGRESS** (this doc is the resume point if the session is interrupted).
 
+**Progress:** ✅ domain + data repo + 4 UseCases + invariant/safety test (committed). ✅ Android app-built display: presenter, parser, FcmMessageHandler branch, FCMService wiring + tests (committed). ⏳ Remaining: VM wiring (+ a read-side `ObserveTestNotificationStateUseCase`, since VMs can't inject repos), DI (AppComponent + NativeComponent), Function List UI, ComponentGraphTest assertSame, VM test, validate.sh.
+
 A diagnostic-gated, **purely additive** Android feature to prototype app-owned
 notification infrastructure (app-built notifications, dedicated channel,
 `tag`-based inline replace, foreground handling) **in isolation** from the


### PR DESCRIPTION
## What

A **diagnostic-gated, purely additive** Test Notification Sandbox: the app generates a personal FCM topic, lets a `featureFunctionList`-allowlisted user copy it, and renders **app-built** notifications for messages on that topic. It's the isolated prototype of the app-owned notification infrastructure (dedicated channel, `tag`-based inline replace, foreground rendering) the reliable open-door "Resolved" feature will later reuse — proven in a sandbox first, **touching nothing in the production door-notification path**.

Design doc: `docs/TEST_NOTIFICATION_SANDBOX_PLAN.md`. Investigation that motivated it: `docs/NOTIFICATION_RELIABILITY.md` (R6/M4).

## The repository invariant (the core)

`DefaultTestNotificationRepository` enforces **at most one active FCM subscription, regardless of UseCase call order** — in the repo, not the UseCases:
- A single `reconcile()` under a `Mutex`; every mutating call converges to `subscribedTopic ∈ { currentTopic, none }`.
- Tear-down-old-before-subscribe-new; subscription record written **only on confirmed success** (M1 lesson).
- `changeTopic` while subscribed → the subscription **follows** to the new topic.

## Safety: only ever touches its own topics

- Topics are `testNotification-<uuid>` — disjoint from `door_open-*` / `buttonHealth-*`.
- `reconcile()` only ever unsubscribes its own tracked topic; never reads `fcmDoorTopic`, never enumerates.
- **Prefix guard** before every `MessagingBridge` call → a corrupted value throws (fails safe) rather than unsubscribing a production topic.
- Tested: `DefaultTestNotificationRepositoryTest` drives call-order permutations + concurrency, asserts only `testNotification-*` ever reaches the bridge, and that a corrupted production-topic value is **refused, never unsubscribed**.

## UseCases (as specified)

4 thin action delegators — `Subscribe` / `Unsubscribe` / `GetTopic` / `ChangeTopic` — plus a read-side `ObserveTestNotificationStateUseCase` (the VM can't inject a repo per the layer-import lint).

## Display + UI

- `TestNotificationPresenter`: dedicated channel, `notify(tag, id)` inline replace, permission-guarded; pure `TestNotificationPayload` parser (+ test); `FcmMessageHandler` `testNotification-*` branch (+ test) via `FCMService`.
- Function List screen: copy topic + subscribe/unsubscribe/change, gated by `featureFunctionList`, **hidden until the topic generates → previews/screenshots unaffected**.

## Isolation

Zero changes to `OldDataFCM` / `EventFCM` / the door path. No server code. Send is manual (Firebase console → the copied topic, `data: { title, body, tag }`; send twice with the same `tag` to see inline replace).

## Testing

`./scripts/validate.sh` green (repo invariant/safety test, handler-routing test, parser test, VM test, DI singleton guard, all lints incl. Konsist). DI wired for both Android (`AppComponent`) and iOS (`NativeComponent`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
