### PR TITLE
harden(ci): pin r0adkll/upload-google-play to the v1.1.5 commit SHA

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -102,7 +102,11 @@ jobs:
           retention-days: 1
 
       - name: Deploy to Google Play (Internal Track)
-        uses: r0adkll/upload-google-play@v1.1.5
+        # Pinned to the v1.1.5 commit SHA (audit M4): a third-party action on a
+        # moving tag could be swapped underneath us; this one handles the Play
+        # service-account credential. Bump by resolving the new tag's SHA:
+        #   gh api repos/r0adkll/upload-google-play/git/ref/tags/<tag> --jq .object.sha
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.chriscartland.garage


### PR DESCRIPTION
Audit **M4** (2026-05-14 security audit, deferred mediums): `r0adkll/upload-google-play` was referenced by the moving tag `v1.1.5` in `release-android.yml`. A third-party action on a moving tag can be re-pointed upstream, and this one handles the `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` credential — pin it to the tag's commit SHA (`e738b9dd` = v1.1.5, resolved via `gh api repos/r0adkll/upload-google-play/git/ref/tags/v1.1.5`).

First-party `actions/*` stay on major tags per the audit's risk assessment (lower risk; Dependabot's github-actions ecosystem keeps them updated). A bump procedure comment is inline.

No behavior change — same action version, immutable reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)