### PR TITLE
refactor(arch): route copy-auth-token through the ViewModel (ADR-033 burn-down 1/2)

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -178,7 +178,6 @@ abstract class AppComponent(
     abstract val messagingBridge: MessagingBridge
     abstract val authRepository: AuthRepository
 
-    abstract val getAuthTokenForCopyUseCase: GetAuthTokenForCopyUseCase
     abstract val doorRepository: DoorRepository
     abstract val serverConfigRepository: ServerConfigRepository
     abstract val snoozeRepository: SnoozeRepository
@@ -213,11 +212,13 @@ abstract class AppComponent(
     fun provideDiagnosticsViewModel(
         observeAppLogCount: ObserveDiagnosticsCountUseCase,
         clearDiagnostics: ClearDiagnosticsUseCase,
+        getAuthTokenForCopy: GetAuthTokenForCopyUseCase,
         dispatchers: DispatcherProvider,
     ): DefaultDiagnosticsViewModel =
         DefaultDiagnosticsViewModel(
             observeAppLogCount,
             clearDiagnostics,
+            getAuthTokenForCopy,
             dispatchers,
         )
 
@@ -268,6 +269,7 @@ abstract class AppComponent(
         subscribeTestNotification: SubscribeTestNotificationUseCase,
         unsubscribeTestNotification: UnsubscribeTestNotificationUseCase,
         observeTestNotificationState: ObserveTestNotificationStateUseCase,
+        getAuthTokenForCopy: GetAuthTokenForCopyUseCase,
         dispatchers: DispatcherProvider,
         appVersion: String,
     ): DefaultFunctionListViewModel =
@@ -291,6 +293,7 @@ abstract class AppComponent(
             subscribeTestNotificationUseCase = subscribeTestNotification,
             unsubscribeTestNotificationUseCase = unsubscribeTestNotification,
             observeTestNotificationStateUseCase = observeTestNotificationState,
+            getAuthTokenForCopyUseCase = getAuthTokenForCopy,
             dispatchers = dispatchers,
             appVersion = appVersion,
         )

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/FunctionListContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/FunctionListContent.kt
@@ -58,7 +58,7 @@ fun FunctionListContent(
     val googleSignIn = rememberGoogleSignIn(
         onTokenReceived = { token -> resolved.signInWithGoogle(token) },
     )
-    val copyAuthToken = rememberAuthTokenCopier()
+    val copyAuthToken = rememberAuthTokenCopier(resolved::fetchAuthTokenForCopy)
     val testNotificationState by resolved.testNotificationState.collectAsState()
     val clipboard = LocalClipboardManager.current
 

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/auth/AuthTokenCopier.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/auth/AuthTokenCopier.kt
@@ -28,15 +28,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import com.chriscartland.garage.R
-import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.AppResult
+import com.chriscartland.garage.domain.model.AuthError
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
  * Composable hook returning a click handler that:
- *   1. Fetches the current Firebase ID token via [GetAuthTokenForCopyUseCase].
+ *   1. Fetches the current Firebase ID token via [fetch] — the screen passes
+ *      its ViewModel's `fetchAuthTokenForCopy` (ADR-033: UI routes through the
+ *      VM, never the UseCase directly).
  *   2. On success, writes the token to the system clipboard with
  *      `ClipDescription.EXTRA_IS_SENSITIVE` set so the OS preview chip
  *      (API 33+) redacts the value instead of displaying it on-screen.
@@ -44,12 +46,11 @@ import kotlinx.coroutines.withContext
  *      *"Sign in to copy auth token"* so the user knows the copy didn't
  *      happen.
  *
- * Single source of truth for the developer-only token-copy action.
- * Both [DiagnosticsScreen] and [FunctionListContent] call this hook so
- * the two surfaces decode + format + write the token identically — a
- * regression in clipboard behavior breaks both call sites at once,
- * which is the verification property the user asked for ("powered by a
- * UseCase in both places so it should be easy to verify both").
+ * Single source of truth for the developer-only token-copy clipboard+feedback
+ * behavior. Both [DiagnosticsScreen] and [FunctionListContent] call this hook so
+ * the two surfaces decode + format + write the token identically — a regression
+ * in clipboard behavior breaks both call sites at once. The token *fetch* is the
+ * VM's (`fetchAuthTokenForCopy`), shared at the UseCase level under both VMs.
  *
  * No success Toast: the OS clipboard preview chip with content hidden
  * is the confirmation; a Toast on top would be duplicate noise (mirrors
@@ -63,15 +64,13 @@ import kotlinx.coroutines.withContext
  * button is the only way to keep the action safe on older Android.
  */
 @Composable
-fun rememberAuthTokenCopier(): () -> Unit {
-    val component = rememberAppComponent()
+fun rememberAuthTokenCopier(fetch: suspend () -> AppResult<String, AuthError>): () -> Unit {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    val useCase = component.getAuthTokenForCopyUseCase
-    return remember(useCase, context, scope) {
+    return remember(fetch, context, scope) {
         {
             scope.launch {
-                val result = withContext(Dispatchers.IO) { useCase() }
+                val result = withContext(Dispatchers.IO) { fetch() }
                 when (result) {
                     is AppResult.Success -> SensitiveClipboard.write(context, result.data)
                     is AppResult.Error ->

--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/DiagnosticsContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/DiagnosticsContent.kt
@@ -96,7 +96,7 @@ fun DiagnosticsScreen(
     val component = rememberAppComponent()
     val diagnosticsViewModel: DiagnosticsViewModel = viewModel { component.diagnosticsViewModel }
     val context = LocalContext.current
-    val copyAuthToken = rememberAuthTokenCopier()
+    val copyAuthToken = rememberAuthTokenCopier(diagnosticsViewModel::fetchAuthTokenForCopy)
 
     val initCurrent by diagnosticsViewModel.initCurrentDoorCount.collectAsState()
     val initRecent by diagnosticsViewModel.initRecentDoorCount.collectAsState()

--- a/AndroidGarage/iosApp/Features/FunctionList/AuthTokenCopier.swift
+++ b/AndroidGarage/iosApp/Features/FunctionList/AuthTokenCopier.swift
@@ -26,37 +26,24 @@ enum AuthTokenCopyOutcome {
     case notSignedIn
 }
 
-/// Single source of truth for the developer-only "copy auth token" action — the
-/// iOS analog of Android's `rememberAuthTokenCopier` + `SensitiveClipboard`.
-/// Fetches the current Firebase ID token via the shared `GetAuthTokenForCopyUseCase`;
-/// on success writes it to the pasteboard with a short expiration.
-///
-/// iOS has no `ClipDescription.EXTRA_IS_SENSITIVE` equivalent (and shows no
-/// post-copy preview chip), so the **expiration is the sensitivity posture** —
-/// the JWT auto-clears from the pasteboard — and the caller flashes a "Copied"
-/// confirmation in place of the OS chip Android relies on.
+/// The developer-only "copy auth token" clipboard write — the iOS analog of
+/// Android's `SensitiveClipboard`. The token *fetch* now goes through the
+/// ViewModel (`fetchAuthTokenForCopy`, ADR-033); this owns only the iOS
+/// sensitivity posture: iOS has no `ClipDescription.EXTRA_IS_SENSITIVE`
+/// equivalent (and shows no post-copy preview chip), so the JWT is written with
+/// a short **expiration** (auto-clears from the pasteboard) and the caller
+/// flashes a "Copied" confirmation in place of the OS chip Android relies on.
 enum AuthTokenCopier {
     /// Pasteboard auto-clear window for the copied JWT.
     private static let expirySeconds: TimeInterval = 120
 
+    /// Write [token] to the pasteboard with the expiration sensitivity posture.
     @MainActor
-    static func copy(using useCase: UsecaseGetAuthTokenForCopyUseCase) async -> AuthTokenCopyOutcome {
-        // `invoke()` is `async throws` over the SKIE bridge; any thrown error
-        // (or the typed `AppResult.Error` for "not signed in") means no copy.
-        do {
-            switch onEnum(of: try await useCase.invoke()) {
-            case .success(let success):
-                UIPasteboard.general.setItems(
-                    [[UTType.utf8PlainText.identifier: success.data]],
-                    options: [.expirationDate: Date().addingTimeInterval(expirySeconds)]
-                )
-                return .copied
-            case .error:
-                return .notSignedIn
-            }
-        } catch {
-            return .notSignedIn
-        }
+    static func writeSensitive(_ token: Any) {
+        UIPasteboard.general.setItems(
+            [[UTType.utf8PlainText.identifier: token]],
+            options: [.expirationDate: Date().addingTimeInterval(expirySeconds)]
+        )
     }
 }
 

--- a/AndroidGarage/iosApp/Features/FunctionList/FunctionListViewModelWrapper.swift
+++ b/AndroidGarage/iosApp/Features/FunctionList/FunctionListViewModelWrapper.swift
@@ -38,14 +38,8 @@ final class FunctionListViewModelWrapper: ObservableObject {
     private var tasks: [Task<Void, Never>] = []
     private var vm: DefaultFunctionListViewModel { shared.instance }
 
-    /// Shared token-fetch usecase for the developer-only copy-auth-token action
-    /// (the token isn't VM state, so it's read straight from the graph — same as
-    /// Android's `rememberAuthTokenCopier`, which reads the usecase off the component).
-    private let getAuthTokenForCopyUseCase: UsecaseGetAuthTokenForCopyUseCase
-
     init(component: NativeComponent) {
         shared = SharedViewModel(component.functionListViewModel)
-        getAuthTokenForCopyUseCase = component.getAuthTokenForCopyUseCase
         accessGranted = vm.accessGranted.value?.boolValue
         applyTestState(vm.testNotificationState.value)
 
@@ -89,11 +83,22 @@ final class FunctionListViewModelWrapper: ObservableObject {
     }
 
     /// Copy the current Firebase ID token to the clipboard (developer-only).
-    /// Delegates to the shared [AuthTokenCopier] so the fetch + sensitivity
-    /// posture (pasteboard expiration) live in one place; returns the outcome so
-    /// the button can flash "Copied" or "Sign in to copy auth token".
+    /// The token *fetch* routes through the ViewModel (`fetchAuthTokenForCopy`,
+    /// ADR-033 — not the UseCase directly); `AuthTokenCopier` owns the iOS
+    /// sensitivity posture (pasteboard expiration). Returns the outcome so the
+    /// button can flash "Copied" or "Sign in to copy auth token".
     func copyAuthToken() async -> AuthTokenCopyOutcome {
-        await AuthTokenCopier.copy(using: getAuthTokenForCopyUseCase)
+        do {
+            switch onEnum(of: try await vm.fetchAuthTokenForCopy()) {
+            case .success(let success):
+                AuthTokenCopier.writeSensitive(success.data)
+                return .copied
+            case .error:
+                return .notSignedIn
+            }
+        } catch {
+            return .notSignedIn
+        }
     }
 
     deinit { tasks.forEach { $0.cancel() } }

--- a/AndroidGarage/iosFramework/src/commonMain/kotlin/com/chriscartland/garage/iosframework/NativeComponent.kt
+++ b/AndroidGarage/iosFramework/src/commonMain/kotlin/com/chriscartland/garage/iosframework/NativeComponent.kt
@@ -204,7 +204,6 @@ abstract class NativeComponent(
     abstract val doorResolvedFcmSubscriptionManager: DoorResolvedFcmSubscriptionManager
     abstract val initialDoorFetchManager: InitialDoorFetchManager
     abstract val computeButtonHealthDisplayUseCase: ComputeButtonHealthDisplayUseCase
-    abstract val getAuthTokenForCopyUseCase: GetAuthTokenForCopyUseCase
 
     // --- ViewModels ---
 
@@ -212,8 +211,9 @@ abstract class NativeComponent(
     fun provideDiagnosticsViewModel(
         observeAppLogCount: ObserveDiagnosticsCountUseCase,
         clearDiagnostics: ClearDiagnosticsUseCase,
+        getAuthTokenForCopy: GetAuthTokenForCopyUseCase,
         dispatchers: DispatcherProvider,
-    ): DefaultDiagnosticsViewModel = DefaultDiagnosticsViewModel(observeAppLogCount, clearDiagnostics, dispatchers)
+    ): DefaultDiagnosticsViewModel = DefaultDiagnosticsViewModel(observeAppLogCount, clearDiagnostics, getAuthTokenForCopy, dispatchers)
 
     @Provides
     fun provideFunctionListViewModel(
@@ -236,6 +236,7 @@ abstract class NativeComponent(
         subscribeTestNotification: SubscribeTestNotificationUseCase,
         unsubscribeTestNotification: UnsubscribeTestNotificationUseCase,
         observeTestNotificationState: ObserveTestNotificationStateUseCase,
+        getAuthTokenForCopy: GetAuthTokenForCopyUseCase,
         dispatchers: DispatcherProvider,
         appVersion: String,
     ): DefaultFunctionListViewModel =
@@ -259,6 +260,7 @@ abstract class NativeComponent(
             subscribeTestNotificationUseCase = subscribeTestNotification,
             unsubscribeTestNotificationUseCase = unsubscribeTestNotification,
             observeTestNotificationStateUseCase = observeTestNotificationState,
+            getAuthTokenForCopyUseCase = getAuthTokenForCopy,
             dispatchers = dispatchers,
             appVersion = appVersion,
         )

--- a/AndroidGarage/ui-layer-graph-access-exemptions.txt
+++ b/AndroidGarage/ui-layer-graph-access-exemptions.txt
@@ -5,8 +5,6 @@
 # route through its ViewModel. The goal is an EMPTY list — the check fails on a
 # stale entry (one that no longer violates) so the file can't accumulate.
 #
-# Burn-down:
-#   auth/AuthTokenCopier.kt       -> copy-token through FunctionListViewModel/DiagnosticsViewModel
+# Burn-down (copy-token DONE — routed through the VMs; one left):
 #   settings/DiagnosticsContent.kt -> Export CSV through DiagnosticsViewModel
-auth/AuthTokenCopier.kt
 settings/DiagnosticsContent.kt

--- a/AndroidGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/DiagnosticsViewModel.kt
+++ b/AndroidGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/DiagnosticsViewModel.kt
@@ -21,7 +21,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.AppLoggerKeys
+import com.chriscartland.garage.domain.model.AppResult
+import com.chriscartland.garage.domain.model.AuthError
 import com.chriscartland.garage.usecase.ClearDiagnosticsUseCase
+import com.chriscartland.garage.usecase.GetAuthTokenForCopyUseCase
 import com.chriscartland.garage.usecase.ObserveDiagnosticsCountUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -63,11 +66,19 @@ interface DiagnosticsViewModel {
      * Confirmation dialog is the caller's responsibility.
      */
     fun clearDiagnostics()
+
+    /**
+     * Fetch the current Firebase ID token for the developer-only copy action
+     * (ADR-033 — the UI routes this through the VM rather than calling the
+     * UseCase directly). The platform UI does the clipboard write + feedback.
+     */
+    suspend fun fetchAuthTokenForCopy(): AppResult<String, AuthError>
 }
 
 class DefaultDiagnosticsViewModel(
     private val observeAppLogCount: ObserveDiagnosticsCountUseCase,
     private val clearDiagnosticsUseCase: ClearDiagnosticsUseCase,
+    private val getAuthTokenForCopyUseCase: GetAuthTokenForCopyUseCase,
     private val dispatchers: DispatcherProvider,
 ) : ViewModel(),
     DiagnosticsViewModel {
@@ -131,4 +142,6 @@ class DefaultDiagnosticsViewModel(
             }
         }
     }
+
+    override suspend fun fetchAuthTokenForCopy(): AppResult<String, AuthError> = getAuthTokenForCopyUseCase()
 }

--- a/AndroidGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/FunctionListViewModel.kt
+++ b/AndroidGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/FunctionListViewModel.kt
@@ -22,6 +22,8 @@ import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.AppLoggerLimits
+import com.chriscartland.garage.domain.model.AppResult
+import com.chriscartland.garage.domain.model.AuthError
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.GoogleIdToken
 import com.chriscartland.garage.domain.model.SnoozeDurationUIOption
@@ -35,6 +37,7 @@ import com.chriscartland.garage.usecase.FetchButtonHealthUseCase
 import com.chriscartland.garage.usecase.FetchCurrentDoorEventUseCase
 import com.chriscartland.garage.usecase.FetchRecentDoorEventsUseCase
 import com.chriscartland.garage.usecase.FetchSnoozeStatusUseCase
+import com.chriscartland.garage.usecase.GetAuthTokenForCopyUseCase
 import com.chriscartland.garage.usecase.GetTestNotificationTopicUseCase
 import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
 import com.chriscartland.garage.usecase.ObserveFeatureAccessUseCase
@@ -107,6 +110,14 @@ interface FunctionListViewModel {
     fun unsubscribeTestNotification()
 
     fun changeTestNotificationTopic()
+
+    /**
+     * Fetch the current Firebase ID token for the developer-only copy action
+     * (ADR-033 — the UI routes this through the VM rather than calling the
+     * UseCase directly). Returns the typed result; the platform UI does the
+     * clipboard write + "Copied" / "Sign in" feedback.
+     */
+    suspend fun fetchAuthTokenForCopy(): AppResult<String, AuthError>
 }
 
 class DefaultFunctionListViewModel(
@@ -129,6 +140,7 @@ class DefaultFunctionListViewModel(
     private val subscribeTestNotificationUseCase: SubscribeTestNotificationUseCase,
     private val unsubscribeTestNotificationUseCase: UnsubscribeTestNotificationUseCase,
     private val observeTestNotificationStateUseCase: ObserveTestNotificationStateUseCase,
+    private val getAuthTokenForCopyUseCase: GetAuthTokenForCopyUseCase,
     private val dispatchers: DispatcherProvider,
     private val appVersion: String,
 ) : ViewModel(),
@@ -254,4 +266,6 @@ class DefaultFunctionListViewModel(
         Logger.d { "changeTestNotificationTopic" }
         viewModelScope.launch(dispatchers.io) { changeTestNotificationTopicUseCase() }
     }
+
+    override suspend fun fetchAuthTokenForCopy(): AppResult<String, AuthError> = getAuthTokenForCopyUseCase()
 }

--- a/AndroidGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/DefaultFunctionListViewModelTest.kt
+++ b/AndroidGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/DefaultFunctionListViewModelTest.kt
@@ -47,6 +47,7 @@ import com.chriscartland.garage.usecase.FetchButtonHealthUseCase
 import com.chriscartland.garage.usecase.FetchCurrentDoorEventUseCase
 import com.chriscartland.garage.usecase.FetchRecentDoorEventsUseCase
 import com.chriscartland.garage.usecase.FetchSnoozeStatusUseCase
+import com.chriscartland.garage.usecase.GetAuthTokenForCopyUseCase
 import com.chriscartland.garage.usecase.GetTestNotificationTopicUseCase
 import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
 import com.chriscartland.garage.usecase.ObserveFeatureAccessUseCase
@@ -141,6 +142,7 @@ class DefaultFunctionListViewModelTest {
             subscribeTestNotificationUseCase = SubscribeTestNotificationUseCase(testNotif),
             unsubscribeTestNotificationUseCase = UnsubscribeTestNotificationUseCase(testNotif),
             observeTestNotificationStateUseCase = ObserveTestNotificationStateUseCase(testNotif),
+            getAuthTokenForCopyUseCase = GetAuthTokenForCopyUseCase(authRepository),
             dispatchers = TestDispatcherProvider(testDispatcher),
             appVersion = "test",
         )

--- a/AndroidGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/DiagnosticsViewModelTest.kt
+++ b/AndroidGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/DiagnosticsViewModelTest.kt
@@ -19,9 +19,11 @@ package com.chriscartland.garage.viewmodel
 
 import com.chriscartland.garage.domain.model.AppLoggerKeys
 import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
+import com.chriscartland.garage.testcommon.FakeAuthRepository
 import com.chriscartland.garage.testcommon.FakeDiagnosticsCountersRepository
 import com.chriscartland.garage.testcommon.TestDispatcherProvider
 import com.chriscartland.garage.usecase.ClearDiagnosticsUseCase
+import com.chriscartland.garage.usecase.GetAuthTokenForCopyUseCase
 import com.chriscartland.garage.usecase.ObserveDiagnosticsCountUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -50,6 +52,7 @@ class DiagnosticsViewModelTest {
         viewModel = DefaultDiagnosticsViewModel(
             observeAppLogCount = ObserveDiagnosticsCountUseCase(counters),
             clearDiagnosticsUseCase = ClearDiagnosticsUseCase(logger, counters),
+            getAuthTokenForCopyUseCase = GetAuthTokenForCopyUseCase(FakeAuthRepository()),
             dispatchers = dispatchers,
         )
     }


### PR DESCRIPTION
## What

First burn-down of the ADR-033 exemptions: copy-auth-token no longer reaches `component.getAuthTokenForCopyUseCase` directly from the UI — it routes through the screen's **ViewModel**. Removes the `auth/AuthTokenCopier.kt` exemption from `checkUiLayerNoGraphAccess`.

## Changes

**Shared (`:viewmodel`):**
- `FunctionListViewModel` + `DiagnosticsViewModel` gain `suspend fun fetchAuthTokenForCopy(): AppResult<String, AuthError>` (delegates to the injected `GetAuthTokenForCopyUseCase`). The VM owns the produce/decision; the UI does only the clipboard write (the irreducible platform side-effect, per ADR-033).
- Both VM ctors take the usecase; **both DI graphs** (`AppComponent` + `NativeComponent`) updated (two-DI-graph trap), and the now-unused `abstract val getAuthTokenForCopyUseCase` entry point is **removed from both**.
- VM test builders updated (`FakeAuthRepository`).

**Android:** `rememberAuthTokenCopier(fetch)` takes the VM's `fetchAuthTokenForCopy` (no `component` access); the Functions + Diagnostics screens pass their VM's method ref. The clipboard write + "Copied"/"Sign in" feedback stay shared in the hook.

**iOS:** `FunctionListViewModelWrapper.copyAuthToken()` calls `vm.fetchAuthTokenForCopy()`; `AuthTokenCopier` becomes `writeSensitive(_:)` — just the pasteboard-expiration sensitivity posture.

## Verification

- **validate.sh green** — `:viewmodel:testDebugUnitTest` PASS; `checkUiLayerNoGraphAccess` now **1 grandfathered** (down from 2); all checks pass.
- **CI-exact iOS build clean** — `NativeComponent`'s iOS targets compile (validate.sh skips these) + the Swift bridging of the new suspend VM method (`onEnum(of: try await vm.fetchAuthTokenForCopy())`).
- **Byte-identical iOS snapshots** (no visual change).

## Next

Export CSV through `DiagnosticsViewModel` removes the last exemption (`settings/DiagnosticsContent.kt`) → the file goes empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)