### PR TITLE
fix(server): combined resolved uses HIGH priority (device gate: PRIORITY_LOW is a no-op)

### DIFF
--- a/FirebaseServer/src/controller/fcm/ResolvedNotificationFCM.ts
+++ b/FirebaseServer/src/controller/fcm/ResolvedNotificationFCM.ts
@@ -21,7 +21,7 @@ import { DATABASE as ServerConfigDatabase } from '../../database/ServerConfigDat
 import { isResolvedOnCloseEnabled, isResolvedNotificationPayloadEnabled } from '../config/ConfigAccessors';
 
 import { SensorEvent } from '../../model/SensorEvent';
-import { AndroidMessagePriority, TopicMessage, AndroidConfig, Notification, AndroidNotification, NotificationPriority } from '../../model/FCM';
+import { AndroidMessagePriority, TopicMessage, AndroidConfig, Notification, AndroidNotification } from '../../model/FCM';
 import { buildTimestampToFcmTopicV2 } from '../../model/FcmTopic';
 
 /**
@@ -185,9 +185,14 @@ function formatOpenDuration(durationSeconds: number): string {
  *    §9): the same `data` block PLUS a `notification` block sharing the warning's
  *    `garage_door` tag. An alive app still builds the rich device-local body from
  *    the data block; a never-woken app OS-renders the notification block, whose
- *    body is a timezone-free duration and whose priority is lowered (NORMAL /
- *    PRIORITY_LOW) so the all-clear does not heads-up or buzz (FCM has no
- *    only_alert_once wire field, so priority is the only server lever).
+ *    body is a timezone-free duration. HIGH delivery priority (like the data-only
+ *    shape) so the message actually reaches a dozing device — that prompt delivery
+ *    is what makes the never-woken replacement happen. The all-clear DOES heads-up
+ *    / buzz: on Android 8+ the HIGH "Garage door" channel importance overrides any
+ *    per-notification `notification_priority`, so there is no server lever to quiet
+ *    it (device gate 2026-07-02 confirmed PRIORITY_LOW had no effect). The
+ *    maintainer accepted the buzzing all-clear (§9.4); a silent all-clear would
+ *    need a dedicated lower-importance channel, deferred.
  *
  * `kind` discriminates the notification intent (distinct from the door-event
  * `type` key). collapse_key matches the warning's so an offline device coalesces
@@ -209,16 +214,17 @@ export function getResolvedMessage(
   };
   message.android = <AndroidConfig>{};
   message.android.collapse_key = 'door_not_closed';
+  // HIGH in BOTH shapes: the data-only shape wakes the app; the combined shape
+  // needs prompt Doze delivery so the never-woken replacement actually arrives.
+  // Lowering it does NOT quiet the all-clear (channel importance wins, gate
+  // 2026-07-02) and would only risk deferring it. See the docstring + §9.4.
+  message.android.priority = AndroidMessagePriority.HIGH;
   if (includeNotificationPayload) {
     message.notification = <Notification>{};
     message.notification.title = 'Resolved: garage door closed';
     message.notification.body = 'Was open for ' + formatOpenDuration(closeTimestampSeconds - openTimestampSeconds);
-    message.android.priority = AndroidMessagePriority.NORMAL;
     message.android.notification = <AndroidNotification>{};
-    message.android.notification.notification_priority = NotificationPriority.PRIORITY_LOW;
     message.android.notification.tag = RESOLVED_REPLACE_TAG;
-  } else {
-    message.android.priority = AndroidMessagePriority.HIGH;
   }
   return message;
 }

--- a/FirebaseServer/test/controller/fcm/ResolvedNotificationFCMFakeTest.ts
+++ b/FirebaseServer/test/controller/fcm/ResolvedNotificationFCMFakeTest.ts
@@ -51,7 +51,7 @@ import { FakeNotificationsDatabase } from '../../fakes/FakeNotificationsDatabase
 import { FakeServerConfigDatabase } from '../../fakes/FakeServerConfigDatabase';
 import { SensorEvent, SensorEventType } from '../../../src/model/SensorEvent';
 import { buildTimestampToFcmTopic } from '../../../src/model/FcmTopic';
-import { AndroidMessagePriority, NotificationPriority } from '../../../src/model/FCM';
+import { AndroidMessagePriority } from '../../../src/model/FCM';
 
 const BUILD_TIMESTAMP = 'Sat Mar 13 14:45:00 2021';
 const EXPECTED_V2_TOPIC = 'door_open_v2-Sat.Mar.13.14.45.00.2021';
@@ -226,7 +226,7 @@ describe('sendFCMForResolvedDoor (via fakes)', () => {
   // --- Combined notification+data resolved (relaxed-A, resolvedNotificationPayloadEnabled) ---
   // docs/RESOLVED_NOTIFICATION_NO_COMPROMISE.md §9. Requires BOTH flags on.
 
-  it('sends a COMBINED message (notification + shared tag + lowered priority) when the payload flag is on', async () => {
+  it('sends a COMBINED message (notification + shared tag + HIGH priority) when the payload flag is on', async () => {
     fakeConfig.seed({ body: { resolvedOnCloseEnabled: true, resolvedNotificationPayloadEnabled: true } });
     fakeNotifications.seed(BUILD_TIMESTAMP, warnedMarker(OPEN_TS));
 
@@ -240,9 +240,13 @@ describe('sendFCMForResolvedDoor (via fakes)', () => {
     expect(sent.notification.title).to.equal('Resolved: garage door closed');
     expect(sent.notification.body).to.equal('Was open for 14 minutes'); // timezone-free duration
     expect(sent.android.notification.tag).to.equal('garage_door');
-    // Lowered alerting so the all-clear does not heads-up / buzz.
-    expect(sent.android.priority).to.equal(AndroidMessagePriority.NORMAL);
-    expect(sent.android.notification.notification_priority).to.equal(NotificationPriority.PRIORITY_LOW);
+    // HIGH delivery priority so the never-woken replacement reaches a dozing
+    // device. No notification_priority lever: it can't quiet the all-clear (the
+    // HIGH channel importance wins on Android 8+, device gate 2026-07-02), and the
+    // buzzing all-clear is accepted — so the field is simply not set.
+    expect(sent.android.priority).to.equal(AndroidMessagePriority.HIGH);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((sent.android.notification as any).notification_priority).to.be.undefined;
     // Data block UNCHANGED — still drives the rich device-local foreground body.
     expect(sent.data).to.deep.equal(RESOLVED_FIXTURE);
     expect(sent.topic).to.equal(EXPECTED_V2_TOPIC);
@@ -358,13 +362,14 @@ describe('sendFCMForResolvedDoor (via fakes)', () => {
       expect(message.data).to.deep.equal(RESOLVED_FIXTURE);
     });
 
-    it('adds notification + tag + lowered priority when includeNotificationPayload is true, data unchanged', () => {
+    it('adds notification + tag + HIGH priority when includeNotificationPayload is true, data unchanged', () => {
       const message = getResolvedMessage(BUILD_TIMESTAMP, OPEN_TS, CLOSE_TS, true);
       expect(message.topic).to.equal(EXPECTED_V2_TOPIC);
       expect(message.notification.title).to.equal('Resolved: garage door closed');
       expect(message.notification.body).to.equal('Was open for 14 minutes');
-      expect(message.android.priority).to.equal(AndroidMessagePriority.NORMAL);
-      expect(message.android.notification.notification_priority).to.equal(NotificationPriority.PRIORITY_LOW);
+      expect(message.android.priority).to.equal(AndroidMessagePriority.HIGH);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((message.android.notification as any).notification_priority).to.be.undefined;
       expect(message.android.notification.tag).to.equal('garage_door');
       // Data block is identical across both shapes — the wire contract never changes.
       expect(message.data).to.deep.equal(RESOLVED_FIXTURE);

--- a/docs/RESOLVED_NOTIFICATION_NO_COMPROMISE.md
+++ b/docs/RESOLVED_NOTIFICATION_NO_COMPROMISE.md
@@ -468,17 +468,27 @@ degradation, but it is a larger change; keep it out of the minimal design and re
 
 ### 9.4 Gates before this is safe to build
 
-1. **Undocumented FCM id behavior (hard device gate).** The whole never-woken win depends on two
-   same-tagged notification-payloads — even across `door_open-` and `door_open_v2-` — being posted by
-   FCM under the same `id`, so the OS replaces rather than stacks them on the new app. If FCM assigns
-   per-message ids, cross-topic replacement silently degrades to two cards (cosmetic, safe) and the
-   old-app tag change bought a smaller gain. This **must be device-verified first**: send two
-   same-tag notification-payloads from two topics to a backgrounded device and confirm the OS collapses
-   them to one card (and observe whether the second re-buzzes). Extend `scripts/send-test-notification.sh`
-   with a `--notification-payload` + `--tag` mode to reproduce it.
-2. **Re-buzz on OS replace.** The OS-rendered resolved cannot set `setOnlyAlertOnce`, so it may re-alert
-   when it replaces the warning in the background. Mitigate via notification priority, or accept one
-   all-clear buzz. The foreground app-built path already suppresses it.
+> **Gate results — Pixel, 2026-07-02 (PASS).** Run via `send-test-notification.sh --mode
+> notification|combined --tag garage_door` with the app backgrounded. (1) A same-tag warning
+> replacement **re-alerted** (buzzed) — the A-prime result: tagging the warning does not degrade old
+> apps. (2) A `--mode notification` warning followed by a `--mode combined` resolved with the same tag
+> **collapsed to one card** — cross-topic same-tag replacement works, so the never-woken single-card
+> holds. (3) The resolved **buzzed** despite `PRIORITY_LOW` (see #2 below). Warning-tag is cleared to
+> enable on Pixel; the OEM-variable re-alert should be re-run on a Samsung/Xiaomi if available.
+
+1. **Undocumented FCM id behavior — VERIFIED on Pixel.** The never-woken win depends on two same-tagged
+   notification-payloads — even across `door_open-` and `door_open_v2-` — replacing rather than
+   stacking. Confirmed on Pixel via the sandbox (`--mode notification` then `--mode combined`, same
+   tag, backgrounded → one card). Re-run on another OEM if the fleet includes Samsung/Xiaomi. If some
+   OEM assigns per-message ids, cross-topic replacement degrades to two cards there (cosmetic, safe).
+2. **Re-buzz on OS replace — confirmed on-device 2026-07-02; buzz accepted.** The OS-rendered resolved
+   cannot set `setOnlyAlertOnce`. The Pixel gate confirmed that lowering `notification_priority`
+   (PRIORITY_LOW) does **not** quiet it: on Android 8+ the HIGH "Garage door" channel importance
+   overrides any per-notification priority, so the all-clear heads-up / buzzes. The maintainer
+   **accepted the buzzing all-clear**, so the combined resolved uses **HIGH** delivery priority (like
+   the warning) for reliable never-woken Doze delivery and sets no `notification_priority`. A silent
+   all-clear would require a dedicated lower-importance channel (app-created + `channel_id` on the
+   payload) — deferred, not built. The foreground app-built path is still silent (`setOnlyAlertOnce`).
 3. **Time formatting in the background.** The OS-rendered resolved text is server-provided and cannot
    know the device timezone, so drop the local clock ("2:00-2:14 PM") from the background variant and
    keep the timezone-independent duration ("open for 14 minutes"). The foreground app-built path keeps


### PR DESCRIPTION
## What

Follow-up to the relaxed-A combined resolved (#1039), driven by the **Pixel device gate** (2026-07-02).

The gate confirmed the two results that matter:
- ✅ A same-tag **warning** replacement **re-alerts** (buzzes) → tagging the warning does **not** degrade old apps.
- ✅ A `--mode notification` warning → `--mode combined` resolved (same tag) **collapses to one card** → never-woken single-card works.

…and surfaced that **`PRIORITY_LOW` does not quiet the OS-rendered all-clear**: on Android 8+ the HIGH "Garage door" channel importance overrides any per-notification priority, so it heads-up/buzzes regardless.

## Change (maintainer accepted the buzzing all-clear)

- Combined resolved `android.priority` **`NORMAL → HIGH`** — reliable never-woken Doze delivery (the whole point of the combined shape; `NORMAL` risked deferral).
- **Drop** the ineffective `notification_priority=PRIORITY_LOW` (and its now-unused import) — no server lever quiets a HIGH-channel notification.
- Data-only shape unchanged. Tests + doc §9.4 updated with the Pixel gate results.

A silent all-clear would need a dedicated lower-importance channel — deferred, not built.

## Safety

Still **dark** (`resolvedNotificationPayloadEnabled` default off). `validate-firebase.sh` green (392 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)