### PR TITLE
feat(ios): copy auth token from the Functions developer panel

### DIFF
--- a/AndroidGarage/iosApp/Features/FunctionList/AuthTokenCopier.swift
+++ b/AndroidGarage/iosApp/Features/FunctionList/AuthTokenCopier.swift
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import SwiftUI
+import UIKit
+import UniformTypeIdentifiers
+@preconcurrency import shared
+
+/// Outcome of a copy-auth-token attempt, so the UI can flash the right message.
+enum AuthTokenCopyOutcome {
+    case copied
+    case notSignedIn
+}
+
+/// Single source of truth for the developer-only "copy auth token" action — the
+/// iOS analog of Android's `rememberAuthTokenCopier` + `SensitiveClipboard`.
+/// Fetches the current Firebase ID token via the shared `GetAuthTokenForCopyUseCase`;
+/// on success writes it to the pasteboard with a short expiration.
+///
+/// iOS has no `ClipDescription.EXTRA_IS_SENSITIVE` equivalent (and shows no
+/// post-copy preview chip), so the **expiration is the sensitivity posture** —
+/// the JWT auto-clears from the pasteboard — and the caller flashes a "Copied"
+/// confirmation in place of the OS chip Android relies on.
+enum AuthTokenCopier {
+    /// Pasteboard auto-clear window for the copied JWT.
+    private static let expirySeconds: TimeInterval = 120
+
+    @MainActor
+    static func copy(using useCase: UsecaseGetAuthTokenForCopyUseCase) async -> AuthTokenCopyOutcome {
+        // `invoke()` is `async throws` over the SKIE bridge; any thrown error
+        // (or the typed `AppResult.Error` for "not signed in") means no copy.
+        do {
+            switch onEnum(of: try await useCase.invoke()) {
+            case .success(let success):
+                UIPasteboard.general.setItems(
+                    [[UTType.utf8PlainText.identifier: success.data]],
+                    options: [.expirationDate: Date().addingTimeInterval(expirySeconds)]
+                )
+                return .copied
+            case .error:
+                return .notSignedIn
+            }
+        } catch {
+            return .notSignedIn
+        }
+    }
+}
+
+/// Self-contained "Copy auth token" button with a transient confirmation flash.
+/// The flash `@State` is internal to this view, so it doesn't lower the
+/// synthesized memberwise init of the screen content views that embed it (same
+/// isolation rationale as `SettingsRow`'s copy flash). Mirrors Android's
+/// developer-panel button; the fetch + clipboard write live in [AuthTokenCopier].
+struct CopyAuthTokenButton: View {
+    /// Performs the copy and returns the outcome (typically `wrapper.copyAuthToken`).
+    let copy: () async -> AuthTokenCopyOutcome
+
+    @State private var flash: Flash?
+
+    private struct Flash {
+        let text: String
+        let systemImage: String
+    }
+
+    var body: some View {
+        Button {
+            Task {
+                let outcome = await copy()
+                let next: Flash = outcome == .copied
+                    ? Flash(text: "Copied", systemImage: "checkmark")
+                    : Flash(text: "Sign in to copy auth token", systemImage: "exclamationmark.triangle")
+                withAnimation { flash = next }
+                try? await Task.sleep(nanoseconds: 1_500_000_000)
+                withAnimation { flash = nil }
+            }
+        } label: {
+            if let flash {
+                Label(flash.text, systemImage: flash.systemImage)
+            } else {
+                Text("Copy auth token")
+            }
+        }
+    }
+}

--- a/AndroidGarage/iosApp/Features/FunctionList/FunctionListScreen.swift
+++ b/AndroidGarage/iosApp/Features/FunctionList/FunctionListScreen.swift
@@ -43,6 +43,7 @@ struct FunctionListScreen: View {
                 deregisterFcm: { wrapper.deregisterFcm() },
                 pruneDiagnosticsLog: { wrapper.pruneDiagnosticsLog() },
                 clearDiagnostics: { wrapper.clearDiagnostics() },
+                copyAuthToken: { await wrapper.copyAuthToken() },
                 copyTestTopic: { wrapper.copyTestTopic() },
                 subscribeTestNotification: { wrapper.subscribeTestNotification() },
                 unsubscribeTestNotification: { wrapper.unsubscribeTestNotification() },
@@ -65,6 +66,10 @@ struct FunctionListActions {
     var deregisterFcm: () -> Void = {}
     var pruneDiagnosticsLog: () -> Void = {}
     var clearDiagnostics: () -> Void = {}
+    /// Developer-only: copy the Firebase ID token. `async` (token fetch) and
+    /// returns the outcome so the button can flash. Defaults to `.notSignedIn`
+    /// for previews (no live component).
+    var copyAuthToken: () async -> AuthTokenCopyOutcome = { .notSignedIn }
     var copyTestTopic: () -> Void = {}
     var subscribeTestNotification: () -> Void = {}
     var unsubscribeTestNotification: () -> Void = {}
@@ -114,6 +119,13 @@ struct FunctionListContentView: View {
                 Section("FCM") {
                     Button("Register FCM") { actions.registerFcm() }
                     Button("Deregister FCM") { actions.deregisterFcm() }
+                }
+                Section("Auth") {
+                    // Developer-only: copy the Firebase ID token (mirrors
+                    // Android's `function_list_copy_auth_token`). The button owns
+                    // its own confirmation flash; the fetch + sensitivity posture
+                    // live in `AuthTokenCopier`.
+                    CopyAuthTokenButton(copy: actions.copyAuthToken)
                 }
                 Section("Diagnostics") {
                     Button("Prune diagnostics log") { actions.pruneDiagnosticsLog() }

--- a/AndroidGarage/iosApp/Features/FunctionList/FunctionListViewModelWrapper.swift
+++ b/AndroidGarage/iosApp/Features/FunctionList/FunctionListViewModelWrapper.swift
@@ -38,8 +38,14 @@ final class FunctionListViewModelWrapper: ObservableObject {
     private var tasks: [Task<Void, Never>] = []
     private var vm: DefaultFunctionListViewModel { shared.instance }
 
+    /// Shared token-fetch usecase for the developer-only copy-auth-token action
+    /// (the token isn't VM state, so it's read straight from the graph — same as
+    /// Android's `rememberAuthTokenCopier`, which reads the usecase off the component).
+    private let getAuthTokenForCopyUseCase: UsecaseGetAuthTokenForCopyUseCase
+
     init(component: NativeComponent) {
         shared = SharedViewModel(component.functionListViewModel)
+        getAuthTokenForCopyUseCase = component.getAuthTokenForCopyUseCase
         accessGranted = vm.accessGranted.value?.boolValue
         applyTestState(vm.testNotificationState.value)
 
@@ -77,9 +83,17 @@ final class FunctionListViewModelWrapper: ObservableObject {
     func changeTestNotificationTopic() { vm.changeTestNotificationTopic() }
 
     /// Copy the personal test topic to the clipboard. No sensitivity flag (the
-    /// topic is not a secret) — unlike the auth token, which is deferred.
+    /// topic is not a secret) — unlike the auth token (see [copyAuthToken]).
     func copyTestTopic() {
         if let topic = testTopic { UIPasteboard.general.string = topic }
+    }
+
+    /// Copy the current Firebase ID token to the clipboard (developer-only).
+    /// Delegates to the shared [AuthTokenCopier] so the fetch + sensitivity
+    /// posture (pasteboard expiration) live in one place; returns the outcome so
+    /// the button can flash "Copied" or "Sign in to copy auth token".
+    func copyAuthToken() async -> AuthTokenCopyOutcome {
+        await AuthTokenCopier.copy(using: getAuthTokenForCopyUseCase)
     }
 
     deinit { tasks.forEach { $0.cancel() } }


### PR DESCRIPTION
## What

iOS had no copy-auth-token action — the Functions wrapper's `copyTestTopic` explicitly **deferred** it. It now mirrors Android's `function_list_copy_auth_token`, consuming the **already-shared** `GetAuthTokenForCopyUseCase` (no DI/VM change).

## Changes (iOS-only Swift)

- **`AuthTokenCopier`** (new) — single source of truth for the action, the iOS analog of Android's `rememberAuthTokenCopier` + `SensitiveClipboard`: fetches the token via the shared usecase; on success writes it to the pasteboard with a **2-minute expiration**. iOS has no `ClipDescription.EXTRA_IS_SENSITIVE` equivalent (and no post-copy preview chip), so the expiration is the sensitivity posture and the caller flashes a "Copied" confirmation in place of the OS chip Android relies on.
- **`CopyAuthTokenButton`** (new) — self-contained button with a transient flash ("Copied" / "Sign in to copy auth token"); the `@State` is isolated to this view so it doesn't lower the screen content views' synthesized memberwise init (the `SettingsRow` pattern).
- **Functions screen** gains an "Auth" section with the button; the wrapper exposes `copyAuthToken()` delegating to `AuthTokenCopier`.

## SKIE gotchas hit (both already documented; reinforced here)

- `:usecase` types are **module-prefixed** in Swift → `UsecaseGetAuthTokenForCopyUseCase`.
- A suspend usecase bridges to **`async throws`** → `try await useCase.invoke()` + a `do/catch`.
- (Confirmed the reverse of an earlier worry: `onEnum(of:)` **does** work on the generic sealed `AppResult<String, AuthError>`.)

## Verification (no manual smoke)

- **CI-exact iOS build** clean (the two gotchas above were caught + fixed locally across the build cycles; `success.data` → pasteboard items).
- **Snapshot re-record byte-identical** — the new Auth section sits below the snapshot fold (same as the test-notification section), so no PNG churn.
- iOS-only Swift — Android/Firebase checks unaffected; iOS CI is non-required, verified CI-exact locally and will watch the run (confirming via `gh run view --json conclusion`).

## Follow-up

Android shows copy-token in **both** Functions + Diagnostics; this PR does the iOS Functions screen. iOS Diagnostics is a trivial follow-up reusing `AuthTokenCopier` + `CopyAuthTokenButton`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)