### PR TITLE
ci: make Android CI Dependabot-resilient (placeholder google-services + skip release signing)

### DIFF
--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -31,3 +31,20 @@ runs:
       run: ./release/decrypt-secrets.sh
       env:
         ENCRYPT_KEY: ${{ inputs.encrypt-key }}
+
+    # Dependabot-triggered runs don't receive repo secrets, so the decrypt above
+    # is skipped and google-services.json is absent — which fails
+    # processGoogleServices and every Android job. Drop in a committed placeholder
+    # so the build / test / lint jobs can still validate the dependency change.
+    # (The release-AAB job, which also needs the real signing keystore, is skipped
+    # on Dependabot runs in ci-checks.yml.) Guarded on the empty key so a real CI /
+    # release run — where decrypt produced the real file — is never touched.
+    - name: Provide placeholder google-services.json (no encrypt key)
+      if: inputs.encrypt-key == ''
+      working-directory: AndroidGarage
+      shell: bash
+      run: |
+        if [ ! -f androidApp/google-services.json ]; then
+          cp release/google-services-placeholder.json androidApp/google-services.json
+          echo "No encrypt key (e.g. Dependabot run): copied placeholder google-services.json."
+        fi

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -141,7 +141,13 @@ jobs:
 
   build_release:
     name: Build Release AAB
-    if: inputs.android == 'true'
+    # Skipped on Dependabot runs: GitHub withholds the signing-keystore secrets
+    # from them, so a real release AAB can't be built. The "Android CI Complete"
+    # gate uses `if: always()` and only fails on a failed/cancelled check, so a
+    # skipped job here still lets the gate pass. The other jobs validate the
+    # dependency change (with the placeholder google-services.json from
+    # setup-android). A real release goes through release-android.yml, not here.
+    if: inputs.android == 'true' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/AndroidGarage/release/google-services-placeholder.json
+++ b/AndroidGarage/release/google-services-placeholder.json
@@ -1,0 +1,48 @@
+{
+  "project_info": {
+    "project_number": "000000000000",
+    "project_id": "garage-dependabot-placeholder",
+    "storage_bucket": "garage-dependabot-placeholder.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000001",
+        "android_client_info": {
+          "package_name": "com.chriscartland.garage"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyA0000000000000000000000000000000000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000002",
+        "android_client_info": {
+          "package_name": "com.chriscartland.garage.debug"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyA0000000000000000000000000000000000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
## Why

GitHub withholds repo Actions secrets from Dependabot-triggered runs, so
`setup-android`'s decrypt step is skipped and `google-services.json` is absent —
failing `processGoogleServices` and **every** Android job. That's why all the
gradle/actions Dependabot PRs were red (nothing to do with their actual change).
This makes the gradle/actions **minor/patch** Dependabot PRs able to pass the gate.

## Changes

- **`setup-android`**: when there's no encrypt key (Dependabot), copy a committed
  placeholder `google-services.json`. Guarded so a real CI/release run (where
  decrypt produced the real file) is never touched.
- **`release/google-services-placeholder.json`**: dummy config with **both** the
  release (`com.chriscartland.garage`) and debug (`.debug`) package clients — the
  plugin requires an exact package-name match per variant.
- **`ci-checks.yml`**: skip **Build Release AAB** on Dependabot (it needs the real
  signing keystore, also withheld). `Android CI Complete` uses `if: always()` and
  only fails on a failed/cancelled check, so a skipped job still lets the gate pass.

## Verification

- Swapped the placeholder in for the real (gitignored) `google-services.json` and ran
  `:androidApp:assembleDebug -PSERVER_CONFIG_KEY="" -PGOOGLE_WEB_CLIENT_ID=""` (the
  Dependabot env: placeholder + no secrets) → `processDebugGoogleServices` runs,
  **BUILD SUCCESSFUL**. Real file restored.
- The actor-based release-skip is confirmed against the gate's `always()`/failure-only
  logic; full end-to-end behavior confirms on the next live Dependabot PR.
- `release/*.json` is **not** docs → full CI runs on this PR (with real secrets, so it
  exercises the unchanged real-decrypt path; the placeholder branch only triggers when
  the key is empty).

Pairs with #1000 (Dependabot → minor/patch only). Together: quiet, safe background
updates that can actually merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)