### PR TITLE
feat(ios): drive the live garage-door trajectory (12s slide + spring-settle)

### DIFF
--- a/AndroidGarage/iosApp/Features/Home/GarageDoorCanvas.swift
+++ b/AndroidGarage/iosApp/Features/Home/GarageDoorCanvas.swift
@@ -20,45 +20,77 @@ import SwiftUI
 
 // SwiftUI port of Android's `GarageDoorCanvas.kt` / `GarageIcon.kt` — the
 // animated garage-door visualization that is part of the shared "Garage"
-// identity (ADR-029 § 3). The drawing **geometry** (`GarageDoorGeometry`) and
-// the door-fill **palette** (`GarageDoorPalette`) are now shared `:domain`
-// single sources of truth, consumed by both platforms via SKIE — as is the
-// **animation spec** (`DoorAnimation`: offset constants + the
-// `DoorPosition → offset / overlay / color-state` mappings). The door
-// visualization is now fully shared `:domain`; no hand-mirrored mappings remain.
+// identity (ADR-029 § 3). The drawing **geometry** (`GarageDoorGeometry`), the
+// door-fill **palette** (`GarageDoorPalette`), and the **animation spec**
+// (`DoorAnimation`: offset constants, the `DoorPosition → offset / overlay /
+// color-state` mappings, the live-slide duration, and the
+// `DoorAnimationMemory` replay policy) are all shared `:domain` single sources
+// of truth, consumed by both platforms via SKIE. No hand-mirrored mappings
+// remain.
 //
-// Parity scope (v1): the *visual* — door shape, per-state offset, per-state
-// color (fresh / stale), and the directional / warning overlay. The animation
-// is a simple ease between offsets on state change. The full Android trajectory
-// (a 12 s linear tween for OPENING / CLOSING and a once-per-event "replay from
-// the start" gated by `DoorAnimationMemory`) is a deferred polish pass.
+// Animation (ADR-032 spec-vs-execution split): the *spec* is shared/provable —
+// what the door does (from/target offsets, the 12 s linear OPENING/CLOSING
+// slide, the spring settle on the terminal event, the once-per-event replay).
+// The *execution* is best-effort native — Android drives a Compose `Animatable`
+// + `LaunchedEffect`; iOS drives a SwiftUI `@State` offset + `withAnimation`
+// (below). Both read the identical shared parameters; only the frame-by-frame
+// interpolation engine differs. See `AndroidGarage/docs/DOOR_ANIMATION.md`.
 
 /// Renders the garage door for a [DoorPosition], including the directional /
-/// warning overlay, sized to a 1:1 square. Animates the door panels between
-/// states.
+/// warning overlay, sized to a 1:1 square.
+///
+/// Two modes:
+/// - **Static** (the default — History rows, previews, snapshot gallery): renders
+///   the per-state snapshot offset (`DoorAnimation.staticPositionFor`) with a
+///   gentle ease between states. Deterministic, no live trajectory.
+/// - **Animated** (`animated: true` — the live Home door, the one live surface):
+///   drives the full shared trajectory — a 12 s linear OPENING/CLOSING slide and
+///   a spring settle to the terminal state, replaying the slide from the start
+///   once per motion event. See `AnimatedDoorCanvas`.
 struct GarageDoorView: View {
     let position: DoorPosition
     /// Picks the muted "stale" color variant — mirrors Android's
     /// `HomeStatusDisplay.isStale` (which is the device check-in staleness).
     var isStale: Bool = false
+    /// Drive the full live trajectory instead of a static snapshot. Only the
+    /// live Home door sets this; History rows + previews stay static.
+    var animated: Bool = false
+    /// Server timestamp of the door's last position change — identifies one
+    /// motion event so the slide replays once per event (cold-open / first
+    /// view), not on every re-appearance. Only consulted when `animated`.
+    var lastChangeTimeSeconds: Int64?
 
     @Environment(\.colorScheme) private var scheme
+    /// Shared replay memory (`:domain` `DoorAnimationMemory`), injected at the
+    /// app root (`MainScreen`). Mirrors Android's `LocalDoorAnimationMemory`.
+    @Environment(\.doorAnimationMemory) private var memory
 
     var body: some View {
-        let offset = CGFloat(DoorAnimation.shared.staticPositionFor(doorPosition: position))
         let rgb = DoorPalette.doorRGB(for: position, stale: isStale, scheme: scheme)
+        let color = Color(rgb: rgb)
+        let darkColor = Color(rgb: DoorPalette.blendWithBlackHalf(rgb))
         ZStack {
-            GarageDoorCanvas(
-                doorOffset: offset,
-                color: Color(rgb: rgb),
-                darkColor: Color(rgb: DoorPalette.blendWithBlackHalf(rgb))
-            )
-            .animation(.easeInOut(duration: 0.6), value: offset)
-
+            if animated {
+                AnimatedDoorCanvas(
+                    position: position,
+                    lastChangeTimeSeconds: lastChangeTimeSeconds,
+                    memory: memory,
+                    color: color,
+                    darkColor: darkColor
+                )
+            } else {
+                staticCanvas(color: color, darkColor: darkColor)
+            }
             overlay
         }
         .aspectRatio(GarageDoorCanvas.aspectRatio, contentMode: .fit)
         .accessibilityHidden(true) // the status label carries the spoken state
+    }
+
+    private func staticCanvas(color: Color, darkColor: Color) -> some View {
+        let offset = CGFloat(DoorAnimation.shared.staticPositionFor(doorPosition: position))
+        return GarageDoorCanvas(doorOffset: offset, color: color, darkColor: darkColor)
+            .animation(.easeInOut(duration: 0.6), value: offset)
     }
 
     @ViewBuilder private var overlay: some View {
@@ -73,6 +105,89 @@ struct GarageDoorView: View {
             DoorOverlayBadge(systemName: "exclamationmark.triangle.fill", iconScale: 0.6)
         }
     }
+}
+
+/// Drives the live door trajectory in SwiftUI, consuming the shared `:domain`
+/// `DoorAnimation` spec + `DoorAnimationMemory` replay policy (Tier 1, ADR-032).
+/// This is the **execution** layer — best-effort native animation; every
+/// parameter it animates toward is shared and provable.
+///
+/// - First appearance of a not-yet-seen motion event (cold-open / first view):
+///   seed at the `from` end and slide linearly to the target over the shared
+///   `ANIMATION_DURATION_SECONDS`. Re-appearance of the same event snaps.
+/// - A live state change animates from the *current* offset: motion states slide
+///   linearly; terminal/error states settle via a slow no-overshoot spring —
+///   that settle is the "spring shut / spring open" when the real terminal event
+///   arrives over the network mid-slide.
+private struct AnimatedDoorCanvas: View {
+    let position: DoorPosition
+    let lastChangeTimeSeconds: Int64?
+    let memory: DoorAnimationMemory
+    let color: Color
+    let darkColor: Color
+
+    @State private var offset: CGFloat
+
+    init(
+        position: DoorPosition,
+        lastChangeTimeSeconds: Int64?,
+        memory: DoorAnimationMemory,
+        color: Color,
+        darkColor: Color
+    ) {
+        self.position = position
+        self.lastChangeTimeSeconds = lastChangeTimeSeconds
+        self.memory = memory
+        self.color = color
+        self.darkColor = darkColor
+        // Snap-safe default seed = the target. `onAppear` dips to the `from` end
+        // and slides only when this is a newly observed motion event.
+        _offset = State(initialValue: CGFloat(DoorAnimation.shared.targetPositionFor(doorPosition: position)))
+    }
+
+    var body: some View {
+        GarageDoorCanvas(doorOffset: offset, color: color, darkColor: darkColor)
+            .onAppear { seedAndAnimate() }
+            // iOS 16 single-parameter onChange (the two-param form is iOS 17+).
+            .onChange(of: position) { _ in animate(to: position) }
+    }
+
+    private func seedAndAnimate() {
+        let isMotion = !DoorAnimation.shared.useSpringFor(doorPosition: position)
+        let key = DoorMotionKey(
+            doorPosition: position,
+            lastChangeTimeSeconds: lastChangeTimeSeconds.map { KotlinLong(value: $0) }
+        )
+        let replay = isMotion && memory.consumeAnimateFromStart(key: key)
+        guard replay else {
+            offset = CGFloat(DoorAnimation.shared.targetPositionFor(doorPosition: position))
+            return
+        }
+        // Seed at the `from` end (no animation), then slide to target on the next
+        // runloop tick so SwiftUI animates the full slide instead of coalescing
+        // both assignments into the final value.
+        offset = CGFloat(DoorAnimation.shared.fromPositionFor(doorPosition: position))
+        DispatchQueue.main.async {
+            withAnimation(.linear(duration: Self.slideDuration)) {
+                offset = CGFloat(DoorAnimation.shared.targetPositionFor(doorPosition: position))
+            }
+        }
+    }
+
+    private func animate(to position: DoorPosition) {
+        let target = CGFloat(DoorAnimation.shared.targetPositionFor(doorPosition: position))
+        if DoorAnimation.shared.useSpringFor(doorPosition: position) {
+            // Slow, no-overshoot settle — the native analog of Android's
+            // spring(DampingRatioNoBouncy, StiffnessVeryLow). Exact feel is Tier-3
+            // native taste; the fact that terminal states *settle* is shared.
+            withAnimation(.spring(response: 0.6, dampingFraction: 1.0)) { offset = target }
+        } else {
+            withAnimation(.linear(duration: Self.slideDuration)) { offset = target }
+        }
+    }
+
+    /// Shared product-decision slide duration (12 s) read from `:domain`.
+    private static var slideDuration: Double { Double(DoorAnimation.shared.ANIMATION_DURATION_SECONDS) }
 }
 
 /// Pure drawing of the door at a vertical [doorOffset] (proportion of the drawn
@@ -207,6 +322,25 @@ private struct DoorOverlayBadge: View {
             .frame(width: diameter, height: diameter)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+    }
+}
+
+// MARK: - Shared door-animation replay memory (environment)
+
+/// Carries the shared `:domain` `DoorAnimationMemory` (the once-per-event slide
+/// dedup) down the view tree. The **iOS holder lifecycle** — analogous to
+/// Android's `LocalDoorAnimationMemory` `CompositionLocal`: a single instance is
+/// created once at the app root (`MainScreen`, a `@State` so it survives tab
+/// switches and resets on process death) and injected here. The default is a
+/// throwaway instance, harmless because static-mode rendering never consults it.
+private struct DoorAnimationMemoryKey: EnvironmentKey {
+    static let defaultValue = DoorAnimationMemory()
+}
+
+extension EnvironmentValues {
+    var doorAnimationMemory: DoorAnimationMemory {
+        get { self[DoorAnimationMemoryKey.self] }
+        set { self[DoorAnimationMemoryKey.self] = newValue }
     }
 }
 

--- a/AndroidGarage/iosApp/Features/Home/HomeScreen.swift
+++ b/AndroidGarage/iosApp/Features/Home/HomeScreen.swift
@@ -31,6 +31,7 @@ struct HomeScreen: View {
     var body: some View {
         HomeContentView(
             doorPosition: wrapper.doorPosition,
+            lastChangeTimeSeconds: wrapper.lastChangeTimeSeconds,
             sinceLine: wrapper.sinceLine,
             warningText: wrapper.warningText,
             isCheckInStale: wrapper.isCheckInStale,
@@ -52,6 +53,12 @@ struct HomeScreen: View {
 /// `#Preview`s and snapshot gallery capture.
 struct HomeContentView: View {
     let doorPosition: DoorPosition
+    /// Server timestamp of the door's last position change. Threaded to the live
+    /// `GarageDoorView(animated:)` so the open/close slide replays once per
+    /// motion event (cold-open / first view), not on every re-render. `nil` when
+    /// the last-change time is unknown. Mirrors Android's `lastChangeTimeSeconds`
+    /// passed to `GarageIcon`.
+    let lastChangeTimeSeconds: Int64?
     /// Pre-formatted "Since 9:47 AM · 2 hr 14 min" line (resolved from the shared
     /// typed `SinceStatus` in the wrapper); `nil` when the last-change time is
     /// unknown. Mirrors Android's status line; replaces the old raw door message.
@@ -90,6 +97,7 @@ struct HomeContentView: View {
 
     init(
         doorPosition: DoorPosition,
+        lastChangeTimeSeconds: Int64?,
         sinceLine: String?,
         warningText: String?,
         isCheckInStale: Bool,
@@ -104,6 +112,7 @@ struct HomeContentView: View {
         onAlertAction: @escaping (HomeAlertItem.Kind) -> Void
     ) {
         self.doorPosition = doorPosition
+        self.lastChangeTimeSeconds = lastChangeTimeSeconds
         self.sinceLine = sinceLine
         self.warningText = warningText
         self.isCheckInStale = isCheckInStale
@@ -131,9 +140,18 @@ struct HomeContentView: View {
 
             Section {
                 VStack(spacing: GarageSpacing.card) {
-                    GarageDoorView(position: doorPosition, isStale: isCheckInStale)
-                        .frame(height: 160)
-                        .frame(maxWidth: .infinity)
+                    // Live door — the one surface that drives the full shared
+                    // trajectory (12 s linear slide + spring-settle on the
+                    // terminal event), replaying once per motion event keyed by
+                    // `lastChangeTimeSeconds`. History rows stay static.
+                    GarageDoorView(
+                        position: doorPosition,
+                        isStale: isCheckInStale,
+                        animated: true,
+                        lastChangeTimeSeconds: lastChangeTimeSeconds
+                    )
+                    .frame(height: 160)
+                    .frame(maxWidth: .infinity)
                     VStack(spacing: GarageSpacing.tight) {
                         Text(doorPosition.statusLabel)
                             .font(.title2.weight(.semibold))
@@ -425,6 +443,7 @@ private struct HomeInfoSheetView: View {
     NavigationStack {
         HomeContentView(
             doorPosition: .closed,
+            lastChangeTimeSeconds: nil,
             sinceLine: "Since 11:22 AM · 38 min",
             warningText: nil,
             isCheckInStale: true,
@@ -445,6 +464,7 @@ private struct HomeInfoSheetView: View {
     NavigationStack {
         HomeContentView(
             doorPosition: .open,
+            lastChangeTimeSeconds: nil,
             sinceLine: "Since 9:47 AM · 2 hr 14 min",
             warningText: nil,
             isCheckInStale: false,
@@ -465,6 +485,7 @@ private struct HomeInfoSheetView: View {
     NavigationStack {
         HomeContentView(
             doorPosition: .openingTooLong,
+            lastChangeTimeSeconds: nil,
             sinceLine: "Since 12:01 PM · 4 min",
             warningText: "Opening, taking longer than expected",
             isCheckInStale: false,
@@ -485,6 +506,7 @@ private struct HomeInfoSheetView: View {
     NavigationStack {
         HomeContentView(
             doorPosition: .unknown,
+            lastChangeTimeSeconds: nil,
             sinceLine: "Since 8:15 AM · 1 hr 5 min",
             warningText: nil,
             isCheckInStale: true,

--- a/AndroidGarage/iosApp/Features/Main/MainScreen.swift
+++ b/AndroidGarage/iosApp/Features/Main/MainScreen.swift
@@ -24,6 +24,14 @@ import SwiftUI
 struct MainScreen: View {
     let component: NativeComponent
 
+    /// App-root holder for the shared door-animation replay memory (`:domain`
+    /// `DoorAnimationMemory`). `@State` so the single instance survives tab
+    /// switches (the shell isn't recreated) but resets on process death —
+    /// exactly when a cold open should replay the slide. Mirrors Android's
+    /// `remember { DoorAnimationMemory() }` at the Compose root; injected into
+    /// the tree via the `\.doorAnimationMemory` environment value.
+    @State private var doorAnimationMemory = DoorAnimationMemory()
+
     var body: some View {
         TabView {
             ForEach(MainTab.allCases) { tab in
@@ -35,6 +43,7 @@ struct MainScreen: View {
                 }
             }
         }
+        .environment(\.doorAnimationMemory, doorAnimationMemory)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## What

iOS rendered only the **static** door snapshot; the live Home door now drives the **same trajectory Android does** — the 12s linear OPENING/CLOSING slide and the spring-settle to the terminal state — consuming the shared `:domain` spec landed in #959.

This closes the last door-visual divergence between platforms. The maintainer confirmed the 12s slide is a **product decision** (real door travel + ~2s network slack, so the actual terminal event lands mid-slide and the icon **springs to target** = the satisfying snap-shut), not native animation taste — so it had to converge, not stay divergent.

Per ADR-032's spec-vs-execution split: the **parameters** are shared and provable (from/target offsets, the 12s duration, the spring-vs-linear choice, the once-per-event replay), the **SwiftUI interpolation** is best-effort native execution.

## Changes (iOS-only Swift)

- **`GarageDoorView`** gains an `animated` mode + `lastChangeTimeSeconds`. The live Home door (the one live surface) sets `animated: true`; History rows + all `#Preview`s stay static (the default).
- **`AnimatedDoorCanvas`** drives a SwiftUI `@State` offset via `withAnimation`: a 12s linear slide for motion states (shared `DoorAnimation.ANIMATION_DURATION_SECONDS`) and a slow no-overshoot spring settle for terminal/error states.
- **Replay-once-per-event**: seeds at `fromPositionFor` and slides on first sight of a motion event, snaps on re-appearance — gated by the shared `DoorAnimationMemory.consumeAnimateFromStart`, held app-root in `MainScreen` as `@State` and injected via a new `\.doorAnimationMemory` environment value (the iOS holder lifecycle mirroring Android's `LocalDoorAnimationMemory`).
- Threads `wrapper.lastChangeTimeSeconds` through `HomeScreen → HomeContentView`.

## Verification (no manual smoke)

- **CI-exact iOS build** (no `OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED` → Gradle rebuilds the framework, both arch slices) compiles clean — confirms the SKIE bridge shapes (`KotlinLong(value:)`, the `Int32` duration → `Double`, `consumeAnimateFromStart(key:)`, the `EnvironmentKey`).
- **iOS snapshot re-record is byte-identical** (0 changed PNGs) — all Home preview states are non-motion, so animated mode's at-rest frame equals the static frame; no static-render regression.
- The live motion's **parameters** are pinned by commonTest in #959 (`DoorAnimationTest` + `DoorAnimationMemoryTest`). The frame-by-frame motion is Tier-3 execution reading those provable values.

## Notes

- iOS-only Swift — no Android/Firebase code touched, so the Android required checks are unaffected. iOS CI (`Build iOS app + framework test`) is non-required; verified CI-exact locally and will watch the run.
- Depends on #959 (merged) for the shared `ANIMATION_DURATION_SECONDS` + `DoorAnimationMemory`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)