### PR TITLE
docs: ADR-032 cross-platform UI fidelity tiers + per-surface classification

### DIFF
--- a/AndroidGarage/docs/DECISIONS.md
+++ b/AndroidGarage/docs/DECISIONS.md
@@ -1665,6 +1665,8 @@ Until now this intent existed only implicitly, scattered across mechanical "mirr
 - Not matching platform-specific affordances 1:1 (Android's nav rail / 3-pane has no iOS equivalent; iOS's interactive swipe-back has no Android equivalent).
 - Not simultaneous release — platforms version independently (`android/N`, `ios/N`).
 
+> **Refined by [ADR-032](#adr-032).** The blanket "not pixel-identical" above is too coarse — some surfaces (the door visualization, state colors) *are* brand-locked, while chrome fully diverges. ADR-032 replaces this single principle with four **fidelity tiers** (Identity / Convergent / Native-idiomatic / Platform-exclusive) and a decision rule; the per-surface classification lives in [`UI_FIDELITY_TIERS.md`](./UI_FIDELITY_TIERS.md).
+
 ### Current deliberate gaps (north star ≠ current state)
 
 iOS is mid-build; these are known, tracked in [`PENDING_FOLLOWUPS.md`](./PENDING_FOLLOWUPS.md), and are not violations of this ADR:
@@ -1801,3 +1803,67 @@ Principles:
 - [`PRESENTATION_MODEL_REALIZATION.md`](./PRESENTATION_MODEL_REALIZATION.md) — the phased plan, slice checklist, and parity-gap inventory.
 - Dormant scaffolding: `presentation-model/.../{HomeScreenState,DoorHistoryScreenState,ProfileScreenState}.kt`.
 - Mappers to relocate: `androidApp/.../ui/home/{HomeMapper,HomeStatusFormatter,DoorWarning}.kt`, `androidApp/.../ui/history/HistoryMapper.kt`.
+
+---
+
+## ADR-032: Cross-platform UI fidelity tiers — how much each surface should match across Android and iOS
+
+### Status
+
+Accepted — 2026-06-28. Refines ADR-029. Per-surface classification table: [`UI_FIDELITY_TIERS.md`](./UI_FIDELITY_TIERS.md).
+
+### Context
+
+ADR-029 stated the parity *principle* — capability parity is the north star, UI is platform-native, one shared "Garage" identity spans both — and a blanket "we do NOT pursue pixel-identical screens." That blanket is too coarse. In practice the door-status visualization and the door-state colors were always meant to be **brand-locked** (a different color literally means a different door state), while the navigation chrome was always meant to **fully diverge** (tab bar vs nav rail / 3-pane). Most screens sit *between* those: the same sections, data, and label-meaning, rendered with native styling.
+
+Without a stated spectrum, every new feature reopens an ad-hoc "how closely should iOS match Android here?" debate, and reviewers have no shared vocabulary for "this should match to the pixel" vs "this should look native." ADR-029's single principle needs a **classification lens** that says, for any given element, *how much* fidelity we owe and *which shared layer* enforces it.
+
+This ADR adds that lens. It does **not** introduce new infrastructure — the tiers map 1:1 onto the layers we already have (shared constants, the `presentation-model` of ADR-031, `domain`/`usecase`, and "no sharing").
+
+### Decision
+
+Classify every UI element into one of four **fidelity tiers**. For any element, apply the decision rule top-down — **first match wins**:
+
+1. **Does it carry brand identity, or does *looking different mean something different*?** → **Tier 1 — Identity (brand-locked).**
+2. **Is it content whose *structure* should match but whose styling can be native?** → **Tier 2 — Convergent.**
+3. **Is it navigation / chrome / a system integration with a strong OS idiom?** → **Tier 3 — Native-idiomatic.**
+4. **Is it genuinely one-platform, by *deliberate* decision?** → **Tier 4 — Platform-exclusive.**
+
+**Tie-breaker** (from ADR-029 §4): when torn between two adjacent tiers, prefer the **more-shared** one (push the logic/state down) unless a platform idiom clearly serves the user better. A single surface may be **split** across tiers — a status pill is Tier 1 in *meaning + color* but Tier 2 in its capsule chrome; the tab *set* is Tier 1 but its *rendering* is Tier 3.
+
+#### The four tiers
+
+| Tier | Name | Fidelity owed | Enforcing layer | Examples |
+|---|---|---|---|---|
+| **1** | **Identity (brand-locked)** | **Visually equivalent**, not literally pixel-matched — same shape, palette, icon family, proportions, and color→meaning. Native fonts/densities still differ. | Shared **constants** in `domain` (geometry, palette, door-offset positions — the `AppLinks` pattern) + a stated visual contract. | Door-status visualization; door-state colors (closed / open / opening-too-long / unknown); pill & warning *meaning + color*; app icon; brand naming; the tab *set*. |
+| **2** | **Convergent** | Same sections, order, data, and label-*meaning*; styling adopts platform norms ("mostly a pixel match, local styles allowed"). | Shared **`presentation-model`** typed state (ADR-031); each UI formats strings + picks card-vs-`List` chrome locally. | Home status-card information architecture; "Since · duration" line; alert banners; History day-grouping + rows; Settings *content* (account, About, snooze, privacy). |
+| **3** | **Native-idiomatic** | Platform *form* deliberately diverges; *logical structure + semantics* are shared. | Shared **`domain`/`usecase`** semantics; per-platform UI. No shared *display*. | Tab bar (iOS) vs nav rail / bottom-nav / 3-pane (Android); `.sheet` vs `ModalBottomSheet`; iOS Settings `List` vs Android sections; swipe-back vs predictive-back; safe-area vs edge-to-edge insets; notification presentation. |
+| **4** | **Platform-exclusive** | Exists on one platform only, by an **explicit** decision — *not* "only built once" (that is a parity *gap*, a Tier 1–3 item unported). | None. Recorded as an exception (here + in [`UI_FIDELITY_TIERS.md`](./UI_FIDELITY_TIERS.md)). | Android adaptive 3-pane / nav rail; iOS interactive swipe-back; API-33 clipboard `EXTRA_IS_SENSITIVE` redaction; a future widget / watch surface. |
+
+#### "Brand-locked" ≠ "pixel-perfect"
+
+Tier 1 aims for **visual equivalence across two rendering engines**, not byte-identical pixels — native font metrics, text layout, and display densities differ and that is fine. The lock is on *shape, palette, icon family, proportions, and the color→meaning contract*. The mechanism is **shared constants**, not a shared renderer: geometry/palette/offsets live once in `domain` (`AppLinks.PRIVACY_POLICY_URL` is the canonical shared-config example; door geometry/palette are the next candidates), so the two platforms render the same source numbers. The literal-pixel interpretation was explicitly rejected (2026-06-28) — it fights native typography and is unverifiable on iOS.
+
+#### Parity gap vs. platform-exclusive (Tier 4) — keep them distinct
+
+- A **parity gap** is a Tier 1–3 element that *should* exist on both but is currently on one (iOS mid-build). It is tracked to be closed (`PENDING_FOLLOWUPS.md`, the realization plan's inventory). Not a Tier 4.
+- **Tier 4** is a *deliberate end state*: we chose, or the platform forces, that it lives on one side only. It must be recorded with its reason. Mislabeling a gap as Tier 4 silently accepts drift.
+
+### Consequences
+
+- **Reviewers get shared vocabulary.** An iOS PR is reviewed against its tier: Tier 1 → "does it read as the same brand / same state?"; Tier 2 → "same structure + data, native styling OK"; Tier 3 → "is it idiomatic, and is the *meaning* shared?"; Tier 4 → "is the exception recorded?"
+- **The new-feature checklist gains a step:** classify each new surface, then build it through that tier's enforcing layer (Tier 1 → shared constant; Tier 2 → presentation-model slice; Tier 3 → shared semantics + native UI; Tier 4 → record the exception).
+- **The classification is a living `reference` doc** ([`UI_FIDELITY_TIERS.md`](./UI_FIDELITY_TIERS.md)), kept in sync as screens are added — not frozen in this ADR.
+- No new infrastructure or CI gate; this is a lens over existing layers. (A future lint could assert "no shared user-visible strings" and "Tier 1 constants live in `domain`," but is not built yet.)
+
+### When this decision might change
+
+- If a fifth distinct fidelity posture emerges that none of the four tiers expresses, add it here.
+- If the product deliberately splits into materially different iOS vs Android experiences (not anticipated; would also revise ADR-029).
+
+### References
+
+- ADR-029 — the parity principle this refines (capability parity, platform-native, shared identity).
+- ADR-031 + [`PRESENTATION_MODEL_REALIZATION.md`](./PRESENTATION_MODEL_REALIZATION.md) — the Tier-2 enforcing layer (shared typed display state).
+- [`UI_FIDELITY_TIERS.md`](./UI_FIDELITY_TIERS.md) — the per-surface classification table (kept in sync with the screens).
+- The shared-constant rule (Tier 1 mechanism): `PRESENTATION_MODEL_REALIZATION.md` § Architectural rules, "locale-invariant config belongs in shared"; canonical `domain/.../model/AppLinks.kt`.

--- a/AndroidGarage/docs/UI_FIDELITY_TIERS.md
+++ b/AndroidGarage/docs/UI_FIDELITY_TIERS.md
@@ -1,0 +1,133 @@
+---
+category: reference
+status: active
+last_verified: 2026-06-28
+---
+
+# UI fidelity tiers — per-surface classification
+
+Which Android↔iOS surfaces should **match to the (visual) pixel**, which should
+**converge in structure but style natively**, which should **adopt the OS idiom**,
+and which are **deliberately one-platform**.
+
+The four tiers, the decision rule, and the rationale are owned by
+**[ADR-032](./DECISIONS.md#adr-032)** (which refines [ADR-029](./DECISIONS.md#adr-029)).
+This doc is the **living classification** — it stays in sync with the screens as
+they're built. When you add or change a surface, classify it here.
+
+## Quick lookup — the decision rule
+
+For any UI element, apply top-down, **first match wins**:
+
+1. Carries brand identity, or **looks different ⇒ means different**? → **Tier 1 — Identity (brand-locked)**
+2. Content whose **structure** should match but styling can be native? → **Tier 2 — Convergent**
+3. Navigation / chrome / system integration with a strong OS idiom? → **Tier 3 — Native-idiomatic**
+4. Genuinely one-platform, by **deliberate** decision? → **Tier 4 — Platform-exclusive**
+
+Tie-breaker: when torn between adjacent tiers, prefer the **more-shared** one unless
+a platform idiom clearly serves the user better. A surface may **split** across tiers.
+
+| Tier | Owed | Enforcing layer |
+|---|---|---|
+| **1 Identity** | Visually equivalent (shape/palette/icon/proportions/color→meaning); *not* literal pixels | Shared **constants** in `domain` + visual contract |
+| **2 Convergent** | Same sections/order/data/label-meaning; native styling | Shared **`presentation-model`** typed state (ADR-031) |
+| **3 Native-idiomatic** | Platform form diverges; semantics shared | Shared **`domain`/`usecase`**; per-platform UI |
+| **4 Platform-exclusive** | One platform, deliberate end state | None — recorded exception |
+
+> **Parity gap ≠ Tier 4.** A Tier 1–3 element that exists on only one platform because
+> iOS is mid-build is a *gap to close* (tracked in
+> [`PENDING_FOLLOWUPS.md`](./PENDING_FOLLOWUPS.md) + the realization plan's inventory),
+> **not** a Tier 4 exception. Tier 4 is a deliberate "one platform, on purpose."
+
+## Cross-cutting
+
+| Surface / element | Tier | Notes |
+|---|---|---|
+| Door-status visualization (canvas geometry, panel layout, proportions) | **1** | Brand through-line. Geometry constants are the next shared-constant candidate (`GarageDoorCanvas.swift` ↔ `AnimatableGarageDoor.kt` currently duplicate them). |
+| Door-state color semantics (closed / open / opening-too-long / unknown) | **1** | Color **is** meaning; must not drift. `DoorPalette` (iOS) mirrors Android `Color.kt` by hand today → candidate to share. |
+| App icon, feature graphic, brand naming ("Garage") | **1** | Identity assets. See the `play-store-assets` skill + `distribution/playstore/`. |
+| Tab **set** (Home / History / Profile / Functions / Diagnostics) | **1** | The *which-tabs* is identity (ADR-029 §3). |
+| Tab **rendering** (iOS `TabView` vs Android bottom-nav / nav rail / 3-pane) | **3** | Platform idiom; adaptive layout is Android-only (see Tier 4 below). |
+| Theme tokens (color roles, typography scale, spacing) | **2** | `iosApp/Core/Theme/` mirrors `androidApp/.../ui/theme/`; same role meanings, native type. |
+| Navigation chrome (sheets, back gesture, modal presentation) | **3** | `.sheet` vs `ModalBottomSheet`; swipe-back vs predictive-back. |
+| Window insets / safe area (edge-to-edge vs safe-area) | **3** | Platform layout idiom. Android `WindowInsets.safeDrawing`; iOS safe-area. |
+| Notification presentation (channels/heads-up vs `UNUserNotificationCenter`) | **3** | Shared = the door-state semantics + copy *intent*; rendering is per-OS. See [`docs/NOTIFICATION_RELIABILITY.md`](../../docs/NOTIFICATION_RELIABILITY.md). |
+| Status/warning **copy** intent | **1 (intent) / 2 (string)** | Meaning is identity; the localized string is per-UI (ADR-031 "no shared user-visible strings"). |
+
+## Home
+
+| Surface / element | Tier | Notes |
+|---|---|---|
+| Door visualization (static state render) | **1** | See cross-cutting. iOS shipped #919. |
+| Door **animation** trajectory + once-per-event replay | **1 (intent), deferred** | Identity-level, but **verification-gap deferred** — trajectory/replay can't be CLI/snapshot-verified on iOS. See realization plan § Door-canvas animation + ADR-025. |
+| Status pill, check-in pill, button-health pill — **meaning + color** | **1** | Device-availability grammar; antenna/antenna-slash + state colors mirror Android. |
+| Pill capsule **chrome** (shape, padding, typography) | **2** | Native styling of the shell. |
+| Status-card information architecture | **2** | Same sections/data; card vs `List` styling local. |
+| "Since · duration" status line | **2** | Shared `SinceStatus` / `ElapsedDuration` (P2); clock/duration formatting per-UI. |
+| Alert banners (stale / fetch-error / permission-missing) | **2** | Shared `HomeAlert` + `HomeAlertMapper` (P4); permission probe + escalation copy per-UI. |
+| Info sheets (tap a pill → explanation) | **2 (content) / 3 (sheet idiom)** | Static copy mirrored verbatim; `.sheet` vs `ModalBottomSheet`. |
+| Network-progress diagram | **2, not started** | Optional richness; remote-button-tied. |
+
+## History
+
+| Surface / element | Tier | Notes |
+|---|---|---|
+| Day grouping, door icons, durations, transit/anomaly/misaligned tags, empty-state | **2** | Shared `DoorEvent→HistoryDay` pipeline + typed state (P3); 60-case test in commonTest. |
+| Day/time/duration **formatting** | **2 (per-UI)** | Trivial `%60` decomposition stays per-UI (P3 rationale); the gnarly merge/group is shared. |
+| Load-more (scroll-to-end pagination) | **2, deferred** | iOS renders the current `recentDoorEvents` window; scroll trigger is a P3 follow-up. |
+
+## Settings / Profile
+
+| Surface / element | Tier | Notes |
+|---|---|---|
+| 3-tab restructure + gated Developer section | **2 (structure) / 3 (Settings idiom)** | Same content; iOS `List`/sectioned-settings idiom vs Android sections. |
+| Account name/email, About/version | **2** | Shared data; native row styling. |
+| Tap-to-copy version/build/package | **2 (behavior) / 3 (clipboard idiom)** | iOS `UIPasteboard` + "Copied ✓"; Android `LocalClipboardManager` + API-33 Toast gate. |
+| Snooze controls + typed failure messages | **2** | Shared `SnoozeAction.Failed` cases; per-UI verbatim copy. |
+| Snooze permission state (denied → tap-to-enable) | **2 (state) / 3 (permission flow)** | Shared "granted" boolean; native permission request. |
+| Privacy-policy link | **1 (URL) / 3 (link affordance)** | URL is a **shared constant** `AppLinks.PRIVACY_POLICY_URL` (canonical Tier-1-config example); the link/`Link` affordance is native. |
+| App Store / Play Store link | **3, deferred** | Per-platform store; iOS link waits on a published listing. |
+
+## Functions
+
+| Surface / element | Tier | Notes |
+|---|---|---|
+| "Developers only" warning | **1 (intent) / 2 (string)** | Verbatim `function_list_warning`. |
+| Test-notification sandbox (topic copy/subscribe/change) | **2** | Diagnostic tool; shared `testNotificationState`. |
+| Sign in/out | **4 (intentionally skipped on iOS)** | Settings owns auth; the screen is `functionListAccess`-gated, so a sign-in button is unreachable and sign-out pops you out — platform-native structure. |
+| Copy auth token | **2, not started** | Needs an iOS token-fetch bridge + pasteboard-sensitivity decision. |
+
+## Diagnostics
+
+| Surface / element | Tier | Notes |
+|---|---|---|
+| Log buffer list, lifetime counters, "Clear all" | **2** | Shared diagnostics state; native list/button styling. |
+| Export CSV | **2, not started** | Needs a shared CSV-content API + iOS share sheet (shared change → both DI graphs). |
+| Copy auth token | **2, not started** | Same bridge gap as Functions. |
+
+## Tier 4 — deliberate platform-exclusive (recorded exceptions)
+
+These are **not** parity gaps; they are end states, kept on one platform on purpose.
+
+| Element | Platform | Why exclusive |
+|---|---|---|
+| Adaptive 3-pane / navigation rail | Android | No iOS equivalent; iPad `NavigationSplitView` is a *separate* future item, deprioritized — see [`PENDING_FOLLOWUPS.md`](./PENDING_FOLLOWUPS.md) § 1. |
+| Interactive swipe-back gesture | iOS | Native iOS affordance; Android uses predictive-back. |
+| Clipboard `EXTRA_IS_SENSITIVE` redaction (API 33+) | Android | OS-specific redaction flag; iOS pasteboard has no clean equivalent (decision pending if copy-token lands). |
+
+## How to use this when building a surface
+
+1. Classify the surface with the decision rule above (it may split across tiers).
+2. Build it through that tier's **enforcing layer**:
+   - Tier 1 → put the locale-invariant value in a shared `domain` constant; match the visual.
+   - Tier 2 → a `presentation-model` slice (typed state + shared test in commonTest), rendered per-UI. Follow the [realization plan](./PRESENTATION_MODEL_REALIZATION.md) checklist.
+   - Tier 3 → share the `domain`/`usecase` semantics; build the UI natively.
+   - Tier 4 → add a row to the table above with the reason.
+3. Update this doc + `last_verified` in the same PR.
+
+## References
+
+- [ADR-032](./DECISIONS.md#adr-032) — the tiers, decision rule, and rationale (canonical).
+- [ADR-029](./DECISIONS.md#adr-029) — the parity principle this operationalizes.
+- [ADR-031](./DECISIONS.md#adr-031) + [`PRESENTATION_MODEL_REALIZATION.md`](./PRESENTATION_MODEL_REALIZATION.md) — the Tier-2 layer + parity-gap inventory.
+- [`PENDING_FOLLOWUPS.md`](./PENDING_FOLLOWUPS.md) § 1 — iOS construction status + open parity gaps.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -108,6 +108,7 @@ When you need to find or update a fact, this table tells you which doc owns it. 
 | CI architecture | `CLAUDE.md` § CI Architecture |
 | Release & deploy strategy (layered principles + conformance audit) | `docs/RELEASE_STRATEGY.md` |
 | FCM push-data & notification reliability (findings + proposed fixes) | `docs/NOTIFICATION_RELIABILITY.md` |
+| Cross-platform UI fidelity (how much each Android↔iOS surface should match) | `AndroidGarage/docs/DECISIONS.md` ADR-032 (tiers + rule) + `AndroidGarage/docs/UI_FIDELITY_TIERS.md` (per-surface table) |
 | Agent design + doc taxonomy | This file |
 
 ### Android


### PR DESCRIPTION
## Why

We had no documented strategy for *how much* each Android↔iOS screen should match. ADR-029 stated only a blanket "platform-native, **not** pixel-identical" — too coarse: the door visualization and state-colors were always meant to be brand-locked (a different color literally means a different door state), while navigation chrome was always meant to fully diverge. Most surfaces sit between. Reviewers had no shared vocabulary for "match to the pixel" vs "look native."

## What

A **four-tier fidelity model** + a top-down decision rule, mapped 1:1 onto the shared layers we already have (no new infrastructure):

| Tier | Owed | Enforcing layer |
|---|---|---|
| **1 Identity (brand-locked)** | Visually equivalent — shape/palette/icon/proportions/color→meaning; *not* literal pixels | Shared **constants** in `domain` (`AppLinks` pattern) |
| **2 Convergent** | Same sections/data/label-meaning; native styling | Shared **`presentation-model`** typed state (ADR-031) |
| **3 Native-idiomatic** | Platform form diverges; semantics shared | Shared **`domain`/`usecase`**; per-platform UI |
| **4 Platform-exclusive** | One platform, deliberate end state | None — recorded exception |

Decision rule (first match wins): identity/looks-different-means-different → 1; structure-matches-styling-native → 2; OS-idiom chrome → 3; deliberate one-platform → 4. Tie-breaker: prefer the more-shared tier. Surfaces may split (a pill is Tier 1 in meaning/color, Tier 2 in chrome).

**Decided this session:** Tier 1 = *brand-locked / visually equivalent* (not literal pixels — that fights native typography and is unverifiable on iOS). Home = new ADR-032 + a companion living `reference` table.

## Files
- **`AndroidGarage/docs/DECISIONS.md`** — ADR-032 (tiers, rule, tie-breaker, parity-gap-vs-Tier-4 distinction); ADR-029 gains a "Refined by ADR-032" pointer.
- **`AndroidGarage/docs/UI_FIDELITY_TIERS.md`** (new `reference`) — per-surface classification table for every screen (Home / History / Settings / Functions / Diagnostics) + cross-cutting chrome; kept in sync as screens are added.
- **`docs/AGENTS.md`** — new cross-cutting source-of-truth row.

## Verification
- Docs-only → Android/Firebase CI fast-path; `scripts/check-doc-frontmatter.sh` passes locally (exit 0).
- All relative link targets confirmed present; `#adr-NNN` short anchors match existing repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)