### PR TITLE
feat(ios): add PrivacyInfo.xcprivacy (Phase G App Store prep)

### DIFF
--- a/MobileGarage/iosApp/GarageControl/PrivacyInfo.xcprivacy
+++ b/MobileGarage/iosApp/GarageControl/PrivacyInfo.xcprivacy
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  App privacy manifest (Phase G, App Store submission prep).
+
+  Scope: the APP's own practices + required-reason APIs referenced by
+  app code and the Kotlin shared.framework (which has no manifest of
+  its own). The Firebase / GoogleSignIn SPM packages ship their own
+  PrivacyInfo.xcprivacy inside their bundles and are NOT re-declared
+  here.
+
+  Collected data: Google Sign-In gives the app a user ID + email,
+  linked to identity, used only for app functionality (the server-side
+  email allowlists). No tracking, no tracking domains, no ads.
+
+  Accessed API categories (required-reason):
+  - FileTimestamp: SettingsScreen's About "Built" row reads the app
+    executable's modificationDate to display the build time (DDA9.1 =
+    display to the person using the device); the Kotlin/Native runtime +
+    bundled SQLite also stat files inside the app container (C617.1).
+  - UserDefaults: CA92.1 (app's own container use — GoogleSignIn /
+    Firebase persistence; the shared framework's settings access).
+  - SystemBootTime: 35F9.1 (the Kotlin/Native runtime and
+    kotlinx.coroutines read monotonic uptime clocks for internal
+    timing; standard declaration for KMP apps).
+-->
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeUserID</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeEmailAddress</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+    </array>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>DDA9.1</string>
+                <string>C617.1</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>35F9.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
First committable piece of **Phase G** (App Store submission prep, PENDING_FOLLOWUPS §1).

App-level privacy manifest for the `GarageControl` target:
- **No tracking** (`NSPrivacyTracking = false`, no tracking domains).
- **Collected data:** User ID + Email address — linked to identity, not tracking, purpose App Functionality (Google Sign-In identity checked against the server-side allowlists). Matches what the App Store Connect privacy questionnaire will declare.
- **Required-reason APIs:** FileTimestamp (`DDA9.1` — the About "Built" row displays the executable's modification date; `C617.1` — Kotlin/Native runtime + bundled SQLite stat files in the app container), UserDefaults (`CA92.1`), SystemBootTime (`35F9.1` — Kotlin/Native + kotlinx.coroutines monotonic timing; the standard KMP-app declaration).

The Firebase / GoogleSignIn SPM packages bundle their own `PrivacyInfo.xcprivacy` and are not re-declared here.

**Verification:** `plutil -lint` OK; XcodeGen picks the file up as a bundle resource — the simulator build's `GarageControl.app/PrivacyInfo.xcprivacy` contains the declared content (inspected with `plutil -p`). The submitted binary must contain this manifest, so the next `ios/N` release after this merge is the one to submit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)