### PR TITLE
feat(ios): FCM data-message receive -> DoorEvent via shared parser

### DIFF
--- a/AndroidGarage/iosApp/README.md
+++ b/AndroidGarage/iosApp/README.md
@@ -62,13 +62,19 @@ Swift requirements, and `observeAuthUser()` must return
 `SkieSwiftOptionalFlow<DataAuthUserInfo>` (Swift can't construct a Kotlin Flow, so
 the holder supplies one).
 
-**Pending (gated on user setup):**
-- Garage backend `GARAGE_BASE_URL` + `GARAGE_SERVER_CONFIG_KEY` in `Info.plist`
-  (iOS equivalent of Android's `SERVER_CONFIG_KEY` + base URL). Until set, the app
-  uses `defaultDevAppConfig`, so Firebase Auth works but **door data does not load**.
-- APNs `.p8` key uploaded to Firebase Cloud Messaging. Until then **push is not
-  delivered**; the messaging bridge + registration compile and run inertly.
-- FCM notification-receive → `DoorEvent` parsing (mirrors Android `FcmMessageHandler`),
-  wired in `AppDelegate.userNotificationCenter(_:didReceive:)`. Deferred until the
-  APNs key lands (untestable without it); door state still refreshes on cold start.
-- TestFlight + App Store (Phase G) — needs the Apple Developer account.
+**Door data + FCM receive (wired):** the garage backend config (`GARAGE_BASE_URL`
+committed; secret `GARAGE_SERVER_CONFIG_KEY` via gitignored `Secrets.local.xcconfig`)
+flows into the shared Ktor client — verified on the simulator showing real door
+STATUS. FCM data messages are parsed with the **shared** `FcmPayloadParser`
+(via `IosNativeHelper.parseFcmDoorEvent`, so the payload-key contract matches
+Android) in `AppDelegate.application(_:didReceiveRemoteNotification:…)` and applied
+through `ReceiveFcmDoorEventUseCase` → the door-event cache the UI observes.
+
+**Pending:**
+- **APNs key** is uploaded to Firebase, but real push *delivery* needs a signed
+  device build (`aps-environment` entitlement). The FCM-receive path is wired but
+  **not runtime-verified**: `simctl` silent (`content-available`) push does not
+  reliably reach `didReceiveRemoteNotification` (a known limitation, compounded by
+  Firebase app-delegate swizzling), so this is a device / Phase-G check.
+- **Google Sign-In end-to-end** — wired; the OAuth flow needs an interactive tap-through.
+- **TestFlight + App Store** (Phase G) — needs device signing + entitlements.

--- a/AndroidGarage/iosApp/iosApp/AppDelegate.swift
+++ b/AndroidGarage/iosApp/iosApp/AppDelegate.swift
@@ -68,6 +68,39 @@ final class AppDelegate: NSObject, UIApplicationDelegate, MessagingDelegate, UNU
         GIDSignIn.sharedInstance.handle(url)
     }
 
+    // MARK: Door-event push (data messages)
+
+    /// Data FCM messages (door state changes) arrive here. Parse with the SHARED
+    /// `FcmPayloadParser` (via `IosNativeHelper`, so the payload-key contract
+    /// matches Android and can't drift) and hand the result to the shared use
+    /// case, which updates the door-event cache the UI observes — the live-update
+    /// counterpart to the cold-start `InitialDoorFetchManager`.
+    func application(
+        _ application: UIApplication,
+        didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+        fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+    ) {
+        if let event = doorEvent(from: userInfo) {
+            component.receiveFcmDoorEventUseCase.invoke(event: event)
+            completionHandler(.newData)
+        } else {
+            completionHandler(.noData)
+        }
+    }
+
+    /// Map an APNs/FCM `userInfo` to a `DoorEvent` via the shared parser, or nil
+    /// if it isn't a door event. The parser reads string key/value pairs, matching
+    /// the Android FCM data-message shape ("type", "timestampSeconds", …).
+    private func doorEvent(from userInfo: [AnyHashable: Any]) -> DoorEvent? {
+        var data: [String: String] = [:]
+        for (key, value) in userInfo {
+            if let key = key as? String, let value = value as? String {
+                data[key] = value
+            }
+        }
+        return IosNativeHelper().parseFcmDoorEvent(data: data)
+    }
+
     // MARK: MessagingDelegate
 
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
@@ -90,11 +123,10 @@ final class AppDelegate: NSObject, UIApplicationDelegate, MessagingDelegate, UNU
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse
     ) async {
-        // TODO (Phase C, push-receive): parse
-        // `response.notification.request.content.userInfo` into a `DoorEvent` and
-        // call `component.receiveFcmDoorEventUseCase(event:)` — mirrors Android's
-        // `FcmMessageHandler`. Deferred until the APNs key lands (untestable
-        // without it); door state still refreshes on cold start via
-        // `InitialDoorFetchManager`.
+        // Tapping a notification opens the app; if it carries door-event data,
+        // apply it too. (The live data-message path is didReceiveRemoteNotification.)
+        if let event = doorEvent(from: response.notification.request.content.userInfo) {
+            component.receiveFcmDoorEventUseCase.invoke(event: event)
+        }
     }
 }

--- a/AndroidGarage/iosFramework/src/iosShared/kotlin/com/chriscartland/garage/iosframework/IosNativeHelper.kt
+++ b/AndroidGarage/iosFramework/src/iosShared/kotlin/com/chriscartland/garage/iosframework/IosNativeHelper.kt
@@ -73,8 +73,7 @@ class IosNativeHelper {
      * the framework's exported ObjC/Swift API: Kotlin/Native only exports
      * declarations reachable from an entry point, and nothing else references it.
      */
-    fun parseFcmDoorEvent(data: Map<String, String>): DoorEvent? =
-        FcmPayloadParser.parseDoorEvent(data)
+    fun parseFcmDoorEvent(data: Map<String, String>): DoorEvent? = FcmPayloadParser.parseDoorEvent(data)
 
     private fun currentAppVersion(): String {
         val bundle = NSBundle.mainBundle

--- a/AndroidGarage/iosFramework/src/iosShared/kotlin/com/chriscartland/garage/iosframework/IosNativeHelper.kt
+++ b/AndroidGarage/iosFramework/src/iosShared/kotlin/com/chriscartland/garage/iosframework/IosNativeHelper.kt
@@ -18,10 +18,12 @@
 package com.chriscartland.garage.iosframework
 
 import com.chriscartland.garage.data.AuthBridge
+import com.chriscartland.garage.data.FcmPayloadParser
 import com.chriscartland.garage.data.MessagingBridge
 import com.chriscartland.garage.datalocal.DataStoreFactory
 import com.chriscartland.garage.datalocal.DatabaseFactory
 import com.chriscartland.garage.domain.model.AppConfig
+import com.chriscartland.garage.domain.model.DoorEvent
 import platform.Foundation.NSBundle
 
 /**
@@ -59,6 +61,20 @@ class IosNativeHelper {
             appConfig = appConfig,
             appVersion = currentAppVersion(),
         )
+
+    /**
+     * Parse an FCM data-message payload into a [DoorEvent] using the SHARED
+     * [FcmPayloadParser] — the same parser Android uses, so the payload-key
+     * contract cannot drift between platforms. Returns null if the payload is
+     * not a door event.
+     *
+     * Exposed on this entry point because the Swift `AppDelegate` receives the
+     * raw push `userInfo`, and `FcmPayloadParser` is otherwise not reachable in
+     * the framework's exported ObjC/Swift API: Kotlin/Native only exports
+     * declarations reachable from an entry point, and nothing else references it.
+     */
+    fun parseFcmDoorEvent(data: Map<String, String>): DoorEvent? =
+        FcmPayloadParser.parseDoorEvent(data)
 
     private fun currentAppVersion(): String {
         val bundle = NSBundle.mainBundle


### PR DESCRIPTION
Completes the receive side of the iOS push path (builds on #912/#913).

## What changed
- **`IosNativeHelper.parseFcmDoorEvent(data:)`** delegates to the **shared** `FcmPayloadParser` — the same parser Android uses, so the FCM payload-key contract cannot drift between platforms. Exposed on the entry point because Kotlin/Native only exports API reachable from one, and nothing else referenced the parser.
- **`AppDelegate.application(_:didReceiveRemoteNotification:fetchCompletionHandler:)`** maps the push `userInfo` (string k/v pairs, matching the Android data-message shape) to a `DoorEvent` and applies it via `ReceiveFcmDoorEventUseCase` → the door-event cache the UI observes (the live-update counterpart to the cold-start fetch). The notification-tap handler applies a carried payload too.

## Verification — honest status
- ✅ Compiles + links against the framework; `simctl` install + launch OK.
- ✅ Uses the **shared** parser (no Swift reimplementation → no key drift) and mirrors Android's proven `FcmMessageHandler` flow.
- ⚠️ **NOT runtime-verified.** `simctl` silent (`content-available`) push does not reliably reach `didReceiveRemoteNotification` — a known simctl limitation, compounded by Firebase app-delegate swizzling. Tried both foreground and backgrounded; STATUS did not flip (and kermit logs don't surface in `log show`, so I couldn't even confirm the handler fired). Real FCM → APNs → device delivery is genuinely device-only (on CLAUDE.md's device-only list) and is a **Phase-G** verification.

Additive + dormant until a real push arrives; does not affect the verified auth / door-data paths. iOS-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)