### PR TITLE
docs(ios): ADR-031 + phased plan — realize the shared presentation-model layer

### DIFF
--- a/AndroidGarage/docs/DECISIONS.md
+++ b/AndroidGarage/docs/DECISIONS.md
@@ -1748,3 +1748,56 @@ iOS had no equivalent. The app had no Swift test target at all; iOS CI only buil
 - ADR-029 — iOS ↔ Android parity / platform-native / shared identity (the door visualization this first captures is an identity item).
 - [`PENDING_FOLLOWUPS.md`](./PENDING_FOLLOWUPS.md) § 1 — iOS construction status.
 - Android analog: `scripts/generate-android-screenshots.sh`, `android-screenshot-tests/SCREENSHOT_GALLERY.md`, `checkPreviewCoverage`.
+
+---
+
+## ADR-031: Realize the shared `presentation-model` layer — typed display state in shared ViewModels, rendered by both Compose and SwiftUI
+
+### Status
+
+Accepted — 2026-06-27. **Plan only; not yet implemented.** Phased rollout: [`PRESENTATION_MODEL_REALIZATION.md`](./PRESENTATION_MODEL_REALIZATION.md).
+
+### Context
+
+ADR-029 set the principle: *the shared KMP layer is the parity contract; prefer pushing logic and state down so the other platform gets it nearly for free.* The iOS↔Android feature-parity audit (2026-06-27) showed where that principle is currently violated.
+
+The per-screen **display mapping** — `DoorPosition → DoorWarning`, the "Since 9:47 AM · 2 hr 14 min" status line, the `DoorEvent → HistoryEntry` typing (Opened / Closed / Anomaly, transit warnings, anomaly kinds, day grouping) — lives in `androidApp/`'s UI-layer mappers (`HomeMapper`, `HomeStatusFormatter`, `DoorWarning`, `HistoryMapper`). **iOS cannot reach `androidApp` code.** So today iOS either shows a thinner screen (raw door message instead of typed warning; no duration line; flat history list) or would have to **re-implement** the mapping in Swift — a second source of truth that drifts.
+
+A shared `presentation-model` KMP module already exists (`HomeScreenState`, `DoorHistoryScreenState`, `ProfileScreenState`) but is **dormant**: the types are skeletal and nothing produces or consumes them. The scaffolding is there; it was never wired.
+
+### Decision
+
+**Realize the `presentation-model` layer.** Move the per-screen display mapping out of `androidApp/` and into the shared KMP layer, expose the resulting typed state from the shared `Default*ViewModel`s, and have **both** Jetpack Compose and SwiftUI render it.
+
+Principles:
+
+1. **Shared emits typed state, never user-visible strings.** Per the string-resource migration rule (ADR-023 era), mappers/VMs emit sealed types, enums, and primitive/numeric parts (`DoorWarning`, `AnomalyKind`, `TransitWarning`, day-group keys, duration as `days/hours/minutes` ints, epoch deltas). Each UI converts those to **localized strings at render time** (Compose `stringResource`/`pluralStringResource`; SwiftUI `Text` + formatters). Locale-dependent formatting (clock time, plurals) stays per-UI; the *typed/numeric* inputs are shared so the two renders cannot diverge in meaning.
+2. **The mapping logic lives in `commonMain`** — in `presentation-model` (pure functions over domain types) and/or computed `StateFlow`s on the shared VM. No platform types.
+3. **The shared VM exposes the typed screen state** (enrich `HomeScreenState` / `DoorHistoryScreenState` etc.), so the UI layers are thin renderers.
+4. **Android gets thinner.** Each slice deletes the corresponding `androidApp/` mapper and points `*Content.kt` at the VM state. The mapper unit tests move to shared `commonTest` (so they run on every platform and guard the contract).
+
+### What moves vs. what stays
+
+| Concern | Where |
+|---|---|
+| `DoorWarning`, `AnomalyKind`, `TransitWarning`, history-entry kind, day-group key | **Shared** (typed) |
+| `DoorPosition → DoorWarning`, `DoorEvent → HistoryEntry`, since/duration *as numeric parts*, grouping | **Shared** (pure mapping) |
+| "9:47 AM", "2 hr 14 min", plural rendering, icon/color choice | **Per-UI** (locale + platform), driven by the shared typed/numeric inputs |
+
+### Consequences
+
+- **Cross-cutting per slice** (shared + Android + iOS + tests) → `validate.sh` is required (custom lints, `:test-common` compile, VM↔UseCase boundary). VM ctor changes touch **both** DI graphs (`AppComponent` + `NativeComponent`) — see the two-DI-component rule in CLAUDE.md.
+- iOS feature parity (the audit's richness gaps) is delivered as a by-product of each slice, not as duplicated Swift.
+- The typed shared state becomes the cross-platform "wire contract" for UI meaning — analogous to `wire-contracts/` for HTTP.
+- Net less code: one mapping + one test suite instead of one-per-platform.
+
+### When this decision might change
+
+- If a screen's display logic turns out to be genuinely platform-specific (no shared meaning), that piece stays per-UI — recorded as an exception in the plan doc.
+
+### References
+
+- ADR-029 — the parity principle this implements.
+- [`PRESENTATION_MODEL_REALIZATION.md`](./PRESENTATION_MODEL_REALIZATION.md) — the phased plan, slice checklist, and parity-gap inventory.
+- Dormant scaffolding: `presentation-model/.../{HomeScreenState,DoorHistoryScreenState,ProfileScreenState}.kt`.
+- Mappers to relocate: `androidApp/.../ui/home/{HomeMapper,HomeStatusFormatter,DoorWarning}.kt`, `androidApp/.../ui/history/HistoryMapper.kt`.

--- a/AndroidGarage/docs/PENDING_FOLLOWUPS.md
+++ b/AndroidGarage/docs/PENDING_FOLLOWUPS.md
@@ -85,10 +85,13 @@ Ordered by leverage. Phases 1–2 are verification of already-built code; Phases
    - Consider promoting iOS CI (`Build iOS app + framework test`) to a required check once stable (per CLAUDE.md branch-protection ordering) — closes the non-required-iOS-CI / auto-merge race.
 4. **Phase G — App Store** (1 PR, last): 1024² icon (reuse Android glyph), App Store Connect screenshots (iPhone + iPad), listing copy, `ITSAppUsesNonExemptEncryption = NO` (already set), `PrivacyInfo.xcprivacy` (Firebase Auth = "User ID, linked, App Functionality"), submit for review. **User-gated.**
 
-**Feature-parity audit (ADR-029).** Capability parity is the north star; these are the known iOS gaps vs Android (UI may differ by platform, but the capability/identity should land):
-- **Animated door canvas — DONE (PR #919, 2026-06-26).** iOS Home now renders a SwiftUI `GarageDoorView` (port of Android's `GarageDoorCanvas.kt` + `GarageIcon.kt`): U-frame + panels + handle + gradient, per-state color (fresh/stale, light/dark) and offset, directional/warning overlays, eased transitions. The full Android animation trajectory (12 s linear tween + once-per-event `DoorAnimationMemory` replay) remains a deferred polish pass; the identity *visual* has landed.
-- **Adaptive / iPad layout.** Android adapts via `AppLayoutMode` (nav rail, 3-pane, wide dashboard); iOS `MainScreen` is a plain phone-style `TabView` + `NavigationStack` with no size-class adaptation, even though the app is Universal (iPhone + iPad). Add iPad/landscape adaptation with SwiftUI-idiomatic constructs (e.g. `NavigationSplitView`) — platform-native, not a port of the Android rail.
-- **Capability spot-check.** Audit each Android screen's actions against its iOS counterpart for any silently-missing capability (the screens exist, but parity is action-level, not screen-level). Run before the first TestFlight so the published app isn't missing a meaningful feature.
+**Feature-parity audit (ADR-029).** Capability parity is the north star. The full iOS↔Android audit ran 2026-06-27 → the gap inventory + the execution plan now live in **[ADR-031](./DECISIONS.md#adr-031) + [`PRESENTATION_MODEL_REALIZATION.md`](./PRESENTATION_MODEL_REALIZATION.md)** (realize the shared `presentation-model` layer so typed display state is computed once in `commonMain` and rendered by both Compose and SwiftUI). Status:
+- **Animated door canvas — DONE (#919).** SwiftUI `GarageDoorView` (full Android trajectory deferred; identity visual landed).
+- **Snapshot gallery — DONE (#920–#924).** All 5 screens captured (ADR-030).
+- **3-tab restructure + gated Developer section — DONE (#926).** Diagnostics + Functions moved under Settings, `developerAccess`-gated (no longer leaked to all users).
+- **Account identity + About/version — DONE (#927).**
+- **Remaining richness (Home warnings/duration/alerts, History day-grouping/rich-rows/load-more, info sheets, dev-action gaps)** is the `presentation-model` realization — phased in the plan doc above. This is the active iOS workstream.
+- **Adaptive / iPad layout — DEPRIORITIZED (user, 2026-06-27).** `NavigationSplitView` adaptation is low-value right now; revisit after the richness parity lands.
 
 **Sequencing:** Phase 1 (verify sign-in) now → parity items (door canvas, adaptive layout) can proceed in parallel any time → Phase 3 (release tooling + signing) → Phase 2 (device push verify, folds into TestFlight) → Phase 4 (App Store). Phases 3–4 and Phase 2 are user-gated on Apple signing.
 

--- a/AndroidGarage/docs/PRESENTATION_MODEL_REALIZATION.md
+++ b/AndroidGarage/docs/PRESENTATION_MODEL_REALIZATION.md
@@ -1,0 +1,141 @@
+---
+category: plan
+status: active
+last_verified: 2026-06-27
+---
+
+# Presentation-model realization — phased plan
+
+Realize the dormant shared `presentation-model` layer so the per-screen **display
+mapping** lives in `commonMain`, is exposed by the shared `Default*ViewModel`s,
+and is rendered by **both** Jetpack Compose (Android) and SwiftUI (iOS). This is
+the implementation plan for **[ADR-031](./DECISIONS.md#adr-031)** (decision +
+principles) and the mechanism for closing the iOS↔Android feature-parity gaps
+from the 2026-06-27 audit (ADR-029).
+
+> **One-line goal:** move `androidApp/`'s `HomeMapper` / `HistoryMapper` /
+> `DoorWarning` / `HomeStatusFormatter` into shared typed state, so iOS gets the
+> richness for free and Android's UI gets thinner.
+
+## Why (short)
+
+The display mapping (typed warnings, "Since … · duration", history-entry kinds,
+day grouping) is in `androidApp/` today, unreachable from iOS. Re-implementing it
+in Swift = a second source of truth that drifts. A shared `presentation-model`
+module already exists (`HomeScreenState`, `DoorHistoryScreenState`,
+`ProfileScreenState`) but is skeletal and unused. Wire it up.
+
+## Architectural rules (from ADR-031)
+
+- **Shared emits typed state, never user-visible strings.** Sealed types, enums,
+  numeric parts (`days/hours/minutes`, epoch deltas). Each UI renders localized
+  strings at render time (Compose `stringResource`/plurals; SwiftUI formatters).
+- Mapping logic is **pure functions in `presentation-model/commonMain`** and/or
+  computed `StateFlow`s on the shared VM. No platform types.
+- Android `*Content.kt` and iOS `*ContentView`/wrapper become thin renderers of
+  the VM's typed state. The `androidApp/` mapper is **deleted** per slice.
+- Mapper unit tests move to shared `commonTest`.
+
+## Per-slice checklist
+
+Each slice is one PR (cross-cutting; `validate.sh` required):
+
+- [ ] Add/enrich the typed state in `presentation-model/commonMain` (sealed
+      types/enums/numeric parts).
+- [ ] Add the pure mapping (domain → typed state) in `presentation-model`
+      (or a computed `StateFlow` on the VM). No strings, no platform types.
+- [ ] Expose it from the shared `Default*ViewModel` (enrich `*ScreenState` or add
+      a `StateFlow`). Update **both** DI graphs if the ctor changes —
+      `androidApp/.../di/AppComponent.kt` **and**
+      `iosFramework/.../NativeComponent.kt` (two-DI-component rule).
+- [ ] Android: point `*Content.kt` at the VM state; **delete** the `androidApp/`
+      mapper + its now-dead types.
+- [ ] Move the mapper's unit tests to shared `commonTest` (guards the contract on
+      every platform).
+- [ ] iOS: render the typed state in the `*ContentView` (+ expose via the
+      `*ViewModelWrapper`); add/refresh `#Preview`s → snapshot gallery.
+- [ ] `./scripts/validate.sh` (Android) + iOS CI-exact build + regenerate both
+      galleries. Android screenshots may change — that's expected (the render is
+      equivalent; verify the diff).
+
+## Phases (ordered by leverage / risk)
+
+Start small to prove the pattern, then widen.
+
+### Phase 1 — `DoorWarning` (smallest end-to-end slice; proves the pattern)
+
+`DoorPosition → DoorWarning` (sealed: `ServerMessage(text)` + enum fallbacks
+`OpeningTooLong` / `ClosingTooLong` / `OpenMisaligned` / `SensorConflict`). Move
+`androidApp/.../ui/home/DoorWarning.kt` + the `HomeMapper.warning` mapping into
+shared; expose `warning: DoorWarning?` on `DefaultHomeViewModel`. Android renders
+the existing chip from VM state; iOS renders a warning chip (today it shows the
+raw server message only). Smallest cross-cutting change — establishes the
+pattern, lints, and the two-UI render.
+
+### Phase 2 — Home status line + door color/icon semantics
+
+The "Since 9:47 AM · 2 hr 14 min" line and the fresh/stale door color state.
+Shared exposes the *typed/numeric* parts (epoch delta, since-timestamp, color
+state enum from `DoorColorState`); each UI formats clock time + duration with its
+own locale APIs (Compose plurals; SwiftUI `Date.FormatStyle` /
+`RelativeDateTimeFormatter`). iOS gains the duration line.
+
+### Phase 3 — History entries
+
+`DoorEvent → HistoryEntry` (Opened / Closed / Anomaly), `AnomalyKind`,
+`TransitWarning`, and the day-grouping key (Today / Yesterday / date). Move
+`androidApp/.../ui/history/HistoryMapper.kt` to shared. iOS gains day grouping,
+door icons, durations, transit/anomaly tags — and load-more pagination
+(server + Android data already support it; ADR-028).
+
+### Phase 4 — Home alerts + permission/notification state
+
+`HomeAlert` typed state (Stale / FetchError / PermissionMissing) as shared typed
+state where it's platform-neutral; the notification-permission piece stays
+per-UI (iOS `UNUserNotificationCenter` vs Android runtime permission), driven by
+a shared "permission needed" boolean. iOS gains the alert banners.
+
+### Phase 5 — Remaining richness
+
+Info sheets (door-status / remote-control), check-in + button-health pills as
+typed display state, then the developer-surface gaps (Diagnostics Export CSV /
+copy-token; Functions auth + test-notification actions), and door-canvas
+animation polish.
+
+## iOS parity-gap inventory (the work this plan delivers)
+
+Condensed from the 2026-06-27 audit. Items already shipped are struck through.
+
+- **Settings** — ~~3-tab restructure + gated Developer section (#926)~~;
+  ~~account name/email + About/version (#927)~~. Remaining: store/privacy links
+  (deferred until published), tap-to-copy version, typed snooze-failure messages,
+  snooze permission state.
+- **Home** — typed `DoorWarning` chip (P1); "Since · duration" line (P2);
+  alert banners stale/fetch-error/permission (P4); info sheets + check-in/health
+  pills (P5); network-progress diagram (P5, optional).
+- **History** — day grouping, door icons, durations, transit/anomaly tags,
+  empty-state, load-more (P3).
+- **Diagnostics** — Export CSV, copy-auth-token (P5).
+- **Functions** — sign in/out, copy-auth-token, test-notification topic
+  (copy/subscribe/change), "developers only" warning (P5).
+
+## Risks / guards
+
+- **High blast radius on Android.** Every slice edits `androidApp/` UI + deletes a
+  mapper. `validate.sh` is mandatory (architecture lints, `:test-common` compile,
+  unit-test compile, screenshot/preview coverage).
+- **Two DI graphs.** A VM ctor change that compiles on Android can break iOS
+  (`NativeComponent`) — iOS CI is not required, so grep `NativeComponent.kt` after
+  any `viewmodel/` ctor change.
+- **Screenshot churn.** Android reference PNGs may change when a screen switches
+  from mapper-computed to VM-computed state; the render should be equivalent —
+  inspect the diff, don't blindly accept. iOS gallery regenerates too.
+- **Keep the typed-not-string rule.** If a slice is tempted to expose a formatted
+  string from shared, stop — expose the typed/numeric input instead and format
+  per-UI (the whole point of the string-resource migration).
+
+## Done = 
+
+Every screen's display *meaning* is computed once in `commonMain`, exposed by the
+shared VM, and rendered by both UIs; `androidApp/` has no display mappers; the
+iOS parity-gap inventory above is cleared.


### PR DESCRIPTION
Captures the architecture decision you signed off on (B: shared ViewModels expose typed KMP state for both Compose and SwiftUI) + the executable plan. **Plan only — no code change.**

## What's in here

- **ADR-031** (`DECISIONS.md`) — realize the dormant `presentation-model` KMP module: move per-screen display mapping (`DoorWarning`, "Since · duration", history-entry kinds, day grouping) out of `androidApp/` into `commonMain`, expose typed state from the shared `Default*ViewModel`s, render it in **both** Compose and SwiftUI. Principles: shared emits **typed state, never strings**; each UI formats locale strings; Android gets thinner; iOS gets richness for free; one mapping + one test suite.
- **`PRESENTATION_MODEL_REALIZATION.md`** — the actionable plan: per-slice checklist (cross-cutting; `validate.sh` + both DI graphs + gallery regen), phased sequence (P1 `DoorWarning` → P2 status/duration → P3 history → P4 alerts → P5 richness), the iOS parity-gap inventory (with #919–#927 struck through), and the guards.
- **`PENDING_FOLLOWUPS` § 1** — points the parity audit at ADR-031 + the plan; records shipped work (restructure #926, account/About #927); notes iPad layout **deprioritized** per your call.

## Key finding it records

The `presentation-model` module already exists (`HomeScreenState` etc.) but is **dormant/skeletal** — the scaffolding was never wired. This plan wires it.

## Why a plan-only PR

The realization is a cross-cutting Android+shared+iOS refactor (high blast radius). Per your direction, capturing it durably now so it can be executed fresh with full `validate.sh` headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)