### PR TITLE
fix(scripts): replace A && pass || fail with explicit if/then/else in validate scripts

### DIFF
--- a/scripts/validate-firebase.sh
+++ b/scripts/validate-firebase.sh
@@ -55,9 +55,11 @@ pass "Node $NODE_VERSION"
 
 # Build (includes lint + tsc)
 step "Build (lint + tsc)"
-npm --prefix "$REPO_ROOT/FirebaseServer" run build \
-    && pass "npm run build" \
-    || fail "npm run build"
+if npm --prefix "$REPO_ROOT/FirebaseServer" run build; then
+    pass "npm run build"
+else
+    fail "npm run build"
+fi
 
 # Mocha pre-conditions (single-quoted glob + strip-types pin).
 # Both pitfalls are silent: a wrong glob silently skips nested test
@@ -82,9 +84,11 @@ fi
 # Tests (mocha) — includes collection-name contract tests and
 # verifyIdToken library-chain tests
 step "Tests (mocha)"
-npm --prefix "$REPO_ROOT/FirebaseServer" run tests \
-    && pass "npm run tests" \
-    || fail "npm run tests"
+if npm --prefix "$REPO_ROOT/FirebaseServer" run tests; then
+    pass "npm run tests"
+else
+    fail "npm run tests"
+fi
 
 # Record successful validation so release-firebase.sh knows we validated.
 git rev-parse HEAD > "$REPO_ROOT/.claude/.firebase-validation-passed"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -20,109 +20,249 @@ fail() { echo -e "${RED}FAIL${RESET} $1"; exit 1; }
 step() { echo -e "\n${BOLD}--- $1 ---${RESET}"; }
 
 step "Spotless (formatting — all modules)"
-$GRADLE spotlessCheck && pass "spotlessCheck" || fail "spotlessCheck"
+if $GRADLE spotlessCheck; then
+    pass "spotlessCheck"
+else
+    fail "spotlessCheck"
+fi
 
 step "Import boundary check (shared modules)"
-$GRADLE :domain:checkImportBoundary :data:checkImportBoundary :data-local:checkImportBoundary :usecase:checkImportBoundary :presentation-model:checkImportBoundary && pass "import boundaries" || fail "import boundaries"
+if $GRADLE :domain:checkImportBoundary :data:checkImportBoundary :data-local:checkImportBoundary :usecase:checkImportBoundary :presentation-model:checkImportBoundary; then
+    pass "import boundaries"
+else
+    fail "import boundaries"
+fi
 
 step "No fully qualified names in code"
-$GRADLE checkNoFullyQualifiedNames && pass "no FQNs" || fail "no FQNs"
+if $GRADLE checkNoFullyQualifiedNames; then
+    pass "no FQNs"
+else
+    fail "no FQNs"
+fi
 
 step "No Navigation 2 imports (use Nav3)"
-$GRADLE checkNoNav2Imports && pass "no Nav2" || fail "no Nav2"
+if $GRADLE checkNoNav2Imports; then
+    pass "no Nav2"
+else
+    fail "no Nav2"
+fi
 
 step "UI layer routes through ViewModel (no direct component.UseCase/Repository)"
-$GRADLE checkUiLayerNoGraphAccess && pass "ui layer no graph access" || fail "ui layer no graph access"
+if $GRADLE checkUiLayerNoGraphAccess; then
+    pass "ui layer no graph access"
+else
+    fail "ui layer no graph access"
+fi
 
 step "RememberSaveable guard (no unsaved custom types)"
-$GRADLE checkRememberSaveable && pass "rememberSaveable guard" || fail "rememberSaveable guard"
+if $GRADLE checkRememberSaveable; then
+    pass "rememberSaveable guard"
+else
+    fail "rememberSaveable guard"
+fi
 
 step "Architecture (module dependency graph)"
-$GRADLE checkArchitecture && pass "architecture" || fail "architecture"
+if $GRADLE checkArchitecture; then
+    pass "architecture"
+else
+    fail "architecture"
+fi
 
 step "Singleton guard (Database, Settings, HttpClient)"
-$GRADLE checkSingletonGuard && pass "singleton guard" || fail "singleton guard"
+if $GRADLE checkSingletonGuard; then
+    pass "singleton guard"
+else
+    fail "singleton guard"
+fi
 
 step "Singleton caching (kotlin-inject generated _scoped.get matches @Singleton)"
-$GRADLE checkSingletonCaching && pass "singleton caching" || fail "singleton caching"
+if $GRADLE checkSingletonCaching; then
+    pass "singleton caching"
+else
+    fail "singleton caching"
+fi
 
 step "DataStore + Room singleton annotations (provideAppSettings, provideAppDatabase)"
-$GRADLE checkDataStoreSingleton && pass "datastore singleton" || fail "datastore singleton"
+if $GRADLE checkDataStoreSingleton; then
+    pass "datastore singleton"
+else
+    fail "datastore singleton"
+fi
 
 step "No raw Dispatchers (ADR-005 — VM/UseCase must inject DispatcherProvider)"
-$GRADLE checkNoRawDispatchers && pass "no raw dispatchers" || fail "no raw dispatchers"
+if $GRADLE checkNoRawDispatchers; then
+    pass "no raw dispatchers"
+else
+    fail "no raw dispatchers"
+fi
 
 step "No bare top-level functions (ADR-009 — group in object {})"
-$GRADLE checkNoBareTopLevelFunctions && pass "no bare top-level functions" || fail "no bare top-level functions"
+if $GRADLE checkNoBareTopLevelFunctions; then
+    pass "no bare top-level functions"
+else
+    fail "no bare top-level functions"
+fi
 
 step "No literal Text() in Composable scope (Phase 3 — string-resource migration)"
-$GRADLE checkNoLiteralStringsInCompose && pass "no literal Text() in Composable" || fail "no literal Text() in Composable"
+if $GRADLE checkNoLiteralStringsInCompose; then
+    pass "no literal Text() in Composable"
+else
+    fail "no literal Text() in Composable"
+fi
 
 step "No *Impl suffix on class names (ADR-008 — use descriptive prefix)"
-$GRADLE checkNoImplSuffix && pass "no *Impl suffix" || fail "no *Impl suffix"
+if $GRADLE checkNoImplSuffix; then
+    pass "no *Impl suffix"
+else
+    fail "no *Impl suffix"
+fi
 
 step "No 'Ui' / 'View' in class names (KMP collision; ported from battery-butler)"
-$GRADLE checkNamingConvention && pass "naming convention" || fail "naming convention"
+if $GRADLE checkNamingConvention; then
+    pass "naming convention"
+else
+    fail "naming convention"
+fi
 
 step "Previews don't transitively use Clock.System.now() / Instant.now() (deterministic screenshots)"
-$GRADLE checkPreviewTime && pass "preview time determinism" || fail "preview time determinism"
+if $GRADLE checkPreviewTime; then
+    pass "preview time determinism"
+else
+    fail "preview time determinism"
+fi
 
 step "isSystemInDarkTheme() only inside theme module (theme-detection isolation)"
-$GRADLE checkThemeDetection && pass "theme detection isolation" || fail "theme detection isolation"
+if $GRADLE checkThemeDetection; then
+    pass "theme detection isolation"
+else
+    fail "theme detection isolation"
+fi
 
 step "No idToken parameter on UseCases (ADR-027 — token internal to repos)"
-$GRADLE checkNoTokenInUseCase && pass "no token in UseCase" || fail "no token in UseCase"
+if $GRADLE checkNoTokenInUseCase; then
+    pass "no token in UseCase"
+else
+    fail "no token in UseCase"
+fi
 
 step "No idToken parameter on domain repository interfaces (ADR-027)"
-$GRADLE checkRepositoryInterfaceNoToken && pass "no token in repo interface" || fail "no token in repo interface"
+if $GRADLE checkRepositoryInterfaceNoToken; then
+    pass "no token in repo interface"
+else
+    fail "no token in repo interface"
+fi
 
 step "Every NavDisplay entry uses RouteContent (single source of horizontal layout)"
-$GRADLE checkRouteContentUsage && pass "RouteContent usage" || fail "RouteContent usage"
+if $GRADLE checkRouteContentUsage; then
+    pass "RouteContent usage"
+else
+    fail "RouteContent usage"
+fi
 
 step "ContentWidth cap applied only at RouteContent (no per-screen widthIn(max))"
-$GRADLE checkContentWidthCap && pass "ContentWidth cap" || fail "ContentWidth cap"
+if $GRADLE checkContentWidthCap; then
+    pass "ContentWidth cap"
+else
+    fail "ContentWidth cap"
+fi
 
 step "No LocalConfiguration dimension reads (use LocalAppWindowSizeClass)"
-$GRADLE checkNoLocalConfigurationDimensionReads && pass "no LocalConfiguration dim reads" || fail "no LocalConfiguration dim reads"
+if $GRADLE checkNoLocalConfigurationDimensionReads; then
+    pass "no LocalConfiguration dim reads"
+else
+    fail "no LocalConfiguration dim reads"
+fi
 
 step "AppLayoutMode boundary (no direct LocalAppWindowSizeClass.current reads)"
-$GRADLE checkAppLayoutModeBoundary && pass "AppLayoutMode boundary" || fail "AppLayoutMode boundary"
+if $GRADLE checkAppLayoutModeBoundary; then
+    pass "AppLayoutMode boundary"
+else
+    fail "AppLayoutMode boundary"
+fi
 
 step "No raw WindowInsets.<x>.asPaddingValues() (use LocalContentEdgeInsets / safeListContentPadding)"
-$GRADLE checkNoRawSafeDrawingPaddingValues && pass "no raw asPaddingValues" || fail "no raw asPaddingValues"
+if $GRADLE checkNoRawSafeDrawingPaddingValues; then
+    pass "no raw asPaddingValues"
+else
+    fail "no raw asPaddingValues"
+fi
 
 step "No Mockito imports (ADR-003 — fakes over mocks)"
-$GRADLE checkNoMockitoImports && pass "no Mockito imports" || fail "no Mockito imports"
+if $GRADLE checkNoMockitoImports; then
+    pass "no Mockito imports"
+else
+    fail "no Mockito imports"
+fi
 
 step "Mutex withLock (no bare .lock()/.unlock())"
-$GRADLE checkMutexWithLock && pass "mutex withLock" || fail "mutex withLock"
+if $GRADLE checkMutexWithLock; then
+    pass "mutex withLock"
+else
+    fail "mutex withLock"
+fi
 
 step "Auth state projection (no raw authState in side-effecting combine watchers)"
-$GRADLE checkAuthStateProjection && pass "authState projection" || fail "authState projection"
+if $GRADLE checkAuthStateProjection; then
+    pass "authState projection"
+else
+    fail "authState projection"
+fi
 
 step "Layer imports (ViewModel→UseCase, UseCase→domain)"
-$GRADLE checkLayerImports && pass "layer imports" || fail "layer imports"
+if $GRADLE checkLayerImports; then
+    pass "layer imports"
+else
+    fail "layer imports"
+fi
 
 step "Hardcoded colors (must use theme)"
-$GRADLE checkHardcodedColors && pass "hardcoded colors" || fail "hardcoded colors"
+if $GRADLE checkHardcodedColors; then
+    pass "hardcoded colors"
+else
+    fail "hardcoded colors"
+fi
 
 step "ViewModel StateFlow (no stateIn(viewModelScope, ...))"
-$GRADLE checkViewModelStateFlow && pass "viewmodel stateflow" || fail "viewmodel stateflow"
+if $GRADLE checkViewModelStateFlow; then
+    pass "viewmodel stateflow"
+else
+    fail "viewmodel stateflow"
+fi
 
 step "Screen ↔ ViewModel cardinality (1 VM per screen, exemptions tracked)"
-$GRADLE checkScreenViewModelCardinality && pass "screen↔viewmodel cardinality" || fail "screen↔viewmodel cardinality"
+if $GRADLE checkScreenViewModelCardinality; then
+    pass "screen↔viewmodel cardinality"
+else
+    fail "screen↔viewmodel cardinality"
+fi
 
 step "Preview coverage (every public *Preview is imported by a screenshot test)"
-$GRADLE checkPreviewCoverage && pass "preview coverage" || fail "preview coverage"
+if $GRADLE checkPreviewCoverage; then
+    pass "preview coverage"
+else
+    fail "preview coverage"
+fi
 
 step "Fake public var (no unguarded public var on Fake* classes)"
-$GRADLE checkFakePublicVar && pass "fake public var" || fail "fake public var"
+if $GRADLE checkFakePublicVar; then
+    pass "fake public var"
+else
+    fail "fake public var"
+fi
 
 step "Detekt (static analysis)"
-$GRADLE :androidApp:detekt && pass "detekt" || fail "detekt"
+if $GRADLE :androidApp:detekt; then
+    pass "detekt"
+else
+    fail "detekt"
+fi
 
 step "Android Lint"
-$GRADLE :androidApp:lint && pass "lint" || fail "lint"
+if $GRADLE :androidApp:lint; then
+    pass "lint"
+else
+    fail "lint"
+fi
 
 # Discover all non-Android modules with test sources and run their tests.
 # Checks both src/test/ (pure JVM) and src/commonTest/ (KMP).
@@ -142,27 +282,50 @@ for module_dir in "$REPO_ROOT"/MobileGarage/*/; do
     [ "$has_tests" = true ] || continue
     FOUND_MODULES=$((FOUND_MODULES + 1))
     # KMP Android library modules use testDebugUnitTest
-    $GRADLE ":${module}:testDebugUnitTest" && pass ":${module}:testDebugUnitTest" || fail ":${module}:testDebugUnitTest"
+    if $GRADLE ":${module}:testDebugUnitTest"; then
+        pass ":${module}:testDebugUnitTest"
+    else
+        fail ":${module}:testDebugUnitTest"
+    fi
 done
 if [ "$FOUND_MODULES" -eq 0 ]; then
     echo "  (no shared modules with tests found)"
 fi
 
 step "Unit Tests (debug)"
-$GRADLE :androidApp:testDebugUnitTest && pass "testDebugUnitTest" || fail "testDebugUnitTest"
+if $GRADLE :androidApp:testDebugUnitTest; then
+    pass "testDebugUnitTest"
+else
+    fail "testDebugUnitTest"
+fi
 
 step "Unit Tests (release)"
-$GRADLE :androidApp:testReleaseUnitTest && pass "testReleaseUnitTest" || fail "testReleaseUnitTest"
+if $GRADLE :androidApp:testReleaseUnitTest; then
+    pass "testReleaseUnitTest"
+else
+    fail "testReleaseUnitTest"
+fi
 
 step "Unit Tests (benchmark)"
-$GRADLE :androidApp:testBenchmarkUnitTest && pass "testBenchmarkUnitTest" || fail "testBenchmarkUnitTest"
+if $GRADLE :androidApp:testBenchmarkUnitTest; then
+    pass "testBenchmarkUnitTest"
+else
+    fail "testBenchmarkUnitTest"
+fi
 
 step "Build Debug APK"
-$GRADLE :androidApp:assembleDebug && pass "assembleDebug" || fail "assembleDebug"
+if $GRADLE :androidApp:assembleDebug; then
+    pass "assembleDebug"
+else
+    fail "assembleDebug"
+fi
 
 step "Screenshot tests (compile)"
-$GRADLE :android-screenshot-tests:compileDebugScreenshotTestKotlin \
-    && pass "screenshot test compilation" || fail "screenshot test compilation"
+if $GRADLE :android-screenshot-tests:compileDebugScreenshotTestKotlin; then
+    pass "screenshot test compilation"
+else
+    fail "screenshot test compilation"
+fi
 
 # androidTest sources compile here (no device / runtime needed). Catches
 # signature-breaking changes to public Composables that test sources call.
@@ -170,16 +333,25 @@ $GRADLE :android-screenshot-tests:compileDebugScreenshotTestKotlin \
 # AuthStateUIPropagationTest still called the old shape, and the failure only
 # surfaced in post-merge CI's instrumented-tests job. Compile is fast (~2s).
 step "Instrumented tests (compile)"
-$GRADLE :androidApp:compileDebugAndroidTestKotlin \
-    && pass "instrumented test compilation" || fail "instrumented test compilation"
+if $GRADLE :androidApp:compileDebugAndroidTestKotlin; then
+    pass "instrumented test compilation"
+else
+    fail "instrumented test compilation"
+fi
 
 step "Documentation front-matter (AGENTS.md contract)"
-"$REPO_ROOT/scripts/check-doc-frontmatter.sh" \
-    && pass "doc front-matter" || fail "doc front-matter"
+if "$REPO_ROOT/scripts/check-doc-frontmatter.sh"; then
+    pass "doc front-matter"
+else
+    fail "doc front-matter"
+fi
 
 step "Play Store whatsnew length (Google Play 500-char limit)"
-"$REPO_ROOT/scripts/check-whatsnew-length.sh" \
-    && pass "whatsnew length" || fail "whatsnew length"
+if "$REPO_ROOT/scripts/check-whatsnew-length.sh"; then
+    pass "whatsnew length"
+else
+    fail "whatsnew length"
+fi
 
 step "Room schema drift check"
 # After compilation, Room KSP generates schema JSON files.
@@ -232,13 +404,15 @@ if [ "${VALIDATE_R8:-0}" = "1" ]; then
     if ! adb devices 2>/dev/null | grep -q "device$"; then
         fail "No device/emulator connected. Plug in a device or start an emulator, then retry."
     fi
-    $GRADLE \
+    if $GRADLE \
         -PtestR8=true \
         -PdebuggableBenchmark=true \
         -PVERSION_CODE=99999 \
-        :androidApp:connectedBenchmarkAndroidTest \
-        && pass "connectedBenchmarkAndroidTest (R8 minified)" \
-        || fail "connectedBenchmarkAndroidTest (R8 minified)"
+        :androidApp:connectedBenchmarkAndroidTest; then
+        pass "connectedBenchmarkAndroidTest (R8 minified)"
+    else
+        fail "connectedBenchmarkAndroidTest (R8 minified)"
+    fi
 else
     step "R8 instrumented tests (skipped — opt-in via VALIDATE_R8=1)"
     echo "  To reproduce release-only R8 failures locally, run:"


### PR DESCRIPTION
## What

Replaces the `A && pass "X" || fail "X"` idiom (shellcheck [SC2015](https://www.shellcheck.net/wiki/SC2015): "A && B || C is not if-then-else — C may run when A is true") with explicit `if A; then pass "X"; else fail "X"; fi` in `scripts/validate.sh` (44 single-line call sites + the multi-line R8-instrumented-tests block) and `scripts/validate-firebase.sh` (2 call sites).

## Why

CLAUDE.md already documents a related pain point: *"validate.sh runs checks sequentially and stops at the first failure, but the wrapper does NOT always propagate Gradle's non-zero exit code upstream... Always grep / scan the output for FAIL and BUILD FAILED before treating a validate run as green."* The `A && B || C` construct is exactly the anti-pattern that class of bug comes from — it happens to behave correctly here only because `fail()` unconditionally calls `exit 1` (so if `pass` — an `echo`, which can itself fail on e.g. a closed stdout/SIGPIPE — ever failed, `fail` would still fire), but that's incidental to the construct rather than guaranteed by it. Explicit `if/then/else` removes the whole class of ambiguity shellcheck is warning about, independent of whether it's the literal root cause of the documented issue.

## How verified

- `bash -n` + `shellcheck --severity=style` clean on both files (was 46 SC2015 findings, now 0).
- Isolated behavioral test harness reproducing the exact idiom with a fake command: success path continues and exits 0, failure path prints FAIL and exits 1 — both before and after the transform, confirming no behavior change.
- **Ran `scripts/validate-firebase.sh` to completion end-to-end** (only script in the two that doesn't need the Android toolchain): confirmed both the fail path (real `npm run build` failure with `eslint` not yet installed → `FAIL npm run build`, exit 1) and the pass path (after `npm install`, full build + lint + 407 mocha tests → `All Firebase checks passed`, exit 0) under the new `if/then/else` blocks.
- `scripts/validate.sh` needs the Android toolchain/Gradle to run end-to-end, which this environment doesn't have — verified via `bash -n`, `shellcheck`, and manual line-by-line diff review instead; behavior is structurally identical to `validate-firebase.sh`'s verified case.

No functional change intended — this is a hardening/clarity pass, not a bug fix for a reproduced failure.