### PR TITLE
feat(ios): typed snooze-failure messages in Settings (ADR-031 P5)

### DIFF
--- a/AndroidGarage/docs/PRESENTATION_MODEL_REALIZATION.md
+++ b/AndroidGarage/docs/PRESENTATION_MODEL_REALIZATION.md
@@ -334,9 +334,9 @@ delivery, release tooling, App Store).
 Condensed from the 2026-06-27 audit. Items already shipped are struck through.
 
 - **Settings** — ~~3-tab restructure + gated Developer section (#926)~~;
-  ~~account name/email + About/version (#927)~~. Remaining: store/privacy links
-  (deferred until published), tap-to-copy version, typed snooze-failure messages,
-  snooze permission state.
+  ~~account name/email + About/version (#927)~~; ~~tap-to-copy version/build/package
+  (#943)~~ ✅; ~~typed snooze-failure messages~~ ✅. Remaining: store/privacy links
+  (deferred until published), snooze permission state.
 - **Home** — ~~typed `DoorWarning` chip (P1)~~ ✅; ~~"Since · duration" line
   (P2)~~ ✅; ~~alert banners stale/fetch-error/permission (P4)~~ ✅; ~~check-in
   pill (P5)~~ ✅; ~~button-health pill render (P5)~~ ✅; ~~info sheets (P5)~~ ✅

--- a/AndroidGarage/iosApp/Features/Settings/SettingsViewModelWrapper.swift
+++ b/AndroidGarage/iosApp/Features/Settings/SettingsViewModelWrapper.swift
@@ -108,9 +108,22 @@ final class SettingsViewModelWrapper: ObservableObject {
         case .sending:
             snoozeSending = true
             snoozeError = nil
-        case .failed:
+        case .failed(let failed):
             snoozeSending = false
-            snoozeError = "Snooze failed, try again"
+            // Typed copy, verbatim from Android's `snooze_failed_*` strings.
+            // `SnoozeAction.Failed` is a shared sealed type, so this switch is
+            // exhaustive — a new failure case forces an update here rather than
+            // silently falling back to a generic message.
+            switch onEnum(of: failed) {
+            case .eventChanged:
+                snoozeError = "Door state changed before snooze could apply. Try again."
+            case .networkError:
+                snoozeError = "Snooze did not apply. Check your connection and try again."
+            case .notAuthenticated:
+                snoozeError = "Sign in to snooze notifications."
+            case .missingData:
+                snoozeError = "No recent door event available. Try again in a moment."
+            }
         case .idle, .succeeded:
             snoozeSending = false
             snoozeError = nil


### PR DESCRIPTION
## What

The iOS Settings wrapper flattened every snooze failure to a generic "Snooze failed, try again". The shared `SnoozeAction.Failed` is **already a sealed type with four typed cases**, so this maps each to a specific, actionable message — verbatim from Android's `snooze_failed_*` strings:

| Case | Message |
|---|---|
| `EventChanged` | "Door state changed before snooze could apply. Try again." |
| `NetworkError` | "Snooze did not apply. Check your connection and try again." |
| `NotAuthenticated` | "Sign in to snooze notifications." |
| `MissingData` | "No recent door event available. Try again in a moment." |

## Notes

- **iOS-only** — the typed reasons already exist in the shared domain model (`SnoozeNotificationsModel.kt`); no shared / Android / Kotlin change.
- The nested `onEnum(of: failed)` switch is **exhaustive** — a new shared failure case forces an update here rather than silently falling back to a generic message.
- Runs in parallel with #943 (no file overlap — that PR touches `SettingsScreen.swift`; this one touches `SettingsViewModelWrapper.swift` + the plan doc).
- Also strikes tap-to-copy version (#943) + this item from the Settings parity inventory in `PRESENTATION_MODEL_REALIZATION.md`.

## Verification

CI-exact iOS build (no Gradle override → framework rebuilt) confirms the SKIE nested-sealed bridging compiles — this is **iOS-build-only**, not caught by `validate.sh`. No view change; gallery unchanged at 18 PNGs. (The mapping is wrapper logic, not snapshot-rendered; its correctness rests on the compile-time-exhaustive switch + verbatim Android copy.) iOS CI (non-required) runs the full build post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)