### PR TITLE
Harden release pipeline: mainline gate, self-verifying Firebase deploy, tag-push guard

### DIFF
--- a/.claude/hooks/git-guardrails.sh
+++ b/.claude/hooks/git-guardrails.sh
@@ -100,6 +100,32 @@ if echo "$STRIPPED" | grep -qE '\bgit\s+tag\b'; then
   fi
 fi
 
+# --- Block pushing release tags directly (use release scripts instead) ---
+# `git tag` (above) only blocks half the path: a tag ref can reach origin
+# without ever calling `git tag` -- e.g. `git push origin
+# HEAD:refs/tags/android/999`, `git push origin --tags`, `git push origin tag
+# android/999` (git's `push <remote> tag <name>` shorthand), or a bare `git
+# push origin android/999`. Each publishes a remote tag directly, bypassing
+# the validation/changelog/mainline gates the release scripts enforce just as
+# fully as a bare `git tag` would.
+#
+# Checked against each isolated `git push ...` segment with quote
+# *characters* (not quoted *content*, unlike $STRIPPED above) removed, so a
+# quoted ref name (`git push origin "android/999"`) can't slip through the
+# way it would if we matched against $STRIPPED. Isolating each match to the
+# push segment alone (stops at `;`/`&`/`|`) keeps this from being tripped by
+# unrelated quoted text elsewhere in a compound command (e.g. a chained
+# `gh pr create --body "...android/123..."`).
+PUSH_SEGMENTS=$(echo "$COMMAND" | sed '/<<.*EOF/,/^EOF/d' | grep -oE 'git[[:space:]]+push\b[^;&|]*' | sed -E "s/[\"']//g")
+if [ -n "$PUSH_SEGMENTS" ]; then
+  if echo "$PUSH_SEGMENTS" | grep -qE -- '--tags\b|refs/tags/|(^|[[:space:]])tag[[:space:]]'; then
+    deny "BLOCKED: Never push tags directly (--tags, refs/tags/, or the 'push <remote> tag <name>' form). Use ./scripts/release-android.sh, ./scripts/release-ios.sh, or ./scripts/release-firebase.sh -- they push release tags as part of a gated release."
+  fi
+  if echo "$PUSH_SEGMENTS" | grep -qE '(^|[[:space:]:])(android|ios|server)/[0-9]+([[:space:]:]|$)'; then
+    deny "BLOCKED: Never push an android/N, ios/N, or server/N ref directly. Use ./scripts/release-android.sh, ./scripts/release-ios.sh, or ./scripts/release-firebase.sh -- they push release tags as part of a gated release."
+  fi
+fi
+
 # --- Enforce squash merge ---
 if echo "$STRIPPED" | grep -qE '\bgh\s+pr\s+merge\b'; then
   if ! echo "$STRIPPED" | grep -qF -- '--squash'; then

--- a/.claude/skills/release-android/SKILL.md
+++ b/.claude/skills/release-android/SKILL.md
@@ -42,7 +42,7 @@ gh run watch <run-id>
 ## What you should NOT do
 
 - **Don't retype flags from memory.** `--check` prints the right command with the right SHAs filled in. Copy-paste prevents wrong-SHA accidents.
-- **Don't `git tag` directly.** Hooks block it.
+- **Don't `git tag` directly, or push a tag ref by any other route.** Hooks block `git tag`, `--tags`, `refs/tags/`, the `push <remote> tag <name>` form, and a bare `push origin android/N`.
 - **Don't deploy to production.** This script only deploys to the Play Store internal track.
 - **Don't skip validation without asking the user.** If `--check` shows validation is `STALE` or `MISSING`, the right move is almost always to run `./scripts/validate.sh`. Ask before reaching for `--confirm-unvalidated-release`.
 - **Don't skip the changelog.** `MobileGarage/CHANGELOG.md` is the permanent history (every version, including patches). The Play Store whatsnew is rolling and only covers minor/major bumps. `--confirm-no-changelog <sha>` is for emergencies — write the entry retroactively.
@@ -64,4 +64,4 @@ Both SHAs in the rollback command must match what `--check` computed on the chec
 
 - `CLAUDE.md` § Releasing Android — full design principle, why each guard exists
 - `scripts/release-android.sh` itself — the truth of which flags do what
-- `.github/workflows/release-android.yml` — the CI that the tag triggers
+- `.github/workflows/release-android.yml` — the CI that the tag triggers (verifies the tagged commit is on `main` before the build starts)

--- a/.claude/skills/release-firebase/SKILL.md
+++ b/.claude/skills/release-firebase/SKILL.md
@@ -38,13 +38,14 @@ git checkout main && git pull && git status
 # Emergency:     --confirm-tag, --confirm-unvalidated-release <sha>
 # No-changelog:  --confirm-tag, --confirm-no-changelog <sha>
 
-# 6. Watch the deploy AND verify the success marker
+# 6. Watch the deploy
 gh run list --workflow=firebase-deploy.yml --limit 1
 gh run watch <run-id>
-# CRITICAL: confirm `✔ Deploy complete!` is in the log. firebase-tools
-# can exit 0 with a `⚠ failed to update function` warning — workflow
-# shows green but production never updated. See FIREBASE_DEPLOY_SETUP.md
-# § "silent-failure pattern".
+# The workflow now greps its own output for `✔ Deploy complete!` / the
+# `⚠ failed to update function` warning and runs a post-deploy smoke
+# check, failing the job loudly instead of reporting a false green (see
+# FIREBASE_DEPLOY_SETUP.md § "silent-failure pattern"). Still worth a
+# glance at the log if you're debugging a red run.
 ```
 
 ## Supersede rule for the changelog
@@ -62,7 +63,7 @@ Both SHAs in the rollback command must match `--check`'s computed values. You ca
 
 ## What you should NOT do
 
-- **Don't `git tag` directly.** Hooks block it.
+- **Don't `git tag` directly, or push a tag ref by any other route.** Hooks block `git tag`, `--tags`, `refs/tags/`, the `push <remote> tag <name>` form, and a bare `push origin server/N`.
 - **Don't skip validation.** `--confirm-unvalidated-release <sha>` is for emergencies — ask the user first.
 - **Don't skip the changelog.** `--confirm-no-changelog <sha>` is for emergencies — write the entry retroactively.
 - **Don't trust GitHub Actions "success" alone.** Always look for `✔ Deploy complete!` in the deploy log.
@@ -73,4 +74,4 @@ Both SHAs in the rollback command must match `--check`'s computed values. You ca
 - `CLAUDE.md` § Releasing Firebase Server — full design + rules
 - `docs/FIREBASE_DEPLOY_SETUP.md` — operational guide (deploy, rollback, monitoring, GCP setup, troubleshooting table)
 - `scripts/release-firebase.sh` — flag reference is in the script header
-- `.github/workflows/firebase-deploy.yml` — the CI that the tag triggers
+- `.github/workflows/firebase-deploy.yml` — the CI that the tag triggers (verifies the tagged commit is on `main` before touching secrets; deploy step fails on the documented silent-failure pattern; post-deploy smoke check against `serverConfig`)

--- a/.claude/skills/release-ios/SKILL.md
+++ b/.claude/skills/release-ios/SKILL.md
@@ -1,0 +1,72 @@
+---
+description: Release the iOS app to TestFlight Internal via tag-based deployment.
+---
+
+# Release iOS
+
+Canonical procedure: `CLAUDE.md` § Releasing iOS. Full runbook (Apple/App Store Connect setup, secret-vs-committed map, build-numbering, gotchas): `docs/IOS_RELEASE_SETUP.md`. This file is the agent-facing operational shortcut — `--check` is the source of truth for which command to paste.
+
+## The six steps
+
+```bash
+# 1. Clean state
+git checkout main && git pull && git status
+
+# 2. Validate
+./scripts/validate-ios.sh
+# Writes marker at .claude/.ios-validation-passed.
+
+# 3. Add a CHANGELOG entry — REQUIRED by default
+# Edit MobileGarage/iosApp/CHANGELOG.md, add:
+#   ## X.Y.Z          (X.Y.Z = current MARKETING_VERSION from project.yml)
+#   - One or more bullets describing user-facing changes
+# Commit and push. The release script blocks on missing/empty entries.
+
+# 4. Read the next-step command from --check
+./scripts/release-ios.sh --check
+# Prints validation state (PASSED/STALE/MISSING), MARKETING_VERSION,
+# changelog state (PRESENT/EMPTY/MISSING), AND a copy-paste-ready command
+# for the right scenario (normal, rollback, emergency, unvalidated,
+# no-changelog).
+
+# 5. Paste the command --check printed.
+# Normal:        ./scripts/release-ios.sh --confirm-tag ios/N
+# Rollback:      --confirm-tag, --confirm-hash, --confirm-rollback-from (with full SHAs)
+# Emergency:     --confirm-tag, --confirm-unvalidated-release (with target SHA)
+# No-changelog:  --confirm-tag, --confirm-no-changelog <sha>
+
+# 6. Watch the deploy
+gh run list --workflow=release-ios.yml --limit 1
+gh run watch <run-id>
+```
+
+## What you should NOT do
+
+- **Don't retype flags from memory.** `--check` prints the right command with the right SHAs filled in. Copy-paste prevents wrong-SHA accidents.
+- **Don't `git tag` directly.** Hooks block it.
+- **Don't deploy to the public App Store.** This script only uploads to TestFlight Internal. Promotion to App Store review is a manual App Store Connect step.
+- **Don't skip validation without asking the user.** If `--check` shows validation is `STALE` or `MISSING`, the right move is almost always to run `./scripts/validate-ios.sh`. Ask before reaching for `--confirm-unvalidated-release`.
+- **Don't skip the changelog.** `MobileGarage/iosApp/CHANGELOG.md` is the permanent history. `--confirm-no-changelog <sha>` is for emergencies — write the entry retroactively.
+- **Don't hand-pick the build number from a doc.** `ios/N`'s suggested `N` is git-tags-only advisory; App Store Connect is the authoritative source (it can run ahead of git if a build was uploaded out-of-band or a release failed after archiving). Trust `--check`'s live computation, not a remembered value.
+
+## Versioning
+
+`ios/N` tag ↔ `CFBundleVersion (build number) = N`. `MARKETING_VERSION` (X.Y.Z, in `MobileGarage/iosApp/project.yml`) is the CHANGELOG key, bumped by hand alongside the changelog entry — same split as Android's `versionCode`/`versionName`.
+
+`--confirm-tag` accepts any strictly-higher `ios/N` than the highest local git tag (skip-ahead), because the **authoritative** build-number check is the CI pre-flight (`scripts/asc-latest-build.rb`), not the local script — App Store Connect silently renumbers a duplicate build instead of failing, so a collision needs a higher number, and only CI can see what's actually taken.
+
+## Rollback (two steps, by design)
+
+```bash
+git checkout ios/M              # move HEAD to the commit you want to re-release
+./scripts/release-ios.sh --check   # prints the rollback command with the right SHAs
+```
+
+Both SHAs in the rollback command must match what `--check` computed on the checked-out commit. You can only produce them by running `--check` on the rollback target, which forces deliberate HEAD movement.
+
+## See also
+
+- `CLAUDE.md` § Releasing iOS — shipped status, load-bearing setup points
+- `docs/IOS_RELEASE_SETUP.md` — full runbook (Apple/ASC setup, secrets, build-numbering, gotchas)
+- `scripts/release-ios.sh` itself — the truth of which flags do what
+- `.github/workflows/release-ios.yml` — the CI that the tag triggers (pinned `macos-26` for the iOS 26 SDK requirement; verifies the tagged commit is on `main` before touching any secrets)

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -17,6 +17,31 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # full history so the mainline check below can walk ancestry
+
+      # Server-side re-assertion that this is a mainline commit. The release
+      # script already refuses to tag anything off `main` locally, and a
+      # Claude hook blocks pushing a tag ref directly -- but neither of those
+      # is enforced here, on the runner, which is the one place this
+      # workflow can't be argued with. This closes that gap independent of
+      # who cut the tag or how the ref was pushed, and runs before the CI
+      # status check below since it's the cheaper of the two to fail on.
+      - name: Verify tagged commit is on main
+        run: |
+          # Fetch into FETCH_HEAD rather than relying on refs/remotes/origin/main
+          # existing -- actions/checkout's configured refspec for a tag-triggered
+          # checkout is scoped to the tag, not a full branch mirror, so
+          # origin/main may not exist locally even after this fetch.
+          git fetch origin main --quiet
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" FETCH_HEAD; then
+            echo "::error::Tag ${GITHUB_REF_NAME} points to commit $GITHUB_SHA, which is not reachable from origin/main. Refusing to deploy a commit that hasn't gone through the required main-branch checks."
+            exit 1
+          fi
+          echo "Verified: $GITHUB_SHA is on origin/main."
+
       - name: Verify CI passed on tagged commit
         run: |
           TAG_SHA="${GITHUB_SHA}"
@@ -62,9 +87,41 @@ jobs:
         uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
+      # firebase-tools has a known silent-failure mode: it can exit 0 while
+      # printing `⚠ functions: failed to update function <name>` -- the
+      # workflow shows green but nothing actually deployed (see
+      # docs/FIREBASE_DEPLOY_SETUP.md "silent-failure pattern"; this bit
+      # every CI deploy before 2026-04-21). Grep the log for both the
+      # failure warning and the success marker so a silent failure is a
+      # loud CI failure instead of something a human has to notice by
+      # reading the Actions log.
       - name: Deploy to Firebase
-        run: firebase deploy --only functions --project "${{ secrets.FIREBASE_PROJECT_ID }}"
         working-directory: FirebaseServer
+        run: |
+          firebase deploy --only functions --project "${{ secrets.FIREBASE_PROJECT_ID }}" 2>&1 | tee "$RUNNER_TEMP/firebase-deploy.log"
+          if grep -q "failed to update function" "$RUNNER_TEMP/firebase-deploy.log"; then
+            echo "::error::firebase deploy printed 'failed to update function' -- functions did not actually update even though the CLI may report success. See docs/FIREBASE_DEPLOY_SETUP.md 'silent-failure pattern' (likely cause: the deployer service account lost a role)."
+            exit 1
+          fi
+          if ! grep -q "Deploy complete!" "$RUNNER_TEMP/firebase-deploy.log"; then
+            echo "::error::firebase deploy did not print 'Deploy complete!' -- treating this as a failed deploy."
+            exit 1
+          fi
+
+      # Post-deploy smoke check (S4-style self-verification): confirm the
+      # live function actually responds, rather than trusting the deploy
+      # step's exit code alone. Mirrors the manual `curl .../serverConfig`
+      # check documented in FIREBASE_DEPLOY_SETUP.md, now automatic.
+      - name: Smoke check deployed function
+        run: |
+          URL="https://us-central1-${{ secrets.FIREBASE_PROJECT_ID }}.cloudfunctions.net/serverConfig"
+          STATUS="$(curl -s -o /dev/null -w '%{http_code}' "$URL" || true)"
+          STATUS="${STATUS:-000}"
+          echo "serverConfig responded: $STATUS"
+          if [ "$STATUS" -ge 500 ] || [ "$STATUS" = "000" ]; then
+            echo "::error::Post-deploy smoke check failed: $URL returned '$STATUS' (expected a non-5xx response)."
+            exit 1
+          fi
 
   # Track release failures via a single GitHub issue (auto-create on failure,
   # auto-close on the next successful release). Mirrors the post-merge CI pattern.

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -39,6 +39,27 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # full history so the mainline check below can walk ancestry
+
+      # Server-side re-assertion that this is a mainline commit. The release
+      # script already refuses to tag anything off `main` locally, and a
+      # Claude hook blocks pushing a tag ref directly -- but neither of those
+      # is enforced here, on the runner, which is the one place this
+      # workflow can't be argued with. This closes that gap independent of
+      # who cut the tag or how the ref was pushed.
+      - name: Verify tagged commit is on main
+        run: |
+          # Fetch into FETCH_HEAD rather than relying on refs/remotes/origin/main
+          # existing -- actions/checkout's configured refspec for a tag-triggered
+          # checkout is scoped to the tag, not a full branch mirror, so
+          # origin/main may not exist locally even after this fetch.
+          git fetch origin main --quiet
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" FETCH_HEAD; then
+            echo "::error::Tag ${GITHUB_REF_NAME} points to commit $GITHUB_SHA, which is not reachable from origin/main. Refusing to release a commit that hasn't gone through the required main-branch checks."
+            exit 1
+          fi
+          echo "Verified: $GITHUB_SHA is on origin/main."
 
       - uses: ./.github/actions/setup-android
         with:

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -54,6 +54,28 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # full history so the mainline check below can walk ancestry
+
+      # Server-side re-assertion that this is a mainline commit. The release
+      # script already refuses to tag anything off `main` locally, and a
+      # Claude hook blocks pushing a tag ref directly -- but neither of those
+      # is enforced here, on the runner, which is the one place this
+      # workflow can't be argued with. This closes that gap independent of
+      # who cut the tag or how the ref was pushed, and runs before the ASC
+      # pre-flight below so a bad tag fails fast without touching secrets.
+      - name: Verify tagged commit is on main
+        run: |
+          # Fetch into FETCH_HEAD rather than relying on refs/remotes/origin/main
+          # existing -- actions/checkout's configured refspec for a tag-triggered
+          # checkout is scoped to the tag, not a full branch mirror, so
+          # origin/main may not exist locally even after this fetch.
+          git fetch origin main --quiet
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" FETCH_HEAD; then
+            echo "::error::Tag ${GITHUB_REF_NAME} points to commit $GITHUB_SHA, which is not reachable from origin/main. Refusing to release a commit that hasn't gone through the required main-branch checks."
+            exit 1
+          fi
+          echo "Verified: $GITHUB_SHA is on origin/main."
 
       # This workflow is the ONLY credentialed path to a build — the deploy-capable
       # App Store Connect API key lives only here, never on a dev machine. So the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -519,7 +519,7 @@ Do not just tell the user to run it — the next Stop hook fires before they can
 
 ### Claude Hooks (.claude/hooks/)
 - **block-admin-bypass.sh** — Denies `--admin` on PR merges
-- **git-guardrails.sh** — Blocks push to main, force push, destructive commands; enforces squash merge; warns on stale validation; blocks push to branches with auto-merge enabled
+- **git-guardrails.sh** — Blocks push to main, force push, destructive commands; enforces squash merge; warns on stale validation; blocks push to branches with auto-merge enabled; blocks pushing a release tag by any route (`git tag`, `--tags`, `refs/tags/`, `push <remote> tag <name>`, or a bare `push origin android/N`/`ios/N`/`server/N`) — release tags may only reach origin via the release scripts
 - **check-pr-backlog.sh** — Warns at 5+ open PRs, blocks at 10+
 - **dev-mode.sh** — Keeps Claude working when `.claude/.dev-mode` exists
 - **warn-shell-loops.sh** — Warns on `for`/`while` loops (prefer separate Bash calls)

--- a/docs/FIREBASE_DEPLOY_SETUP.md
+++ b/docs/FIREBASE_DEPLOY_SETUP.md
@@ -1,7 +1,7 @@
 ---
 category: reference
 status: active
-last_verified: 2026-04-24
+last_verified: 2026-07-03
 ---
 # Firebase Server Operations
 
@@ -75,9 +75,11 @@ curl -sS -o /dev/null -w "%{http_code}\n" \
 
 Any `5xx` or connection-refused = something's wrong.
 
+**This check now also runs automatically** as a `firebase-deploy.yml` step after every CI-triggered deploy (`Smoke check deployed function`) — it fails the job on a 5xx or connection-refused response, so a broken deploy no longer depends on a human remembering to run the `curl` above. Still worth running by hand after a **manual** deploy (Rollback Option 1 below), since that path isn't covered by the workflow.
+
 ### ⚠️ The silent-failure pattern to watch for
 
-Before 2026-04-21, `firebase deploy` would exit 0 despite printing `⚠ functions: failed to update function <name>` — the workflow "succeeded" but nothing deployed. **Always look for `✔ Deploy complete!` in the log before trusting a "success" conclusion.** If you see the `⚠ failed to update` warning pattern return, the deployer service account has lost a role (see Troubleshooting).
+Before 2026-04-21, `firebase deploy` would exit 0 despite printing `⚠ functions: failed to update function <name>` — the workflow "succeeded" but nothing deployed. **This is now caught automatically**: the `Deploy to Firebase` step in `firebase-deploy.yml` greps its own output for `failed to update function` and requires `Deploy complete!` to appear, failing the job loudly instead of reporting a false green. If you see the `⚠ failed to update` warning pattern on a **manual** deploy (where nothing greps the output for you), the deployer service account has lost a role (see Troubleshooting) — the same fix applies.
 
 ---
 

--- a/docs/IOS_RELEASE_SETUP.md
+++ b/docs/IOS_RELEASE_SETUP.md
@@ -181,6 +181,9 @@ If CI aborts saying build `N` is taken, just re-release with the number it repor
 nothing deployed — and can be deleted: `git push origin :refs/tags/ios/N && git tag -d ios/N`.)
 
 ### Cutting a release
+
+Agent-facing shortcut: the `release-ios` skill (`.claude/skills/release-ios/SKILL.md`) mirrors this section as a copy-paste runbook, same as `release-android` and `release-firebase`.
+
 1. Bump `MARKETING_VERSION` in `project.yml` (if the user-facing version changed) and
    add a matching `## X.Y.Z` heading to `MobileGarage/iosApp/CHANGELOG.md`.
 2. `./scripts/validate-ios.sh` (writes the marker).

--- a/docs/RELEASE_STRATEGY.md
+++ b/docs/RELEASE_STRATEGY.md
@@ -1,7 +1,7 @@
 ---
 category: reference
 status: active
-last_verified: 2026-06-20
+last_verified: 2026-07-03
 ---
 
 # Release & Deployment Strategy
@@ -395,8 +395,9 @@ A multi-component repository:
 - An **Android** app (Compose Multiplatform) — released to the Play **internal** track by
   `android/N` tags; production promotion is manual. *Composes: Foundations + App +
   Android.*
-- An **iOS** app (the shared CMP codebase) — **builds in CI but has no release pipeline
-  yet.** *Would compose: Foundations + App + iOS.*
+- An **iOS** app (the shared CMP codebase) — released to TestFlight **Internal** by
+  `ios/N` tags, mirroring the Android model; production App Store promotion is manual.
+  *Composes: Foundations + App + iOS.*
 - **ESP32 firmware** — flashed manually; outside this strategy (§8).
 
 There is **no web frontend**, so the Web layer (§7) does not apply.
@@ -416,11 +417,11 @@ Legend: ✅ met · ◐ partial · ⚠️ deviation (deliberate, recorded) · ❌
 |---|---|---|
 | F1 tagged/automated | ✅ | `server/N` / `android/N` tags trigger the deploy workflows; never push-to-main. |
 | F2 immutable, monotonic tags | ✅ | Plain incrementing counters; "never delete/move a tag" is documented (F-NOT2 ✅). |
-| F3 only mainline ships | ◐ | The release scripts enforce on-`main` + clean-tree *locally*, and branch protection (required checks, `enforce_admins`, no `--admin`) guards the merge. But the **deploy workflow** only re-checks the tagged commit's CI conclusion — it does not re-assert the commit is an ancestor of `main` server-side. See gap **G5**. |
+| F3 only mainline ships | ✅ | The release scripts enforce on-`main` + clean-tree *locally*, branch protection guards the merge, and all three deploy workflows now run a `git merge-base --is-ancestor "$GITHUB_SHA" origin/main` gate before touching any secrets or build steps — the pipeline itself refuses a tag that isn't reachable from `main`, independent of who cut it or how the ref reached origin. (Closed **G5**.) |
 | F4 preview before commitment | ✅ | `--check` prints state + the exact next command with real SHAs. |
 | F5 confirm = assertion | ✅ | `--confirm-tag` must equal the computed next tag, or it refuses. |
 | F6 grounded overrides | ✅ | Every override flag takes a SHA/tag and fails on mismatch ("a value from reality"). |
-| F7 gates overridable, invariants not | ✅ | Validation + changelog gates have grounded overrides; monotonic tag + confirm-assertion are not overridable. (Smoke override is moot until smoke runs in-pipeline — G4.) |
+| F7 gates overridable, invariants not | ◐ | Validation + changelog gates have grounded overrides; monotonic tag + confirm-assertion are not overridable. The Firebase smoke/silent-failure gate (G4, now in-pipeline) has **no override yet** — a real failure there is meant to be fixed forward, but there's no documented break-glass path if one's ever needed. Low priority: no local manual-deploy wrapper script exists for a grounded flag to live on. |
 | F8 truthful deploy record | ❌ | The running functions do not report the commit they were built from; "what's live?" is reconstructed from `gcloud` update-time + git. See gap **G1**. |
 | F9 recoverable failures | ✅ | A failed tag push deletes the local tag; the silent-success class is documented as a known watch-point. |
 | F10 dry run | ✅ | `--dry-run` runs the gates and creates nothing. |
@@ -429,7 +430,7 @@ Legend: ✅ met · ◐ partial · ⚠️ deviation (deliberate, recorded) · ❌
 | F13 keyless credentials | ❌ | Both Firebase and Play deploys use long-lived stored service-account JSON keys. See gap **G2**. |
 | F14 least-privilege runtime identity | ◐ | The deploy identity is separate from the runtime identity, but the runtime is the project's broad default service account. See gap **G3**. |
 | F-CAN1 break-glass manual path | ✅ | A documented hand-run deploy exists, separate from the tag path. |
-| F-CAN2 ad-hoc-tag guard | ✅ | A commit-time guard blocks direct `git tag`, steering to the release scripts. |
+| F-CAN2 ad-hoc-tag guard | ✅ | A commit-time guard blocks direct `git tag` *and* pushing a tag ref by any other route (`--tags`, `refs/tags/`, the `push <remote> tag <name>` form, or a bare `push origin android/N`/`ios/N`/`server/N`), steering to the release scripts. |
 
 **Server**
 
@@ -438,7 +439,7 @@ Legend: ✅ met · ◐ partial · ⚠️ deviation (deliberate, recorded) · ❌
 | S1 staging + production | ⚠️ | **Single-environment by deliberate choice** (solo-maintained, low blast radius). Recorded deviation; see trigger **D1**. |
 | S2 production anchored | ⚠️ | N/A under single-env (no staging to anchor to). Re-applies if a staging channel is added (D1). |
 | S3 promotion ships identical commit | ⚠️ | N/A under single-env. |
-| S4 self-verifying deploys | ❌ | A smoke check exists but is a **documented manual `curl`**, not a deploy-workflow step — so a deploy can report success without serving. This exact class bit once historically. High-priority gap **G4**. |
+| S4 self-verifying deploys | ✅ | The deploy workflow now greps its own `firebase deploy` output for the documented silent-failure warning (and requires the `Deploy complete!` marker) and runs the `serverConfig` smoke check as a deploy-workflow step, failing the job on a 5xx/connection-refused response or a silent-failure match. This exact class bit once historically. (Closed **G4** — the live deploy-record assertion this doc originally bundled into G4 is tracked separately under G1, since it needs a `/build-info`-style endpoint that doesn't exist yet.) |
 | S5 data changes are migrations | ◐ | Typed per-collection modules + contract tests are in place (see `FIREBASE_DATABASE_REFACTOR.md`); explicit schema-version + expand/migrate/contract discipline is not separately verified here. |
 | S6 staging permissive | ⚠️ | N/A under single-env. |
 | S7 named rollback path | ✅ | Rollback is a first-class script flow (re-release a prior tag with a grounded `--confirm-rollback-from`) and is documented with three options. |
@@ -465,14 +466,19 @@ Legend: ✅ met · ◐ partial · ⚠️ deviation (deliberate, recorded) · ❌
 | A3 / AN3 monotonic tag-derived version | ✅ | Version code is derived from the `android/N` counter. |
 | A4 / AN4 validation marker | ✅ | A validation marker must match the released commit (grounded override for emergencies). |
 | AN2 signing protected | ✅ | Keystore encrypted at rest, decrypted at build via an injected key, passwords as secrets, decrypted keystore removed after the build. |
-| A5 / AN5 release-note length checked | ◐ | A "what's new" directory ships, but its length is not auto-checked against store limits. Minor gap **G7**. |
+| A5 / AN5 release-note length checked | ✅ | `scripts/check-whatsnew-length.sh` enforces Google Play's 500-char-per-language limit on every `whatsnew-*` file and is wired into `validate.sh`, so the release script's validation gate (A4/AN4) already blocks an over-length entry. (Closed **G7**.) |
 | AN6 screenshots as record, not gate | ✅ | Screenshot assets are a reviewable record, not a pixel-diff CI gate. |
 
 **iOS**
 
 | Rule | State | Notes |
 |---|---|---|
-| IO1–IO6 | ❌ | The iOS app builds in CI (not a required check) but has **no release pipeline** — no TestFlight/App Store automation. Entire layer is a pending gap **G8**. |
+| IO1 TestFlight from automation only | ✅ | `release-ios.yml` uploads to TestFlight Internal only; App Store promotion is a manual App Store Connect action. (Closed **G8**.) |
+| IO2 signing protected | ✅ | No certificate is imported or stored — cloud signing via an App Store Connect API key (Admin role) creates the distribution cert/profile on demand; the key is written to a runner temp file and removed in an `if: always()` cleanup step. |
+| IO3 monotonic build number | ✅ | `ios/N` tag → `CFBundleVersion = N`, enforced strictly-increasing by the release script; the CI pre-flight (`scripts/asc-latest-build.rb`) is the authoritative check against App Store Connect's actual highest build (which can run ahead of git if a build was uploaded out-of-band). |
+| IO4 validation marker | ✅ | `scripts/validate-ios.sh` writes `.claude/.ios-validation-passed`; the release script blocks on a missing/stale marker (grounded override for emergencies), same pattern as Android/Firebase. |
+| IO5 release-note length checked | ❌ | No automated "What to Test" upload or length check exists yet — TestFlight test notes are still a manual App Store Connect step. Minor gap **G9**. |
+| IO6 screenshots as record, not gate | ✅ | The Prefire/swift-snapshot-testing gallery is a browsable reference, explicitly **not** a gating CI check. |
 
 **Web** — N/A (no web frontend).
 
@@ -494,26 +500,43 @@ toward full conformance.
   starts to matter (more data, more surfaces). *Action:* provision a dedicated runtime
   service account with narrow roles and run the functions as it; grant the deployer only
   `actAs` on it.
-- **G4 — S4: deploy not self-verifying.** *Trigger:* already bit once — treat as the
-  highest-priority gap. *Action:* run the existing smoke check as a **deploy-workflow
-  step** that fails the job on a non-expected response, and (with G1) assert the live
-  deploy record equals the just-shipped commit. Add a grounded `OVERRIDE_SKIP_SMOKE=<sha>`
-  for break-glass (F7), never set in CI.
-- **G5 — F3: server-side mainline re-assertion is partial.** *Trigger:* low (local script
-  + branch protection already cover the normal path), but cheap to close. *Action:* add a
-  `git merge-base --is-ancestor "$GITHUB_SHA" origin/main` gate to the deploy workflow so
-  the pipeline refuses any tag not on `main`, independent of who cut it.
+- **G4 — S4: deploy not self-verifying. RESOLVED.** The deploy workflow now runs the
+  `serverConfig` smoke check as a deploy-workflow step (fails the job on a 5xx/
+  connection-refused response) and greps its own `firebase deploy` output for the
+  documented silent-failure warning, requiring the `Deploy complete!` marker. A grounded
+  break-glass override (`OVERRIDE_SKIP_SMOKE=<sha>`, F7) was considered but deferred —
+  there's no local manual-deploy wrapper script for it to live on yet (the manual deploy
+  path in `FIREBASE_DEPLOY_SETUP.md` is still a raw `firebase deploy` command); add one if
+  a real need for a smoke override on the CI path emerges. The **live deploy-record**
+  half of the original combined action (asserting the running function reports the
+  just-shipped commit) still needs G1's `/build-info`-style endpoint and is tracked there,
+  not here.
+- **G5 — F3: server-side mainline re-assertion is partial. RESOLVED.** All three deploy
+  workflows (`release-android.yml`, `release-ios.yml`, `firebase-deploy.yml`) now run
+  `git fetch origin main && git merge-base --is-ancestor "$GITHUB_SHA" FETCH_HEAD` (with
+  `fetch-depth: 0`) before any secrets or build steps, refusing any tag not on `main`
+  independent of who cut it or how the ref reached origin. (`FETCH_HEAD`, not
+  `origin/main` — the checkout action's configured refspec for a tag-triggered checkout
+  is scoped to the tag, so `refs/remotes/origin/main` isn't guaranteed to exist locally.)
 - **G6 — FB3: rules/indexes not deployed with code.** *Trigger:* the first change that
   couples a function to a Firestore rules or index change. *Action:* include `firestore`
   (rules + indexes) — and hosting if it ever serves content — in the deploy scope so they
   ship atomically with the functions, or add a documented coupled-deploy step.
-- **G7 — A5/AN5: release-note length unchecked.** *Trigger:* the first time a store upload
-  is rejected/truncated for length. *Action:* add a length check against the store limit to
-  the release gate.
-- **G8 — iOS has no release pipeline.** *Trigger:* when you want to ship iOS to testers.
-  *Action:* add an `ios/N` tag-driven release mirroring Android — TestFlight-only,
-  monotonic build number from the counter, signing material encrypted at rest, manual App
-  Store promotion (the §6 layer).
+- **G7 — A5/AN5: release-note length unchecked. RESOLVED.** `scripts/check-whatsnew-length.sh`
+  already enforces Google Play's 500-char-per-language limit and is wired into
+  `validate.sh` — this was already in place; the audit above had drifted stale.
+- **G8 — iOS has no release pipeline. RESOLVED.** `scripts/release-ios.sh` +
+  `.github/workflows/release-ios.yml` ship an `ios/N` tag-driven release mirroring
+  Android: TestFlight Internal only, monotonic build number from the tag counter (cross-
+  checked against App Store Connect), cloud code-signing (no cert stored), manual App
+  Store promotion. Shipped `ios/1` (2026-06-30); see `docs/IOS_RELEASE_SETUP.md`. The
+  `release-ios` skill shortcut (mirroring `release-android`/`release-firebase`) was the
+  one missing piece and has been added.
+- **G9 — IO5: iOS release-note length unchecked, and no automated "What to Test" upload
+  at all.** *Trigger:* the first time a TestFlight upload is rejected/truncated for
+  length, or the first time someone wants test notes to ship without a manual App Store
+  Connect step. *Action:* if/when "What to Test" upload is automated, add a length check
+  against App Store Connect's limit to the release gate (mirroring G7's Android check).
 
 ### 9.4 Deliberate deviations
 


### PR DESCRIPTION
## Summary

A review of the release tooling (scripts, CI workflows, hooks, skills) against the gaps already tracked in `docs/RELEASE_STRATEGY.md`'s own conformance audit turned up a few concrete, closeable items, plus one missing skill and some stale doc drift.

- **`git-guardrails.sh`**: blocked `git tag` directly, but a release tag could still reach `origin` via `--tags`, `refs/tags/`, the `push <remote> tag <name>` form, or a bare `push origin android/999` — none of which call `git tag`. Closed all of those (including a quoted-argument variant that would've slipped past the existing quote-stripping), scoped to just the isolated `git push` segment so it can't be tripped by unrelated quoted text elsewhere in a compound command.
- **Server-side mainline gate**: none of the three deploy workflows re-asserted that the tagged commit is reachable from `main` — only the local script + a client-side hook enforced it. Added a `git merge-base --is-ancestor "$GITHUB_SHA" FETCH_HEAD` gate to `release-android.yml`, `release-ios.yml`, and `firebase-deploy.yml`, before any secrets or build steps run. (Uses `FETCH_HEAD` rather than `origin/main` since the checkout action's tag-scoped refspec doesn't guarantee a local `origin/main` ref exists.)
- **Self-verifying Firebase deploy**: `FIREBASE_DEPLOY_SETUP.md` already documented a known firebase-tools silent-failure mode (`⚠ failed to update function` while exiting 0) and a manual smoke-check `curl`, both human-remembered steps. Automated both in `firebase-deploy.yml` — the deploy step now fails loudly on the documented warning pattern, and a post-deploy smoke check hits `serverConfig` and fails the job on a 5xx/connection-refused response.
- **Added the missing `release-ios` skill** — `release-android` and `release-firebase` each have one; `release-ios.sh`/`release-ios.yml` are fully shipped and verified live (`ios/1`, 2026-06-30) but never got the agent-facing shortcut.
- **Corrected stale drift in `RELEASE_STRATEGY.md`'s conformance audit** — it still listed iOS as "no release pipeline" and the release-note-length check as unimplemented; both were already done. Re-audited the affected rows against current repo state and marked the two gaps this PR closes (G4, G5) resolved.

## Test plan

- [x] Manually regression-tested `git-guardrails.sh` against 9 bypass attempts (all denied) and 8 legitimate/near-miss commands including compound commands with unrelated quoted text (all allowed) — no change in pre-existing behavior (push-to-main, force-push, `cd`, `git -C`, `reset --hard`, `clean -f`, squash-merge enforcement all still fire correctly).
- [x] Validated YAML syntax on all three edited workflow files.
- [x] Verified empirically that a tag-triggered checkout's configured refspec doesn't guarantee `origin/main` exists locally, hence using `FETCH_HEAD` for the ancestry check instead.
- [x] Ran the existing script test suite (`node --test .github/scripts/**/*.test.mjs`) — all 9 pass.
- [x] Ran `scripts/check-doc-frontmatter.sh` — passes; bumped `last_verified` on the two docs I substantively re-audited.
- [ ] The mainline-gate and self-verifying-deploy steps only really get exercised by a real tag push (same caveat `IOS_RELEASE_SETUP.md` already notes for release-pipeline changes generally) — first real use will be the next `android/N`, `ios/N`, or `server/N` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)