### PR TITLE
docs: dump session context — iOS Phase A setup in progress

### DIFF
--- a/AndroidGarage/docs/PENDING_FOLLOWUPS.md
+++ b/AndroidGarage/docs/PENDING_FOLLOWUPS.md
@@ -20,6 +20,19 @@ Concrete things only the user can do. Each item points to the detailed section b
 
 ### A. Unblock iOS Phase C/G — Apple Developer + Firebase iOS setup (~1 hour, one-time)
 
+> **Progress 2026-06-23 (in flight):** Sub-step 2 (Firebase iOS app) is **done** — the iOS
+> app is registered in the existing `escape-echo` project (bundle `com.chriscartland.garage`),
+> and `GoogleService-Info.plist` is placed at `AndroidGarage/iosApp/iosApp/` (config, not a
+> secret; currently uncommitted in the working tree — handling deferred to the Phase C PR).
+> The plist already carries `CLIENT_ID` + `REVERSED_CLIENT_ID`, so the **Google Sign-In
+> provider is already enabled** in Firebase Auth — no extra Auth-provider step is needed for
+> iOS. Sub-step 1 (Apple Developer Program enrollment) is **processing** (started 2026-06-23;
+> Apple quotes "up to 48 hours"). Sub-step 3 (APNs `.p8` key) is **blocked** until enrollment
+> clears. **Phase C (Swift bridges + `AppDelegate`) needs only the plist and can start now** —
+> Google Sign-In + live door data work in the simulator without the Apple account; only push/FCM
+> verification waits on the APNs upload. Still open beyond the three sub-steps below: the iOS
+> equivalent of `SERVER_CONFIG_KEY` + backend base URL read into `AppConfig` from `Info.plist`.
+
 **The Xcode project, iOS CI, and all 5 SwiftUI screens already exist and build on the
 simulator + macOS CI** (Phases B/D/E/F shipped 2026-06-01, PRs #856/#857/#858). The app
 currently runs against `defaultDevAppConfig` + NoOp auth/push, so it renders signed-out /


### PR DESCRIPTION
## Summary

Captures 2026-06-23 progress on the iOS Phase A/C/G unblock work into `AndroidGarage/docs/PENDING_FOLLOWUPS.md § A`.

What changed in reality this session (now recorded durably):
- **Firebase iOS app registered** in the existing `escape-echo` project (bundle `com.chriscartland.garage`).
- **`GoogleService-Info.plist` obtained** and placed at `AndroidGarage/iosApp/iosApp/` — *not committed in this PR* (config handling deferred to the Phase C PR; an inert config-only commit does nothing alone).
- The plist carries `CLIENT_ID` + `REVERSED_CLIENT_ID`, so the **Google Sign-In provider is already enabled** in Firebase Auth — no extra Auth-provider step for iOS.
- **Apple Developer Program enrollment started** (processing, up to 48h) → the **APNs `.p8` key is blocked** until it clears.
- **Phase C (Swift bridges + `AppDelegate`) can start now** with just the plist — Google Sign-In + live door data work in the simulator without the Apple account; only push/FCM verification waits on the APNs upload.

Docs-only change — fast CI path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)