### PR TITLE
feat(server): flag-gated replace-tag on the open-door warning (relaxed-A, dark)

### DIFF
--- a/FirebaseServer/src/controller/config/ConfigAccessors.ts
+++ b/FirebaseServer/src/controller/config/ConfigAccessors.ts
@@ -200,3 +200,26 @@ export function isSnoozeNotificationsEnabled(config: any): boolean {
 export function isResolvedOnCloseEnabled(config: any): boolean {
   return config?.body?.resolvedOnCloseEnabled === true;
 }
+
+/**
+ * Gate for adding `android.notification.tag = 'garage_door'` to the open-door
+ * WARNING so a newer warning (or the resolved) replaces it in the tray instead
+ * of stacking — the relaxed-A single-card design
+ * (docs/RESOLVED_NOTIFICATION_NO_COMPROMISE.md §9). Stored as
+ * `body.warningReplaceTagEnabled: boolean` on `configCurrent/current`, edited
+ * in-place in the Firestore console (NEVER a whole-doc POST — see
+ * docs/FIREBASE_CONFIG_AUTHORITY.md). Read live per warning send.
+ *
+ * The tag is the ONLY wire change frozen old apps (< 2.19.0) can observe, so
+ * this flag MUST stay false in production until the on-device re-alert gate
+ * (docs/RESOLVED_NOTIFICATION_NO_COMPROMISE.md §9.4) passes on the target OEM
+ * set: a non-conformant ROM that silently coalesces a same-tag update could
+ * drop a warning's re-alert. On conformant Android the only change is
+ * stacking → replace-to-latest, which is neutral-to-improving.
+ *
+ * Fail-safe: anything other than literal `true` → false → the warning is sent
+ * WITHOUT a tag, byte-identical to today (guarded by the warning freeze-test).
+ */
+export function isWarningReplaceTagEnabled(config: any): boolean {
+  return config?.body?.warningReplaceTagEnabled === true;
+}

--- a/FirebaseServer/src/controller/fcm/OldDataFCM.ts
+++ b/FirebaseServer/src/controller/fcm/OldDataFCM.ts
@@ -17,6 +17,8 @@
 import * as firebase from 'firebase-admin';
 
 import { DATABASE as NotificationsDatabase } from '../../database/NotificationsDatabase';
+import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
+import { isWarningReplaceTagEnabled } from '../config/ConfigAccessors';
 
 import { SensorEvent, SensorEventType } from '../../model/SensorEvent';
 import { AndroidMessagePriority, TopicMessage, Notification, NotificationPriority, AndroidConfig, AndroidNotification } from '../../model/FCM';
@@ -28,6 +30,12 @@ const CURRENT_EVENT_KEY = 'currentEvent';
 const NOTIFICATION_CURRENT_EVENT_KEY = 'notificationCurrentEvent';
 const NOTIFICATION_MESSAGE_KEY = 'message';
 const TIMESTAMP_SECONDS_KEY = 'timestampSeconds';
+
+// Drawer replace-key shared with the client (DoorNotificationPresenter.TAG =
+// "garage_door") and the resolved. Only attached to the warning when the
+// `warningReplaceTagEnabled` config flag is on — see ConfigAccessors and
+// docs/RESOLVED_NOTIFICATION_NO_COMPROMISE.md §9. Off = byte-identical to today.
+const WARNING_REPLACE_TAG = 'garage_door';
 
 /**
  * Send an FCM message if the current event is old and the door is not closed.
@@ -55,7 +63,16 @@ export async function sendFCMForOldData(buildTimestamp: string, eventData): Prom
     return null;
   }
   console.debug('Decided to send FCM for open door');
-  const message = getDoorNotClosedMessageFromEvent(buildTimestamp, currentEvent, timestampSeconds);
+  // Live config read: whether to attach the drawer replace-tag to the warning
+  // (relaxed-A single-card design, flag-gated + device-gated). Fail-safe: any
+  // read problem yields `false`, i.e. today's tag-less warning.
+  const config = await ServerConfigDatabase.get();
+  const message = getDoorNotClosedMessageFromEvent(
+    buildTimestamp,
+    currentEvent,
+    timestampSeconds,
+    isWarningReplaceTagEnabled(config),
+  );
   if (!message) {
     console.error('Could not generate message to send');
     return null;
@@ -143,7 +160,7 @@ async function shouldSendFcmForOpenDoor(buildTimestamp: string, currentEvent: Se
  * @param now Unix time in seconds.
  * @return FCM message to send to users. Return null if no message is needed.
  */
-export function getDoorNotClosedMessageFromEvent(buildTimestamp: string, currentEvent: SensorEvent, now: number): TopicMessage {
+export function getDoorNotClosedMessageFromEvent(buildTimestamp: string, currentEvent: SensorEvent, now: number, replaceTagEnabled = false): TopicMessage {
   const eventDurationSeconds = now - currentEvent.timestampSeconds;
   const durationMinutes = Math.floor(eventDurationSeconds / 60);
   const durationHours = Math.floor(durationMinutes / 60);
@@ -161,6 +178,14 @@ export function getDoorNotClosedMessageFromEvent(buildTimestamp: string, current
   message.android.collapse_key = 'door_not_closed';
   message.android.priority = AndroidMessagePriority.HIGH;
   message.android.notification.notification_priority = NotificationPriority.PRIORITY_MAX;
+  // Relaxed-A single-card design (docs/RESOLVED_NOTIFICATION_NO_COMPROMISE.md §9):
+  // when enabled, share a fixed drawer tag with the resolved so it replaces this
+  // card instead of stacking. Set before the switch so every warning branch
+  // inherits it; the Closed branch returns null regardless. Flag off (default) =
+  // no tag = today's wire shape, pinned by the warning freeze-test.
+  if (replaceTagEnabled) {
+    message.android.notification.tag = WARNING_REPLACE_TAG;
+  }
   const type = currentEvent.type;
   switch (type) {
     case SensorEventType.Unknown:

--- a/FirebaseServer/test/controller/fcm/OldDataFCMFakeTest.ts
+++ b/FirebaseServer/test/controller/fcm/OldDataFCMFakeTest.ts
@@ -53,9 +53,14 @@ import {
   setImpl as setSnoozeDBImpl,
   resetImpl as resetSnoozeDBImpl,
 } from '../../../src/database/SnoozeNotificationsDatabase';
+import {
+  setImpl as setServerConfigDBImpl,
+  resetImpl as resetServerConfigDBImpl,
+} from '../../../src/database/ServerConfigDatabase';
 import { FakeNotificationsDatabase } from '../../fakes/FakeNotificationsDatabase';
 import { FakeSensorEventDatabase } from '../../fakes/FakeSensorEventDatabase';
 import { FakeSnoozeNotificationsDatabase } from '../../fakes/FakeSnoozeNotificationsDatabase';
+import { FakeServerConfigDatabase } from '../../fakes/FakeServerConfigDatabase';
 import { SensorEvent, SensorEventType } from '../../../src/model/SensorEvent';
 
 const BUILD_TIMESTAMP = 'Sat Mar 13 14:45:00 2021';
@@ -74,6 +79,7 @@ describe('sendFCMForOldData (via fakes)', () => {
   let fakeNotifications: FakeNotificationsDatabase;
   let fakeSensorEvents: FakeSensorEventDatabase;
   let fakeSnoozeDB: FakeSnoozeNotificationsDatabase;
+  let fakeConfig: FakeServerConfigDatabase;
   let sendStub: sinon.SinonStub;
 
   // firebase-admin requires an initialized default app before any service
@@ -89,9 +95,14 @@ describe('sendFCMForOldData (via fakes)', () => {
     fakeNotifications = new FakeNotificationsDatabase();
     fakeSensorEvents = new FakeSensorEventDatabase();
     fakeSnoozeDB = new FakeSnoozeNotificationsDatabase();
+    fakeConfig = new FakeServerConfigDatabase();
+    // Default: relaxed-A replace-tag flag OFF → tag-less warning (today's shape).
+    // sendFCMForOldData now reads config to decide whether to tag the warning.
+    fakeConfig.seed({ body: {} });
     setNotificationsDBImpl(fakeNotifications);
     setSensorEventDBImpl(fakeSensorEvents);
     setSnoozeDBImpl(fakeSnoozeDB);
+    setServerConfigDBImpl(fakeConfig);
 
     // Pin "now" so the 15-minute threshold is deterministic.
     sinon.stub(firebase.firestore.Timestamp, 'now').returns({
@@ -115,6 +126,7 @@ describe('sendFCMForOldData (via fakes)', () => {
     resetNotificationsDBImpl();
     resetSensorEventDBImpl();
     resetSnoozeDBImpl();
+    resetServerConfigDBImpl();
     sinon.restore();
   });
 
@@ -240,6 +252,43 @@ describe('sendFCMForOldData (via fakes)', () => {
     // FCM called exactly once with the built message.
     expect(sendStub.calledOnce).to.be.true;
     expect(sendStub.firstCall.args[0]).to.equal(result);
+  });
+
+  // --- Relaxed-A warning replace-tag flag (docs/RESOLVED_NOTIFICATION_NO_COMPROMISE.md §9) ---
+
+  it('sends a tag-less warning when warningReplaceTagEnabled is off (default)', async () => {
+    const staleOpen: SensorEvent = {
+      type: SensorEventType.Open,
+      timestampSeconds: STALE_EVENT_TS,
+      message: '',
+      checkInTimestampSeconds: 0,
+    };
+    fakeSensorEvents.seed(BUILD_TIMESTAMP, { currentEvent: staleOpen });
+
+    const result = await sendFCMForOldData(BUILD_TIMESTAMP, { currentEvent: staleOpen });
+
+    expect(result).to.not.be.null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((result!.android.notification as any).tag).to.be.undefined;
+  });
+
+  it('tags the sent warning garage_door when warningReplaceTagEnabled is true', async () => {
+    const staleOpen: SensorEvent = {
+      type: SensorEventType.Open,
+      timestampSeconds: STALE_EVENT_TS,
+      message: '',
+      checkInTimestampSeconds: 0,
+    };
+    fakeSensorEvents.seed(BUILD_TIMESTAMP, { currentEvent: staleOpen });
+    fakeConfig.seed({ body: { warningReplaceTagEnabled: true } });
+
+    const result = await sendFCMForOldData(BUILD_TIMESTAMP, { currentEvent: staleOpen });
+
+    expect(result).to.not.be.null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((result!.android.notification as any).tag).to.equal('garage_door');
+    // The flag must not disturb the send itself.
+    expect(sendStub.calledOnce).to.be.true;
   });
 
   // --- Duplicate-notification suppression ---

--- a/FirebaseServer/test/controller/fcm/OldDataFCMWarningTagTest.ts
+++ b/FirebaseServer/test/controller/fcm/OldDataFCMWarningTagTest.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests the flag-gated `replaceTagEnabled` parameter of the open-door warning
+ * (relaxed-A single-card design, docs/RESOLVED_NOTIFICATION_NO_COMPROMISE.md §9).
+ *
+ * The warning is what frozen old apps (< 2.19.0) render, so the ONLY thing the
+ * flag may change is the drawer tag: when off (default) the message is
+ * byte-identical to today (pinned by OldDataFCMWarningFreezeTest); when on it
+ * gains `android.notification.tag = 'garage_door'` and nothing else. These tests
+ * pin exactly that delta so the flag can never smuggle in a broader old-app change.
+ */
+import { expect } from 'chai';
+import { SensorEvent, SensorEventType } from '../../../src/model/SensorEvent';
+import { TopicMessage } from '../../../src/model/FCM';
+import { getDoorNotClosedMessageFromEvent } from '../../../src/controller/fcm/OldDataFCM';
+
+describe('OldDataFCM warning replace-tag (relaxed-A, flag-gated)', () => {
+  const BUILD_TIMESTAMP = 'Sat Mar 13 14:45:00 2021';
+  const EVENT_SECONDS = 1725781091;
+  const NOW = EVENT_SECONDS + 16 * 60;
+
+  // Every warning-producing branch (Closed returns null and is covered separately).
+  const WARNING_TYPES: SensorEventType[] = [
+    SensorEventType.Open,
+    SensorEventType.Opening,
+    SensorEventType.OpeningTooLong,
+    SensorEventType.Closing,
+    SensorEventType.ClosingTooLong,
+    SensorEventType.ErrorSensorConflict,
+    SensorEventType.Unknown,
+    SensorEventType.OpenMisaligned,
+  ];
+
+  function warningFor(type: SensorEventType, replaceTagEnabled?: boolean): TopicMessage {
+    const currentEvent = <SensorEvent>{
+      type,
+      timestampSeconds: EVENT_SECONDS,
+      message: 'Test message',
+      checkInTimestampSeconds: EVENT_SECONDS + 1,
+    };
+    return replaceTagEnabled === undefined
+      ? getDoorNotClosedMessageFromEvent(BUILD_TIMESTAMP, currentEvent, NOW)
+      : getDoorNotClosedMessageFromEvent(BUILD_TIMESTAMP, currentEvent, NOW, replaceTagEnabled);
+  }
+
+  it('defaults to NO tag when the flag arg is omitted (today\'s behavior)', () => {
+    WARNING_TYPES.forEach((type) => {
+      const message = warningFor(type);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((message.android.notification as any).tag, `branch ${type}`).to.be.undefined;
+    });
+  });
+
+  it('adds NO tag when the flag is explicitly false', () => {
+    WARNING_TYPES.forEach((type) => {
+      const message = warningFor(type, false);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((message.android.notification as any).tag, `branch ${type}`).to.be.undefined;
+    });
+  });
+
+  it('adds tag=garage_door on every warning branch when the flag is true', () => {
+    WARNING_TYPES.forEach((type) => {
+      const message = warningFor(type, true);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((message.android.notification as any).tag, `branch ${type}`).to.equal('garage_door');
+    });
+  });
+
+  it('changes ONLY the tag — every other field is identical on vs off', () => {
+    WARNING_TYPES.forEach((type) => {
+      const off = warningFor(type, false);
+      const on = warningFor(type, true);
+      expect(on.topic, `branch ${type} topic`).to.equal(off.topic);
+      expect(on.notification.title, `branch ${type} title`).to.equal(off.notification.title);
+      expect(on.notification.body, `branch ${type} body`).to.equal(off.notification.body);
+      expect(on.android.collapse_key, `branch ${type} collapse_key`).to.equal(off.android.collapse_key);
+      expect(on.android.priority, `branch ${type} priority`).to.equal(off.android.priority);
+      expect(
+        on.android.notification.notification_priority,
+        `branch ${type} notification_priority`,
+      ).to.equal(off.android.notification.notification_priority);
+    });
+  });
+
+  it('produces NO message for a closed door regardless of the flag', () => {
+    expect(warningFor(SensorEventType.Closed, true)).to.be.null;
+    expect(warningFor(SensorEventType.Closed, false)).to.be.null;
+  });
+});


### PR DESCRIPTION
## What

Adds `android.notification.tag = 'garage_door'` to the open-door **warning** — but **only** when a new config flag `warningReplaceTagEnabled` is `true`. Default `false` = today's tag-less warning, byte-identical (pinned by the warning freeze-test from #1036).

This is **PR 4 of the relaxed-A single-card rollout** (`docs/RESOLVED_NOTIFICATION_NO_COMPROMISE.md` §9). The tag lets a newer warning / the resolved replace the card in the tray instead of stacking.

## Changes

- `ConfigAccessors.isWarningReplaceTagEnabled` — fail-safe (`=== true`), live-read, mirrors `isResolvedOnCloseEnabled`.
- `OldDataFCM.getDoorNotClosedMessageFromEvent` — optional `replaceTagEnabled` param (default `false`); `sendFCMForOldData` reads config and passes it.
- Tests: pure-function tag on/off per branch (asserts **only** the tag differs); fake-body integration for the flag flowing through `sendFCMForOldData`; `OldDataFCMFakeTest` now wires `FakeServerConfigDatabase` (default off).

## Safety

- **Merged dark.** The flag stays `false` in production until the on-device re-alert gate (§9.4) passes across the target OEM set (Pixel + Samsung/Xiaomi). A non-conformant ROM that silently coalesces a same-tag update could drop a warning's re-alert — the gate confirms it doesn't.
- Old-app impact **when enabled**: stacking → replace-to-latest (neutral-to-improving, verified no degradation by the adversarial pass). The freeze-test guarantees nothing else in the warning changes.
- `validate-firebase.sh` green (387 passing).

⚠️ **Do not flip `warningReplaceTagEnabled` on until the device gate passes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)