### PR TITLE
chore(deps): fix AGP/Room ignore patterns + add Ktor (complete #1006)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,17 +67,23 @@ updates:
       # These are Bucket C in docs/DEPENDENCY_UPGRADES.md — take by hand, serial,
       # with a real `android/N` release as proof (and they're version-pinned for a
       # reason: kotlin-inject 0.8.0 and the Kotlin<->KSP<->SKIE version lockstep).
+      #
+      # Patterns must match the EXACT name Dependabot prints in the PR body, which
+      # is not always the obvious coordinate. #1006's first attempt missed two
+      # (#1008 still carried them): Room is named bare `androidx.room` (a colon
+      # pattern `androidx.room:*` did NOT match), and the `agp` version is tracked
+      # under the plugin id `com.android.kotlin.multiplatform.library` (not
+      # `com.android.application` / `com.android.tools.build`). When refining,
+      # read the real names from the open group PR's body, not the catalog alias.
       - dependency-name: "org.jetbrains.kotlin:*"
       - dependency-name: "org.jetbrains.kotlin.*"
       - dependency-name: "com.google.devtools.ksp*"
-      - dependency-name: "com.android.application*"
-      - dependency-name: "com.android.library*"
-      - dependency-name: "com.android.test*"
-      - dependency-name: "com.android.tools.build*"
-      - dependency-name: "androidx.room:*"
+      - dependency-name: "com.android*"                 # AGP (incl. com.android.kotlin.multiplatform.library)
+      - dependency-name: "androidx.room*"               # bare `androidx.room`, no colon
       - dependency-name: "me.tatarka.inject:*"
       - dependency-name: "co.touchlab.skie*"
       - dependency-name: "org.jetbrains.kotlinx:kotlinx-serialization*"
+      - dependency-name: "io.ktor:*"                    # HTTP client — wire-contract highest-risk (JSON shape drift)
 
   # GitHub Actions used by the workflows in .github/workflows/. Addresses the
   # low/informational finding that several actions are pinned to floating major

--- a/docs/DEPENDENCY_UPGRADES.md
+++ b/docs/DEPENDENCY_UPGRADES.md
@@ -27,15 +27,25 @@ Kotlin Gradle Plugin can remove a build DSL. The first gradle group PR (#1004,
 deprecated `jvmTarget: String` DSL into a hard **error** — `:buildSrc:compileKotlin`
 failed, which failed every Android job uniformly, making the whole auto-group
 dead-on-arrival. So the gradle ecosystem `ignore`s the Bucket-C toolchain
-outright (`org.jetbrains.kotlin*`, `com.google.devtools.ksp*`, AGP plugin
-markers, `androidx.room:*`, `me.tatarka.inject:*`, `co.touchlab.skie*`,
-`org.jetbrains.kotlinx:kotlinx-serialization*`). These move by hand, serial,
-with a real `android/N` release as proof; their version lockstep (Kotlin ↔ KSP ↔
-SKIE, plus the kotlin-inject 0.8.0 pin) is exactly why they can't auto-group.
-Dependabot still auto-handles the safe libs (androidx, compose-bom, coroutines,
-kermit, datastore, lifecycle, detekt, spotless, mockito, etc.). A wrong ignore
+outright (`org.jetbrains.kotlin*`, `com.google.devtools.ksp*`, `com.android*`
+for AGP, `androidx.room*`, `me.tatarka.inject:*`, `co.touchlab.skie*`,
+`org.jetbrains.kotlinx:kotlinx-serialization*`, and `io.ktor:*`). These move by
+hand, serial, with a real `android/N` release as proof; their version lockstep
+(Kotlin ↔ KSP ↔ SKIE, plus the kotlin-inject 0.8.0 pin) is exactly why they
+can't auto-group. Ktor is in the list because the HTTP client is the
+wire-contract highest-risk surface (silent JSON shape drift). Dependabot still
+auto-handles the safe libs (androidx, compose-bom, coroutines, kermit, datastore,
+lifecycle, detekt, spotless, mockito, navigation3, etc.).
+
+**Match the EXACT name Dependabot prints, not the catalog alias.** #1006's first
+pass missed two — #1008 still carried them — because the obvious coordinate was
+wrong: Room is named bare `androidx.room` (the colon pattern `androidx.room:*`
+did not match), and the `agp` version is tracked under the plugin id
+`com.android.kotlin.multiplatform.library` (not `com.android.application` /
+`com.android.tools.build`). The authoritative names are in the open group PR's
+**body** (the `Updates \`group:artifact\` from X to Y` lines). A wrong ignore
 pattern is non-destructive — it only affects Dependabot's own PRs, never `main`
-— so refine reactively if a future group still drags a toolchain dep in.
+— so close the bad group PR, read its body for the real names, and refine.
 
 **Why Android-side Dependabot PRs need CI help:** GitHub withholds repo Actions
 secrets from Dependabot-triggered runs, so `setup-android`'s `google-services.json`


### PR DESCRIPTION
## Why

#1006 ignored the Kotlin toolchain in the gradle Dependabot group, but the **very next** group PR (#1008) still carried **AGP** and **Room** — because two patterns didn't match the name Dependabot actually prints:

| Dep | Dependabot's real name | #1006 pattern (no match) | Fix |
|-----|------------------------|--------------------------|-----|
| Room | bare `androidx.room` | `androidx.room:*` (colon) | `androidx.room*` |
| AGP | `com.android.kotlin.multiplatform.library` | `com.android.application*` etc. | `com.android*` |

Also adds **`io.ktor:*`** — Ktor 3.1→3.5 was riding the group, and the HTTP client is the wire-contract *highest-risk* surface (silent JSON shape drift) per the playbook, so it's taken by hand too.

Names were read from #1008's PR body (the authoritative `Updates `group:artifact` from X to Y` lines), which is now documented as the refinement procedure in `docs/DEPENDENCY_UPGRADES.md`.

## Result

Next weekly gradle group will carry only the ~37 safe libs (androidx, compose-bom, lifecycle, datastore, navigation3, …) and should auto-merge clean. #1004 and #1008 are closed; #1007 (Firebase dev-deps) merged green.

A wrong ignore pattern is non-destructive — it only affects Dependabot's own PRs, never `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)