### PR TITLE
refactor(android): remove dead fetch-error ErrorCard in DoorHistory

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/DoorHistoryContent.kt
@@ -106,12 +106,12 @@ fun DoorHistoryContent(
 
     // Outer Column owns inter-banner spacing via spacedBy. Top chrome
     // clearance (16 dp below the TopAppBar) is owned by the outer
-    // Column ONLY when at least one banner is shown — otherwise
+    // Column ONLY when the stale-check-in banner is shown — otherwise
     // HistoryContent's safeListContentPadding.top provides it.
     // Without this conditional, the no-banner case would double-pad
     // (16 dp outer + 16 dp safeListContentPadding = 32 dp before the
     // first day section).
-    val anyBannerShown = isCheckInStale || recentDoorEvents is LoadingResult.Error
+    val anyBannerShown = isCheckInStale
     val outerModifier = if (anyBannerShown) {
         modifier.fillMaxSize().padding(top = 16.dp)
     } else {
@@ -130,17 +130,6 @@ fun DoorHistoryContent(
                     onResetFcm()
                     onFetchRecentDoorEvents()
                 },
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
-        if (recentDoorEvents is LoadingResult.Error) {
-            ErrorCard(
-                text = stringResource(
-                    R.string.home_history_fetch_error,
-                    recentDoorEvents.exception.toString().take(500),
-                ),
-                buttonText = stringResource(R.string.home_history_retry_button),
-                onClick = { onFetchRecentDoorEvents() },
                 modifier = Modifier.fillMaxWidth(),
             )
         }

--- a/AndroidGarage/androidApp/src/main/res/values/strings.xml
+++ b/AndroidGarage/androidApp/src/main/res/values/strings.xml
@@ -120,8 +120,6 @@
     <!-- History tab — error / stale-data banner copy. -->
     <string name="home_history_stale_check_in_error">Not receiving updates from server</string>
     <string name="home_history_retry_button">Retry</string>
-    <!-- History tab — fetch-error banner. %1$s is the truncated exception message. -->
-    <string name="home_history_fetch_error">Error fetching recent door events:%1$s</string>
 
     <!-- Home → Door status info bottom sheet. -->
     <string name="home_info_door_status_title">Door status</string>


### PR DESCRIPTION
## Summary
`DefaultDoorHistoryViewModel` **never** emits `LoadingResult.Error` — every path (init, fetch success, fetch failure) writes `Complete(prev)` per the stale-while-revalidate convention. So the `recentDoorEvents is LoadingResult.Error` branch in `DoorHistoryContent` (and the `ErrorCard` it rendered) was unreachable from every call site:

- The VM (sole runtime source) only writes `Complete`/`Loading`.
- All preview/dashboard call sites pass `LoadingResult.Complete`.

This removes the dead block, simplifies `anyBannerShown` to just `isCheckInStale`, and drops the now-orphaned `home_history_fetch_error` string. The **live** stale-check-in `ErrorCard` (driven by `isCheckInStale`) is unchanged.

## Why
From the 2026-06-28 iOS↔Android parity audit (`PENDING_FOLLOWUPS § 4`, Tier 2/3: "Dead Android `ErrorCard` in `DoorHistoryContent` — delete or wire").

## Verification
- `validate.sh` — **All checks passed.**
- Zero screenshot churn (no preview or test ever rendered the error state — every call site passes `Complete`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)