### PR TITLE
fix(test): make KtorNetworkFeatureAllowlistDataSourceTest deterministic

### DIFF
--- a/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/ktor/KtorNetworkFeatureAllowlistDataSourceTest.kt
+++ b/AndroidGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/ktor/KtorNetworkFeatureAllowlistDataSourceTest.kt
@@ -31,6 +31,8 @@ import io.ktor.http.URLBuilder
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import java.io.File
@@ -79,16 +81,25 @@ class KtorNetworkFeatureAllowlistDataSourceTest {
     private fun mockClient(
         responses: Map<String, EndpointResponse>,
         capturedRequests: MutableList<RecordedRequest> = mutableListOf(),
-    ): HttpClient =
-        HttpClient(
+    ): HttpClient {
+        // The data source issues both endpoint GETs in parallel (coroutineScope +
+        // async), so MockEngine can invoke this handler concurrently on different
+        // threads. `capturedRequests` is a plain mutableListOf — guard every
+        // mutation with a Mutex so two concurrent `add`s can't race and drop one
+        // (which made `assertEquals(2, captured.size)` flaky in CI). withLock keeps
+        // the capture deterministic regardless of the engine's dispatcher.
+        val capturedMutex = Mutex()
+        return HttpClient(
             MockEngine { request ->
-                capturedRequests.add(
-                    RecordedRequest(
-                        method = request.method,
-                        urlPath = request.url.encodedPath,
-                        headers = request.headers.entries().associate { it.key to it.value },
-                    ),
-                )
+                capturedMutex.withLock {
+                    capturedRequests.add(
+                        RecordedRequest(
+                            method = request.method,
+                            urlPath = request.url.encodedPath,
+                            headers = request.headers.entries().associate { it.key to it.value },
+                        ),
+                    )
+                }
                 val match = responses[request.url.encodedPath]
                     ?: error("No mock response configured for ${request.url.encodedPath}")
                 respond(
@@ -115,6 +126,7 @@ class KtorNetworkFeatureAllowlistDataSourceTest {
                 url(URLBuilder("https://example.invalid/").build().toString())
             }
         }
+    }
 
     private data class EndpointResponse(
         val status: HttpStatusCode,


### PR DESCRIPTION
## Problem

`KtorNetworkFeatureAllowlistDataSourceTest.sendsAuthTokenHeaderAndUsesGetForBothEndpoints` flakes in CI — observed as `1 of 148 tests failed` on an **unrelated iOS-only PR** (#922), failing `assertEquals(2, captured.size)`. Passes locally.

## Root cause — a data race, not the test logic

The data source issues both allowlist GETs **in parallel** (`coroutineScope { async {…}; async {…} }`), so Ktor's `MockEngine` can invoke the mock handler **concurrently on different threads**. The handler appended each request to a shared plain `mutableListOf` (`capturedRequests`):

```kotlin
MockEngine { request ->
    capturedRequests.add(RecordedRequest(...))   // two concurrent add()s race
    ...
}
```

Two concurrent `add`s can interleave and drop one → `captured.size == 1` → the assertion fails. The test already handles request **order** non-determinism (it keys by path: `"Order is non-deterministic (parallel async); check by path."`); only the *capture* itself was unsynchronized.

## Fix

Guard the capture with a `Mutex` (`withLock`) in the test's `mockClient` helper, so the shared list mutation is serialized regardless of the engine's dispatcher. Deterministic by construction. **Test-only change — no production code touched.**

## Verification

- `:data:testReleaseUnitTest` → `BUILD SUCCESSFUL` (the class runs 6/6, the module 148, 0 failures). Test report confirms `sendsAuthTokenHeaderAndUsesGetForBothEndpoints` executed.
- `:data:spotlessCheck` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)