### PR TITLE
test(server): pin resolved-on-close old-app isolation invariant

### DIFF
--- a/FirebaseServer/test/controller/fcm/ResolvedNotificationFCMFakeTest.ts
+++ b/FirebaseServer/test/controller/fcm/ResolvedNotificationFCMFakeTest.ts
@@ -50,9 +50,14 @@ import {
 import { FakeNotificationsDatabase } from '../../fakes/FakeNotificationsDatabase';
 import { FakeServerConfigDatabase } from '../../fakes/FakeServerConfigDatabase';
 import { SensorEvent, SensorEventType } from '../../../src/model/SensorEvent';
+import { buildTimestampToFcmTopic } from '../../../src/model/FcmTopic';
 
 const BUILD_TIMESTAMP = 'Sat Mar 13 14:45:00 2021';
 const EXPECTED_V2_TOPIC = 'door_open_v2-Sat.Mar.13.14.45.00.2021';
+// The LEGACY door topic old app builds subscribe to. The resolved feature must
+// NEVER target this — that is the boundary that keeps the feature isolated to
+// new (door_open_v2-) builds. See docs/RESOLVED_NOTIFICATION_PLAN.md.
+const LEGACY_DOOR_TOPIC = buildTimestampToFcmTopic(BUILD_TIMESTAMP);
 
 const OPEN_TS = 1_800_000_000;
 const CLOSE_TS = OPEN_TS + 14 * 60; // 14 minutes later — a normal warned episode.
@@ -259,6 +264,39 @@ describe('sendFCMForResolvedDoor (via fakes)', () => {
     expect(result).to.be.null;
     expect(sendStub.calledOnce).to.be.true;
     expect(fakeNotifications.saved).to.be.empty; // marker left un-consumed
+  });
+
+  // --- Old-app isolation invariant ---
+  // The resolved feature is isolated to NEW builds (door_open_v2- subscribers)
+  // purely because it only ever targets the v2 topic. Old builds (< 2.19.0)
+  // subscribe only to the legacy door_open- topic, so a message that never goes
+  // there can never reach them. These tests pin that invariant so it can't
+  // silently regress (e.g. a refactor swapping the topic builder). Combined with
+  // the "flag off → no send, no save" test above (which proves server/31 is inert
+  // for everyone until the flag is flipped), this is the backwards-compatibility
+  // guarantee in code. See docs/RESOLVED_NOTIFICATION_PLAN.md § Isolation guarantee.
+
+  describe('old-app isolation (never targets the legacy door_open- topic)', () => {
+    it('sends the resolved ONLY to the v2 topic, never to the legacy door topic', async () => {
+      enableFlag();
+      fakeNotifications.seed(BUILD_TIMESTAMP, warnedMarker(OPEN_TS));
+
+      await ResolvedNotificationFCMService.sendFCMForResolvedDoor(
+        BUILD_TIMESTAMP, closedEventAt(CLOSE_TS),
+      );
+
+      expect(sendStub.calledOnce).to.be.true;
+      const sentTopic = sendStub.firstCall.args[0].topic;
+      expect(sentTopic).to.equal(EXPECTED_V2_TOPIC);
+      expect(sentTopic.startsWith('door_open_v2-')).to.be.true;
+      expect(sentTopic).to.not.equal(LEGACY_DOOR_TOPIC); // old builds never hear this
+    });
+
+    it('getResolvedMessage targets the v2 topic, never the legacy door topic', () => {
+      const topic = getResolvedMessage(BUILD_TIMESTAMP, OPEN_TS, CLOSE_TS).topic;
+      expect(topic).to.equal(EXPECTED_V2_TOPIC);
+      expect(topic).to.not.equal(LEGACY_DOOR_TOPIC);
+    });
   });
 
   // --- Pure message builder ---

--- a/docs/RESOLVED_NOTIFICATION_PLAN.md
+++ b/docs/RESOLVED_NOTIFICATION_PLAN.md
@@ -62,6 +62,39 @@ Phase-2-or-not decision later. If the goal is to *strengthen* notifications, the
 better-aligned, lower-risk move is **R6** (make the existing warning show in the
 foreground) — hardening what works, not adding to it.
 
+## Isolation guarantee (risk stays on new builds)
+
+Confirmed 2026-06-20. The feature's risk is isolated to **new** Android builds by
+**construction**, not by being careful — the boundary is **app version → topic
+subscription**:
+
+- **Old builds (< 2.19.0) never receive the resolved.** They subscribe only to
+  `door_open-`; the resolved is sent **only** to `door_open_v2-`, which only the
+  new build (via `DoorResolvedFcmSubscriptionManager`) subscribes to. A message
+  that never goes to `door_open-` can't reach them. Pinned by
+  `ResolvedNotificationFCMFakeTest` § "old-app isolation."
+- **What old builds DO receive is byte-for-byte unchanged.** Phase 1 doesn't touch
+  the warning (`OldDataFCM` → `door_open-`) or the state-sync (`EventFCM` →
+  `door_open-`); it only *appends* a resolved send on the `Closed` transition,
+  after the state-sync, in a try/catch. So old builds' warning + live state are
+  identical with the flag on or off.
+- **`server/31` is inert until the flag flips.** With `resolvedOnCloseEnabled` off
+  (default), the resolved path does one config read and returns — no send, no
+  marker write. Pinned by the "flag off → no send, no save" test. So the global
+  server deploy is a no-op for every user until you flip it.
+- **Backwards + forward compatible.** No existing topic or payload key was renamed
+  (only added) — satisfies the CLAUDE.md FCM-safety rule. The v2 channel is also
+  forward-compatible: the `2.19.0` client gates on `kind == "open_door_resolved"`
+  and ignores unknown kinds, so a future Phase-2 `open_door_warning` payload won't
+  break today's build.
+
+**Controls (mobile):** there is **no per-user opt-in** — the gates are app version
+(must be `2.19.0+`) + the **global** server flag. The kill switch is global and
+instant: flip `resolvedOnCloseEnabled` off → the flag-agnostic client stops
+rendering immediately, no app update. A per-user opt-in/kill would require adding a
+`featureXAllowedEmails`-style allowlist gating the v2 subscription (not built;
+global was accepted as sufficient 2026-06-21).
+
 ## Goal
 
 When the garage door **closes after an open-door warning was actually sent**,


### PR DESCRIPTION
Before testing the resolved-on-close feature, make the **backwards-compatibility / old-app isolation** guarantee explicit and **enforced**, not just documented.

## Why
The feature is isolated to new (`2.19.0+`) builds purely because the server only ever sends the resolved to `door_open_v2-`, a topic old builds (< 2.19.0) don't subscribe to. This pins that invariant so a refactor can't silently leak it onto the legacy `door_open-` topic that old builds *do* hear.

## Changes
- **`ResolvedNotificationFCMFakeTest.ts`** — new "old-app isolation" describe block:
  - the live send targets **only** `door_open_v2-`, and explicitly **not** the legacy `door_open-` topic;
  - `getResolvedMessage` does the same.
  - (The existing "flag off → no send, no save" test already pins that `server/31` is inert for everyone until the flag is flipped.)
- **`RESOLVED_NOTIFICATION_PLAN.md`** — adds an **"Isolation guarantee"** section: the version→topic boundary, `server/31` inert until the flag, backwards + forward compatibility, and the mobile control surface (no per-user opt-in; global instant kill switch; per-user would need a `featureXAllowedEmails` allowlist — global accepted as sufficient).

Test-only + docs. No production code change. Firebase build + tests green locally (the two new assertions pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)