### PR TITLE
docs(ios): finalize 0.1.0 changelog for the first release

### DIFF
--- a/AndroidGarage/iosApp/CHANGELOG.md
+++ b/AndroidGarage/iosApp/CHANGELOG.md
@@ -10,29 +10,24 @@ the Android `AndroidGarage/CHANGELOG.md` convention: newest first, one `## X.Y.Z
 heading per release matching `MARKETING_VERSION` in `iosApp/project.yml`, with a
 non-empty body of user-facing changes.
 
-When iOS release tooling lands (Phase F — `scripts/release-ios.sh` + the
-archive/upload workflow, paired with Apple code-signing), a release gate will
-require the `## X.Y.Z` heading for the version being shipped — same model as the
-Android `release-android.sh` changelog gate. Until then this file is the running
-log; keep it current as iOS changes merge so the first release has its history.
+The `scripts/release-ios.sh` gate requires a `## X.Y.Z` heading (matching
+`MARKETING_VERSION`) with a non-empty body before it will cut the `ios/N` tag —
+same model as the Android `release-android.sh` changelog gate. Keep this current
+as iOS changes merge.
 
 Versioning mirrors Android (see `AndroidGarage/CHANGELOG.md` § versioning):
 major = rewrite or core-experience shift; minor = a user-facing feature added or
 removed; patch = fixes, polish, refactors. iOS uses independent `ios/N` tags.
 
-## Unreleased (0.1.0)
+## 0.1.0
 
-The app is functional on the simulator with real production backend data but has
-not yet shipped to TestFlight or the App Store (Phase F/G — user-gated on Apple
-code-signing). Built so far:
+First TestFlight (Internal) release — a native SwiftUI iOS app that shares all
+business logic with Android via the Kotlin `shared.framework` (`:iosFramework`),
+wired through SKIE and `SharedViewModel<VM>`.
 
-- Five-tab SwiftUI app (Home / History / Profile / Functions / Diagnostics)
-  sharing all business logic with Android via the Kotlin `shared.framework`
-  (`:iosFramework`), wired through SKIE and `SharedViewModel<VM>`.
+- Five tabs: Home / History / Profile / Functions / Diagnostics.
 - Real Firebase Auth + Google Sign-In, live door STATUS from the production
   server, and the FCM-receive path (data message → shared `FcmPayloadParser`).
-- Door visualization (geometry, palette, animation spec, live trajectory) shared
-  from `:domain`, plus the History pipeline, snooze, info sheets, and access
+- Door visualization (geometry, palette, animation, live trajectory) shared from
+  `:domain`, plus the History pipeline, snooze, info sheets, and access
   tri-states — feature parity with Android per ADR-029/ADR-031/ADR-032.
-- Browsable snapshot gallery of every SwiftUI `#Preview` (ADR-030).
-- `scripts/validate-ios.sh` — local CI-exact build verification.


### PR DESCRIPTION
Converts `## Unreleased (0.1.0)` → `## 0.1.0` with a finalized body so the `release-ios.sh` changelog gate passes for the first `ios/N` release. Also updates the intro (the release tooling has landed, so the gate is active rather than future).

Verified the gate's awk finds a non-empty `0.1.0` body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)