### PR TITLE
ci(scripts): add a Shellcheck CI gate + close remaining findings

### DIFF
--- a/.claude/hooks/dev-mode.sh
+++ b/.claude/hooks/dev-mode.sh
@@ -31,6 +31,7 @@ if [ "$OPEN_PRS" -ge 10 ]; then
   MERGEABLE="${MERGEABLE:-0}"
   if [ "$MERGEABLE" -eq 0 ]; then
     # All PRs waiting on CI, nothing to do — let Claude stop
+    # shellcheck disable=SC2016 # single-quoted on purpose: the backtick command is literal text for the user, not meant to expand
     echo '{"systemMessage":"Dev mode: 5+ PRs open, all waiting on CI. Pausing until PRs merge. Re-enable with `touch .claude/.dev-mode` when ready."}'
     exit 0
   fi

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,50 @@
+name: Shellcheck
+
+# Lints every shell script in the repo with ShellCheck. Added after a manual
+# audit (PRs #1061, #1062) found and fixed several real bugs shellcheck
+# catches by default — most notably an unquoted ${ENCRYPT_KEY} in
+# MobileGarage/release/{en,de}crypt-secrets.sh that silently breaks on any
+# passphrase containing a space. This workflow is the permanent guardrail so
+# the next script edit can't reintroduce that class of bug unnoticed.
+#
+# Severity threshold is `info`, not the stricter `style`: `style`-level
+# findings (e.g. SC2129 "prefer a single redirect block") are pure
+# micro-optimizations with no correctness impact, and gating on them invites
+# noise/bikeshedding. `info` still catches real correctness issues —
+# SC2015 (A && B || C is not if/else), SC2086 (unquoted expansion — the
+# ENCRYPT_KEY bug above), SC2295 (unquoted glob pattern) are all `info`
+# severity despite being genuine bugs.
+#
+# Deliberately NO `paths:` filter, same reasoning as scripts-tests.yml's
+# "Script unit tests": a path-filtered required check stays
+# "Expected/pending" forever on a PR that doesn't touch a .sh file, which
+# blocks the merge. ShellCheck across ~28 files takes seconds, so running it
+# on every PR/push costs nothing and the check always concludes.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 5 # never hang; the lint itself takes seconds
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Ensure shellcheck is available
+        run: command -v shellcheck || (sudo apt-get update && sudo apt-get install -y shellcheck)
+
+      - name: Run shellcheck
+        run: |
+          find . -name '*.sh' \
+            -not -path '*/node_modules/*' \
+            -not -path '*/build/*' \
+            -not -path '*/.git/*' \
+            -not -path '*/DerivedData/*' \
+            -print0 | xargs -0 shellcheck --severity=info

--- a/MobileGarage/distribution/playstore/generate.sh
+++ b/MobileGarage/distribution/playstore/generate.sh
@@ -67,6 +67,7 @@ out.paste(src, (0, 0), mask)
 out.save(sys.argv[2])
 PY
 for entry in "${sizes[@]}"; do
+  # shellcheck disable=SC2086 # word-splitting is intentional: $entry is a "dens px" pair meant to split into $1/$2
   set -- $entry; dens="$1"; px="$2"
   mkdir -p "$RES/mipmap-$dens"
   sips -z "$px" "$px" "$MASTER" --out "$RES/mipmap-$dens/ic_launcher.png" >/dev/null

--- a/scripts/release-android.sh
+++ b/scripts/release-android.sh
@@ -169,10 +169,7 @@ fi
 
 CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
 if [ -z "$CURRENT_BRANCH" ]; then
-    IS_DETACHED="true"
     CURRENT_BRANCH="(detached)"
-else
-    IS_DETACHED="false"
 fi
 
 # Validation marker state.

--- a/scripts/release-firebase.sh
+++ b/scripts/release-firebase.sh
@@ -164,10 +164,7 @@ fi
 
 CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
 if [ -z "$CURRENT_BRANCH" ]; then
-    IS_DETACHED="true"
     CURRENT_BRANCH="(detached)"
-else
-    IS_DETACHED="false"
 fi
 
 # Local validation marker state.


### PR DESCRIPTION
## What

Adds `.github/workflows/shellcheck.yml`, mirroring `scripts-tests.yml`'s "Script unit tests" pattern (no `paths:` filter, fast, runs on every push/PR) so it's safe to promote to a required check later. Also closes the remaining repo-wide `shellcheck --severity=info` findings so the gate starts from a clean baseline instead of landing already-red:

- `scripts/release-android.sh`, `scripts/release-firebase.sh` — drop `IS_DETACHED` (SC2034), assigned in both branches of an `if`/`else` and never read. `CURRENT_BRANCH` (the variable actually used downstream — e.g. the not-on-main guard, the printed release summary) is untouched.
- `.claude/hooks/dev-mode.sh` — `# shellcheck disable=SC2016` with a one-line rationale: the single-quoted backtick text is a literal instruction shown to the user, not meant to expand.
- `MobileGarage/distribution/playstore/generate.sh` — `# shellcheck disable=SC2086` with a one-line rationale: `set -- $entry` relies on intentional word-splitting to unpack a `"density px"` pair into `$1`/`$2`.

## Why

#1061 and #1062 fixed everything a one-time manual `shellcheck` audit found — including a real bug (unquoted `${ENCRYPT_KEY}` breaking on any passphrase with a space). Without a permanent gate, the next script edit can silently reintroduce that same class of bug with nothing catching it. This workflow is that gate.

**Threshold is `info`, not `style`.** `style`-level findings (e.g. SC2129's "prefer one redirect block") are pure cosmetic suggestions with no correctness impact — gating on them invites noise/bikeshedding for no safety benefit. `info` still catches everything that mattered in #1061/#1062: SC2015 (`A && B || C` isn't if/else), SC2086 (unquoted expansion — the `ENCRYPT_KEY` bug), and SC2295 (unquoted glob pattern) are all `info` severity despite being genuine bugs.

## How verified

- Ran the exact `find ... -print0 | xargs -0 shellcheck --severity=info` pipeline the workflow uses, locally, across the whole repo: **0 findings**.
- `bash -n` on every edited file; re-ran `scripts/release-android.sh --check` and `scripts/release-firebase.sh --check` after the `IS_DETACHED` removal — both still print the correct state (including `Branch: <current-branch>`, confirming `CURRENT_BRANCH` logic is intact) and exit 0. Both are read-only in `--check` mode, so this didn't touch any release state.
- YAML validated with `yaml.safe_load`.

## Follow-up (not in this PR)

Once this lands and shows one green run on `main`, the natural next step is promoting `Shellcheck` to a required status check (same bootstrap sequence CLAUDE.md documents for `Script unit tests` / `Doc front-matter`: land workflow → observe a passing run on main → add to `required_status_checks.contexts`). Flagging it here rather than doing it in the same PR, since promoting a required check is a branch-protection change worth its own visible step — happy to do it right after this merges if that's still the intent.