### PR TITLE
harden(android): restrict cleartext localhost exceptions to debug builds

### DIFF
--- a/MobileGarage/androidApp/src/debug/res/xml/network_security_config.xml
+++ b/MobileGarage/androidApp/src/debug/res/xml/network_security_config.xml
@@ -17,14 +17,16 @@
   -->
 
 <!--
-  Release/production config: no cleartext anywhere. The localhost /
-  127.0.0.1 / 10.0.2.2 cleartext exceptions (Firebase emulator + local
-  dev) live in the debug source set's override of this same resource
-  (src/debug/res/xml/network_security_config.xml), so debug builds keep
-  them and release builds cannot make a cleartext connection at all.
-  Security audit low-finding: cleartext-localhost was previously allowed
-  in the main variant.
+  Debug-only override of the main network security config: allow
+  cleartext to loopback + the emulator host bridge (10.0.2.2) for the
+  Firebase emulator suite and local development. Release builds use the
+  main config (no cleartext) — this file is excluded from them by the
+  source-set split.
 -->
 <network-security-config>
-    <base-config cleartextTrafficPermitted="false" />
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">localhost</domain>
+        <domain includeSubdomains="true">127.0.0.1</domain>
+        <domain includeSubdomains="true">10.0.2.2</domain>
+    </domain-config>
 </network-security-config>


### PR DESCRIPTION
Security-audit low finding: `network_security_config.xml` allowed cleartext to `localhost` / `127.0.0.1` / `10.0.2.2` in the **main** variant, so release builds shipped with loopback cleartext enabled.

**Fix (source-set split):** main's config is now an explicit no-cleartext `<base-config>`; the debug source set overrides the same resource with the permissive config, so Firebase-emulator / local-dev workflows are unchanged in debug builds while release (and benchmark) builds cannot make a cleartext connection at all.

**Verification:** merged-resource inspection per variant — the debug variant's merged `network_security_config` contains the localhost domain-config; the release variant's contains only `cleartextTrafficPermitted="false"`. Full `validate.sh`: all checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)