### PR TITLE
fix(scripts): fix shellcheck-flagged quoting bugs + drop dead var

### DIFF
--- a/MobileGarage/release/decrypt-secrets.sh
+++ b/MobileGarage/release/decrypt-secrets.sh
@@ -26,9 +26,9 @@ decrypt() {
 # branch below, not an "unbound variable" abort.
 if [[ -n "${ENCRYPT_KEY:-}" ]]; then
   # Decrypt Release key
-  decrypt ${ENCRYPT_KEY} release/app-release.gpg release/app-release.jks
+  decrypt "${ENCRYPT_KEY}" release/app-release.gpg release/app-release.jks
   # Decrypt Google Services key (Android)
-  decrypt ${ENCRYPT_KEY} release/google-services.gpg androidApp/google-services.json
+  decrypt "${ENCRYPT_KEY}" release/google-services.gpg androidApp/google-services.json
 else
   echo "ENCRYPT_KEY is empty"
 fi

--- a/MobileGarage/release/encrypt-secrets.sh
+++ b/MobileGarage/release/encrypt-secrets.sh
@@ -26,9 +26,9 @@ encrypt() {
 # branch below, not an "unbound variable" abort.
 if [[ -n "${ENCRYPT_KEY:-}" ]]; then
   # Encrypt Release key
-  encrypt ${ENCRYPT_KEY} release/app-release.jks release/app-release.gpg
+  encrypt "${ENCRYPT_KEY}" release/app-release.jks release/app-release.gpg
   # Encrypt Google Services key (Android)
-  encrypt ${ENCRYPT_KEY} androidApp/google-services.json release/google-services.gpg
+  encrypt "${ENCRYPT_KEY}" androidApp/google-services.json release/google-services.gpg
 else
   echo "ENCRYPT_KEY is empty"
 fi

--- a/scripts/check-doc-frontmatter.sh
+++ b/scripts/check-doc-frontmatter.sh
@@ -102,7 +102,7 @@ date_to_epoch() {
 
 validate_file() {
     local file="$1"
-    local rel="${file#$REPO_ROOT/}"
+    local rel="${file#"$REPO_ROOT"/}"
 
     # Read the file once with CR stripped so CRLF-terminated files validate
     # the same as LF (hit during a doc edit on 2026-04-25 — MobileGarage/README.md

--- a/scripts/generate-screenshot-collections.sh
+++ b/scripts/generate-screenshot-collections.sh
@@ -137,7 +137,7 @@ for yaml_file in "$COLLECTIONS_DIR"/*.yaml; do
             fi
 
             # Glob for {test_name}_*_0.png (the hash varies across generations)
-            matches=("$class_dir"/${test_name}_*_0.png)
+            matches=("$class_dir"/"${test_name}"_*_0.png)
             if [ -f "${matches[0]}" ]; then
                 rel_path="$(python3 -c "import os.path; print(os.path.relpath('${matches[0]}', '$COLLECTIONS_DIR'))")"
                 image_paths+=("$rel_path")

--- a/scripts/validate-ios.sh
+++ b/scripts/validate-ios.sh
@@ -31,7 +31,6 @@ set -euo pipefail
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
 BOLD='\033[1m'
 RESET='\033[0m'
 


### PR DESCRIPTION
## What

Fixes real correctness findings from a full-repo `shellcheck --severity=style` pass (excluding the `validate.sh`/`validate-firebase.sh` `A && B || C` cleanup, which is #1061):

- **`MobileGarage/release/{en,de}crypt-secrets.sh`** — quote `${ENCRYPT_KEY}` ([SC2086](https://www.shellcheck.net/wiki/SC2086)). Unquoted, a passphrase containing a space word-splits into extra positional args to the `encrypt()`/`decrypt()` functions, silently shifting `INPUT`/`OUTPUT`.
- **`scripts/generate-screenshot-collections.sh`** — quote `${test_name}` inside the glob array assignment ([SC2206](https://www.shellcheck.net/wiki/SC2206)) so a test name containing whitespace/glob metacharacters can't be mis-split.
- **`scripts/check-doc-frontmatter.sh`** — quote `$REPO_ROOT` inside the `${file#...}` prefix-removal pattern ([SC2295](https://www.shellcheck.net/wiki/SC2295)); unquoted it's matched as a glob pattern rather than a literal prefix.
- **`scripts/validate-ios.sh`** — remove `YELLOW`, assigned but never read ([SC2034](https://www.shellcheck.net/wiki/SC2034)).

Not included: the same `IS_DETACHED` dead-var finding (SC2034) also appears in `scripts/release-android.sh` and `scripts/release-firebase.sh`, but I left those two files untouched given how much scrutiny CLAUDE.md and `.claude/settings.json` (`ask` permission tier) put specifically on the release scripts — happy to include it separately if you'd rather not leave it dangling.

## Why

The `ENCRYPT_KEY` one is a real, reproducible bug in a secrets-handling script, not just style. See verification below.

## How verified

- `bash -n` + `shellcheck --severity=style` clean on all 5 files. Repo-wide re-scan afterward shows zero remaining findings other than two pre-existing false positives I confirmed by reading context (intentional unquoted word-splitting in `MobileGarage/distribution/playstore/generate.sh`'s `set -- $entry`, and an intentional single-quoted literal backtick in `dev-mode.sh`'s JSON `systemMessage`) — left both as-is.
- **Reproduced the `ENCRYPT_KEY` bug against the pre-fix scripts**: with `ENCRYPT_KEY="my secret passphrase"` (a realistic multi-word passphrase) in an isolated scratch dir, the *old* `encrypt-secrets.sh` fails with a misleading `gpg: can't open 'secret': No such file or directory` (word-split into extra args). The *fixed* version round-trips correctly end-to-end: encrypt → delete plaintext → decrypt → content byte-for-byte matches the original.
- `check-doc-frontmatter.sh` re-run against the full repo post-fix: still exits 0 (no regression across every doc it validates).