### PR TITLE
chore(deps): stop Dependabot grouping the Kotlin toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,13 @@
 # pins), not a drop-in auto-PR. Take majors by hand when you choose. Minor/patch
 # bumps are grouped per ecosystem and auto-merge once CI is green.
 #
+# The Kotlin/AGP/KSP/Room/kotlin-inject/SKIE/serialization toolchain is ALSO
+# ignored in the gradle ecosystem below (not just its majors): these are
+# high-impact even at a semver-MINOR bump and are Bucket C (hand-managed, serial,
+# release-proof). Exemplar: the first gradle group (#1004) bundled Kotlin
+# 2.1.20 -> 2.4.0, which turned `jvmTarget: String` into a hard error and broke
+# :buildSrc for all 58 grouped updates. See the per-ecosystem `ignore` for the list.
+#
 # NOTE (Android-side CI): GitHub withholds repo Actions secrets from
 # Dependabot-triggered runs, so the google-services.json decrypt no-ops. CI is
 # made Dependabot-resilient separately (placeholder google-services.json +
@@ -52,6 +59,25 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # Kotlin / AGP / KSP toolchain + KMP-bridge + wire-contract deps: HIGH-IMPACT
+      # even at a semver-MINOR bump, so they must not ride the auto android-minor-patch
+      # group. Exemplar: Dependabot's first gradle group (#1004) bumped Kotlin
+      # 2.1.20 -> 2.4.0, which turned the deprecated `jvmTarget: String` Gradle DSL
+      # into a hard error and broke `:buildSrc:compileKotlin` for the whole group.
+      # These are Bucket C in docs/DEPENDENCY_UPGRADES.md — take by hand, serial,
+      # with a real `android/N` release as proof (and they're version-pinned for a
+      # reason: kotlin-inject 0.8.0 and the Kotlin<->KSP<->SKIE version lockstep).
+      - dependency-name: "org.jetbrains.kotlin:*"
+      - dependency-name: "org.jetbrains.kotlin.*"
+      - dependency-name: "com.google.devtools.ksp*"
+      - dependency-name: "com.android.application*"
+      - dependency-name: "com.android.library*"
+      - dependency-name: "com.android.test*"
+      - dependency-name: "com.android.tools.build*"
+      - dependency-name: "androidx.room:*"
+      - dependency-name: "me.tatarka.inject:*"
+      - dependency-name: "co.touchlab.skie*"
+      - dependency-name: "org.jetbrains.kotlinx:kotlinx-serialization*"
 
   # GitHub Actions used by the workflows in .github/workflows/. Addresses the
   # low/informational finding that several actions are pinned to floating major

--- a/docs/DEPENDENCY_UPGRADES.md
+++ b/docs/DEPENDENCY_UPGRADES.md
@@ -20,6 +20,23 @@ several majors (agp 8→9, spotless 7→8, firebase-functions 6→7, firebase-ad
 drop-in auto-PR. **Take majors by hand** when you choose; let Dependabot handle
 the safe minor/patch churn (grouped per ecosystem, `open-pull-requests-limit: 3`).
 
+**The Kotlin toolchain is ignored even at semver-minor.** Dependabot's
+semver classification is too coarse for a Kotlin project: a "minor" bump of the
+Kotlin Gradle Plugin can remove a build DSL. The first gradle group PR (#1004,
+58 grouped updates) bumped **Kotlin 2.1.20 → 2.4.0**, and 2.4.0 turned the
+deprecated `jvmTarget: String` DSL into a hard **error** — `:buildSrc:compileKotlin`
+failed, which failed every Android job uniformly, making the whole auto-group
+dead-on-arrival. So the gradle ecosystem `ignore`s the Bucket-C toolchain
+outright (`org.jetbrains.kotlin*`, `com.google.devtools.ksp*`, AGP plugin
+markers, `androidx.room:*`, `me.tatarka.inject:*`, `co.touchlab.skie*`,
+`org.jetbrains.kotlinx:kotlinx-serialization*`). These move by hand, serial,
+with a real `android/N` release as proof; their version lockstep (Kotlin ↔ KSP ↔
+SKIE, plus the kotlin-inject 0.8.0 pin) is exactly why they can't auto-group.
+Dependabot still auto-handles the safe libs (androidx, compose-bom, coroutines,
+kermit, datastore, lifecycle, detekt, spotless, mockito, etc.). A wrong ignore
+pattern is non-destructive — it only affects Dependabot's own PRs, never `main`
+— so refine reactively if a future group still drags a toolchain dep in.
+
 **Why Android-side Dependabot PRs need CI help:** GitHub withholds repo Actions
 secrets from Dependabot-triggered runs, so `setup-android`'s `google-services.json`
 decrypt no-ops and **every Android job fails at `processGoogleServices`** — a


### PR DESCRIPTION
## Why

The first gradle Dependabot group (#1004, **58 updates**) was confirmed unmergeable — a re-run failed identically, not a flake. It bumped **Kotlin 2.1.20 → 2.4.0**, and Kotlin 2.4.0 turns the deprecated `jvmTarget: String` Gradle DSL into a hard **error**:

```
e: .../android-screenshot-tests/build.gradle.kts:22:9: Using 'jvmTarget: String' is an error.
Script compilation error
```

That fails `:buildSrc:compileKotlin`, which fails **every** Android job uniformly (they all compile buildSrc first) — so the whole auto-group is dead-on-arrival.

The group also dragged along the **kotlin-inject 0.8.0 → 0.9.0** pin tripwire, **AGP 8.10 → 8.13**, **KSP**, **Room 2.7 → 2.8**, **SKIE**, and **kotlinx-serialization 1.8 → 1.11** — all Bucket-C 'take by hand, serial, release-proof' deps per `docs/DEPENDENCY_UPGRADES.md`. Dependabot calls them semver-minor, but for a Kotlin project the toolchain is high-impact and version-locked.

## What

- `.github/dependabot.yml`: add `ignore` entries to the **gradle** ecosystem for the toolchain (`org.jetbrains.kotlin*`, `com.google.devtools.ksp*`, AGP plugin markers, `androidx.room:*`, `me.tatarka.inject:*`, `co.touchlab.skie*`, `org.jetbrains.kotlinx:kotlinx-serialization*`). The weekly group now carries only safe libs (androidx, compose-bom, coroutines, kermit, datastore, lifecycle, detekt, spotless, mockito, …).
- `docs/DEPENDENCY_UPGRADES.md`: document the lesson (semver-minor is too coarse for the Kotlin toolchain) under the Dependabot posture section.

#1004 is **closed**; the Kotlin/AGP toolchain bump should be taken deliberately via the playbook when chosen.

A wrong ignore pattern is non-destructive — it only affects Dependabot's own PRs, never `main` — so this can be refined reactively if a future group still drags a toolchain dep in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)