### PR TITLE
feat(ios): wire garage backend config for door data

### DIFF
--- a/AndroidGarage/iosApp/.gitignore
+++ b/AndroidGarage/iosApp/.gitignore
@@ -1,6 +1,10 @@
 # The Xcode project is generated from project.yml by XcodeGen — never commit it.
 *.xcodeproj/
 
+# Local secret overlay (real GARAGE_SERVER_CONFIG_KEY). Mirrors gitignored
+# local.properties on Android. The committed Secrets.xcconfig #include?s it.
+Secrets.local.xcconfig
+
 # Build output
 build/
 DerivedData/

--- a/AndroidGarage/iosApp/Secrets.xcconfig
+++ b/AndroidGarage/iosApp/Secrets.xcconfig
@@ -1,0 +1,18 @@
+// Build-setting config for the garage backend secret.
+//
+// Non-secret values are committed directly in iosApp/Info.plist (e.g. GARAGE_BASE_URL).
+// The SECRET server config key is injected via the GARAGE_SERVER_CONFIG_KEY build
+// setting and substituted into Info.plist ($(GARAGE_SERVER_CONFIG_KEY)).
+//
+// Real secret values go in Secrets.local.xcconfig (GITIGNORED) -- this mirrors how
+// Android reads SERVER_CONFIG_KEY from the gitignored local.properties. Create it as:
+//
+//     GARAGE_SERVER_CONFIG_KEY = your-key-here
+//
+// When that file is absent (CI, fresh clone), the optional include below is skipped
+// and the key stays empty, so the app still builds and runs -- door data just will
+// not load (Firebase Auth still works). The key never enters git.
+
+GARAGE_SERVER_CONFIG_KEY =
+
+#include? "Secrets.local.xcconfig"

--- a/AndroidGarage/iosApp/iosApp/Info.plist
+++ b/AndroidGarage/iosApp/iosApp/Info.plist
@@ -23,13 +23,15 @@
 			</array>
 		</dict>
 	</array>
-	<!-- Garage backend config (iOS equivalent of Android SERVER_CONFIG_KEY + base URL).
-	     Leave blank to fall back to IosNativeHelper.defaultDevAppConfig (Firebase Auth
-	     still works; door data will not load until these are set). Supply real values
-	     here or via an xcconfig before any production-track build. -->
+	<!-- Garage backend config (iOS equivalent of Android's BASE_URL + SERVER_CONFIG_KEY).
+	     BASE_URL is non-secret (matches androidApp/build.gradle.kts) and committed here.
+	     The server config key is a SECRET, substituted from the GARAGE_SERVER_CONFIG_KEY
+	     build setting (Secrets.xcconfig -> Secrets.local.xcconfig, gitignored). When the
+	     key resolves empty (CI / no local secret), AppConfigFactory keeps the dev fallback
+	     for the key and door data does not load (Firebase Auth still works). -->
 	<key>GARAGE_BASE_URL</key>
-	<string></string>
+	<string>https://us-central1-escape-echo.cloudfunctions.net/</string>
 	<key>GARAGE_SERVER_CONFIG_KEY</key>
-	<string></string>
+	<string>$(GARAGE_SERVER_CONFIG_KEY)</string>
 </dict>
 </plist>

--- a/AndroidGarage/iosApp/project.yml
+++ b/AndroidGarage/iosApp/project.yml
@@ -60,6 +60,9 @@ targets:
         product: FirebaseMessaging
       - package: GoogleSignIn
         product: GoogleSignIn
+    configFiles:
+      Debug: Secrets.xcconfig
+      Release: Secrets.xcconfig
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.chriscartland.garage


### PR DESCRIPTION
## Summary

Wires the iOS app to the real garage backend so it loads live door data — the iOS equivalent of Android's `BASE_URL` + `SERVER_CONFIG_KEY`. Builds on Phase C (#912).

## What changed
- **`Info.plist`** — `GARAGE_BASE_URL` committed (non-secret; matches `androidApp/build.gradle.kts` → `https://us-central1-escape-echo.cloudfunctions.net/`). `GARAGE_SERVER_CONFIG_KEY` is substituted from a build setting (`$(GARAGE_SERVER_CONFIG_KEY)`).
- **Secret handling** — the server config key is a **secret** (gates the garage API). It's injected via `Secrets.xcconfig` (committed scaffold, empty default) → `#include?` of **`Secrets.local.xcconfig` (gitignored)**, mirroring Android's gitignored `local.properties`. **CI-safe:** when the local overlay is absent (CI, fresh clone) the optional include is skipped, the key stays empty, and the build still succeeds (door data just won't load).
- **`project.yml`** — `configFiles` wires `Secrets.xcconfig` into Debug/Release.
- **`.gitignore`** — ignores `Secrets.local.xcconfig`.

The key never enters git. `AppConfig.baseUrl` → `KtorHttpClientFactory`; `AppConfig.serverConfigKey` → `X-ServerConfigKey` header on the config fetch — both shared, unchanged.

## Verification (simulator)
- Server-config fetch returns **HTTP 200** (logged), and Home **STATUS shows real door state ("Closed")** instead of "Unknown".
- Door status is config-key gated (no auth needed); device-health/account correctly still show signed-out (those need Google Sign-In).
- iOS-only change; doesn't touch Android-compiled targets.

## To run it locally
Create `AndroidGarage/iosApp/Secrets.local.xcconfig` with `GARAGE_SERVER_CONFIG_KEY = <key>` (same value as Android's `local.properties`), then `xcodegen generate` + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)