### PR TITLE
feat(android): resolved notification falls back to server text on data-parse failure

### DIFF
--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/DoorNotificationPresenter.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/DoorNotificationPresenter.kt
@@ -78,10 +78,40 @@ class DoorNotificationPresenter(
         post(title = title, body = body)
     }
 
-    /** Render the additive resolved-on-close message. */
-    fun show(data: Map<String, String>) {
-        val content = DoorResolvedPayload.parse(data) ?: run {
-            Logger.d { "DoorNotification: payload not a resolved-on-close message; ignoring" }
+    /**
+     * Render the additive resolved-on-close message.
+     *
+     * The rich body (device-local start/end times) is computed client-side from
+     * the raw timestamps in [data]. [fallbackTitle]/[fallbackBody] are the server's
+     * notification-block strings, present only for the relaxed-A COMBINED resolved
+     * (`resolvedNotificationPayloadEnabled`); the data-only resolved carries none.
+     *
+     * Failure mode — defensive, SHOULD NOT happen. The server always sends a
+     * well-formed data block (pinned byte-for-byte to
+     * `wire-contracts/openDoorResolved/`), so [DoorResolvedPayload.parse] should
+     * never return null for a real resolved. If it somehow does AND a server
+     * notification block was present, render that instead of silently dropping the
+     * notification. The ONLY UI degradation is the missing device-local start/end
+     * clock times ("2:00-2:14 PM") — the server body still states the door closed
+     * and the open duration. See docs/RESOLVED_NOTIFICATION_NO_COMPROMISE.md §9.4.
+     */
+    fun show(
+        data: Map<String, String>,
+        fallbackTitle: String? = null,
+        fallbackBody: String? = null,
+    ) {
+        val content = DoorResolvedPayload.parse(data)
+        if (content == null) {
+            if (!fallbackTitle.isNullOrBlank() || !fallbackBody.isNullOrBlank()) {
+                Logger.w {
+                    "DoorNotification: resolved data-parse failed; rendering server " +
+                        "notification fallback (degraded: missing device-local times)"
+                }
+                ensureChannel()
+                post(title = fallbackTitle.orEmpty(), body = fallbackBody.orEmpty())
+            } else {
+                Logger.d { "DoorNotification: payload not a resolved-on-close message; ignoring" }
+            }
             return
         }
         ensureChannel()

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FCMService.kt
@@ -64,7 +64,15 @@ class FCMService : FirebaseMessagingService() {
 
         serviceScope.launch(Dispatchers.IO) {
             try {
-                handler.handleMessage(topic, remoteMessage.data)
+                // Forward the server notification title/body (present on the
+                // relaxed-A combined resolved) so the resolved presenter can fall
+                // back to them if its data block ever fails to parse.
+                handler.handleMessage(
+                    topic,
+                    remoteMessage.data,
+                    remoteMessage.notification?.title,
+                    remoteMessage.notification?.body,
+                )
             } catch (e: IllegalStateException) {
                 Logger.e { "Failed to handle FCM message: $e" }
             }

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FcmMessageHandler.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/fcm/FcmMessageHandler.kt
@@ -44,7 +44,7 @@ class FcmMessageHandler(
     private val receiveFcmDoorEvent: ReceiveFcmDoorEventUseCase,
     private val applyButtonHealthFcm: ApplyButtonHealthFcmUseCase,
     private val showTestNotification: (Map<String, String>) -> Unit,
-    private val showDoorNotification: (Map<String, String>) -> Unit,
+    private val showDoorNotification: (data: Map<String, String>, fallbackTitle: String?, fallbackBody: String?) -> Unit,
 ) {
     /**
      * Process an FCM data message. Topic prefix determines which
@@ -54,11 +54,17 @@ class FcmMessageHandler(
      *   the `/topics/` prefix). Used to route between door and button-
      *   health channels.
      * @param data the FCM data payload (string key/value pairs).
+     * @param notificationTitle/notificationBody the server's notification-block
+     *   strings when the message carried one (the relaxed-A COMBINED resolved).
+     *   Forwarded to the door-resolved presenter as a fallback for a
+     *   should-never-happen data-parse failure; null for pure data messages.
      * @return true if the message was successfully parsed and handed off.
      */
     suspend fun handleMessage(
         topic: String,
         data: Map<String, String>,
+        notificationTitle: String? = null,
+        notificationBody: String? = null,
     ): Boolean {
         if (data.isEmpty()) {
             Logger.d { "Message data payload is empty" }
@@ -72,7 +78,7 @@ class FcmMessageHandler(
             }
             topic.startsWith(DOOR_RESOLVED_FCM_TOPIC_PREFIX) -> {
                 Logger.d { "Door resolved FCM payload: $data" }
-                showDoorNotification(data)
+                showDoorNotification(data, notificationTitle, notificationBody)
                 true
             }
             topic.startsWith("buttonHealth-") -> handleButtonHealthMessage(data)

--- a/MobileGarage/androidApp/src/test/java/com/chriscartland/garage/fcm/FcmMessageHandlerTest.kt
+++ b/MobileGarage/androidApp/src/test/java/com/chriscartland/garage/fcm/FcmMessageHandlerTest.kt
@@ -41,13 +41,13 @@ class FcmMessageHandlerTest {
     private val buttonHealthRepo = RecordingButtonHealthRepository()
     private val applyButtonHealthFcm = ApplyButtonHealthFcmUseCase(buttonHealthRepo)
     private val testNotifications = mutableListOf<Map<String, String>>()
-    private val doorNotifications = mutableListOf<Map<String, String>>()
+    private val doorNotifications = mutableListOf<Triple<Map<String, String>, String?, String?>>()
     private val handler =
         FcmMessageHandler(
             receiveFcmDoorEvent,
             applyButtonHealthFcm,
             showTestNotification = { testNotifications.add(it) },
-            showDoorNotification = { doorNotifications.add(it) },
+            showDoorNotification = { data, title, body -> doorNotifications.add(Triple(data, title, body)) },
         )
 
     private fun doorPayload(
@@ -190,10 +190,34 @@ class FcmMessageHandlerTest {
 
             assertTrue(result)
             assertEquals(1, doorNotifications.size)
-            assertEquals(data, doorNotifications.single())
+            assertEquals(data, doorNotifications.single().first)
             // The legacy door state-sync branch must NOT be invoked for v2.
             assertNull(receiveFcmDoorEvent.lastEvent)
             assertNull(buttonHealthRepo.lastApplied)
+        }
+
+    @Test
+    fun doorResolvedV2Topic_forwardsServerNotificationAsFallback() =
+        runTest {
+            // The server notification title/body must reach the presenter so it can
+            // fall back to them if the data block ever fails to parse (defensive).
+            val data = mapOf(
+                "kind" to "open_door_resolved",
+                "openTimestampSeconds" to "1800000000",
+                "closeTimestampSeconds" to "1800000840",
+            )
+            val result = handler.handleMessage(
+                topic = "door_open_v2-X",
+                data = data,
+                notificationTitle = "Resolved: garage door closed",
+                notificationBody = "Was open for 14 minutes",
+            )
+
+            assertTrue(result)
+            val (fwdData, title, body) = doorNotifications.single()
+            assertEquals(data, fwdData)
+            assertEquals("Resolved: garage door closed", title)
+            assertEquals("Was open for 14 minutes", body)
         }
 
     @Test


### PR DESCRIPTION
## What

Defensive client change for the relaxed-A combined resolved (`docs/RESOLVED_NOTIFICATION_NO_COMPROMISE.md` §9.4).

When a combined resolved is handled in the **foreground**, `DoorNotificationPresenter.show` parses the data block to build the rich device-local body. If that parse ever returns `null` **and** the message carried a server `notification` block, it now renders the **server title/body** instead of silently dropping the notification.

## Failure mode (documented in the KDoc)

This **should not happen** — the server always sends a well-formed data block, pinned byte-for-byte to `wire-contracts/openDoorResolved/`. If it somehow does, the **only UI degradation is the missing device-local start/end clock times** ("2:00–2:14 PM"); the server body still states the door closed and the open duration.

## Plumbing

Server `notification` title/body flow `FCMService` → `FcmMessageHandler` (`handleMessage` gains **defaulted** `notificationTitle`/`notificationBody`) → the door presenter as `fallbackTitle`/`fallbackBody`. Existing calls unaffected (defaults). Handler test asserts the fallback strings are forwarded.

## Safety

Purely additive/defensive. Not required to enable the server feature — insurance for a can't-happen case. `validate.sh` green (all checks passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)