### PR TITLE
docs+tooling: resolved-notification goal + test-notification CLI script

### DIFF
--- a/docs/NOTIFICATION_RELIABILITY.md
+++ b/docs/NOTIFICATION_RELIABILITY.md
@@ -1,7 +1,7 @@
 ---
 category: reference
 status: active
-last_verified: 2026-06-14
+last_verified: 2026-06-15
 ---
 
 # Notification & push-data reliability
@@ -224,3 +224,46 @@ the open-door gating are already solid (see "What's already solid"). All four ar
    `buildTimestamp` changes while the app process stays alive (cold-start
    re-subscribes anyway). Wire the existing `FcmRegistrationManager.restart()`
    to a server-config `buildTimestamp` change when convenient.
+
+---
+
+## Resolved-on-close notification — design goal (validated in the sandbox)
+
+When the door **closes** after a "too long open" warning was sent, the app shows
+a **"Resolved"** notification. Validated end-to-end on a real released build
+(`android/251`, 2.18.0) via the Test Notification Sandbox: an app-built
+notification on a dedicated channel + icon, with `tag`-based inline replace.
+
+**Display behavior (decided 2026-06-15 — this is the GOAL, not a bug):**
+- Warning **still showing** → the resolved **replaces it in place** (same
+  `(tag, id)` via `NotificationManagerCompat.notify`).
+- Warning **already dismissed** → the resolved **appears as a new notification**.
+  This is **intentional**: the user should always learn the door closed, even if
+  they swiped the warning away. A stale "door open" alert quietly vanishing
+  without confirmation is worse than an informative re-ping.
+- **Do NOT** add a `getActiveNotifications()` "suppress if dismissed" gate. This
+  deliberately **reverses** the "don't resurrect a dismissed warning" concern
+  raised during the feasibility investigation — the settled product decision is
+  **resurface-always**.
+- `setOnlyAlertOnce(true)` is fine (silent update when replacing an active one);
+  it does not affect the dismissed-then-resurfaced case.
+
+**Finalized copy (template):**
+- **Title:** `Resolved: garage door closed` (static)
+- **Body:** `It was open for {duration} ({startTime}-{endTime}).`
+- Sentence case, no em dashes (repo string rules).
+
+**Duration / time source:** the open-episode **start** is the timestamp the
+warning measured from — the `NotificationsDatabase` marker's
+`notificationCurrentEvent.timestampSeconds`, **not** the immediate `previousEvent`
+(which understates in a multi-step `Open → Closing → Closed`). End = the close
+event timestamp. Format in the device's locale/timezone.
+
+**Trigger gate:** fire **only if a warning was actually sent** for that open
+episode (the marker exists; it is absent when snoozed, or when the door closed
+before the 15-min threshold).
+
+**Built on:** the app-built notification infrastructure (R6 foreground display +
+M4 dedicated channel) — this feature is the forcing function for those. The Test
+Notification Sandbox ([`docs/TEST_NOTIFICATION_SANDBOX_PLAN.md`](TEST_NOTIFICATION_SANDBOX_PLAN.md))
+is the isolated, shipped prototype of that infra, proven on a real device.

--- a/docs/TEST_NOTIFICATION_SANDBOX_PLAN.md
+++ b/docs/TEST_NOTIFICATION_SANDBOX_PLAN.md
@@ -5,7 +5,7 @@ status: active
 
 # Test Notification Sandbox — implementation plan
 
-**Status: v1 COMPLETE (in PR).**
+**Status: SHIPPED — `android/251` / 2.18.0 (internal track). Permanent diagnostic feature; do not roll it back. The real "Resolved" feature builds alongside it, reusing this infra.**
 
 **Progress:** ✅ Engine (repo invariant + 4 UseCases + safety test). ✅ App-built display (presenter, parser, handler branch, FCMService). ✅ VM + read-side `ObserveTestNotificationStateUseCase` + DI (AppComponent + NativeComponent) + Function List UI + ComponentGraphTest singleton guard + VM test. ✅ `validate.sh` green (one fix: screen Composable used `String = ""` not `String? = null` per the Konsist nullable-default ban).
 
@@ -23,6 +23,26 @@ can be refactored onto this foundation.
 - **Gated** behind the existing `featureFunctionList` flag (lives in the Function
   List screen — no new flag).
 - **Zero touch** to `OldDataFCM` / `EventFCM` / the door path.
+
+## Sending test notifications (CLI)
+
+Use the checked-in script — no Firebase console needed:
+
+```bash
+# A "warning"
+scripts/send-test-notification.sh <topic> \
+  --title "Garage door open" --body "Open for 12 minutes" --tag door-1
+
+# The "resolved" — SAME --tag replaces the warning in place
+scripts/send-test-notification.sh <topic> \
+  --title "Resolved: garage door closed" \
+  --body "It was open for 14 minutes (2:00-2:14 PM)." --tag door-1
+```
+
+- `<topic>` is the `testNotification-<id>` value copied from the app (Function List → sandbox).
+- The script **refuses any non-`testNotification-` topic**, so a typo can't target a production topic.
+- Auth is `gcloud auth print-access-token` (run `gcloud auth login` if it fails). Project defaults to `escape-echo` (override with `--project` or `$FCM_PROJECT_ID`).
+- It sends a **data** message so it routes through the app-built presenter (foreground + background render identically). `scripts/send-test-notification.sh --help` for all options.
 
 ## Architecture
 

--- a/scripts/send-test-notification.sh
+++ b/scripts/send-test-notification.sh
@@ -18,7 +18,10 @@
 #   scripts/send-test-notification.sh <topic> [options]
 #
 # Required:
-#   <topic>          a testNotification-* topic copied from the app
+#   <topic>          a testNotification-<id> topic.
+#                    How to get it: open the app signed in with an allowlisted
+#                    account, go to the Function List screen, and tap
+#                    "Copy test topic" under the Test Notification Sandbox section.
 #
 # Options:
 #   --title TEXT     notification title   (default: "Test notification")
@@ -50,8 +53,9 @@ TAG="test"
 TOPIC=""
 
 usage() {
-    # Print the leading comment block (lines starting with '#') as help.
-    sed -n '3,46p' "$0" | sed 's/^#\{0,1\} \{0,1\}//'
+    # Print the leading comment block (every comment line after the shebang,
+    # until the first non-comment line) as help. Robust to header edits.
+    awk 'NR==1 { next } /^#/ { sub(/^#[[:space:]]?/, ""); print; next } { exit }' "$0"
 }
 
 # Escape a string for embedding inside a JSON double-quoted value. Covers the
@@ -85,7 +89,9 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -z "$TOPIC" ]; then
-    echo "Error: <topic> is required." >&2
+    echo "Error: a <topic> is required." >&2
+    echo "  Get it from the app: sign in with an allowlisted account -> Function List" >&2
+    echo "  -> Test Notification Sandbox -> 'Copy test topic'. Pass it as the first arg." >&2
     echo >&2
     usage >&2
     exit 1

--- a/scripts/send-test-notification.sh
+++ b/scripts/send-test-notification.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# send-test-notification.sh
+#
+# Send a test FCM data message to a Test Notification Sandbox topic.
+#
+# The diagnostic "Test Notification Sandbox" (Function List screen, allowlisted
+# users only — see docs/TEST_NOTIFICATION_SANDBOX_PLAN.md) generates a personal
+# topic of the form `testNotification-<id>`. Copy it from the app and pass it
+# here. The app renders the message as an app-built notification on its own
+# channel.
+#
+# Reuse the SAME --tag across two sends to test inline replace: send a "warning",
+# then a "resolved" with the same --tag, and the second replaces the first in
+# place (the mechanic the open-door "Resolved" feature will use).
+#
+# Usage:
+#   scripts/send-test-notification.sh <topic> [options]
+#
+# Required:
+#   <topic>          a testNotification-* topic copied from the app
+#
+# Options:
+#   --title TEXT     notification title   (default: "Test notification")
+#   --body TEXT      notification body    (default: empty)
+#   --tag TAG        notification tag; same tag replaces in place (default: "test")
+#   --project ID     Firebase project id  (default: $FCM_PROJECT_ID or "escape-echo")
+#   -h, --help       show this help
+#
+# Auth:
+#   Uses `gcloud auth print-access-token`. If it fails, run `gcloud auth login`
+#   with an account that can send FCM messages for the project.
+#
+# Examples:
+#   # a "warning"
+#   scripts/send-test-notification.sh testNotification-7684a7abdd069826 \
+#     --title "Garage door open" --body "Open for 12 minutes" --tag door-1
+#
+#   # the "resolved" — same --tag, so it replaces the warning in place
+#   scripts/send-test-notification.sh testNotification-7684a7abdd069826 \
+#     --title "Resolved: garage door closed" \
+#     --body "It was open for 14 minutes (2:00-2:14 PM)." --tag door-1
+#
+set -euo pipefail
+
+PROJECT_ID="${FCM_PROJECT_ID:-escape-echo}"
+TITLE="Test notification"
+BODY=""
+TAG="test"
+TOPIC=""
+
+usage() {
+    # Print the leading comment block (lines starting with '#') as help.
+    sed -n '3,46p' "$0" | sed 's/^#\{0,1\} \{0,1\}//'
+}
+
+# Escape a string for embedding inside a JSON double-quoted value. Covers the
+# characters that occur in notification copy (backslash, quote, newline, tab, CR).
+json_escape() {
+    local s=$1
+    s=${s//\\/\\\\}
+    s=${s//\"/\\\"}
+    s=${s//$'\n'/\\n}
+    s=${s//$'\t'/\\t}
+    s=${s//$'\r'/\\r}
+    printf '%s' "$s"
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help) usage; exit 0 ;;
+        --title)   TITLE="${2:?--title needs a value}"; shift 2 ;;
+        --body)    BODY="${2:?--body needs a value}"; shift 2 ;;
+        --tag)     TAG="${2:?--tag needs a value}"; shift 2 ;;
+        --project) PROJECT_ID="${2:?--project needs a value}"; shift 2 ;;
+        --*) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)
+            if [ -z "$TOPIC" ]; then
+                TOPIC="$1"; shift
+            else
+                echo "Unexpected argument: $1" >&2; exit 1
+            fi
+            ;;
+    esac
+done
+
+if [ -z "$TOPIC" ]; then
+    echo "Error: <topic> is required." >&2
+    echo >&2
+    usage >&2
+    exit 1
+fi
+
+# Safety: only ever send to a sandbox topic. The app subscribes the device to
+# testNotification-* topics only; refusing other prefixes here means a typo can't
+# accidentally target a production topic (door_open-* / buttonHealth-*).
+case "$TOPIC" in
+    testNotification-*) ;;
+    *)
+        echo "Error: topic must start with 'testNotification-' (got: '$TOPIC')." >&2
+        exit 1
+        ;;
+esac
+
+if ! command -v gcloud >/dev/null 2>&1; then
+    echo "Error: gcloud not found. Install the Google Cloud SDK and run 'gcloud auth login'." >&2
+    exit 1
+fi
+
+TOKEN="$(gcloud auth print-access-token 2>/dev/null || true)"
+if [ -z "$TOKEN" ]; then
+    echo "Error: could not get an access token. Run 'gcloud auth login'." >&2
+    exit 1
+fi
+
+PAYLOAD="$(printf \
+    '{"message":{"topic":"%s","data":{"title":"%s","body":"%s","tag":"%s"},"android":{"priority":"HIGH"}}}' \
+    "$(json_escape "$TOPIC")" \
+    "$(json_escape "$TITLE")" \
+    "$(json_escape "$BODY")" \
+    "$(json_escape "$TAG")")"
+
+echo "Sending to $TOPIC (project: $PROJECT_ID, tag: $TAG)"
+RESPONSE="$(curl -s -X POST \
+    "https://fcm.googleapis.com/v1/projects/${PROJECT_ID}/messages:send" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$PAYLOAD")"
+
+echo "$RESPONSE"
+
+# Success: {"name":"projects/<id>/messages/<n>"}. Anything else is an error.
+if printf '%s' "$RESPONSE" | grep -q '"name"'; then
+    echo "OK: FCM accepted the message (delivery is best-effort)."
+else
+    echo "Error: FCM did not accept the message (see the response above)." >&2
+    exit 1
+fi


### PR DESCRIPTION
Follow-on to the Test Notification Sandbox (#899), after validating the mechanic end-to-end on `android/251` / 2.18.0.

## Docs
- **`NOTIFICATION_RELIABILITY.md`** — adds the **resolved-on-close notification design goal**: validated behavior, finalized copy template (`Resolved: garage door closed` / `It was open for {duration} ({start}-{end}).`), duration source (the marker timestamp, not `previousEvent`), trigger gate. Records the **deliberate decision that the resolved notification resurfaces even if the warning was dismissed** (resurface-always) — explicitly reversing the earlier "don't resurrect" concern.
- **`TEST_NOTIFICATION_SANDBOX_PLAN.md`** — marks the sandbox **permanent / shipped** (do not roll back) and adds a **CLI usage** section.

## Tooling
- **`scripts/send-test-notification.sh`** — checked-in helper to send a test FCM data message to a `testNotification-*` topic (gcloud + curl, no extra deps). **Requires a topic** and, when missing, explains exactly how to get it (app → Function List → Test Notification Sandbox → Copy test topic). Refuses any non-`testNotification-` topic so a typo can't hit a production topic. `--title/--body/--tag` (same `--tag` replaces in place), `--help`.

No production-path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)