### PR TITLE
chore(deps): ignore AGP-coupled androidx in gradle Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -84,6 +84,17 @@ updates:
       - dependency-name: "co.touchlab.skie*"
       - dependency-name: "org.jetbrains.kotlinx:kotlinx-serialization*"
       - dependency-name: "io.ktor:*"                    # HTTP client — wire-contract highest-risk (JSON shape drift)
+      # AGP-coupled androidx: these gate on `checkDebugAarMetadata` ("requires
+      # Android Gradle plugin 9.1.0 or higher") but AGP is pinned at 8.10.1 above,
+      # so they can't auto-bump — they poison the whole group red (exemplar: #1010,
+      # core 1.19 / lifecycle 2.11 / navigation3 1.2.0-alpha each demand AGP 9.1).
+      # Hold them with AGP; they move together by hand when the toolchain moves.
+      # The decoupled deps (spotless, detekt, compose-bom, mockito, kermit, junit,
+      # screenshot, activity, datastore, sqlite, test libs) still auto-merge.
+      - dependency-name: "androidx.core*"
+      - dependency-name: "androidx.lifecycle*"
+      - dependency-name: "androidx.navigation3*"
+      - dependency-name: "org.jetbrains.androidx*"      # KMP nav3 / lifecycle variants (same AGP-coupled wave)
 
   # GitHub Actions used by the workflows in .github/workflows/. Addresses the
   # low/informational finding that several actions are pinned to floating major

--- a/docs/DEPENDENCY_UPGRADES.md
+++ b/docs/DEPENDENCY_UPGRADES.md
@@ -47,6 +47,23 @@ did not match), and the `agp` version is tracked under the plugin id
 pattern is non-destructive — it only affects Dependabot's own PRs, never `main`
 — so close the bad group PR, read its body for the real names, and refine.
 
+**androidx is coupled to AGP — modern androidx "minor" bumps can't auto-merge
+while AGP is pinned.** After the toolchain was ignored, the next clean group
+(#1010, 31 updates, zero Kotlin/AGP/Room/Ktor) *still* failed —
+`:androidApp:checkDebugAarMetadata` rejected `androidx.core:1.19.0`,
+`androidx.lifecycle:2.11.0`, and `androidx.navigation3:1.2.0-alpha03` with
+"requires Android Gradle plugin 9.1.0 or higher." AGP is pinned at 8.10.1
+(Bucket C), so these androidx waves are gated on an AGP we hold by hand. They're
+therefore ALSO in the gradle `ignore` (`androidx.core*`, `androidx.lifecycle*`,
+`androidx.navigation3*`, `org.jetbrains.androidx*`) and move with AGP. The
+decoupled gradle deps (spotless, detekt, compose-bom, mockito, kermit, junit,
+screenshot, activity, datastore, sqlite, test libs) build fine on 8.10.1 and
+still auto-merge. **Caveat:** an allowed bump can still pull an AGP-gated androidx
+version *transitively* (core is a near-universal transitive dep), which would
+re-poison the group; if a future group goes red on AarMetadata despite these
+ignores, that's the cause — verify on the next run and widen the ignore or move
+the whole androidx+AGP+Kotlin wave by hand as one coordinated upgrade.
+
 **Why Android-side Dependabot PRs need CI help:** GitHub withholds repo Actions
 secrets from Dependabot-triggered runs, so `setup-android`'s `google-services.json`
 decrypt no-ops and **every Android job fails at `processGoogleServices`** — a


### PR DESCRIPTION
## Why

After the toolchain was ignored (#1006/#1009), the next clean group (#1010, 31 updates, **zero** Kotlin/AGP/Room/Ktor) *still* failed — `:androidApp:checkDebugAarMetadata`:

```
androidx.core:1.19.0                requires Android Gradle plugin 9.1.0 or higher
androidx.lifecycle:2.11.0           requires Android Gradle plugin 9.1.0 or higher
androidx.navigation3:1.2.0-alpha03  requires Android Gradle plugin 9.1.0 or higher
```

AGP is pinned at 8.10.1 (Bucket C, hand-managed), so these androidx waves are **coupled** to an AGP we hold by hand. They can't auto-bump and poison the whole group red.

## What

Ignore `androidx.core*`, `androidx.lifecycle*`, `androidx.navigation3*`, `org.jetbrains.androidx*` in the **gradle** ecosystem. The group now carries only the deps that build on 8.10.1 — spotless, detekt, compose-bom, mockito, kermit, junit, screenshot, activity, datastore, sqlite, test libs — which **can** auto-merge. androidx + AGP + Kotlin move together by hand as one coordinated upgrade via `docs/DEPENDENCY_UPGRADES.md`.

**Caveat (documented):** an allowed bump could still pull an AGP-gated androidx version *transitively* (core is near-universal). If a future group goes red on AarMetadata despite these ignores, that's the cause — verified on the next weekly run.

#1010 closed. Per the maintainer decision (ignore AGP-coupled androidx, keep the working auto-bumps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)