### PR TITLE
chore(deps): ignore the whole kotlinx group (datetime broke #1013)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,7 +82,12 @@ updates:
       - dependency-name: "androidx.room*"               # bare `androidx.room`, no colon
       - dependency-name: "me.tatarka.inject:*"
       - dependency-name: "co.touchlab.skie*"
-      - dependency-name: "org.jetbrains.kotlinx:kotlinx-serialization*"
+      # Whole kotlinx ecosystem (serialization, coroutines, datetime) — all
+      # Kotlin-version-coupled, so they move with Kotlin by hand. serialization is
+      # wire-contract highest-risk (JSON shape drift); datetime tracks kotlin.time
+      # and a "minor" bump (0.6→0.8) made HistoryMapper's Clock/Instant usage
+      # require @OptIn(ExperimentalTime) and broke compile (#1013).
+      - dependency-name: "org.jetbrains.kotlinx:*"
       - dependency-name: "io.ktor:*"                    # HTTP client — wire-contract highest-risk (JSON shape drift)
       # AGP-coupled androidx: these gate on `checkDebugAarMetadata` ("requires
       # Android Gradle plugin 9.1.0 or higher") but AGP is pinned at 8.10.1 above,


### PR DESCRIPTION
#1013 (25 updates) got **past** the androidx/AGP `checkDebugAarMetadata` gate — so the #1012 androidx ignores worked — but failed compiling `:presentation-model`: **kotlinx-datetime 0.6→0.8** moved `Clock`/`Instant` onto `kotlin.time` and made `HistoryMapper`'s usage require `@OptIn(ExperimentalTime)`.

kotlinx-datetime is Kotlin-version-coupled (like serialization), so widen the ignore from `org.jetbrains.kotlinx:kotlinx-serialization*` to the whole **`org.jetbrains.kotlinx:*`** group (also covers coroutines). They move with Kotlin by hand.

#1013 closed. The next weekly group is the test of whether the remaining deps (spotless, detekt, mockito, firebase-bom, screenshot, play-services-auth, junit…) are finally all decoupled and auto-merge clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)