### PR TITLE
feat(ios): App Store Connect build-number check (CI abort + local tag calc)

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -87,6 +87,29 @@ jobs:
           printf '%s\n' "$KEY_P8" > "$RUNNER_TEMP/asc_keys/AuthKey_${KEY_ID}.p8"
           echo "ASC_KEY_PATH=$RUNNER_TEMP/asc_keys/AuthKey_${KEY_ID}.p8" >> "$GITHUB_ENV"
 
+      # Fail loudly BEFORE archiving if the tag's build number is already on App
+      # Store Connect. Otherwise Apple silently auto-resolves the collision to a
+      # different number (that's how ios/1 landed as CFBundleVersion 2), which
+      # breaks the "tag N == build number" guarantee. release-ios.sh runs the same
+      # check locally when ASC creds are available.
+      - name: Pre-flight — build number must be free on App Store Connect
+        env:
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          ASC_BUNDLE_ID: com.chriscartland.garage
+          N: ${{ steps.validate.outputs.build_number }}
+        run: |
+          LATEST=$(ruby scripts/asc-latest-build.rb) || {
+            echo "::error::Could not query App Store Connect for existing builds (see log above)."
+            exit 1
+          }
+          echo "Latest build on App Store Connect: $LATEST; this release (tag ios/$N): build $N"
+          if [ "$N" -le "$LATEST" ]; then
+            echo "::error::Build number $N is not greater than the latest App Store Connect build ($LATEST). CFBundleVersion must strictly increase — retag as ios/$((LATEST + 1)) (or run ./scripts/release-ios.sh --check with local ASC creds, which computes the right tag)."
+            exit 1
+          fi
+          echo "Build number $N is free (> $LATEST). Proceeding."
+
       - name: Generate Xcode project
         working-directory: AndroidGarage/iosApp
         run: xcodegen generate

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 .claude/.dev-mode
 .claude/scheduled_tasks.lock
 
+# App Store Connect API creds for release-ios.sh (local only; never commit)
+scripts/.asc-credentials.local
+
 # macOS
 .DS_Store
 .DS_Store?

--- a/docs/IOS_RELEASE_SETUP.md
+++ b/docs/IOS_RELEASE_SETUP.md
@@ -155,14 +155,35 @@ Distribution cert + profile on demand):
    - `APP_STORE_CONNECT_KEY_P8` — the full contents of the `.p8`
    - `GARAGE_SERVER_CONFIG_KEY` — the door-backend key (so the TestFlight build loads door data)
 
+### Build numbering (tag `ios/N` == `CFBundleVersion`)
+The tag `ios/N` sets `CURRENT_PROJECT_VERSION = N`, which becomes the build's
+`CFBundleVersion`. App Store Connect requires each build number to be **unique and
+strictly increasing**, and it *silently auto-resolves* a collision to a different
+number rather than failing — that's how `ios/1` landed as build 2 (a manual upload
+had already taken build 1). To keep the tag matching the build number and to fail
+loudly instead:
+- **CI pre-flight (always on):** `release-ios.yml` queries App Store Connect
+  (`scripts/asc-latest-build.rb`) *before archiving* and **aborts** if `N` is not
+  strictly greater than the latest existing build.
+- **Local (optional):** if you provide ASC credentials, `release-ios.sh --check`
+  computes the next tag as **(latest App Store Connect build + 1)**, so it proposes
+  the correct `ios/N` even when git tags and build numbers have drifted. Copy
+  `scripts/asc-credentials.local.example` → `scripts/.asc-credentials.local`
+  (gitignored) and fill in the same Admin key's ID / Issuer ID / `.p8` path. Without
+  it the script falls back to git tags and prints a note (CI still enforces the check).
+
+Because the build number climbs monotonically with `N`, don't reuse a number — if
+CI aborts saying build `N` is taken, retag with the number it reports.
+
 ### Cutting a release
 1. Bump `MARKETING_VERSION` in `project.yml` (if the user-facing version changed) and
    add a matching `## X.Y.Z` heading to `AndroidGarage/iosApp/CHANGELOG.md`.
 2. `./scripts/validate-ios.sh` (writes the marker).
-3. `./scripts/release-ios.sh --check` → copy-paste the printed `--confirm-tag ios/N` command.
-4. The tag push triggers `release-ios.yml` → archive → upload → the build appears in
-   TestFlight after processing. Monitor the Actions run; a failure opens a
-   `release-failure/ios` issue (auto-closed on the next success).
+3. `./scripts/release-ios.sh --check` → copy-paste the printed `--confirm-tag ios/N`
+   command (the tag == the next free build number when local ASC creds are set).
+4. The tag push triggers `release-ios.yml` → **pre-flight build-number check** →
+   archive → upload → the build appears in TestFlight after processing. Monitor the
+   Actions run; a failure opens a `release-failure/ios` issue (auto-closed on the next success).
 
 **Status: verified end-to-end (`ios/1`, build 1 / 0.1.0, 2026-06-30).** The
 `app-store-connect` method + cloud-signing-via-API-key + `destination: upload` path

--- a/scripts/asc-credentials.local.example
+++ b/scripts/asc-credentials.local.example
@@ -1,0 +1,16 @@
+# App Store Connect API credentials for scripts/release-ios.sh (OPTIONAL, local only).
+#
+# Copy to scripts/.asc-credentials.local (gitignored) and fill in. With it,
+# release-ios.sh --check computes the next ios/N tag from App Store Connect's
+# latest build number, so the tag always equals the next free CFBundleVersion.
+# Without it, the script falls back to git tags only and prints a note (the CI
+# pre-flight in release-ios.yml still enforces the check either way).
+#
+# Same values as the GitHub Actions secrets — must be the Admin-role API key
+# (App Manager can't cloud-sign the Distribution cert). ASC_KEY_PATH points at
+# the downloaded .p8 on disk (never committed).
+
+export ASC_KEY_ID="XXXXXXXXXX"
+export ASC_ISSUER_ID="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+export ASC_KEY_PATH="$HOME/path/to/AuthKey_XXXXXXXXXX.p8"
+# export ASC_BUNDLE_ID="com.chriscartland.garage"   # default; override only if needed

--- a/scripts/asc-latest-build.rb
+++ b/scripts/asc-latest-build.rb
@@ -1,0 +1,104 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Print the highest CFBundleVersion (build number) currently on App Store Connect
+# for the app, or 0 if there are none. Ruby stdlib only — no gems, so it runs
+# identically on the macOS CI runner and a local Mac.
+#
+# Shared by:
+#   - .github/workflows/release-ios.yml  (pre-flight: abort if the tag's build
+#     number is not strictly greater than this)
+#   - scripts/release-ios.sh             (compute the next ios/N tag = this + 1,
+#     so the tag always equals the next free CFBundleVersion)
+#
+# Env:
+#   ASC_KEY_ID      App Store Connect API Key ID
+#   ASC_ISSUER_ID   App Store Connect API Issuer ID
+#   ASC_KEY_PATH    path to AuthKey_<KEYID>.p8 (unencrypted EC private key, PEM)
+#   ASC_BUNDLE_ID   app bundle id (default: com.chriscartland.garage)
+#
+# Prints the integer to stdout and exits 0 on success. On ANY error (missing
+# creds, key unreadable, API failure, app not found) it prints a diagnostic to
+# stderr and exits 2 — so callers can distinguish "0 builds exist" (stdout "0",
+# exit 0) from "couldn't check" (exit 2).
+#
+# Build numbers are assumed integer (the release sets CURRENT_PROJECT_VERSION=N).
+# If a CFBundleVersion is dotted (e.g. "1.2.3"), its leading integer is used.
+
+require 'openssl'
+require 'base64'
+require 'json'
+require 'net/http'
+require 'uri'
+
+def die(msg)
+  warn("asc-latest-build: #{msg}")
+  exit 2
+end
+
+key_id    = ENV['ASC_KEY_ID']    || die('ASC_KEY_ID not set')
+issuer_id = ENV['ASC_ISSUER_ID'] || die('ASC_ISSUER_ID not set')
+key_path  = ENV['ASC_KEY_PATH']  || die('ASC_KEY_PATH not set')
+bundle_id = ENV['ASC_BUNDLE_ID'] || 'com.chriscartland.garage'
+
+die("key file not found: #{key_path}") unless File.file?(key_path)
+
+def b64(bin)
+  Base64.urlsafe_encode64(bin, padding: false)
+end
+
+# --- ES256 JWT for the App Store Connect API (hand-rolled, stdlib only) ---
+begin
+  pkey = OpenSSL::PKey.read(File.read(key_path))
+rescue StandardError => e
+  die("could not read EC private key: #{e.message}")
+end
+
+header  = { alg: 'ES256', kid: key_id, typ: 'JWT' }
+payload = { iss: issuer_id, iat: Time.now.to_i, exp: Time.now.to_i + 1200, aud: 'appstoreconnect-v1' }
+signing_input = "#{b64(header.to_json)}.#{b64(payload.to_json)}"
+
+der  = pkey.sign(OpenSSL::Digest.new('SHA256'), signing_input) # DER ECDSA sig
+asn1 = OpenSSL::ASN1.decode(der)
+# JOSE wants raw r||s, each left-padded to 32 bytes for P-256.
+r = asn1.value[0].value.to_s(2).rjust(32, "\x00".b)
+s = asn1.value[1].value.to_s(2).rjust(32, "\x00".b)
+jwt = "#{signing_input}.#{b64(r + s)}"
+
+def asc_get(path, jwt)
+  uri = URI("https://api.appstoreconnect.apple.com#{path}")
+  req = Net::HTTP::Get.new(uri)
+  req['Authorization'] = "Bearer #{jwt}"
+  res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, open_timeout: 15, read_timeout: 30) do |http|
+    http.request(req)
+  end
+  [res.code.to_i, res.body.to_s]
+end
+
+# --- Resolve the app id from the bundle id ---
+code, body = asc_get("/v1/apps?filter%5BbundleId%5D=#{URI.encode_www_form_component(bundle_id)}&limit=1", jwt)
+die("apps query failed (HTTP #{code}): #{body[0, 300]}") unless code == 200
+apps = JSON.parse(body)
+die("no app found for bundleId #{bundle_id}") if apps['data'].nil? || apps['data'].empty?
+app_id = apps['data'][0]['id']
+
+# --- Walk all builds, return the max integer CFBundleVersion ---
+max_build = 0
+path = "/v1/builds?filter%5Bapp%5D=#{app_id}&limit=200&fields%5Bbuilds%5D=version"
+loop do
+  code, body = asc_get(path, jwt)
+  die("builds query failed (HTTP #{code}): #{body[0, 300]}") unless code == 200
+  data = JSON.parse(body)
+  (data['data'] || []).each do |build|
+    version = build.dig('attributes', 'version').to_s
+    leading = version[/\A\d+/]
+    n = leading ? leading.to_i : 0
+    max_build = n if n > max_build
+  end
+  nxt = data.dig('links', 'next')
+  break unless nxt
+
+  path = nxt.sub('https://api.appstoreconnect.apple.com', '')
+end
+
+puts max_build

--- a/scripts/release-ios.sh
+++ b/scripts/release-ios.sh
@@ -110,21 +110,54 @@ done
 
 git fetch origin --tags --quiet
 
-# Compute latest ios/N tag number and its SHA.
-HIGHEST_VERSION=$(git tag -l 'ios/[0-9]*' | sed 's|ios/||' | grep -E '^[0-9]+$' || true)
-HIGHEST_VERSION=$(echo "$HIGHEST_VERSION" | sort -n | tail -1)
+# --- App Store Connect build-number authority (optional, graceful) ---
+# App Store Connect is the real source of truth for the CFBundleVersion, and the
+# workflow numbers each build by the tag N. If ASC credentials are available
+# locally, compute the next tag as (latest ASC build + 1) so the ios/N tag always
+# equals the next FREE build number — even if a build was uploaded out-of-band
+# (which is what put ios/1 at CFBundleVersion 2). Load creds from
+# scripts/.asc-credentials.local (gitignored; see scripts/asc-credentials.local.example)
+# or the environment. If unavailable, fall back to git tags only and say so; the CI
+# pre-flight in release-ios.yml enforces the same check regardless.
+ASC_CREDS_FILE="$REPO_ROOT/scripts/.asc-credentials.local"
+# shellcheck disable=SC1090
+[ -f "$ASC_CREDS_FILE" ] && . "$ASC_CREDS_FILE"
+ASC_LATEST=""
+if command -v ruby >/dev/null 2>&1 && [ -n "${ASC_KEY_ID:-}" ] && [ -n "${ASC_ISSUER_ID:-}" ] && [ -n "${ASC_KEY_PATH:-}" ]; then
+    ASC_ERR="$(mktemp)"
+    if ASC_LATEST=$(ASC_BUNDLE_ID="${ASC_BUNDLE_ID:-com.chriscartland.garage}" \
+            ruby "$REPO_ROOT/scripts/asc-latest-build.rb" 2>"$ASC_ERR"); then
+        ASC_NOTE="App Store Connect latest build: $ASC_LATEST (authoritative for the build number)"
+    else
+        ASC_NOTE="App Store Connect check FAILED — $(head -1 "$ASC_ERR" 2>/dev/null); using git tags only"
+        ASC_LATEST=""
+    fi
+    rm -f "$ASC_ERR"
+else
+    ASC_NOTE="App Store Connect check skipped (no local ASC creds — see scripts/asc-credentials.local.example); using git tags only"
+fi
 
-if [ -z "$HIGHEST_VERSION" ]; then
-    NEXT_VERSION=1
+# Highest ios/N git tag (0 if none).
+GIT_HIGHEST=$(git tag -l 'ios/[0-9]*' | sed 's|ios/||' | grep -E '^[0-9]+$' | sort -n | tail -1)
+GIT_HIGHEST=${GIT_HIGHEST:-0}
+
+# Next build number = strictly greater than BOTH the highest git tag AND the
+# latest App Store Connect build (when known), so the tag can never collide.
+if [ -n "$ASC_LATEST" ] && [ "$ASC_LATEST" -gt "$GIT_HIGHEST" ]; then
+    BASE=$ASC_LATEST
+else
+    BASE=$GIT_HIGHEST
+fi
+NEXT_VERSION=$((BASE + 1))
+NEW_TAG="ios/$NEXT_VERSION"
+
+if [ "$GIT_HIGHEST" -eq 0 ]; then
     LATEST_TAG="(none)"
     LATEST_TAG_SHA="(none)"
 else
-    NEXT_VERSION=$((HIGHEST_VERSION + 1))
-    LATEST_TAG="ios/$HIGHEST_VERSION"
+    LATEST_TAG="ios/$GIT_HIGHEST"
     LATEST_TAG_SHA=$(git rev-parse "$LATEST_TAG" 2>/dev/null || echo "(missing)")
 fi
-
-NEW_TAG="ios/$NEXT_VERSION"
 
 # Resolve target commit.
 if [ -n "$CONFIRM_HASH" ]; then
@@ -225,7 +258,8 @@ fi
 # === --check mode ===
 if [ "$MODE" = "check" ]; then
     echo "Latest tag:   $LATEST_TAG (sha: $LATEST_TAG_SHA)"
-    echo "Next tag:     $NEW_TAG"
+    echo "Next tag:     $NEW_TAG  (build number $NEXT_VERSION)"
+    echo "Build source: $ASC_NOTE"
     echo "HEAD:         $TARGET_COMMIT"
     echo "Branch:       $CURRENT_BRANCH"
 
@@ -479,6 +513,7 @@ echo "  Branch:      $CURRENT_BRANCH"
 echo "  Latest tag:  $LATEST_TAG ($LATEST_TAG_SHA)"
 echo "  New tag:     $NEW_TAG  (build number $NEXT_VERSION)"
 echo "  Marketing:   $VERSION_NAME"
+echo "  Build src:   $ASC_NOTE"
 echo "  Commit:      $TARGET_COMMIT_SHORT ($TARGET_COMMIT)"
 echo ""
 


### PR DESCRIPTION
Makes the iOS build number deterministic and fail-loud, per request — CI aborts on a collision, and the local script attempts the same check.

## The problem
Tag `ios/N` sets `CFBundleVersion=N`, but App Store Connect **silently auto-resolves** a duplicate build number to a different one instead of failing — that's how `ios/1` landed as build **2** (a manual upload had already taken build 1). That breaks the "tag == build number" guarantee.

## The fix
- **`scripts/asc-latest-build.rb`** — shared Ruby (stdlib only; hand-rolled ES256 JWT, **no gems**) that prints the highest existing `CFBundleVersion` for the app via the App Store Connect API. Used by both CI and the local script.
- **`release-ios.yml`** — a **pre-flight** step queries ASC *before archiving* and **aborts** if the tag's build number isn't strictly greater than the latest. No silent drift; no wasted archive.
- **`release-ios.sh`** — when local ASC creds are present, computes the next tag as **(latest ASC build + 1)** so `ios/N` always equals the next free build number (would correctly propose `ios/3` now, not `ios/2`). Falls back to git tags + a printed note when creds are absent — CI still enforces the check either way. Creds load from a gitignored `scripts/.asc-credentials.local` (template: `scripts/asc-credentials.local.example`).

## Verified
`ruby -c`; the ES256 JWT DER→raw signature path round-trips + **verifies** with a throwaway P-256 key; valid workflow YAML; `release-ios.sh --check` shows the graceful git fallback ("ASC check skipped — using git tags only"). The **live ASC API call** is exercised on the next release (I can't hit the API without the key, same as the workflow itself).

Docs: `IOS_RELEASE_SETUP.md § Build numbering` explains the model + the local-creds setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)