### PR TITLE
docs: dump session context — deploy-state verification + config-constant rule

### DIFF
--- a/AndroidGarage/docs/PRESENTATION_MODEL_REALIZATION.md
+++ b/AndroidGarage/docs/PRESENTATION_MODEL_REALIZATION.md
@@ -30,6 +30,18 @@ module already exists (`HomeScreenState`, `DoorHistoryScreenState`,
 - **Shared emits typed state, never user-visible strings.** Sealed types, enums,
   numeric parts (`days/hours/minutes`, epoch deltas). Each UI renders localized
   strings at render time (Compose `stringResource`/plurals; SwiftUI formatters).
+- **But locale-invariant *config* DOES belong in shared — that's the opposite of
+  display strings.** A URL, a numeric threshold, a topic prefix, an ID — values
+  that are the same in every locale and on every platform — are a single-source
+  constant in `domain` (e.g. an `object` with a `const val`), consumed by both
+  UIs, NOT duplicated per platform. The test: *would a translator ever change
+  it?* If yes → per-platform display string. If no → shared `domain` constant.
+  Canonical: `AppLinks.PRIVACY_POLICY_URL` (P5, #946) — the privacy URL was an
+  Android-only `private const val`; it moved to `domain/.../model/AppLinks.kt`
+  (the `AppLoggerLimits` "cannot drift" convention) and both Android and iOS now
+  read it (iOS via SKIE `AppLinks.shared.PRIVACY_POLICY_URL`, since `domain` is an
+  exported framework module). When iOS is about to hardcode a value that already
+  exists on Android, ask "is this config or display?" before duplicating.
 - Mapping logic is **pure functions in `presentation-model/commonMain`** and/or
   computed `StateFlow`s on the shared VM. No platform types.
 - Android `*Content.kt` and iOS `*ContentView`/wrapper become thin renderers of
@@ -201,14 +213,24 @@ inlined to `HomeAlert.PermissionMissing.attemptCount`.
   Stale banner + muted door color (`GarageDoorView(isStale:)`) signal staleness,
   matching Android (which never had an in-card stale label).
 
-### Phase 5 — Remaining richness (paused 2026-06-28)
+### Phase 5 — Remaining richness (clean slices done 2026-06-28)
 
-Run as a sequence of small PRs, each one a self-contained slice. **Status:** the
-clean, snapshot-verifiable iOS-only content-parity slices are done (check-in pill,
-button-health pill, info sheets #939, Functions warning + test-notification #941).
-Paused here by the user — each remaining item either has a verification gap
-(door-canvas animation) or needs shared-module work (Export CSV, copy-auth-token),
-so they're picked up deliberately rather than auto-continued.
+Run as a sequence of small PRs, each one a self-contained slice. **Status:** every
+clean, snapshot-verifiable iOS-only parity slice is now shipped — check-in pill,
+button-health pill, info sheets (#939), Functions warning + test-notification
+(#941), Settings tap-to-copy version/build/package (#943), typed snooze-failure
+messages (#944), snooze permission state (#945), privacy-policy link with the URL
+shared via `domain` (#946). **iOS now has full verifiable parity across all five
+surfaces** (Home / History / Settings / Diagnostics / Functions).
+
+What remains all crosses the "needs a decision / can't be CLI-verified / shared
+work" line and is picked up deliberately, not auto-continued:
+- **Door-canvas animation** & **network-progress diagram** — verification gap
+  (animation trajectory isn't snapshot-verifiable on iOS; see the door-canvas
+  bullet below). The network diagram is also tied to the remote-button flow.
+- **Export CSV** & **copy-auth-token** (Diagnostics/Functions) — shared-module
+  work (shared CSV API + iOS share sheet; token-fetch bridge → two-DI-component).
+- **App Store link** (Settings) — deferred until the iOS listing is published.
 
 - **Check-in pill — ✅ SHIPPED.** `DoorEvent.lastCheckInTimeSeconds` + the live
   clock → typed `CheckInStatus` (`NoData` / `Reported(age, isStale)`) with a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,6 +324,16 @@ git checkout android/M                 # 1. move HEAD to the commit you want to 
 - **versionCode ↔ tag:** each `android/N` tag has `versionCode == N`, so the snapshot maps a code back to its `versionName` via `git show android/N:AndroidGarage/version.properties` (needs `fetch-depth: 0`).
 - **Gotcha (baked into the workflow):** read a just-created issue's number straight from `gh issue create`'s output URL — `gh issue list` is eventually consistent and won't surface it yet. Rendering is unit-tested (`.github/scripts/lib/format-snapshot.mjs` + `play-track-snapshot.test.mjs`). Shipped 2026-06-09 in PRs #860, #862 (first-run race fix), #863 (body+history+rollover+tests).
 
+### Determining what's actually deployed / live (verify, don't recall)
+
+**Before telling the user what is live in production, check authoritative sources — NOT memory and NOT a doc's status header.** Both drift fast; deploy/release state is exactly the kind of fact memories and "Status:" lines get wrong. Empirical (2026-06-28 session): an agent twice reported stale state to the user — "you should deploy `server/28`" when it had been **live since 2026-06-10**, and "the resolved-notification is parked" when its flag had been **on since 2026-06-22** — both from trusting a memory description + a stale doc header. The authoritative sources:
+
+- **Server (Cloud Functions) — what `server/N` is live:** `gh run list --workflow=firebase-deploy.yml --limit 8` → the latest `success` run is the deployed tag. Deploys are **cumulative from the tagged commit**, so everything merged up to that tag is live (e.g. `server/30` deploying means `server/28`'s pagination is live too). Each `server/N` tag pushed via `release-firebase.sh` triggers a deploy, so a tag existing ≈ deployed — but confirm with the run list.
+- **Android — what version is on which track:** the `play-track-log` issue (label `play-track-log`, currently #861) **body** holds the latest snapshot (internal / alpha / beta / production → versionName). Releases only ever reach the **internal** track; an empty `production` row means there is no public production release (the normal state for this repo).
+- **A live config flag's value** (e.g. `resolvedOnCloseEnabled`) is in Firestore `configCurrent/current` — it is **not** knowable from the repo at all. Ask the user or read the config; never infer it from a doc that says "off by default."
+
+When a memory or doc header conflicts with these sources, the sources win — and fix the stale doc/memory in the same pass (that's what PR #947 did for the resolved-notification status).
+
 ### Play Store listing assets (icon, feature graphic, screenshots)
 
 Uploading store-listing graphics is a **manual Play Console step** — the release workflow only ships the AAB + `whatsnew/`, never images. The procedure is the **`play-store-assets` skill** (`/play-store-assets`); read it before touching store assets. Shipped 2026-06-11 in PRs #882 (icon + feature graphic), #883 (generators + skill + staging), #884 (screenshots promoted to distribution).


### PR DESCRIPTION
Captures the two reusable lessons from the 2026-06-28 session (the iOS-parity slices themselves were already documented in-flight via the plan doc + the resolved-notification correction in #947).

## CLAUDE.md — "Determining what's actually deployed / live"
A new note on verifying deploy/release state from **authoritative sources**, not memory or a doc's `Status:` header (both drift):
- **Server:** `gh run list --workflow=firebase-deploy.yml` → latest `success` = the live `server/N` (deploys are cumulative).
- **Android tracks:** the `play-track-log` issue (#861) body.
- **Live config flags:** Firestore `configCurrent/current` — not knowable from the repo; ask/read, don't infer from "off by default."

Added because an agent twice reported stale production state to the user this session — claimed `server/28` needed deploying when it had been live since 2026-06-10, and called the resolved-notification "parked" when its flag had been on since 2026-06-22.

## PRESENTATION_MODEL_REALIZATION.md — config-constant sharing rule
The complement to ADR-031's "shared emits typed state, never user-visible strings": **locale-invariant config (URLs, thresholds, IDs) DOES belong in shared `domain`** as a single-source constant, not duplicated per-platform. Test: *would a translator ever change it?* Canonical: `AppLinks.PRIVACY_POLICY_URL` (#946). Also reconciled the Phase 5 status header — every clean iOS-only parity slice is shipped (#939–#946); iOS now has full verifiable parity across all five surfaces.

Memory entries (iOS tracker, no-walk-away/bounded-watcher, the two stale deploy-state memories) were corrected in the same pass.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)