### PR TITLE
chore: Bump versionName to 2.18.0 (test notification sandbox)

### DIFF
--- a/AndroidGarage/CHANGELOG.md
+++ b/AndroidGarage/CHANGELOG.md
@@ -15,6 +15,10 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
 
+## 2.18.0
+- **Test notification sandbox (allowlisted users only).** On the Function List screen, allowlisted users can generate a personal notification topic, copy it, and subscribe / unsubscribe / change it. Messages sent to that topic (manually, from the Firebase console) render as app-built notifications on a dedicated channel with tag-based inline replace — an isolated sandbox for prototyping notification display. No change to the production door-open notifications. PR #899.
+- **Internal:** repository-enforced max-one-subscription invariant (mutex + reconcile + own-topic prefix guard, so it can never touch production topics), four action UseCases + an observe UseCase, and an app-built notification presenter. Design: [`docs/TEST_NOTIFICATION_SANDBOX_PLAN.md`](../../docs/TEST_NOTIFICATION_SANDBOX_PLAN.md).
+
 ## 2.17.1
 - **New app icon.** The launcher icon is now the app's own green garage door (the closed-door graphic drawn in the app), replacing the old placeholder. Includes the adaptive icon (foreground/background) and an Android 13+ themed-icon (monochrome) layer. PR #882.
 

--- a/AndroidGarage/version.properties
+++ b/AndroidGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.17.1
+versionName=2.18.0


### PR DESCRIPTION
Minor bump to **2.18.0** for the test notification sandbox (#899) — a new capability for allowlisted users (Function List screen). Adds the `## 2.18.0` CHANGELOG entry required by the release gate.

Releases to the **internal track only**; the feature is additionally gated by the `featureFunctionList` allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)