### PR TITLE
fix(kmp): pin kermit/datastore/sqlite — Kotlin 2.2+ KLIBs broke iOS main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -94,12 +94,23 @@ updates:
       # so they can't auto-bump — they poison the whole group red (exemplar: #1010,
       # core 1.19 / lifecycle 2.11 / navigation3 1.2.0-alpha each demand AGP 9.1).
       # Hold them with AGP; they move together by hand when the toolchain moves.
-      # The decoupled deps (spotless, detekt, compose-bom, mockito, kermit, junit,
-      # screenshot, activity, datastore, sqlite, test libs) still auto-merge.
+      # The decoupled deps (spotless, detekt, compose-bom, mockito, junit,
+      # screenshot, activity, test libs) still auto-merge.
       - dependency-name: "androidx.core*"
       - dependency-name: "androidx.lifecycle*"
       - dependency-name: "androidx.navigation3*"
       - dependency-name: "org.jetbrains.androidx*"      # KMP nav3 / lifecycle variants (same AGP-coupled wave)
+      # kermit 2.1.0+ and androidx.datastore 1.2.x ship iOS KLIBs built with
+      # Kotlin 2.2.x, which the pinned Kotlin 2.1.20 rejects at
+      # :*:compileKotlinIosSimulatorArm64 / :data-local:kspKotlinIosSimulatorArm64
+      # — but the Android JVM side compiles fine, so a group PR passes every
+      # REQUIRED check and auto-merges, breaking main's (non-required) iOS CI.
+      # Empirical: #1033 (2026-07-05). Pinned at 2.0.4 / 1.1.7; unpin with the
+      # Kotlin 2.2+ bump. General rule: any KMP dep consumed from commonMain can
+      # hit this — when adding one, check what Kotlin its iOS KLIBs are built with.
+      - dependency-name: "co.touchlab:kermit*"
+      - dependency-name: "androidx.datastore*"
+      - dependency-name: "androidx.sqlite*"             # 2.7.0 KLIBs are Kotlin 2.3.20-built (same #1033 break)
 
   # GitHub Actions used by the workflows in .github/workflows/. Addresses the
   # low/informational finding that several actions are pinned to floating major

--- a/MobileGarage/gradle/libs.versions.toml
+++ b/MobileGarage/gradle/libs.versions.toml
@@ -23,7 +23,11 @@ androidxCore = "1.16.0"
 androidxNavigation = "2.9.8"
 androidxNavigation3 = "1.0.0-alpha02"
 jbLifecycle = "2.10.0-beta01"
-androidxDatastore = "1.2.1"
+# datastore is PINNED at 1.1.7 for the same reason as kermit below: 1.2.1's
+# iOS KLIBs are built with Kotlin 2.2.20, rejected by this project's Kotlin
+# 2.1.20 (:data-local:kspKotlinIosSimulatorArm64). Unpin with the Kotlin 2.2+
+# bump; also ignored in dependabot.yml.
+androidxDatastore = "1.1.7"
 composeBom = "2025.12.01"
 coroutines = "1.10.2"
 coroutinesTest = "1.10.2"
@@ -36,7 +40,12 @@ gms = "4.5.0"
 kotlinInject = "0.8.0"
 kotlinxSerialization = "1.8.1"
 ktor = "3.1.3"
-kermit = "2.1.0"
+# kermit is PINNED at 2.0.4: 2.1.0's iOS KLIBs are built with Kotlin 2.2.0 and
+# this project's Kotlin 2.1.20 KLIB resolver rejects them (ABI > 1.201.0) — the
+# Android JVM side compiles fine, so only the non-required iOS CI catches it
+# (broke main after #1033). Same story as kotlin-inject 0.8.0. Unpin with the
+# Kotlin 2.2+ bump (PENDING_FOLLOWUPS.md § 2); also ignored in dependabot.yml.
+kermit = "2.0.4"
 kotlinxDatetime = "0.6.2"
 skie = "0.10.9"
 junit = "4.13.2"
@@ -48,7 +57,10 @@ lifecycle = "2.9.1"
 mockito = "5.23.0"
 playServicesAuth = "21.6.0"
 room = "2.7.2"
-sqlite = "2.7.0"
+# sqlite is PINNED at 2.5.0 (same as kermit/datastore above: 2.7.0's iOS KLIBs
+# are built with Kotlin 2.3.20, rejected by Kotlin 2.1.20). Unpin with the
+# Kotlin 2.2+ bump; also ignored in dependabot.yml.
+sqlite = "2.5.0"
 screenshot = "0.0.1-alpha12"
 tracing = "1.3.0"
 spotless = "7.2.1"


### PR DESCRIPTION
**Fix-forward for the red iOS CI on main after #1033.**

The android-minor-patch group bump took **kermit → 2.1.0**, **androidx.datastore → 1.2.1**, and **androidx.sqlite → 2.7.0**. All three ship iOS KLIBs built with Kotlin 2.2.0 / 2.2.20 / 2.3.20, which this project's pinned Kotlin **2.1.20** KLIB resolver rejects (`can consume ABI <= 1.201.0`) at `:*:compileKotlinIosSimulatorArm64` / `:data-local:kspKotlinIosSimulatorArm64`. The Android JVM side compiles fine, so #1033 passed every **required** check and auto-merged — only the non-required iOS CI went red (the documented trap; CI stopped at kermit, the local run surfaced datastore + sqlite behind it).

**This PR:**
- Pins all three back to the pre-#1033 versions (kermit 2.0.4, datastore 1.1.7, sqlite 2.5.0) with comments tied to the Kotlin 2.2+ bump tripwire (`PENDING_FOLLOWUPS.md` §2) — same story as the kotlin-inject 0.8.0 pin.
- Adds them to `dependabot.yml`'s gradle `ignore` (and fixes the now-stale "decoupled deps" comment) so next week's group bump doesn't re-break main identically.

**Verification:** `:iosFramework:iosSimulatorArm64Test` BUILD SUCCESSFUL locally (the CI-exact failing target); full `validate.sh` all checks passed (Android side returns to the versions in use until this morning).

New general rule captured in the dependabot comment: any KMP dep consumed from commonMain can hit this — check what Kotlin its iOS KLIBs are built with before bumping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)