### PR TITLE
feat(server): flag-gated combined notification+data resolved (relaxed-A, dark)

### DIFF
--- a/FirebaseServer/src/controller/config/ConfigAccessors.ts
+++ b/FirebaseServer/src/controller/config/ConfigAccessors.ts
@@ -223,3 +223,25 @@ export function isResolvedOnCloseEnabled(config: any): boolean {
 export function isWarningReplaceTagEnabled(config: any): boolean {
   return config?.body?.warningReplaceTagEnabled === true;
 }
+
+/**
+ * Gate for sending the resolved-on-close as a COMBINED notification+data message
+ * (an OS-renderable notification block + the shared `garage_door` tag) instead of
+ * today's data-only message — the relaxed-A single-card design
+ * (docs/RESOLVED_NOTIFICATION_NO_COMPROMISE.md §9). Stored as
+ * `body.resolvedNotificationPayloadEnabled: boolean` on `configCurrent/current`,
+ * edited in-place in the Firestore console. Read live per close event.
+ *
+ * Orthogonal to `resolvedOnCloseEnabled` (which decides whether a resolved fires
+ * at all): this flag only decides data-only (default) vs combined. Both must be
+ * true for a combined resolved to fire. New-app-only — the resolved is on the v2
+ * topic, which frozen old apps never subscribe to.
+ *
+ * Fail-safe: anything other than literal `true` → false → the resolved is the
+ * data-only message that has been live in production, byte-identical (pinned by
+ * ResolvedNotificationFCMFakeTest). MUST stay false until the on-device
+ * cross-topic same-tag replacement gate (§9.4) passes.
+ */
+export function isResolvedNotificationPayloadEnabled(config: any): boolean {
+  return config?.body?.resolvedNotificationPayloadEnabled === true;
+}

--- a/FirebaseServer/src/controller/fcm/ResolvedNotificationFCM.ts
+++ b/FirebaseServer/src/controller/fcm/ResolvedNotificationFCM.ts
@@ -18,10 +18,10 @@ import * as firebase from 'firebase-admin';
 
 import { DATABASE as NotificationsDatabase } from '../../database/NotificationsDatabase';
 import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDatabase';
-import { isResolvedOnCloseEnabled } from '../config/ConfigAccessors';
+import { isResolvedOnCloseEnabled, isResolvedNotificationPayloadEnabled } from '../config/ConfigAccessors';
 
 import { SensorEvent } from '../../model/SensorEvent';
-import { AndroidMessagePriority, TopicMessage, AndroidConfig } from '../../model/FCM';
+import { AndroidMessagePriority, TopicMessage, AndroidConfig, Notification, AndroidNotification, NotificationPriority } from '../../model/FCM';
 import { buildTimestampToFcmTopicV2 } from '../../model/FcmTopic';
 
 /**
@@ -100,11 +100,17 @@ class DefaultResolvedNotificationFCMService implements ResolvedNotificationFCMSe
       return null;
     }
 
-    // 4. Build + send the data-only resolved. Send BEFORE consuming the marker
-    //    (mirror R5): a failed send leaves the marker un-consumed so a duplicate
-    //    Closed report can retry, rather than marking "resolved" with nothing
-    //    delivered.
-    const message = getResolvedMessage(buildTimestamp, openTimestampSeconds, closeTimestampSeconds);
+    // 4. Build + send the resolved. Send BEFORE consuming the marker (mirror
+    //    R5): a failed send leaves the marker un-consumed so a duplicate Closed
+    //    report can retry, rather than marking "resolved" with nothing delivered.
+    //    `resolvedNotificationPayloadEnabled` (live) decides data-only (default,
+    //    today's shape) vs the relaxed-A combined notification+data message.
+    const message = getResolvedMessage(
+      buildTimestamp,
+      openTimestampSeconds,
+      closeTimestampSeconds,
+      isResolvedNotificationPayloadEnabled(config),
+    );
     console.log('Sending resolved-on-close notification', JSON.stringify(message));
     try {
       const response = await firebase.messaging().send(message);
@@ -148,21 +154,51 @@ export function setImpl(impl: ResolvedNotificationFCMService): void { _instance 
 /** TEST-ONLY: restore the default (Firebase-dispatching) implementation. */
 export function resetImpl(): void { _instance = new DefaultResolvedNotificationFCMService(); }
 
+// Drawer replace-key shared with the warning (OldDataFCM WARNING_REPLACE_TAG) and
+// the client (DoorNotificationPresenter.TAG = "garage_door"). Only attached in the
+// combined-message variant, so an OS-rendered resolved can replace the warning
+// in the tray on a never-woken device. See docs/RESOLVED_NOTIFICATION_NO_COMPROMISE.md §9.
+const RESOLVED_REPLACE_TAG = 'garage_door';
+
+/** Timezone-free open duration for the OS-rendered resolved body (server cannot
+ *  know the device timezone, so no wall-clock time — duration only). Mirrors
+ *  OldDataFCM's minutes/hours formatting. */
+function formatOpenDuration(durationSeconds: number): string {
+  const minutes = Math.floor(durationSeconds / 60);
+  if (minutes < 60) {
+    return minutes.toString() + ' minutes';
+  }
+  return Math.floor(minutes / 60).toString() + ' hours';
+}
+
 /**
- * Pure helper — builds the DATA-ONLY resolved payload. No side effects.
+ * Pure helper — builds the resolved payload. No side effects.
  *
- * The client formats the human strings (duration + local start/end times) in the
- * device timezone, so the server sends only raw second timestamps. `kind`
- * discriminates the notification intent (distinct from the door-event `type`
- * key). collapse_key matches the warning's so an offline device coalesces a
- * stale warning with its resolution; HIGH priority so the data wakes the app
- * promptly (there is no `notification` block, so this never renders an OS
- * heads-up — the app owns display).
+ * Two shapes, chosen by `includeNotificationPayload`:
+ *
+ *  - DATA-ONLY (default, today's live shape): only a `data` block + HIGH
+ *    priority. The client formats the human strings (duration + local start/end
+ *    times) in the device timezone, so the server sends only raw second
+ *    timestamps. No `notification` block, so it never renders an OS heads-up —
+ *    the app owns display.
+ *  - COMBINED (relaxed-A single-card, docs/RESOLVED_NOTIFICATION_NO_COMPROMISE.md
+ *    §9): the same `data` block PLUS a `notification` block sharing the warning's
+ *    `garage_door` tag. An alive app still builds the rich device-local body from
+ *    the data block; a never-woken app OS-renders the notification block, whose
+ *    body is a timezone-free duration and whose priority is lowered (NORMAL /
+ *    PRIORITY_LOW) so the all-clear does not heads-up or buzz (FCM has no
+ *    only_alert_once wire field, so priority is the only server lever).
+ *
+ * `kind` discriminates the notification intent (distinct from the door-event
+ * `type` key). collapse_key matches the warning's so an offline device coalesces
+ * a stale warning with its resolution. The `data` block is identical in both
+ * shapes (pinned to wire-contracts/openDoorResolved/payload_resolved.json).
  */
 export function getResolvedMessage(
   buildTimestamp: string,
   openTimestampSeconds: number,
   closeTimestampSeconds: number,
+  includeNotificationPayload = false,
 ): TopicMessage {
   const message = <TopicMessage>{};
   message.topic = buildTimestampToFcmTopicV2(buildTimestamp);
@@ -173,6 +209,16 @@ export function getResolvedMessage(
   };
   message.android = <AndroidConfig>{};
   message.android.collapse_key = 'door_not_closed';
-  message.android.priority = AndroidMessagePriority.HIGH;
+  if (includeNotificationPayload) {
+    message.notification = <Notification>{};
+    message.notification.title = 'Resolved: garage door closed';
+    message.notification.body = 'Was open for ' + formatOpenDuration(closeTimestampSeconds - openTimestampSeconds);
+    message.android.priority = AndroidMessagePriority.NORMAL;
+    message.android.notification = <AndroidNotification>{};
+    message.android.notification.notification_priority = NotificationPriority.PRIORITY_LOW;
+    message.android.notification.tag = RESOLVED_REPLACE_TAG;
+  } else {
+    message.android.priority = AndroidMessagePriority.HIGH;
+  }
   return message;
 }

--- a/FirebaseServer/test/controller/fcm/ResolvedNotificationFCMFakeTest.ts
+++ b/FirebaseServer/test/controller/fcm/ResolvedNotificationFCMFakeTest.ts
@@ -51,6 +51,7 @@ import { FakeNotificationsDatabase } from '../../fakes/FakeNotificationsDatabase
 import { FakeServerConfigDatabase } from '../../fakes/FakeServerConfigDatabase';
 import { SensorEvent, SensorEventType } from '../../../src/model/SensorEvent';
 import { buildTimestampToFcmTopic } from '../../../src/model/FcmTopic';
+import { AndroidMessagePriority, NotificationPriority } from '../../../src/model/FCM';
 
 const BUILD_TIMESTAMP = 'Sat Mar 13 14:45:00 2021';
 const EXPECTED_V2_TOPIC = 'door_open_v2-Sat.Mar.13.14.45.00.2021';
@@ -222,6 +223,45 @@ describe('sendFCMForResolvedDoor (via fakes)', () => {
     expect(sendStub.calledOnce).to.be.true; // only the first sent
   });
 
+  // --- Combined notification+data resolved (relaxed-A, resolvedNotificationPayloadEnabled) ---
+  // docs/RESOLVED_NOTIFICATION_NO_COMPROMISE.md §9. Requires BOTH flags on.
+
+  it('sends a COMBINED message (notification + shared tag + lowered priority) when the payload flag is on', async () => {
+    fakeConfig.seed({ body: { resolvedOnCloseEnabled: true, resolvedNotificationPayloadEnabled: true } });
+    fakeNotifications.seed(BUILD_TIMESTAMP, warnedMarker(OPEN_TS));
+
+    const result = await ResolvedNotificationFCMService.sendFCMForResolvedDoor(
+      BUILD_TIMESTAMP, closedEventAt(CLOSE_TS),
+    );
+
+    expect(result).to.not.be.null;
+    const sent = sendStub.firstCall.args[0];
+    // OS-renderable notification block with the shared drawer tag.
+    expect(sent.notification.title).to.equal('Resolved: garage door closed');
+    expect(sent.notification.body).to.equal('Was open for 14 minutes'); // timezone-free duration
+    expect(sent.android.notification.tag).to.equal('garage_door');
+    // Lowered alerting so the all-clear does not heads-up / buzz.
+    expect(sent.android.priority).to.equal(AndroidMessagePriority.NORMAL);
+    expect(sent.android.notification.notification_priority).to.equal(NotificationPriority.PRIORITY_LOW);
+    // Data block UNCHANGED — still drives the rich device-local foreground body.
+    expect(sent.data).to.deep.equal(RESOLVED_FIXTURE);
+    expect(sent.topic).to.equal(EXPECTED_V2_TOPIC);
+  });
+
+  it('stays DATA-ONLY when resolvedOnCloseEnabled is on but the payload flag is off', async () => {
+    fakeConfig.seed({ body: { resolvedOnCloseEnabled: true, resolvedNotificationPayloadEnabled: false } });
+    fakeNotifications.seed(BUILD_TIMESTAMP, warnedMarker(OPEN_TS));
+
+    const result = await ResolvedNotificationFCMService.sendFCMForResolvedDoor(
+      BUILD_TIMESTAMP, closedEventAt(CLOSE_TS),
+    );
+
+    expect(result).to.not.be.null;
+    const sent = sendStub.firstCall.args[0];
+    expect(sent).to.not.have.property('notification');
+    expect(sent.android.priority).to.equal(AndroidMessagePriority.HIGH);
+  });
+
   // --- Stale-marker guard ---
 
   it('does not send when the marker is stale (duration beyond the cap)', async () => {
@@ -308,6 +348,32 @@ describe('sendFCMForResolvedDoor (via fakes)', () => {
       expect(message).to.not.have.property('notification');
       expect(message.data).to.deep.equal(RESOLVED_FIXTURE);
       expect(message.android.collapse_key).to.equal('door_not_closed');
+      expect(message.android.priority).to.equal(AndroidMessagePriority.HIGH);
+    });
+
+    it('is data-only + HIGH when includeNotificationPayload is false (byte-identical to today)', () => {
+      const message = getResolvedMessage(BUILD_TIMESTAMP, OPEN_TS, CLOSE_TS, false);
+      expect(message).to.not.have.property('notification');
+      expect(message.android.priority).to.equal(AndroidMessagePriority.HIGH);
+      expect(message.data).to.deep.equal(RESOLVED_FIXTURE);
+    });
+
+    it('adds notification + tag + lowered priority when includeNotificationPayload is true, data unchanged', () => {
+      const message = getResolvedMessage(BUILD_TIMESTAMP, OPEN_TS, CLOSE_TS, true);
+      expect(message.topic).to.equal(EXPECTED_V2_TOPIC);
+      expect(message.notification.title).to.equal('Resolved: garage door closed');
+      expect(message.notification.body).to.equal('Was open for 14 minutes');
+      expect(message.android.priority).to.equal(AndroidMessagePriority.NORMAL);
+      expect(message.android.notification.notification_priority).to.equal(NotificationPriority.PRIORITY_LOW);
+      expect(message.android.notification.tag).to.equal('garage_door');
+      // Data block is identical across both shapes — the wire contract never changes.
+      expect(message.data).to.deep.equal(RESOLVED_FIXTURE);
+      expect(message.android.collapse_key).to.equal('door_not_closed');
+    });
+
+    it('formats the duration as hours past 60 minutes', () => {
+      const message = getResolvedMessage(BUILD_TIMESTAMP, OPEN_TS, OPEN_TS + 90 * 60, true);
+      expect(message.notification.body).to.equal('Was open for 1 hours');
     });
   });
 });


### PR DESCRIPTION
## What

Makes the resolved-on-close a **combined** notification+data message — but **only** when a new config flag `resolvedNotificationPayloadEnabled` is `true`. Default `false` = today's **data-only** resolved, byte-identical (the currently-live behavior, pinned by the existing `not.have.property('notification')` tests).

This is **PR 3 of the relaxed-A single-card rollout** (`docs/RESOLVED_NOTIFICATION_NO_COMPROMISE.md` §9) — the new-app side.

## Behavior when enabled

`getResolvedMessage` adds a notification block sharing the warning's `garage_door` tag, so a **never-woken** device OS-renders the all-clear and it replaces the warning in the tray (the single-card win a data-only message can't deliver). Adversarial-pass mitigations baked in:

- **Lowered alerting** — `android.priority=NORMAL` + `notification_priority=PRIORITY_LOW`, so the all-clear does not heads-up/buzz (FCM has no `only_alert_once` wire field).
- **Timezone-free duration-only server body** (`"Was open for X minutes"`), since the server can't know the device timezone. The rich device-local body still renders in the **foreground** from the **unchanged** data block.

## Safety

- **New-app-only.** The resolved is on `door_open_v2-`, which frozen old apps never subscribe to. Zero old-app impact by construction.
- Orthogonal to `resolvedOnCloseEnabled` — **both** must be on for a combined resolved.
- **Data block byte-identical** to `wire-contracts/openDoorResolved/payload_resolved.json` (pinned by test) — no wire-contract change.
- **Merged dark.** `resolvedNotificationPayloadEnabled` stays `false` until the on-device cross-topic same-tag replacement gate (§9.4) passes.
- `validate-firebase.sh` green (392 passing).

Follow-up (small, deferred): a client foreground parse-fallback in `DoorNotificationPresenter` for a malformed data block — defensive, only relevant once the flag is on.

⚠️ **Do not flip `resolvedNotificationPayloadEnabled` on until the device gate passes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)