### PR TITLE
fix(android): order Diagnostics FCM counters to match iOS + shared VM

### DIFF
--- a/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/DiagnosticsContent.kt
+++ b/AndroidGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/DiagnosticsContent.kt
@@ -106,13 +106,16 @@ fun DiagnosticsScreen(
     val exceededFcm by diagnosticsViewModel.exceededExpectedTimeWithoutFcmCount.collectAsState()
     val timeWithoutFcmInRange by diagnosticsViewModel.timeWithoutFcmInExpectedRangeCount.collectAsState()
 
+    // Order matches the shared `DiagnosticsViewModel` field order (the canonical
+    // cross-platform order, also rendered by iOS): FCM received before FCM
+    // subscribe. Keeps Android + iOS Diagnostics visually aligned.
     val counters = listOf(
         DiagnosticsCounter("App init (current door)", initCurrent),
         DiagnosticsCounter("App init (recent doors)", initRecent),
         DiagnosticsCounter("Door fetch (current)", fetchCurrent),
         DiagnosticsCounter("Door fetch (recent)", fetchRecent),
-        DiagnosticsCounter("FCM subscribe", fcmSubscribe),
         DiagnosticsCounter("FCM received", fcmReceived),
+        DiagnosticsCounter("FCM subscribe", fcmSubscribe),
         DiagnosticsCounter("FCM exceeded expected timeout", exceededFcm),
         DiagnosticsCounter("FCM in expected range", timeWithoutFcmInRange),
     )
@@ -373,8 +376,8 @@ fun DiagnosticsContentPreview() {
                 DiagnosticsCounter("App init (recent doors)", 17),
                 DiagnosticsCounter("Door fetch (current)", 836),
                 DiagnosticsCounter("Door fetch (recent)", 412),
-                DiagnosticsCounter("FCM subscribe", 8),
                 DiagnosticsCounter("FCM received", 1247),
+                DiagnosticsCounter("FCM subscribe", 8),
                 DiagnosticsCounter("FCM exceeded expected timeout", 3),
                 DiagnosticsCounter("FCM in expected range", 1244),
             ),
@@ -406,8 +409,8 @@ fun DiagnosticsContentClearInFlightPreview() {
                 DiagnosticsCounter("App init (recent doors)", 17),
                 DiagnosticsCounter("Door fetch (current)", 836),
                 DiagnosticsCounter("Door fetch (recent)", 412),
-                DiagnosticsCounter("FCM subscribe", 8),
                 DiagnosticsCounter("FCM received", 1247),
+                DiagnosticsCounter("FCM subscribe", 8),
                 DiagnosticsCounter("FCM exceeded expected timeout", 3),
                 DiagnosticsCounter("FCM in expected range", 1244),
             ),


### PR DESCRIPTION
## Summary
Android rendered **"FCM subscribe"** before **"FCM received"**; iOS and the shared `DiagnosticsViewModel` field order have **"FCM received"** before **"FCM subscribe"**. Swaps the two Android rows so the Diagnostics counter order is identical across platforms.

The shared VM field order is the canonical source — Android now matches it (iOS already did). Labels stay per-UI (ADR-031); only the order is aligned.

## Why
2026-06-28 parity audit (`PENDING_FOLLOWUPS § 4`, Tier 2 — "Diagnostics counter row order drift").

## Verification
- `validate.sh` — **All checks passed.**
- The committed Diagnostics reference screenshot is stale pending regen on a working environment (local Layoutlib renders blank on this machine — documented in CLAUDE.md). CI only **compiles** screenshot tests (`compileDebugScreenshotTestKotlin`); it does not compare pixels, so this won't fail CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)