### PR TITLE
docs(mobile): refresh Play Store whatsnew for the live single-card notification

### DIFF
--- a/MobileGarage/distribution/whatsnew/whatsnew-en-US
+++ b/MobileGarage/distribution/whatsnew/whatsnew-en-US
@@ -1,1 +1,3 @@
-2.17: Load more door history by scrolling. Older events load as you reach the bottom of the list, all the way back to your first recorded event.
+Garage door notifications are now cleaner. When the door is left open too long, that alert updates in place to a single "Resolved: open for X minutes" notification once the door closes, instead of leaving a second card behind.
+
+You can also load older door history by scrolling to the bottom of the list.


### PR DESCRIPTION
Refreshes the Play Store "what's new" (`MobileGarage/distribution/whatsnew/whatsnew-en-US`), which was stale at the 2.17 load-more line, to lead with the now-live single-card notification.

The relaxed-A single-card notification was **enabled in production 2026-07-03** (server flags flipped via `set-config-flag.sh`) on the already-installed `2.20.2` client — so no version bump; this text ships with the next AAB upload. Kept the load-more line. 305/500 bytes; sentence case, no em dashes.

New text:
> Garage door notifications are now cleaner. When the door is left open too long, that alert updates in place to a single "Resolved: open for X minutes" notification once the door closes, instead of leaving a second card behind.
>
> You can also load older door history by scrolling to the bottom of the list.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)