### PR TITLE
docs: dump context — Phase 1 two-card analysis (icon/channel/sound divergence)

### DIFF
--- a/docs/RESOLVED_NOTIFICATION_PLAN.md
+++ b/docs/RESOLVED_NOTIFICATION_PLAN.md
@@ -1,7 +1,7 @@
 ---
 category: plan
 status: active
-last_verified: 2026-06-20
+last_verified: 2026-06-21
 ---
 
 # Resolved-on-close notification — Phase 1 (additive) implementation plan
@@ -25,20 +25,36 @@ Read it before touching any file below.
 
 ## Phase 1 as-shipped — known limitations (review before deploying)
 
-1. **No inline replace — two coexisting notifications.** The production warning is
-   still the server's **OS-tray** notification (notification-payload on `door_open-`,
-   with FCM's own `(tag,id)`). The resolved is **app-built** (`tag="garage_door"`,
-   id `7001`, channel `garage_door`). Different identities → the resolved **does not
-   replace the warning**; when the door closes you see **both** — a lingering
-   "Garage door open" warning *and* a separate "Resolved" card, briefly
-   contradictory. The clean "the warning *becomes* resolved" experience (validated in
-   the sandbox, where both were app-built) requires **Phase 2** (app-built warning on
-   the same tag). The inline-replace described in the "design goal" of
-   `NOTIFICATION_RELIABILITY.md` is the **Phase 2** behavior, not Phase 1's.
-2. **Resolved is a HIGH-importance heads-up.** Channel `garage_door` is
-   `IMPORTANCE_HIGH` (so it's ready for Phase 2's warning), so on Android 8+ the
-   resolved heads-up/buzzes like the warning — arguably too loud for "good news."
-   Decide: a quieter dedicated channel for the resolved, or accept the buzz.
+1. **No inline replace — two coexisting, visually DIFFERENT notifications.** The
+   production warning is still the server's **OS-tray** notification
+   (notification-payload on `door_open-`, with FCM's own `(tag,id)`). The resolved is
+   **app-built** (`tag="garage_door"`, id `7001`, channel `garage_door`). Different
+   identities → the resolved **does not replace the warning**; in the realistic test
+   path (app backgrounded, warning shown, then close) you see **both** — a lingering
+   "Garage door open" warning *and* a separate "Resolved" card. And they don't just
+   coexist, they look like **two different features** (analysis 2026-06-21):
+
+   | | Warning (existing) | Resolved (new) |
+   |---|---|---|
+   | Channel | FCM **"Miscellaneous"** fallback (manifest sets no `default_notification_channel_id` — the M4 gap) | app-owned **"Garage door"** |
+   | Icon | **app launcher icon** (no `default_notification_icon` meta-data) | **`ic_dialog_info`** ("ⓘ") |
+   | Importance | fallback channel (typically DEFAULT — sound, no heads-up on Android 8+; the message's `PRIORITY_MAX` only affects pre-8) | **HIGH → heads-up + sound** |
+
+   Two consequences worth a decision: (a) different channel + icon means the user
+   manages/mutes them separately and they read as unrelated; (b) the alerting is
+   **backwards** — the informational *resolved* (HIGH, heads-up) is **more prominent**
+   than the safety *warning* (stuck on the uncustomized Miscellaneous channel). The
+   clean "warning *becomes* resolved" experience (validated in the sandbox, where both
+   were app-built on one channel/tag) requires **Phase 2** (app-built warning, same
+   channel + tag). The inline-replace in the `NOTIFICATION_RELIABILITY.md` "design
+   goal" is **Phase 2** behavior, not Phase 1's. *Exceptions to "two cards": you'd see
+   only 1 if you dismissed the warning before closing, or if the app was foregrounded
+   when the warning fired (R6 drops it — but then the warning was silently missed).*
+2. **Resolved is a HIGH-importance heads-up; the warning is not.** Channel
+   `garage_door` is `IMPORTANCE_HIGH` (so it's ready for Phase 2's warning), so on
+   Android 8+ the resolved heads-up/buzzes — and per the table above it out-shouts the
+   actual warning. Decide: a quieter dedicated channel for the resolved, or fix M4
+   (give the warning an app-owned channel) so the two are consistent, or accept it.
 3. **Copy says "open" for non-Open warned states.** A warning can fire for
    `OpeningTooLong` or a sensor-error state; the body still reads "It was open for X,"
    and the duration anchors on the *promotion* time (~60s late) for the


### PR DESCRIPTION
Captures the 2026-06-21 notification-presentation analysis into `RESOLVED_NOTIFICATION_PLAN.md`.

During testing, the new build shows **two** notifications, and they look like **different features**:

| | Warning (existing) | Resolved (new) |
|---|---|---|
| Channel | FCM "Miscellaneous" fallback (no `default_notification_channel_id` — M4 gap) | app-owned "Garage door" |
| Icon | app launcher icon (no `default_notification_icon`) | `ic_dialog_info` ("ⓘ") |
| Importance | fallback (DEFAULT — no heads-up on Android 8+) | **HIGH → heads-up** |

Notable finding: the alerting is **backwards** — the informational *resolved* out-shouts the safety *warning*. Also records the exact two-card cases and the one-card exceptions (warning dismissed, or app foregrounded → R6 drops the warning). Limitation #2 cross-references.

Docs only. No code change. (Companion to #907, which pinned the old-app isolation invariant in code.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)