### PR TITLE
docs: correct 4 stale UI-fidelity rows + record parity-audit gaps

### DIFF
--- a/AndroidGarage/docs/PENDING_FOLLOWUPS.md
+++ b/AndroidGarage/docs/PENDING_FOLLOWUPS.md
@@ -1,7 +1,7 @@
 ---
 category: plan
 status: active
-last_verified: 2026-06-24
+last_verified: 2026-06-28
 ---
 
 > **Last update 2026-05-13:** iOS Phase 38A fully complete — `NativeComponent` DI graph runtime-verified via `NativeComponentTest` (40/40 pass on `iosSimulatorArm64`, PR #826). Phase 38B–G remain blocked on user setup. User-action checklist added as the first subsection below so the user-blocked moves are visible without scrolling.
@@ -170,6 +170,31 @@ Ordered by leverage. Phases 1–2 are verification of already-built code; Phases
 - No `/deleteMyData` endpoint (fine for single-user; GDPR-relevant if ever multi-tenant).
 
 **Picking one to ship:** M6 (allowBackup) and M13 (`set -e` in release scripts) are both single-file, single-PR fixes. M14 (dependabot.yml) is a small additive config that unblocks future Dependabot PRs. The other Mediums are larger or require coordination (M11 = flash encryption rollout; M2 = secrets migration + Android client change).
+
+### 4. iOS ↔ Android parity-audit findings (2026-06-28)
+
+A 13-agent screen-by-screen parity audit (6 auditors + adversarial verifiers + synthesis, all findings file:line-verified) classified every screen against the [ADR-032](./DECISIONS.md#adr-032) fidelity tiers ([`UI_FIDELITY_TIERS.md`](./UI_FIDELITY_TIERS.md)). Overall verdict: **parity is fundamentally healthy** — the meaning-bearing layers are genuinely shared (History pipeline, snooze typed-failures, info-sheet copy, test-notification sandbox, access tri-states, door semantics). The discrete gaps below are each a self-contained PR. **Already fixed in the same batch:** the one HIGH finding — iOS Home showed an inert remote button when signed out with no Home sign-in path — was resolved by auth-gating iOS Home (consume the shared `AuthState`; signed-out → sign-in CTA + button hidden; redundant Account row dropped).
+
+**Tier 1 — identity (highest leverage):**
+- **Door constants shared-hoist (systemic).** Geometry (viewport 300, frame/panel/handle, `clipInset` — *derived* on Android, hardcoded `22` on iOS), the 12 light/dark door-state hex pairs, and the open/close offsets + `DoorPosition→offset/overlay/colorState` mapping are **hand-duplicated** in Kotlin (`GarageDoorCanvas.kt`, `Color.kt`, `AnimatableGarageDoor.kt`, `DoorStatusColorScheme.kt`) and Swift (`GarageDoorCanvas.swift`) with no guard. They match by coincidence; an edit on one side silently drifts the brand on the other. Hoist to shared `domain` constants + a pure mapping usecase (the `AppLinks` pattern), consumed by both. This is the cleanest engineering win.
+- **Device-availability pill icon family diverges.** Android `Sensors`/`SensorsOff` vs iOS SF `antenna.radiowaves…(.slash)`. Pick one visually-equivalent family; record the cross-platform icon-name pairing.
+
+**Tier 2 — convergent gaps (mostly iOS-side):**
+- **Copy auth token** absent on iOS (Functions + Diagnostics). Needs a shared token-fetch usecase + iOS `UIPasteboard` write + an iOS sensitivity posture (no clean `EXTRA_IS_SENSITIVE` equivalent).
+- **Export CSV** absent on iOS Diagnostics. Needs a shared CSV-content usecase + a native share sheet (`UIActivityViewController`/`ShareLink`).
+- **History stale banner + reset-FCM recovery** absent on iOS. Route through a shared `HistoryAlert` mapper (mirroring `HomeAlertMapper`) so the show/hide decision can't diverge.
+- **History load-more pagination** absent on iOS. The shared VM already exposes `paginationState` + `fetchOlderDoorEvents()` — consume them + add a last-row `onAppear` trigger + native footer.
+- **About build-timestamp copy row** absent on iOS (Android exposes 4 copyable values; iOS has 3). Source from a shared `AppVersion` value object / the bundle.
+- **`ProfileScreenState` dead slice.** The shared `presentation-model` slice exists but is consumed nowhere; both platforms hand-roll the account+snooze projection. Realize it as the shared slice both consume, or delete it as dead code.
+- **Diagnostics counter row order drift.** Android renders FCM-subscribe before FCM-received; iOS (and the shared VM field order) is the reverse. Add a shared ordered-counter display model (typed ids, labels per-UI) and align Android.
+
+**Tier 2/3 — low-severity polish:**
+- iOS warning tint is a literal `Color.red` placeholder (`GarageColors.statusWarning`) vs Android's M3 error-container role — map to the iOS theme equivalent.
+- Label drift: Home section header "Remote button" (iOS) vs "Remote control" (Android, and iOS's *own* info-sheet title); Functions chrome title "Function list" (Android) vs "Functions" (iOS). Pick one each (strings stay per-UI per ADR-031; meaning must align).
+- iOS Diagnostics clear-all confirm drops the scope + irreversibility clauses Android states.
+- Dead Android `ErrorCard` in `DoorHistoryContent` (the VM always writes `Complete(prev)`, never `Error`) — delete or wire.
+
+**Doc corrections from the audit (shipped with this entry):** `UI_FIDELITY_TIERS.md` had 4 stale rows — tab-set enumerated 5 tabs (real app ships 3: Home/History/Settings), the pill note wrongly said the icon "mirrors Android," the theme row claimed iOS "mirrors" the Android scheme (it's a 4-color stub on system accent), and History had no banner row. All corrected.
 
 <!-- Historical reference: original Phase 1/2/3 migration plan now in Done. -->
 

--- a/AndroidGarage/docs/UI_FIDELITY_TIERS.md
+++ b/AndroidGarage/docs/UI_FIDELITY_TIERS.md
@@ -46,9 +46,9 @@ a platform idiom clearly serves the user better. A surface may **split** across 
 | Door-status visualization (canvas geometry, panel layout, proportions) | **1** | Brand through-line. Geometry constants are the next shared-constant candidate (`GarageDoorCanvas.swift` ↔ `AnimatableGarageDoor.kt` currently duplicate them). |
 | Door-state color semantics (closed / open / opening-too-long / unknown) | **1** | Color **is** meaning; must not drift. `DoorPalette` (iOS) mirrors Android `Color.kt` by hand today → candidate to share. |
 | App icon, feature graphic, brand naming ("Garage") | **1** | Identity assets. See the `play-store-assets` skill + `distribution/playstore/`. |
-| Tab **set** (Home / History / Profile / Functions / Diagnostics) | **1** | The *which-tabs* is identity (ADR-029 §3). |
+| Tab **set** (Home / History / Settings) | **1** | The *which-tabs* is identity (ADR-029 §3). Both ship **3** top-level tabs; Functions + Diagnostics are `developerAccess`-gated **sub-screens of Settings** (Android rows / iOS `NavigationLink`s), not tabs. |
 | Tab **rendering** (iOS `TabView` vs Android bottom-nav / nav rail / 3-pane) | **3** | Platform idiom; adaptive layout is Android-only (see Tier 4 below). |
-| Theme tokens (color roles, typography scale, spacing) | **2** | `iosApp/Core/Theme/` mirrors `androidApp/.../ui/theme/`; same role meanings, native type. |
+| Theme tokens (color roles, typography scale, spacing) | **2** | iOS intentionally uses **system semantic colors + system accent**, *not* a port of Android's ~30-role scheme: `iosApp/Core/Theme/GarageColors.swift` is a 4-color stub (`statusOk`/`statusOpen`/`statusWarning`/`cardBackground`) and applies no `.tint`. Only the door-state colors (above) are brand-locked Tier 1. If the Android pastel-blue primary (`#A6C8FF`) is brand, escalate that single token to Tier 1 (shared constant) + apply on iOS. |
 | Navigation chrome (sheets, back gesture, modal presentation) | **3** | `.sheet` vs `ModalBottomSheet`; swipe-back vs predictive-back. |
 | Window insets / safe area (edge-to-edge vs safe-area) | **3** | Platform layout idiom. Android `WindowInsets.safeDrawing`; iOS safe-area. |
 | Notification presentation (channels/heads-up vs `UNUserNotificationCenter`) | **3** | Shared = the door-state semantics + copy *intent*; rendering is per-OS. See [`docs/NOTIFICATION_RELIABILITY.md`](../../docs/NOTIFICATION_RELIABILITY.md). |
@@ -60,7 +60,7 @@ a platform idiom clearly serves the user better. A surface may **split** across 
 |---|---|---|
 | Door visualization (static state render) | **1** | See cross-cutting. iOS shipped #919. |
 | Door **animation** trajectory + once-per-event replay | **1 (intent), deferred** | Identity-level, but **verification-gap deferred** — trajectory/replay can't be CLI/snapshot-verified on iOS. See realization plan § Door-canvas animation + ADR-025. |
-| Status pill, check-in pill, button-health pill — **meaning + color** | **1** | Device-availability grammar; antenna/antenna-slash + state colors mirror Android. |
+| Status pill, check-in pill, button-health pill — **meaning + color** | **1** | Device-availability grammar + state colors are brand-locked. ⚠️ Icon **family currently diverges**: Android uses Material `Sensors`/`SensorsOff`, iOS uses SF `antenna.radiowaves…(.slash)` — a Tier-1 drift to reconcile (pick one visually-equivalent family; tracked in PENDING_FOLLOWUPS § 4). Other glyphs (lock, sync, question-circle) + color→meaning already agree. |
 | Pill capsule **chrome** (shape, padding, typography) | **2** | Native styling of the shell. |
 | Status-card information architecture | **2** | Same sections/data; card vs `List` styling local. |
 | "Since · duration" status line | **2** | Shared `SinceStatus` / `ElapsedDuration` (P2); clock/duration formatting per-UI. |
@@ -74,7 +74,8 @@ a platform idiom clearly serves the user better. A surface may **split** across 
 |---|---|---|
 | Day grouping, door icons, durations, transit/anomaly/misaligned tags, empty-state | **2** | Shared `DoorEvent→HistoryDay` pipeline + typed state (P3); 60-case test in commonTest. |
 | Day/time/duration **formatting** | **2 (per-UI)** | Trivial `%60` decomposition stays per-UI (P3 rationale); the gnarly merge/group is shared. |
-| Load-more (scroll-to-end pagination) | **2, deferred** | iOS renders the current `recentDoorEvents` window; scroll trigger is a P3 follow-up. |
+| Alert banner (stale check-in → "Not receiving updates" + reset-FCM Retry) | **2, iOS gap** | Android renders it above the list (`DoorHistoryContent.kt`); iOS has none, so a stale iOS user gets no warning + no recovery. Route via a shared `HistoryAlert` mapper (mirroring `HomeAlertMapper`). Tracked in PENDING_FOLLOWUPS § 4. |
+| Load-more (scroll-to-end pagination) | **2, deferred** | iOS renders the current `recentDoorEvents` window; the shared VM already exposes `paginationState` + `fetchOlderDoorEvents()` — iOS just needs to consume them. P3 follow-up; tracked in PENDING_FOLLOWUPS § 4. |
 
 ## Settings / Profile
 


### PR DESCRIPTION
Follow-up to the 13-agent Android↔iOS screen parity audit (ADR-032 tiers, all findings file:line-verified after an adversarial pass).

## Doc corrections — `UI_FIDELITY_TIERS.md` had 4 stale rows
- **Tab set** enumerated 5 tabs; the app ships **3** (Home / History / Settings) — Functions + Diagnostics are `developerAccess`-gated **sub-screens of Settings**, not tabs.
- **Pill icon note** claimed the availability icon "mirrors Android"; Android uses Material `Sensors`/`SensorsOff`, iOS uses SF `antenna…` — they **diverge** (a Tier-1 drift).
- **Theme-tokens row** claimed iOS "mirrors" Android's ~30-role scheme; iOS is a 4-color stub on **system accent**. Rewritten.
- **History** had no banner row; added the stale-check-in banner (Tier 2, iOS gap).

## `PENDING_FOLLOWUPS.md` § 4 — verified gaps recorded as discrete PRs
Tier 1: door-constants shared-hoist (systemic — geometry/palette/offsets duplicated with no guard), pill icon-family drift. Tier 2 (iOS-side): copy-auth-token, export-CSV, history stale-banner + reset-FCM, history load-more, build-timestamp row, dead `ProfileScreenState` slice, diagnostics counter order. Plus low-severity polish (warning tint, label drift, clear-all copy, dead Android `ErrorCard`).

Notes the **one HIGH finding** — iOS Home showed an inert remote button when signed out — is **fixed in the same batch** (separate iOS PR, auth-gating Home).

## Verification
Docs-only → CI fast-path; `check-doc-frontmatter.sh` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)