### PR TITLE
build(ios): add validate-ios.sh + seed iosApp/CHANGELOG.md (Phase F)

### DIFF
--- a/AndroidGarage/iosApp/CHANGELOG.md
+++ b/AndroidGarage/iosApp/CHANGELOG.md
@@ -1,0 +1,38 @@
+---
+category: reference
+status: active
+last_verified: 2026-06-29
+---
+# iOS Changelog
+
+Permanent, per-release history of the iOS app (`AndroidGarage/iosApp/`). Mirrors
+the Android `AndroidGarage/CHANGELOG.md` convention: newest first, one `## X.Y.Z`
+heading per release matching `MARKETING_VERSION` in `iosApp/project.yml`, with a
+non-empty body of user-facing changes.
+
+When iOS release tooling lands (Phase F — `scripts/release-ios.sh` + the
+archive/upload workflow, paired with Apple code-signing), a release gate will
+require the `## X.Y.Z` heading for the version being shipped — same model as the
+Android `release-android.sh` changelog gate. Until then this file is the running
+log; keep it current as iOS changes merge so the first release has its history.
+
+Versioning mirrors Android (see `AndroidGarage/CHANGELOG.md` § versioning):
+major = rewrite or core-experience shift; minor = a user-facing feature added or
+removed; patch = fixes, polish, refactors. iOS uses independent `ios/N` tags.
+
+## Unreleased (0.1.0)
+
+The app is functional on the simulator with real production backend data but has
+not yet shipped to TestFlight or the App Store (Phase F/G — user-gated on Apple
+code-signing). Built so far:
+
+- Five-tab SwiftUI app (Home / History / Profile / Functions / Diagnostics)
+  sharing all business logic with Android via the Kotlin `shared.framework`
+  (`:iosFramework`), wired through SKIE and `SharedViewModel<VM>`.
+- Real Firebase Auth + Google Sign-In, live door STATUS from the production
+  server, and the FCM-receive path (data message → shared `FcmPayloadParser`).
+- Door visualization (geometry, palette, animation spec, live trajectory) shared
+  from `:domain`, plus the History pipeline, snooze, info sheets, and access
+  tri-states — feature parity with Android per ADR-029/ADR-031/ADR-032.
+- Browsable snapshot gallery of every SwiftUI `#Preview` (ADR-030).
+- `scripts/validate-ios.sh` — local CI-exact build verification.

--- a/scripts/validate-ios.sh
+++ b/scripts/validate-ios.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate the iOS app locally — a CI-exact mirror of .github/workflows/ios-ci.yml
+# ("Build iOS app + framework test"). Run this before pushing iOS changes.
+#
+# WHY THIS EXISTS
+#
+# iOS CI is NOT a required status check, so a PR with auto-merge on can merge
+# before the iOS run finishes — a red only surfaces post-merge on main (see
+# CLAUDE.md § "iOS local verification ... the non-required-iOS-CI trap"). Running
+# this script first is the mitigation: it reproduces exactly what CI does, so an
+# iOS break is caught before the push instead of after the merge.
+#
+# WHAT IT RUNS (identical to ios-ci.yml, in the same order)
+#   1. :iosFramework:iosSimulatorArm64Test  — the NativeComponent DI-graph
+#      identity test (40 cases); also warms the shared.framework the app embeds.
+#   2. xcodegen generate                     — regenerate the (gitignored) .xcodeproj.
+#   3. xcodebuild ... build                  — compile the SwiftUI app against the
+#      framework for a generic iOS Simulator destination, signing disabled.
+#
+# This does NOT run the snapshot-gallery tests (Prefire) — those are
+# regenerate-don't-assert and are not a gating CI check. Regenerate them with
+# ./scripts/generate-ios-screenshots.sh when a view changes.
+#
+# CI-EXACT BUILD NOTE: do NOT pass OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED=YES here.
+# CI doesn't set it, and the generic 'iOS Simulator' destination needs the
+# framework rebuilt for the destination's arch(s) — the override skips that
+# Gradle rebuild and the build then fails with "cannot find type ... in scope"
+# (CLAUDE.md § "CI-exact iOS build trap").
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+IOS_APP_DIR="$REPO_ROOT/AndroidGarage/iosApp"
+XCODEPROJ="$IOS_APP_DIR/iosApp.xcodeproj"
+PROJECT_SPEC="$IOS_APP_DIR/project.yml"
+
+fail() {
+    echo -e "${RED}[FAIL] $1${RESET}" >&2
+    exit 1
+}
+
+# --- Preconditions: macOS + the iOS toolchain (this is a no-op on Linux CI). ---
+if [ "$(uname -s)" != "Darwin" ]; then
+    fail "iOS validation requires macOS (Xcode + xcodegen). Current OS: $(uname -s)."
+fi
+command -v xcodegen >/dev/null 2>&1 || fail "xcodegen not found. Install with: brew install xcodegen"
+command -v xcodebuild >/dev/null 2>&1 || fail "xcodebuild not found. Install Xcode and run: xcode-select --install"
+
+echo -e "${BOLD}=== iOS Validation (mirrors ios-ci.yml) ===${RESET}"
+echo ""
+
+# --- Step 1: iosFramework simulator test (DI-graph identity) ---
+# Flake note (CLAUDE.md): a red here whose log shows "The daemon has terminated
+# unexpectedly on startup" with NO "Test Case ... failed" is a Gradle-daemon
+# infra flake, not a regression — rerun with --rerun-tasks to confirm.
+echo -e "${BOLD}[1/3] iosFramework simulator tests (:iosFramework:iosSimulatorArm64Test)${RESET}"
+"$REPO_ROOT/AndroidGarage/gradlew" -p "$REPO_ROOT/AndroidGarage" :iosFramework:iosSimulatorArm64Test \
+    || fail "iosFramework simulator tests failed."
+echo -e "${GREEN}[PASS] iosFramework simulator tests${RESET}"
+echo ""
+
+# --- Step 2: regenerate the Xcode project from project.yml ---
+echo -e "${BOLD}[2/3] Generate Xcode project (xcodegen)${RESET}"
+xcodegen generate --spec "$PROJECT_SPEC" --project "$IOS_APP_DIR" \
+    || fail "xcodegen generate failed."
+echo -e "${GREEN}[PASS] xcodegen generate${RESET}"
+echo ""
+
+# --- Step 3: build the SwiftUI app for the simulator (signing disabled) ---
+echo -e "${BOLD}[3/3] Build iOS app (xcodebuild, generic iOS Simulator)${RESET}"
+xcodebuild \
+    -project "$XCODEPROJ" \
+    -scheme iosApp \
+    -configuration Debug \
+    -sdk iphonesimulator \
+    -destination 'generic/platform=iOS Simulator' \
+    build \
+    CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
+    || fail "iOS app build failed."
+echo -e "${GREEN}[PASS] iOS app build${RESET}"
+echo ""
+
+echo -e "${GREEN}${BOLD}All iOS checks passed.${RESET}"


### PR DESCRIPTION
## What

The testable, signing-independent half of iOS Phase F (release tooling):

- **`scripts/validate-ios.sh`** — a CI-exact mirror of `ios-ci.yml`:
  `:iosFramework:iosSimulatorArm64Test` → `xcodegen generate` →
  `xcodebuild` simulator build (signing disabled). Run it before pushing iOS
  changes.
- **`AndroidGarage/iosApp/CHANGELOG.md`** — seed history doc (AGENTS.md
  front-matter), the file a future release gate will read.

## Why

`validate-ios.sh` is the local mitigation for the **non-required-iOS-CI trap**
(CLAUDE.md): with auto-merge on, a PR can land before the iOS run finishes, so a
red only surfaces post-merge on `main`. Reproducing CI locally catches an iOS
break pre-push.

## Deferred (intentionally)

`scripts/release-ios.sh` + the archive/upload workflow are **user-gated on Apple
code-signing** and wait for that step — they can only be tested end-to-end
against a real signed archive/upload, and a tag-push script with no workflow
listening would be an inert, untestable half-feature.

## Verified

- Ran `./scripts/validate-ios.sh` → `BUILD SUCCEEDED`, `All iOS checks passed.`
  (also confirms iOS `main` is green).
- `check-doc-frontmatter.sh` exit 0 with the new CHANGELOG.

> Note: iOS CI is non-required and may finish after this auto-merges; it was
> verified locally first (the run is over a doc + a new script — the app build
> is unchanged from the now-green `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)