### PR TITLE
chore(android): bump to 2.20.2 (refactor checkpoint)

### DIFF
--- a/AndroidGarage/CHANGELOG.md
+++ b/AndroidGarage/CHANGELOG.md
@@ -15,6 +15,10 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
 
+## 2.20.2
+- **No user-facing changes.** Refactor checkpoint release: a clean build + internal-track deploy to confirm the in-progress iOS shared-logic work hasn't accidentally regressed Android.
+- **Internal:** ADR-031 Phase 1. The typed door warning (`DoorWarning`) and its mapping moved from `androidApp` into the shared `presentation-model` module so Android and iOS render it from one source of truth. `DefaultHomeViewModel` now exposes `warning: StateFlow<DoorWarning?>` (the route wrapper threads it onto `HomeStatusDisplay`); `HomeMapper.warning` and the androidApp-local `DoorWarning` type were deleted, and the warning-mapping unit tests moved to shared `commonTest` (so they run on Android and iOS). Behavior-preserving: same chip, same copy, same triggers; no resources, manifest, Room schema, FCM, or DI constructor changes. PR #929. Plan: [`docs/PRESENTATION_MODEL_REALIZATION.md`](docs/PRESENTATION_MODEL_REALIZATION.md).
+
 ## 2.20.1
 - **Tapping a garage-door notification now opens the app.** The foreground open-door warning and the resolved-on-close notification are app-built, and were missing a tap action, so tapping them did nothing. They now launch the app. (The OS-rendered background warning already opened the app via FCM's default launch intent; this brings the app-built notifications in line.) The diagnostic test-notification sandbox got the same fix.
 - **Internal:** added `setContentIntent(PendingIntent → MainActivity, FLAG_IMMUTABLE)` to `DoorNotificationPresenter` and `TestNotificationPresenter`. FCM only auto-attaches a launch intent to OS-rendered notification-payload messages; app-built (`NotificationCompat`) notifications must set their own `contentIntent`.

--- a/AndroidGarage/version.properties
+++ b/AndroidGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.20.1
+versionName=2.20.2


### PR DESCRIPTION
Patch bump for an internal **refactor checkpoint** Android release (`android/254`).

## Why
The iOS shared-logic refactoring (ADR-031 presentation-model realization) has started touching code that ships in the Android AAB. PR #929 (Phase 1, shared `DoorWarning`) is the first such change. This checkpoint release exists to confirm — via a clean build + internal-track deploy — that the refactor hasn't accidentally regressed Android, before more phases land.

## Changes
- `version.properties`: `versionName` 2.20.1 → **2.20.2** (patch — refactor, no new capability).
- `CHANGELOG.md`: `## 2.20.2` entry.

## Scope of the release
Captures only #929 (the single AAB-affecting change since `android/253`). Behavior-preserving: same warning chip, same copy, same triggers; no resources, manifest, Room schema, FCM, or DI ctor changes. Verified by `validate.sh` (all unit tests + screenshot/instrumented compile + Room schema) and the iOS CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)