### PR TITLE
ci: add benchmark client to placeholder google-services.json

### DIFF
--- a/MobileGarage/release/google-services-placeholder.json
+++ b/MobileGarage/release/google-services-placeholder.json
@@ -42,6 +42,25 @@
           "other_platform_oauth_client": []
         }
       }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000003",
+        "android_client_info": {
+          "package_name": "com.chriscartland.garage.benchmark"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyA0000000000000000000000000000000000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
     }
   ],
   "configuration_version": "1"


### PR DESCRIPTION
Dependabot-triggered runs get no repo secrets, so `.github/actions/setup-android` drops in the committed placeholder `google-services.json`. The placeholder had clients only for `com.chriscartland.garage` + `.debug`, so `:androidApp:processBenchmarkGoogleServices` failed with *"No matching client found for package name 'com.chriscartland.garage.benchmark'"* on every Dependabot PR's Unit Tests job (the `benchmark` build type sets `applicationIdSuffix = ".benchmark"`; `testBuildType = "benchmark"` pulls it into the test graph). This is half of why #1033 is red.

**Fix:** add a third placeholder client for `com.chriscartland.garage.benchmark`.

**Verified locally** by reproducing the Dependabot condition — swapped the placeholder in for the real `google-services.json` and ran `processDebugGoogleServices` + `processReleaseGoogleServices` + `processBenchmarkGoogleServices`: BUILD SUCCESSFUL. Normal CI/release runs are unaffected (they decrypt the real file; the placeholder path is gated on the encrypt key being absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)