### PR TITLE
fix(ios): animated door used stale captured position in onChange

### DIFF
--- a/MobileGarage/iosApp/Features/Home/GarageDoorCanvas.swift
+++ b/MobileGarage/iosApp/Features/Home/GarageDoorCanvas.swift
@@ -149,7 +149,14 @@ private struct AnimatedDoorCanvas: View {
         GarageDoorCanvas(doorOffset: offset, color: color, darkColor: darkColor)
             .onAppear { seedAndAnimate() }
             // iOS 16 single-parameter onChange (the two-param form is iOS 17+).
-            .onChange(of: position) { _ in animate(to: position) }
+            // MUST use the closure's newValue, not the captured `position`: the
+            // invoked closure can be the one registered by the PREVIOUS body
+            // (stale struct copy), so `animate(to: position)` re-targeted the
+            // OLD state's offset. Empirical: on a fresh install the door seeded
+            // at UNKNOWN's raised offset and stayed there after CLOSED arrived
+            // (color/overlay updated, offset never moved) until app relaunch;
+            // live transitions animated one state behind for the same reason.
+            .onChange(of: position) { newPosition in animate(to: newPosition) }
     }
 
     private func seedAndAnimate() {


### PR DESCRIPTION
**Bug (discovered while capturing App Store screenshots):** on a **fresh install**, the iOS Home door renders visibly half-open while labeled "Closed", and stays that way until the app is relaunched.

**Mechanism:** `AnimatedDoorCanvas`'s `.onChange(of: position) { _ in animate(to: position) }` ignored the closure parameter and read the **captured struct copy's** `position`. When the invoked closure is the one registered by a previous body evaluation, the door re-targets the OLD state's offset. On first launch the view first renders with `.unknown` (empty cache, raised offset + warning overlay); when `.closed` arrives, color + overlay update (computed in body) but the offset re-targets UNKNOWN — stuck. Live transitions would animate **one state behind** for the same reason (never caught: the snapshot gallery only exercises static mode, and live push on device is still unverified).

**Fix:** one line — animate to the closure's `newValue`.

**Verification (CLI, fresh-install simulator repro):**
- Pre-fix timeline (uninstall → install → launch → timed screenshots): gray UNKNOWN door at t=1s → green but **stuck at raised offset** from t=3s across minutes; only a warm relaunch rendered flush.
- Post-fix timeline: green mid-spring at t=1s → **flush closed from t=3s onward**.
- `./scripts/validate-ios.sh`: all iOS checks passed (framework tests + CI-exact app build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)