### PR TITLE
fix(android): exclude Room DB + DataStore from cloud backup [audit M6]

### DIFF
--- a/AndroidGarage/androidApp/src/main/res/xml/backup_rules.xml
+++ b/AndroidGarage/androidApp/src/main/res/xml/backup_rules.xml
@@ -16,15 +16,29 @@
   -->
 
 <!--
-   Sample backup rules file; uncomment and customize as necessary.
-   See https://developer.android.com/guide/topics/data/autobackup
-   for details.
-   Note: This file is ignored for devices older that API 31
-   See https://developer.android.com/about/versions/12/backup-restore
+   Auto Backup rules for API <= 30 (android:fullBackupContent). For API 31+
+   see data_extraction_rules.xml. Reference:
+   https://developer.android.com/guide/topics/data/autobackup
+
+   Security audit finding M6 (2026-05-14): with allowBackup="true" and empty
+   rules, the app's local data was copied to Google Drive Auto Backup by
+   default. None of it is irreplaceable — the Room door-event cache re-syncs
+   from the server and the DataStore files are device-local settings/diagnostics
+   counters — so excluding it from cloud backup removes an off-device copy of
+   the user's door-activity history at no real cost.
+
+   Paths are source-confirmed (so an exclude can't silently fail open):
+   - Room DB file is named "database" (DatabaseFactory.android.kt uses
+     context.getDatabasePath("database")); SQLite also writes -shm/-wal
+     sidecars next to it.
+   - DataStore files land directly in filesDir (DataStoreFactory.android.kt
+     resolves PREFERENCES_FILE_NAME / DIAGNOSTICS_COUNTERS_FILE_NAME against
+     context.filesDir), i.e. the "file" backup domain.
 -->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <exclude domain="database" path="database" />
+    <exclude domain="database" path="database-shm" />
+    <exclude domain="database" path="database-wal" />
+    <exclude domain="file" path="app_settings.preferences_pb" />
+    <exclude domain="file" path="diagnostics_counters.preferences_pb" />
 </full-backup-content>

--- a/AndroidGarage/androidApp/src/main/res/xml/data_extraction_rules.xml
+++ b/AndroidGarage/androidApp/src/main/res/xml/data_extraction_rules.xml
@@ -16,21 +16,23 @@
   -->
 
 <!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
+   Backup / transfer rules for API 31+ (android:dataExtractionRules). For
+   API <= 30 see backup_rules.xml. Reference:
+   https://developer.android.com/about/versions/12/backup-restore#xml-changes
+
+   Security audit finding M6 (2026-05-14): keep the app's local persistence out
+   of Google Drive cloud backup (see backup_rules.xml for the full rationale and
+   the source-confirmed paths). Excludes are scoped to <cloud-backup> only —
+   <device-transfer> is a direct device-to-device copy that never leaves the
+   user's control, and the data re-syncs from the server / sign-in anyway, so
+   there's no need to strip it from a local transfer.
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <exclude domain="database" path="database" />
+        <exclude domain="database" path="database-shm" />
+        <exclude domain="database" path="database-wal" />
+        <exclude domain="file" path="app_settings.preferences_pb" />
+        <exclude domain="file" path="diagnostics_counters.preferences_pb" />
     </cloud-backup>
-    <!--
-    <device-transfer>
-        <include .../>
-        <exclude .../>
-    </device-transfer>
-    -->
 </data-extraction-rules>


### PR DESCRIPTION
## What

Populates `backup_rules.xml` (API ≤30) and `data_extraction_rules.xml` (API 31+)
to exclude the app's own persistence from Google Drive cloud backup. `allowBackup`
stays `true`; `<device-transfer>` is left intact.

Excluded (source-confirmed paths, so an exclude can't silently fail open):

| Data | Path / domain | Source |
|---|---|---|
| Room DB (+ `-shm`/`-wal`) | `database`, domain `database` | `getDatabasePath("database")` in `DatabaseFactory.android.kt` |
| App settings | `app_settings.preferences_pb`, domain `file` | `filesDir`-resolved in `DataStoreFactory.android.kt` |
| Diagnostics counters | `diagnostics_counters.preferences_pb`, domain `file` | same |

## Why

Closes deferred security-audit finding **M6** (2026-05-14): with `allowBackup="true"`
and empty rules, the Room door-event cache + DataStore prefs were copied to Google
Drive by default — an off-device copy of the user's door-activity history.

None of the excluded data is irreplaceable: the Room cache re-syncs from the
server and the DataStore files are device-local settings/diagnostics, so removing
them from cloud backup costs nothing. (The blunter `allowBackup="false"` was the
audit's alternative; targeted excludes keep the backup mechanism standard and were
the audit's primary recommendation. Firebase Auth's own backup behavior is a
separate, fuzzier concern not named in M6 — left as a possible follow-up rather
than chasing fragile internal paths.)

## Verified

`./scripts/validate.sh` — `assembleDebug` + `lint` + resource processing all pass
with the new XML (the only non-passing step was the unrelated iOS-changelog
front-matter, fixed in the separate iOS PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)