### PR TITLE
chore(release): harden secrets scripts with strict mode [audit M13]

### DIFF
--- a/AndroidGarage/release/clean-secrets.sh
+++ b/AndroidGarage/release/clean-secrets.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# set -eu (no pipefail: not portable in POSIX sh). Fail fast so a botched rm
+# doesn't leave decrypted secrets on disk under the illusion of a clean tree.
+set -eu
 
 # Copyright 2021 Google LLC
 #

--- a/AndroidGarage/release/decrypt-secrets.sh
+++ b/AndroidGarage/release/decrypt-secrets.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Copyright 2021 Google LLC
 #
@@ -18,10 +19,12 @@ decrypt() {
   PASSPHRASE=$1
   INPUT=$2
   OUTPUT=$3
-  gpg --quiet --batch --yes --decrypt --passphrase="$PASSPHRASE" --output $OUTPUT $INPUT
+  gpg --quiet --batch --yes --decrypt --passphrase="$PASSPHRASE" --output "$OUTPUT" "$INPUT"
 }
 
-if [[ ! -z "$ENCRYPT_KEY" ]]; then
+# set -u: default ENCRYPT_KEY to empty so the unset case is the clean "empty"
+# branch below, not an "unbound variable" abort.
+if [[ -n "${ENCRYPT_KEY:-}" ]]; then
   # Decrypt Release key
   decrypt ${ENCRYPT_KEY} release/app-release.gpg release/app-release.jks
   # Decrypt Google Services key (Android)

--- a/AndroidGarage/release/encrypt-secrets.sh
+++ b/AndroidGarage/release/encrypt-secrets.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Copyright 2021 Google LLC
 #
@@ -18,10 +19,12 @@ encrypt() {
   PASSPHRASE=$1
   INPUT=$2
   OUTPUT=$3
-  gpg --batch --yes --passphrase="$PASSPHRASE" --cipher-algo AES256 --symmetric --output $OUTPUT $INPUT
+  gpg --batch --yes --passphrase="$PASSPHRASE" --cipher-algo AES256 --symmetric --output "$OUTPUT" "$INPUT"
 }
 
-if [[ ! -z "$ENCRYPT_KEY" ]]; then
+# set -u: default ENCRYPT_KEY to empty so the unset case is the clean "empty"
+# branch below, not an "unbound variable" abort.
+if [[ -n "${ENCRYPT_KEY:-}" ]]; then
   # Encrypt Release key
   encrypt ${ENCRYPT_KEY} release/app-release.jks release/app-release.gpg
   # Encrypt Google Services key (Android)


### PR DESCRIPTION
## What

Adds shell strict mode to the three `AndroidGarage/release/` secrets scripts:

- `decrypt-secrets.sh` / `encrypt-secrets.sh` (bash) → `set -euo pipefail`
- `clean-secrets.sh` (`#!/bin/sh`) → `set -eu` (pipefail isn't POSIX-portable)

`set -u` safety: the `ENCRYPT_KEY` presence test is guarded with
`${ENCRYPT_KEY:-}` so the unset case takes the clean "empty" branch instead of
aborting; the `gpg --output`/input paths are quoted.

## Why

Closes deferred security-audit finding **M13** (2026-05-14): without `set -e`, a
failing `gpg` could continue silently and leave decrypted secrets (or a
half-written keystore) on disk while the script still "succeeds".

## Verified

- `bash -n` (decrypt, encrypt) and `sh -n` (clean) all clean.
- `env -u ENCRYPT_KEY bash decrypt-secrets.sh` → prints `ENCRYPT_KEY is empty`,
  exits 0 — `set -u` does not abort on the unset-key path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)