### PR TITLE
docs(ios): fix two stale release comments post-automation

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -8,8 +8,7 @@ name: iOS Release
 # overridden onto the archive here so the tag is the source of truth for it. The
 # user-facing MARKETING_VERSION (X.Y.Z) comes from project.yml (committed).
 #
-# REQUIRED GitHub secrets (see docs/IOS_RELEASE_SETUP.md § "Future: automated
-# releases"). Until these exist, this workflow fails fast at the steps that use them:
+# REQUIRED GitHub secrets (see docs/IOS_RELEASE_SETUP.md § "Automated releases"):
 #   APP_STORE_CONNECT_KEY_ID      App Store Connect API Key ID
 #   APP_STORE_CONNECT_ISSUER_ID   App Store Connect API Issuer ID
 #   APP_STORE_CONNECT_KEY_P8      full contents of the AuthKey_<KEY_ID>.p8
@@ -18,7 +17,10 @@ name: iOS Release
 # Signing is automatic in CI via the App Store Connect API key
 # (`-allowProvisioningUpdates` + `-authenticationKey*`): xcodebuild creates/downloads
 # the Apple Distribution cert + App Store provisioning profile on demand — no cert
-# is imported into a keychain. The key needs the "App Manager" (or Admin) role.
+# is imported into a keychain. The key MUST have the "Admin" role — "App Manager"
+# archives fine but fails export with "Cloud signing permission error" (empirical,
+# ios/1 attempt 1). This is the ONLY place the deploy-capable key lives; dev machines
+# never hold it (release-ios.sh only suggests a tag from git tags).
 
 on:
   push:

--- a/docs/IOS_RELEASE_SETUP.md
+++ b/docs/IOS_RELEASE_SETUP.md
@@ -37,7 +37,7 @@ the construction status/plan is in
 | `GARAGE_SERVER_CONFIG_KEY` (door backend) | **Yes** | `iosApp/Secrets.local.xcconfig` (**gitignored**) | build setting → `$(GARAGE_SERVER_CONFIG_KEY)` substituted into `Info.plist` |
 | APNs auth key (`.p8`) | **Yes** | uploaded to Firebase Console; `.p8` file kept offline by the maintainer | created in the Apple Developer portal, uploaded to Firebase Cloud Messaging — never in repo |
 | Apple ID + password | **Yes** | maintainer's Apple account | interactive sign-in in Xcode / the portals — never in repo |
-| App Store Connect API key (for *future* CI release) | **Yes** | not yet created → will be GitHub Actions secrets | see "Future: automated releases" |
+| App Store Connect API key (CI release) | **Yes** | GitHub Actions secrets (`APP_STORE_CONNECT_KEY_ID` / `_ISSUER_ID` / `_KEY_P8`) — **Admin** role | never on a dev machine; see "Automated releases" |
 
 \* `GoogleService-Info.plist` is committed on purpose: a Firebase **iOS client config**
 is designed to ship inside the app bundle (it's extractable from any distributed


### PR DESCRIPTION
Follow-up doc accuracy after the release automation landed:
- `IOS_RELEASE_SETUP.md` secret-map row: the App Store Connect API key is no longer "future / not yet created" — it exists (Admin role) and lives in GitHub secrets.
- `release-ios.yml` header: reference "§ Automated releases" (not "Future"); state the key **must be Admin** (App Manager fails cloud signing), and that the deploy key lives only in Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)