### PR TITLE
feat(ios): wire automatic code signing + push entitlement

### DIFF
--- a/AndroidGarage/iosApp/iosApp/iosApp.entitlements
+++ b/AndroidGarage/iosApp/iosApp/iosApp.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	  APNs environment for FCM push. Value is driven by the APS_ENVIRONMENT build
+	  setting (Debug = development, Release = production) so a dev-device build and
+	  a TestFlight/App Store build each get the right APNs routing without editing
+	  this file. See project.yml `settings.configs`.
+	-->
+	<key>aps-environment</key>
+	<string>$(APS_ENVIRONMENT)</string>
+</dict>
+</plist>

--- a/AndroidGarage/iosApp/project.yml
+++ b/AndroidGarage/iosApp/project.yml
@@ -72,6 +72,13 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.chriscartland.garage
+        # Code signing. Team ID is not a secret (it appears in every app's
+        # provisioning), so it's committed. Automatic signing lets Xcode manage
+        # the cert + provisioning profile for the App ID. CI builds pass
+        # CODE_SIGNING_ALLOWED=NO, which makes these inert for the simulator build.
+        DEVELOPMENT_TEAM: 4EFTFGDT4G
+        CODE_SIGN_STYLE: Automatic
+        CODE_SIGN_ENTITLEMENTS: iosApp/iosApp.entitlements
         GENERATE_INFOPLIST_FILE: YES
         INFOPLIST_FILE: iosApp/Info.plist
         INFOPLIST_KEY_UILaunchScreen_Generation: YES
@@ -88,6 +95,14 @@ targets:
           - $(inherited)
           - -framework
           - shared
+      configs:
+        # Drives `aps-environment` in iosApp.entitlements. Debug device builds
+        # use the development APNs sandbox; Release (archive → TestFlight / App
+        # Store) uses production APNs.
+        Debug:
+          APS_ENVIRONMENT: development
+        Release:
+          APS_ENVIRONMENT: production
     preBuildScripts:
       - name: "Build Kotlin shared.framework (embedAndSign)"
         basedOnDependencyAnalysis: false


### PR DESCRIPTION
First repo-side step toward a signed device / TestFlight build.

Adds to the `iosApp` target in `project.yml`:
- **`DEVELOPMENT_TEAM = 4EFTFGDT4G`** (Team ID — not a secret, appears in every app's provisioning) + **automatic** code-sign style, so Xcode manages the cert + provisioning profile for `com.chriscartland.garage`.
- **`CODE_SIGN_ENTITLEMENTS`** → new `iosApp/iosApp.entitlements` declaring `aps-environment` driven by an `APS_ENVIRONMENT` build setting (**Debug = development**, **Release = production**) so a dev-device build and a TestFlight/App Store build each get the right FCM/APNs routing without editing the file.

CI builds pass `CODE_SIGNING_ALLOWED=NO`, so these settings are inert for the simulator build.

**Verified locally:** `xcodegen generate` + the CI-exact simulator build (no override, generic destination) → `** BUILD SUCCEEDED **` with `CODE_SIGN_ENTITLEMENTS=iosApp/iosApp.entitlements` applied. iOS-only change (no Kotlin / no `iosFramework`), so Android required checks are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)