### PR TITLE
feat(cache): status-snapshot store infrastructure (STATUS_CACHE_PLAN PR 1)

### DIFF
--- a/MobileGarage/androidApp/src/androidTest/java/com/chriscartland/garage/di/ComponentGraphTest.kt
+++ b/MobileGarage/androidApp/src/androidTest/java/com/chriscartland/garage/di/ComponentGraphTest.kt
@@ -137,6 +137,34 @@ class ComponentGraphTest {
     }
 
     @Test
+    fun statusCacheStorageIsSingleton() {
+        // Wraps the status-cache DataStore file; a second instance for
+        // the same file throws IllegalStateException at runtime.
+        val c = component
+        assertSame("StatusCacheStorage must be singleton", c.statusCacheStorage, c.statusCacheStorage)
+    }
+
+    @Test
+    fun statusSnapshotStoreIsSingleton() {
+        val c = component
+        assertSame("StatusSnapshotStore must be singleton", c.statusSnapshotStore, c.statusSnapshotStore)
+    }
+
+    @Test
+    fun userScopedCacheIsSingleton() {
+        val c = component
+        assertSame("UserScopedCache must be singleton", c.userScopedCache, c.userScopedCache)
+    }
+
+    @Test
+    fun signOutCacheClearManagerIsSingleton() {
+        // Owns the auth-observing collector Job; two instances would
+        // double-clear and double-collect.
+        val c = component
+        assertSame("SignOutCacheClearManager must be singleton", c.signOutCacheClearManager, c.signOutCacheClearManager)
+    }
+
+    @Test
     fun buttonHealthRepositoryIsSingleton() {
         val c = component
         assertSame("ButtonHealthRepository must be singleton", c.buttonHealthRepository, c.buttonHealthRepository)

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -49,10 +49,16 @@ import com.chriscartland.garage.data.repository.NetworkButtonHealthRepository
 import com.chriscartland.garage.data.repository.NetworkDoorRepository
 import com.chriscartland.garage.data.repository.NetworkRemoteButtonRepository
 import com.chriscartland.garage.data.repository.NetworkSnoozeRepository
+import com.chriscartland.garage.data.statuscache.DefaultStatusSnapshotStore
+import com.chriscartland.garage.data.statuscache.DefaultUserScopedCache
+import com.chriscartland.garage.data.statuscache.StatusCacheKeys
+import com.chriscartland.garage.data.statuscache.StatusCacheStorage
+import com.chriscartland.garage.data.statuscache.StatusSnapshotStore
 import com.chriscartland.garage.datalocal.AppDatabase
 import com.chriscartland.garage.datalocal.DataStoreAppSettings
 import com.chriscartland.garage.datalocal.DataStoreDiagnosticsCounters
 import com.chriscartland.garage.datalocal.DataStoreFactory
+import com.chriscartland.garage.datalocal.DataStoreStatusCacheStorage
 import com.chriscartland.garage.datalocal.DatabaseFactory
 import com.chriscartland.garage.datalocal.DatabaseLocalDoorDataSource
 import com.chriscartland.garage.datalocal.RoomAppLoggerRepository
@@ -73,6 +79,7 @@ import com.chriscartland.garage.domain.repository.RemoteButtonRepository
 import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import com.chriscartland.garage.domain.repository.SnoozeRepository
 import com.chriscartland.garage.domain.repository.TestNotificationRepository
+import com.chriscartland.garage.domain.repository.UserScopedCache
 import com.chriscartland.garage.fcm.FirebaseMessagingBridge
 import com.chriscartland.garage.usecase.AppSettingsUseCase
 import com.chriscartland.garage.usecase.AppStartup
@@ -113,6 +120,7 @@ import com.chriscartland.garage.usecase.RegisterFcmUseCase
 import com.chriscartland.garage.usecase.RunStartupDiagnosticsMaintenanceUseCase
 import com.chriscartland.garage.usecase.SeedDiagnosticsCountersFromRoomUseCase
 import com.chriscartland.garage.usecase.SignInWithGoogleUseCase
+import com.chriscartland.garage.usecase.SignOutCacheClearManager
 import com.chriscartland.garage.usecase.SignOutUseCase
 import com.chriscartland.garage.usecase.SnoozeNotificationsUseCase
 import com.chriscartland.garage.usecase.SubscribeTestNotificationUseCase
@@ -211,6 +219,10 @@ abstract class AppComponent(
     abstract val doorResolvedFcmSubscriptionManager: DoorResolvedFcmSubscriptionManager
     abstract val initialDoorFetchManager: InitialDoorFetchManager
     abstract val computeButtonHealthDisplayUseCase: ComputeButtonHealthDisplayUseCase
+    abstract val statusCacheStorage: StatusCacheStorage
+    abstract val statusSnapshotStore: StatusSnapshotStore
+    abstract val userScopedCache: UserScopedCache
+    abstract val signOutCacheClearManager: SignOutCacheClearManager
 
     // --- ViewModels ---
 
@@ -558,6 +570,38 @@ abstract class AppComponent(
 
     @Provides
     @Singleton
+    fun provideStatusCacheStorage(factory: DataStoreFactory): StatusCacheStorage =
+        DataStoreStatusCacheStorage(factory.createStatusCacheDataStore())
+
+    @Provides
+    @Singleton
+    fun provideStatusSnapshotStore(storage: StatusCacheStorage): StatusSnapshotStore = DefaultStatusSnapshotStore(storage)
+
+    @Provides
+    @Singleton
+    fun provideUserScopedCache(statusSnapshotStore: StatusSnapshotStore): UserScopedCache =
+        DefaultUserScopedCache(
+            statusSnapshotStore = statusSnapshotStore,
+            userScopedKeys = StatusCacheKeys.CLEARED_ON_SIGN_OUT,
+        )
+
+    @Provides
+    @Singleton
+    fun provideSignOutCacheClearManager(
+        authRepository: AuthRepository,
+        userScopedCache: UserScopedCache,
+        applicationScope: CoroutineScope,
+        dispatchers: DispatcherProvider,
+    ): SignOutCacheClearManager =
+        SignOutCacheClearManager(
+            authRepository = authRepository,
+            userScopedCache = userScopedCache,
+            scope = applicationScope,
+            dispatcher = dispatchers.io,
+        )
+
+    @Provides
+    @Singleton
     fun provideAppDatabase(): AppDatabase = DatabaseFactory(application).createDatabase()
 
     @Provides
@@ -835,6 +879,7 @@ abstract class AppComponent(
         buttonHealthFcmSubscriptionManager: ButtonHealthFcmSubscriptionManager,
         doorResolvedFcmSubscriptionManager: DoorResolvedFcmSubscriptionManager,
         initialDoorFetchManager: InitialDoorFetchManager,
+        signOutCacheClearManager: SignOutCacheClearManager,
         applicationScope: CoroutineScope,
         dispatchers: DispatcherProvider,
     ): AppStartup =
@@ -847,6 +892,7 @@ abstract class AppComponent(
             buttonHealthFcmSubscriptionManager = buttonHealthFcmSubscriptionManager,
             doorResolvedFcmSubscriptionManager = doorResolvedFcmSubscriptionManager,
             initialDoorFetchManager = initialDoorFetchManager,
+            signOutCacheClearManager = signOutCacheClearManager,
             externalScope = applicationScope,
             dispatchers = dispatchers,
         )

--- a/MobileGarage/androidApp/src/main/res/xml/backup_rules.xml
+++ b/MobileGarage/androidApp/src/main/res/xml/backup_rules.xml
@@ -32,8 +32,11 @@
      context.getDatabasePath("database")); SQLite also writes -shm/-wal
      sidecars next to it.
    - DataStore files land directly in filesDir (DataStoreFactory.android.kt
-     resolves PREFERENCES_FILE_NAME / DIAGNOSTICS_COUNTERS_FILE_NAME against
-     context.filesDir), i.e. the "file" backup domain.
+     resolves PREFERENCES_FILE_NAME / DIAGNOSTICS_COUNTERS_FILE_NAME /
+     STATUS_CACHE_FILE_NAME against context.filesDir), i.e. the "file"
+     backup domain. Every *_FILE_NAME constant in DataStoreFactory.kt must
+     be excluded here AND in data_extraction_rules.xml — enforced by the
+     checkBackupRulesExcludes Gradle task.
 -->
 <full-backup-content>
     <exclude domain="database" path="database" />
@@ -41,4 +44,5 @@
     <exclude domain="database" path="database-wal" />
     <exclude domain="file" path="app_settings.preferences_pb" />
     <exclude domain="file" path="diagnostics_counters.preferences_pb" />
+    <exclude domain="file" path="status_cache.preferences_pb" />
 </full-backup-content>

--- a/MobileGarage/androidApp/src/main/res/xml/data_extraction_rules.xml
+++ b/MobileGarage/androidApp/src/main/res/xml/data_extraction_rules.xml
@@ -34,5 +34,6 @@
         <exclude domain="database" path="database-wal" />
         <exclude domain="file" path="app_settings.preferences_pb" />
         <exclude domain="file" path="diagnostics_counters.preferences_pb" />
+        <exclude domain="file" path="status_cache.preferences_pb" />
     </cloud-backup>
 </data-extraction-rules>

--- a/MobileGarage/androidApp/src/test/java/com/chriscartland/garage/AppStartupTest.kt
+++ b/MobileGarage/androidApp/src/test/java/com/chriscartland/garage/AppStartupTest.kt
@@ -30,6 +30,7 @@ import com.chriscartland.garage.domain.repository.ButtonHealthFcmRepository
 import com.chriscartland.garage.domain.repository.ButtonHealthRepository
 import com.chriscartland.garage.domain.repository.DoorResolvedFcmRepository
 import com.chriscartland.garage.domain.repository.ServerConfigRepository
+import com.chriscartland.garage.domain.repository.UserScopedCache
 import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
 import com.chriscartland.garage.testcommon.FakeAuthRepository
 import com.chriscartland.garage.testcommon.FakeDiagnosticsCountersRepository
@@ -51,6 +52,7 @@ import com.chriscartland.garage.usecase.PruneDiagnosticsLogUseCase
 import com.chriscartland.garage.usecase.RegisterFcmUseCase
 import com.chriscartland.garage.usecase.RunStartupDiagnosticsMaintenanceUseCase
 import com.chriscartland.garage.usecase.SeedDiagnosticsCountersFromRoomUseCase
+import com.chriscartland.garage.usecase.SignOutCacheClearManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -188,6 +190,14 @@ class AppStartupTest {
         // advanceUntilIdle that swallow the launches; eager dispatch
         // sidesteps the timing.
         val ioDispatcher = UnconfinedTestDispatcher(scope.testScheduler)
+        val signOutCacheClearMgr = SignOutCacheClearManager(
+            authRepository = FakeAuthRepository(),
+            userScopedCache = object : UserScopedCache {
+                override suspend fun clearUserScopedEntries() = Unit
+            },
+            scope = scope.backgroundScope,
+            dispatcher = ioDispatcher,
+        )
         return AppStartup(
             fcmRegistrationManager = fcmManager,
             checkInStalenessManager = stalenessManager,
@@ -200,6 +210,7 @@ class AppStartupTest {
             buttonHealthFcmSubscriptionManager = buttonHealthMgr,
             doorResolvedFcmSubscriptionManager = doorResolvedMgr,
             initialDoorFetchManager = initialDoorFetchMgr,
+            signOutCacheClearManager = signOutCacheClearMgr,
             externalScope = scope.backgroundScope,
             dispatchers = TestDispatcherProvider(ioDispatcher),
         )
@@ -235,6 +246,7 @@ class AppStartupTest {
                     "startButtonHealthFcmSubscription",
                     "startDoorResolvedFcmSubscription",
                     "startInitialDoorFetch",
+                    "startSignOutCacheClear",
                     "logFcmSubscribe",
                     "runDiagnosticsMaintenance",
                 ),

--- a/MobileGarage/build.gradle.kts
+++ b/MobileGarage/build.gradle.kts
@@ -209,6 +209,18 @@ tasks.register<architecture.DataStoreSingletonCheckTask>("checkDataStoreSingleto
         // crash-on-double-construct rule applies (own file, own lazy
         // slot in DataStoreFactory).
         "provideDiagnosticsCountersRepository",
+        // The status-snapshot cache's raw storage — wraps
+        // factory.createStatusCacheDataStore() (own file, own lazy slot).
+        "provideStatusCacheStorage",
+    )
+}
+
+tasks.register<architecture.BackupRulesExcludeCheckTask>("checkBackupRulesExcludes") {
+    dataStoreFactoryFile =
+        "$rootDir/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/DataStoreFactory.kt"
+    backupRulesFiles = listOf(
+        "$rootDir/androidApp/src/main/res/xml/backup_rules.xml",
+        "$rootDir/androidApp/src/main/res/xml/data_extraction_rules.xml",
     )
 }
 

--- a/MobileGarage/buildSrc/src/main/kotlin/architecture/BackupRulesExcludeCheckTask.kt
+++ b/MobileGarage/buildSrc/src/main/kotlin/architecture/BackupRulesExcludeCheckTask.kt
@@ -1,0 +1,101 @@
+package architecture
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Asserts every DataStore file-name constant is excluded from Android
+ * cloud backup in BOTH backup-rules XML files.
+ *
+ * Why: security-audit finding M6 (2026-05-14) keeps all local
+ * persistence out of Google Drive Auto Backup, but the exclude lists
+ * are per-exact-filename — a NEW DataStore file that nobody remembers
+ * to exclude silently fails OPEN into cloud backup. This task closes
+ * that failure class: adding a `*_FILE_NAME` constant to
+ * `DataStoreFactory.kt` without the matching `<exclude>` entries
+ * breaks the build with instructions.
+ *
+ * Parsing contract (library-coupled check rule): the constants are
+ * matched as `*_FILE_NAME = "<value>"` in [dataStoreFactoryFile]. If
+ * ZERO constants parse, the task fails loudly — that means the
+ * factory's shape changed and this check needs updating, not that
+ * everything is excluded.
+ */
+abstract class BackupRulesExcludeCheckTask : DefaultTask() {
+    /** Path to data-local's commonMain DataStoreFactory.kt. */
+    @get:Input
+    var dataStoreFactoryFile: String = ""
+
+    /** backup_rules.xml + data_extraction_rules.xml paths. */
+    @get:Input
+    var backupRulesFiles: List<String> = emptyList()
+
+    private val fileNameConstPattern = Regex("""\w*_FILE_NAME\s*=\s*"([^"]+)"""")
+
+    @TaskAction
+    fun check() {
+        val factory = File(dataStoreFactoryFile)
+        if (!factory.exists()) {
+            throw GradleException(
+                "BackupRulesExcludeCheck FAILED: DataStoreFactory not found at $dataStoreFactoryFile.\n" +
+                    "The file moved — update `dataStoreFactoryFile` in MobileGarage/build.gradle.kts.",
+            )
+        }
+
+        val fileNames = fileNameConstPattern
+            .findAll(factory.readText())
+            .map { it.groupValues[1] }
+            .toList()
+
+        if (fileNames.isEmpty()) {
+            throw GradleException(
+                "BackupRulesExcludeCheck FAILED: no `*_FILE_NAME = \"...\"` constants parsed from\n" +
+                    "$dataStoreFactoryFile.\n" +
+                    "This is a check-assumption failure, not a clean pass: the factory's constant\n" +
+                    "naming changed and this task's regex needs updating to match it.",
+            )
+        }
+
+        val violations = mutableListOf<String>()
+        backupRulesFiles.forEach { rulesPath ->
+            val rulesFile = File(rulesPath)
+            if (!rulesFile.exists()) {
+                throw GradleException(
+                    "BackupRulesExcludeCheck FAILED: backup rules file not found at $rulesPath.\n" +
+                        "The file moved — update `backupRulesFiles` in MobileGarage/build.gradle.kts.",
+                )
+            }
+            val rulesText = rulesFile.readText()
+            fileNames.forEach { fileName ->
+                if (!rulesText.contains("path=\"$fileName\"")) {
+                    violations.add("${rulesFile.name}: missing <exclude domain=\"file\" path=\"$fileName\" />")
+                }
+            }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    append("BackupRulesExcludeCheck FAILED: ")
+                    append(violations.size)
+                    append(" missing exclude(s).\n\n")
+                    violations.forEach { append("  - $it\n") }
+                    append("\n")
+                    append("Every DataStore file must be excluded from Android cloud backup\n")
+                    append("(security-audit posture M6 — local data is device-local and re-syncs\n")
+                    append("from the server; an off-device Google Drive copy is pure downside).\n\n")
+                    append("Fix: add the missing <exclude domain=\"file\" path=\"...\" /> entry to\n")
+                    append("androidApp/src/main/res/xml/backup_rules.xml (<full-backup-content>) and\n")
+                    append("androidApp/src/main/res/xml/data_extraction_rules.xml (<cloud-backup>).\n")
+                },
+            )
+        }
+
+        logger.lifecycle(
+            "BackupRulesExcludeCheck passed: ${fileNames.size} DataStore file(s) excluded in ${backupRulesFiles.size} rules file(s).",
+        )
+    }
+}

--- a/MobileGarage/buildSrc/src/main/kotlin/architecture/DataStoreSingletonCheckTask.kt
+++ b/MobileGarage/buildSrc/src/main/kotlin/architecture/DataStoreSingletonCheckTask.kt
@@ -88,12 +88,27 @@ abstract class DataStoreSingletonCheckTask : DefaultTask() {
                             trimmed.contains("fun $name(")
                         } ?: return@forEachIndexed
 
-                        // Look back up to 5 lines for the `@Provides` and
-                        // scope annotations. Annotations on Kotlin
-                        // functions can stack on separate lines or share
-                        // the same line as the `fun` declaration.
-                        val lookbackStart = maxOf(0, index - 5)
-                        val precedingLines = lines.subList(lookbackStart, index + 1)
+                        // Collect only the annotation/comment block
+                        // contiguously ATTACHED to this `fun` (plus the
+                        // `fun` line itself for same-line annotations).
+                        // A fixed look-back window is wrong here: with
+                        // adjacent providers, the PREVIOUS provider's
+                        // `@Singleton` lands in the window and the check
+                        // false-passes (found empirically when the
+                        // provideStatusCacheStorage red-test passed
+                        // despite a missing annotation).
+                        val precedingLines = mutableListOf(line)
+                        var lookback = index - 1
+                        while (lookback >= 0) {
+                            val t = lines[lookback].trim()
+                            val isAttached = t.startsWith("@") ||
+                                t.startsWith("//") ||
+                                t.startsWith("*") ||
+                                t.startsWith("/*")
+                            if (!isAttached) break
+                            precedingLines.add(lines[lookback])
+                            lookback--
+                        }
 
                         val hasProvidesAnnotation = precedingLines.any { providesPattern.containsMatchIn(it) }
                         // Skip if it's not a @Provides function — the

--- a/MobileGarage/data-local/src/androidMain/kotlin/com/chriscartland/garage/datalocal/DataStoreFactory.android.kt
+++ b/MobileGarage/data-local/src/androidMain/kotlin/com/chriscartland/garage/datalocal/DataStoreFactory.android.kt
@@ -19,8 +19,10 @@ package com.chriscartland.garage.datalocal
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
 import okio.Path.Companion.toPath
 
 /**
@@ -42,9 +44,26 @@ actual class DataStoreFactory(
         createPreferences(DIAGNOSTICS_COUNTERS_FILE_NAME)
     }
 
+    private val statusCacheInstance: DataStore<Preferences> by lazy {
+        // Corruption handler: a corrupted cache file self-heals to empty
+        // instead of throwing on every launch — the cache is re-earned
+        // from the network, so losing it is always safe.
+        PreferenceDataStoreFactory.createWithPath(
+            corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+            produceFile = {
+                context.filesDir
+                    .resolve(STATUS_CACHE_FILE_NAME)
+                    .absolutePath
+                    .toPath()
+            },
+        )
+    }
+
     actual fun createPreferencesDataStore(): DataStore<Preferences> = appSettingsInstance
 
     actual fun createDiagnosticsCountersDataStore(): DataStore<Preferences> = diagnosticsCountersInstance
+
+    actual fun createStatusCacheDataStore(): DataStore<Preferences> = statusCacheInstance
 
     private fun createPreferences(fileName: String): DataStore<Preferences> =
         PreferenceDataStoreFactory.createWithPath(

--- a/MobileGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/DataStoreFactory.kt
+++ b/MobileGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/DataStoreFactory.kt
@@ -61,7 +61,23 @@ expect class DataStoreFactory {
      * unrelated app preferences (snooze, FCM topic, etc.).
      */
     fun createDiagnosticsCountersDataStore(): DataStore<Preferences>
+
+    /**
+     * DataStore for the status-snapshot cache (last-known server
+     * statuses; see `MobileGarage/docs/STATUS_CACHE_PLAN.md`). Own
+     * file so settings/diagnostics clears can never touch it. Created
+     * with a `ReplaceFileCorruptionHandler` — a corrupted cache file
+     * self-heals to empty instead of throwing on every launch.
+     */
+    fun createStatusCacheDataStore(): DataStore<Preferences>
 }
 
+// NOTE: every *_FILE_NAME constant here MUST also appear in the
+// cloud-backup exclude lists (androidApp backup_rules.xml AND
+// data_extraction_rules.xml) — security-audit posture M6 keeps local
+// data out of Google Drive Auto Backup, and the excludes are
+// per-exact-filename, so a new file silently fails OPEN into backup.
+// Enforced by the `checkBackupRulesExcludes` Gradle task.
 internal const val PREFERENCES_FILE_NAME = "app_settings.preferences_pb"
 internal const val DIAGNOSTICS_COUNTERS_FILE_NAME = "diagnostics_counters.preferences_pb"
+internal const val STATUS_CACHE_FILE_NAME = "status_cache.preferences_pb"

--- a/MobileGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/DataStoreStatusCacheStorage.kt
+++ b/MobileGarage/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/DataStoreStatusCacheStorage.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.datalocal
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.chriscartland.garage.data.statuscache.StatusCacheStorage
+import kotlinx.coroutines.flow.first
+
+/**
+ * [StatusCacheStorage] over the dedicated status-cache Preferences
+ * DataStore (`DataStoreFactory.createStatusCacheDataStore()`). Pure
+ * string persistence — envelope encoding and failure policy live in
+ * `:data`'s `DefaultStatusSnapshotStore`. May throw on IO failure;
+ * the typed store above catches.
+ */
+class DataStoreStatusCacheStorage(
+    private val dataStore: DataStore<Preferences>,
+) : StatusCacheStorage {
+    override suspend fun get(key: String): String? = dataStore.data.first()[stringPreferencesKey(key)]
+
+    override suspend fun put(
+        key: String,
+        value: String,
+    ) {
+        dataStore.edit { prefs -> prefs[stringPreferencesKey(key)] = value }
+    }
+
+    override suspend fun remove(keys: Set<String>) {
+        if (keys.isEmpty()) return
+        dataStore.edit { prefs ->
+            keys.forEach { prefs.remove(stringPreferencesKey(it)) }
+        }
+    }
+}

--- a/MobileGarage/data-local/src/iosMain/kotlin/com/chriscartland/garage/datalocal/DataStoreFactory.ios.kt
+++ b/MobileGarage/data-local/src/iosMain/kotlin/com/chriscartland/garage/datalocal/DataStoreFactory.ios.kt
@@ -1,8 +1,10 @@
 package com.chriscartland.garage.datalocal
 
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
 import kotlinx.cinterop.ExperimentalForeignApi
 import okio.Path.Companion.toPath
 import platform.Foundation.NSDocumentDirectory
@@ -26,9 +28,23 @@ actual class DataStoreFactory {
         createPreferences(DIAGNOSTICS_COUNTERS_FILE_NAME)
     }
 
+    private val statusCacheInstance: DataStore<Preferences> by lazy {
+        // Corruption handler: a corrupted cache file self-heals to empty
+        // instead of throwing on every launch — the cache is re-earned
+        // from the network, so losing it is always safe.
+        PreferenceDataStoreFactory.createWithPath(
+            corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+            produceFile = {
+                "${iosDocumentsDirectory()}/$STATUS_CACHE_FILE_NAME".toPath()
+            },
+        )
+    }
+
     actual fun createPreferencesDataStore(): DataStore<Preferences> = appSettingsInstance
 
     actual fun createDiagnosticsCountersDataStore(): DataStore<Preferences> = diagnosticsCountersInstance
+
+    actual fun createStatusCacheDataStore(): DataStore<Preferences> = statusCacheInstance
 
     private fun createPreferences(fileName: String): DataStore<Preferences> =
         PreferenceDataStoreFactory.createWithPath(

--- a/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/statuscache/DefaultStatusSnapshotStore.kt
+++ b/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/statuscache/DefaultStatusSnapshotStore.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.data.statuscache
+
+import co.touchlab.kermit.Logger
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * [StatusSnapshotStore] over a raw [StatusCacheStorage], owning the
+ * envelope format and the never-throw / self-healing policy
+ * (see `MobileGarage/docs/STATUS_CACHE_PLAN.md` §D1).
+ *
+ * Envelope format (one JSON string per entry): the payload rides as a
+ * nested [JsonElement] so an envelope that parses but carries an
+ * incompatible payload still fails cleanly at the payload-decode step
+ * and is deleted. `ignoreUnknownKeys` keeps forward-compat when a
+ * newer app version adds envelope or DTO fields; removing or renaming
+ * a field instead requires bumping the caller's schema version.
+ */
+class DefaultStatusSnapshotStore(
+    private val storage: StatusCacheStorage,
+) : StatusSnapshotStore {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    override suspend fun <T : Any> read(
+        key: StatusCacheKey,
+        schemaVersion: Int,
+        payloadSerializer: KSerializer<T>,
+    ): StatusSnapshot<T>? {
+        val raw = runCatching { storage.get(key.storageKey) }
+            .getOrElse { t ->
+                Logger.w(t) { "StatusSnapshotStore: read failed for ${key.storageKey}; treating as absent" }
+                return null
+            } ?: return null
+
+        val decoded = runCatching {
+            val envelope = json.decodeFromString(StatusSnapshotEnvelope.serializer(), raw)
+            if (envelope.schemaVersion != schemaVersion) {
+                Logger.i {
+                    "StatusSnapshotStore: ${key.storageKey} has schemaVersion ${envelope.schemaVersion}, " +
+                        "expected $schemaVersion; invalidating"
+                }
+                null
+            } else {
+                StatusSnapshot(
+                    payload = json.decodeFromJsonElement(payloadSerializer, envelope.payload),
+                    fetchedAtEpochSeconds = envelope.fetchedAtEpochSeconds,
+                    confirmedAtEpochSeconds = envelope.confirmedAtEpochSeconds,
+                    accountEmail = envelope.accountEmail,
+                )
+            }
+        }.getOrElse { t ->
+            Logger.w(t) { "StatusSnapshotStore: ${key.storageKey} failed to decode; invalidating" }
+            null
+        }
+
+        if (decoded == null) {
+            // Self-heal: a snapshot we can never decode would otherwise sit
+            // on disk failing on every launch.
+            clear(setOf(key))
+        }
+        return decoded
+    }
+
+    override suspend fun <T : Any> write(
+        key: StatusCacheKey,
+        schemaVersion: Int,
+        payloadSerializer: KSerializer<T>,
+        snapshot: StatusSnapshot<T>,
+    ) {
+        runCatching {
+            val envelope = StatusSnapshotEnvelope(
+                schemaVersion = schemaVersion,
+                fetchedAtEpochSeconds = snapshot.fetchedAtEpochSeconds,
+                confirmedAtEpochSeconds = snapshot.confirmedAtEpochSeconds,
+                accountEmail = snapshot.accountEmail,
+                payload = json.encodeToJsonElement(payloadSerializer, snapshot.payload),
+            )
+            storage.put(key.storageKey, json.encodeToString(StatusSnapshotEnvelope.serializer(), envelope))
+        }.onFailure { t ->
+            Logger.w(t) { "StatusSnapshotStore: write failed for ${key.storageKey}; value not persisted" }
+        }
+    }
+
+    override suspend fun clear(keys: Set<StatusCacheKey>) {
+        if (keys.isEmpty()) return
+        runCatching {
+            storage.remove(keys.map { it.storageKey }.toSet())
+        }.onFailure { t ->
+            Logger.w(t) { "StatusSnapshotStore: clear failed for ${keys.map { it.storageKey }}" }
+        }
+    }
+}
+
+/**
+ * On-disk JSON shape of one cache entry. Internal to `:data` — repos
+ * see only [StatusSnapshot]. Field removals/renames here require a
+ * coordinated schema-version bump in every consumer.
+ */
+@Serializable
+internal data class StatusSnapshotEnvelope(
+    val schemaVersion: Int,
+    val fetchedAtEpochSeconds: Long,
+    val confirmedAtEpochSeconds: Long,
+    val accountEmail: String? = null,
+    val payload: JsonElement,
+)

--- a/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/statuscache/DefaultUserScopedCache.kt
+++ b/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/statuscache/DefaultUserScopedCache.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.data.statuscache
+
+import com.chriscartland.garage.domain.repository.UserScopedCache
+
+/**
+ * [UserScopedCache] over the status-snapshot store: clears the
+ * [userScopedKeys] set (DI passes [StatusCacheKeys.CLEARED_ON_SIGN_OUT])
+ * when the sign-out manager fires. Never throws — [StatusSnapshotStore.clear]
+ * swallows storage failures.
+ */
+class DefaultUserScopedCache(
+    private val statusSnapshotStore: StatusSnapshotStore,
+    private val userScopedKeys: Set<StatusCacheKey>,
+) : UserScopedCache {
+    override suspend fun clearUserScopedEntries() {
+        statusSnapshotStore.clear(userScopedKeys)
+    }
+}

--- a/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/statuscache/StatusCacheKey.kt
+++ b/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/statuscache/StatusCacheKey.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.data.statuscache
+
+/**
+ * Identifies one entry in the status-snapshot cache
+ * (see `MobileGarage/docs/STATUS_CACHE_PLAN.md`).
+ *
+ * [storageKey] is the on-disk preferences key. Renaming a storage key
+ * orphans the old entry (it is never read again and never cleaned up),
+ * so treat storage keys as append-only; to change an entry's shape,
+ * bump the schema version passed to [StatusSnapshotStore] instead.
+ */
+data class StatusCacheKey(
+    val storageKey: String,
+)
+
+/**
+ * Registry of status-cache keys with cross-cutting behavior.
+ *
+ * Each repository that persists a snapshot defines its own
+ * [StatusCacheKey] next to its DTO; this object only aggregates the
+ * keys that shared infrastructure needs to know about.
+ */
+object StatusCacheKeys {
+    /**
+     * Entries cleared when the user signs out (consumed by the
+     * sign-out manager via `UserScopedCache`). A PR that persists a
+     * per-user value MUST add its key here in the same change —
+     * anything derived from the signed-in account (feature allowlist,
+     * auth-gated statuses) belongs in this set.
+     */
+    val CLEARED_ON_SIGN_OUT: Set<StatusCacheKey> = emptySet()
+}

--- a/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/statuscache/StatusCacheStorage.kt
+++ b/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/statuscache/StatusCacheStorage.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.data.statuscache
+
+/**
+ * Raw string storage backing [StatusSnapshotStore]. Implemented in
+ * `:data-local` over a dedicated Preferences DataStore file
+ * (`status_cache.preferences_pb`); this interface exists so envelope
+ * encoding, decode-failure policy, and tests stay in `:data`
+ * (`:data-local` depends on `:data`, so the typed store cannot live
+ * there — see `MobileGarage/docs/STATUS_CACHE_PLAN.md` §D1).
+ *
+ * Unlike [StatusSnapshotStore], implementations MAY throw on IO
+ * failure — [DefaultStatusSnapshotStore] owns the catch-and-degrade
+ * policy in one place.
+ */
+interface StatusCacheStorage {
+    suspend fun get(key: String): String?
+
+    suspend fun put(
+        key: String,
+        value: String,
+    )
+
+    suspend fun remove(keys: Set<String>)
+}

--- a/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/statuscache/StatusSnapshot.kt
+++ b/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/statuscache/StatusSnapshot.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.data.statuscache
+
+/**
+ * One persisted last-known value with its freshness metadata
+ * (see `MobileGarage/docs/STATUS_CACHE_PLAN.md`).
+ *
+ * Two timestamps, two purposes:
+ *  - [fetchedAtEpochSeconds] — when the payload VALUE was produced by
+ *    an accepted server write. Consumers use it to decide whether a
+ *    cold-start fetch can be skipped (fetch-TTL).
+ *  - [confirmedAtEpochSeconds] — when a server round-trip last
+ *    confirmed the value as still true. A successful revalidate that
+ *    returns an identical payload refreshes this WITHOUT rewriting the
+ *    value. Display-TTLs key off this one: without the distinction, a
+ *    stable device whose revalidates are rejected as value-equal would
+ *    look permanently stale.
+ *
+ * [accountEmail] is set on per-user entries so hydration can refuse a
+ * snapshot written by a different account (see plan §D4).
+ */
+data class StatusSnapshot<T>(
+    val payload: T,
+    val fetchedAtEpochSeconds: Long,
+    val confirmedAtEpochSeconds: Long,
+    val accountEmail: String? = null,
+) {
+    /** Age of the payload value; see [ageSeconds] for the skew rule. */
+    fun fetchedAgeSeconds(nowEpochSeconds: Long): Long = ageSeconds(fetchedAtEpochSeconds, nowEpochSeconds)
+
+    /** Age of the last server confirmation; see [ageSeconds] for the skew rule. */
+    fun confirmedAgeSeconds(nowEpochSeconds: Long): Long = ageSeconds(confirmedAtEpochSeconds, nowEpochSeconds)
+
+    companion object {
+        /**
+         * A timestamp this far in the future is tolerated as clock
+         * jitter (age 0). Beyond it the snapshot is forced stale —
+         * without this rule, a backwards wall-clock correction would
+         * leave a future-stamped snapshot "fresh" (suppressing
+         * revalidation) until the clock caught back up.
+         */
+        const val CLOCK_SKEW_TOLERANCE_SECONDS: Long = 60L
+
+        internal fun ageSeconds(
+            timestampEpochSeconds: Long,
+            nowEpochSeconds: Long,
+        ): Long =
+            if (timestampEpochSeconds > nowEpochSeconds + CLOCK_SKEW_TOLERANCE_SECONDS) {
+                Long.MAX_VALUE
+            } else {
+                maxOf(0L, nowEpochSeconds - timestampEpochSeconds)
+            }
+    }
+}

--- a/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/statuscache/StatusSnapshotStore.kt
+++ b/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/statuscache/StatusSnapshotStore.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.data.statuscache
+
+import kotlinx.serialization.KSerializer
+
+/**
+ * Persisted last-known-value cache for server-fetched statuses
+ * (see `MobileGarage/docs/STATUS_CACHE_PLAN.md`).
+ *
+ * Repositories hydrate their in-memory `StateFlow` from here at init
+ * (instant last-known display) and write through on accepted server
+ * results. This store is a dumb persistence layer: freshness policy,
+ * write arbitration, and hydration ordering belong to the consuming
+ * repository.
+ *
+ * **The API never throws.** Callers run on the
+ * `CoroutineExceptionHandler`-less `applicationScope`, where an
+ * uncaught exception crashes the process — and a bad on-disk snapshot
+ * would crash it on EVERY launch. So:
+ *  - [read] returns null for missing entries AND for every failure
+ *    (envelope parse, schema-version mismatch, payload decode, storage
+ *    IO); decode-level failures also delete the corrupt entry so the
+ *    cache self-heals.
+ *  - [write] and [clear] swallow-and-log storage failures. A lost
+ *    write costs one redundant fetch on the next cold start — always
+ *    preferable to a crash loop.
+ */
+interface StatusSnapshotStore {
+    /**
+     * Returns the persisted snapshot for [key], or null when the entry
+     * is missing, was written with a different [schemaVersion], or
+     * cannot be decoded (in which case the corrupt entry is deleted).
+     */
+    suspend fun <T : Any> read(
+        key: StatusCacheKey,
+        schemaVersion: Int,
+        payloadSerializer: KSerializer<T>,
+    ): StatusSnapshot<T>?
+
+    /**
+     * Persists [snapshot] for [key], replacing any existing entry.
+     * Storage failures are swallowed (see interface KDoc).
+     */
+    suspend fun <T : Any> write(
+        key: StatusCacheKey,
+        schemaVersion: Int,
+        payloadSerializer: KSerializer<T>,
+        snapshot: StatusSnapshot<T>,
+    )
+
+    /**
+     * Removes the entries for [keys]. No-op for keys with no entry.
+     * Storage failures are swallowed (see interface KDoc).
+     */
+    suspend fun clear(keys: Set<StatusCacheKey>)
+}

--- a/MobileGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/statuscache/DefaultStatusSnapshotStoreTest.kt
+++ b/MobileGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/statuscache/DefaultStatusSnapshotStoreTest.kt
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.data.statuscache
+
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@Serializable
+private data class TestPayload(
+    val label: String,
+    val count: Int = 0,
+)
+
+/** Requires a field [TestPayload] never writes — decoding fails. */
+@Serializable
+private data class IncompatiblePayload(
+    val requiredField: String,
+)
+
+/**
+ * In-memory [StatusCacheStorage] with per-call failure injection.
+ * Throws (like a real IO failure) so the tests exercise the typed
+ * store's never-throw catch-and-degrade policy.
+ */
+private class InMemoryStatusCacheStorage : StatusCacheStorage {
+    val map = mutableMapOf<String, String>()
+    var failNextGet = false
+    var failNextPut = false
+    var failNextRemove = false
+
+    override suspend fun get(key: String): String? {
+        if (failNextGet) {
+            failNextGet = false
+            throw RuntimeException("injected get failure")
+        }
+        return map[key]
+    }
+
+    override suspend fun put(
+        key: String,
+        value: String,
+    ) {
+        if (failNextPut) {
+            failNextPut = false
+            throw RuntimeException("injected put failure")
+        }
+        map[key] = value
+    }
+
+    override suspend fun remove(keys: Set<String>) {
+        if (failNextRemove) {
+            failNextRemove = false
+            throw RuntimeException("injected remove failure")
+        }
+        keys.forEach { map.remove(it) }
+    }
+}
+
+class DefaultStatusSnapshotStoreTest {
+    private val key = StatusCacheKey("testStatus")
+    private val snapshot = StatusSnapshot(
+        payload = TestPayload(label = "online", count = 3),
+        fetchedAtEpochSeconds = 1000L,
+        confirmedAtEpochSeconds = 2000L,
+        accountEmail = "test@example.com",
+    )
+
+    @Test
+    fun writeThenReadRoundTripsPayloadAndMetadata() =
+        runTest {
+            val storage = InMemoryStatusCacheStorage()
+            val store = DefaultStatusSnapshotStore(storage)
+
+            store.write(key, 1, TestPayload.serializer(), snapshot)
+            val result = store.read(key, 1, TestPayload.serializer())
+
+            assertEquals(snapshot, result)
+        }
+
+    @Test
+    fun readMissingEntryReturnsNull() =
+        runTest {
+            val store = DefaultStatusSnapshotStore(InMemoryStatusCacheStorage())
+
+            assertNull(store.read(key, 1, TestPayload.serializer()))
+        }
+
+    @Test
+    fun readCorruptEnvelopeReturnsNullAndDeletesEntry() =
+        runTest {
+            val storage = InMemoryStatusCacheStorage()
+            val store = DefaultStatusSnapshotStore(storage)
+            storage.map[key.storageKey] = "this is not json"
+
+            assertNull(store.read(key, 1, TestPayload.serializer()))
+            // Self-healing: the undecodable entry is gone, so it can't
+            // fail again on the next launch.
+            assertFalse(storage.map.containsKey(key.storageKey))
+        }
+
+    @Test
+    fun readSchemaVersionMismatchReturnsNullAndDeletesEntry() =
+        runTest {
+            val storage = InMemoryStatusCacheStorage()
+            val store = DefaultStatusSnapshotStore(storage)
+            store.write(key, 1, TestPayload.serializer(), snapshot)
+
+            assertNull(store.read(key, 2, TestPayload.serializer()))
+            assertFalse(storage.map.containsKey(key.storageKey))
+        }
+
+    @Test
+    fun readIncompatiblePayloadReturnsNullAndDeletesEntry() =
+        runTest {
+            val storage = InMemoryStatusCacheStorage()
+            val store = DefaultStatusSnapshotStore(storage)
+            store.write(key, 1, TestPayload.serializer(), snapshot)
+
+            // Same schema version but a payload type whose required
+            // field is absent — the model-drift case the plan requires
+            // to degrade to cache-absent instead of crash-looping.
+            assertNull(store.read(key, 1, IncompatiblePayload.serializer()))
+            assertFalse(storage.map.containsKey(key.storageKey))
+        }
+
+    @Test
+    fun readToleratesUnknownEnvelopeAndPayloadKeys() =
+        runTest {
+            val storage = InMemoryStatusCacheStorage()
+            val store = DefaultStatusSnapshotStore(storage)
+            // A future app version added fields at both levels.
+            storage.map[key.storageKey] =
+                """
+                {"schemaVersion":1,"fetchedAtEpochSeconds":1000,"confirmedAtEpochSeconds":2000,
+                 "accountEmail":"test@example.com","futureEnvelopeField":true,
+                 "payload":{"label":"online","count":3,"futurePayloadField":"x"}}
+                """.trimIndent()
+
+            assertEquals(snapshot, store.read(key, 1, TestPayload.serializer()))
+        }
+
+    @Test
+    fun readStorageFailureReturnsNullWithoutDeleting() =
+        runTest {
+            val storage = InMemoryStatusCacheStorage()
+            val store = DefaultStatusSnapshotStore(storage)
+            store.write(key, 1, TestPayload.serializer(), snapshot)
+            storage.failNextGet = true
+
+            // Transient IO failure: degrade to absent but do NOT
+            // delete — the entry itself may be fine.
+            assertNull(store.read(key, 1, TestPayload.serializer()))
+            assertTrue(storage.map.containsKey(key.storageKey))
+
+            // Next read (storage recovered) sees the entry again.
+            assertEquals(snapshot, store.read(key, 1, TestPayload.serializer()))
+        }
+
+    @Test
+    fun writeStorageFailureDoesNotThrow() =
+        runTest {
+            val storage = InMemoryStatusCacheStorage()
+            val store = DefaultStatusSnapshotStore(storage)
+            storage.failNextPut = true
+
+            store.write(key, 1, TestPayload.serializer(), snapshot)
+
+            assertNull(store.read(key, 1, TestPayload.serializer()))
+        }
+
+    @Test
+    fun clearStorageFailureDoesNotThrow() =
+        runTest {
+            val storage = InMemoryStatusCacheStorage()
+            val store = DefaultStatusSnapshotStore(storage)
+            store.write(key, 1, TestPayload.serializer(), snapshot)
+            storage.failNextRemove = true
+
+            store.clear(setOf(key))
+
+            // Clear was dropped; entry still present.
+            assertEquals(snapshot, store.read(key, 1, TestPayload.serializer()))
+        }
+
+    @Test
+    fun clearRemovesOnlyGivenKeys() =
+        runTest {
+            val storage = InMemoryStatusCacheStorage()
+            val store = DefaultStatusSnapshotStore(storage)
+            val otherKey = StatusCacheKey("otherStatus")
+            store.write(key, 1, TestPayload.serializer(), snapshot)
+            store.write(otherKey, 1, TestPayload.serializer(), snapshot)
+
+            store.clear(setOf(key))
+
+            assertNull(store.read(key, 1, TestPayload.serializer()))
+            assertEquals(snapshot, store.read(otherKey, 1, TestPayload.serializer()))
+        }
+
+    @Test
+    fun clearEmptySetIsNoOp() =
+        runTest {
+            val storage = InMemoryStatusCacheStorage()
+            val store = DefaultStatusSnapshotStore(storage)
+            storage.failNextRemove = true
+
+            store.clear(emptySet())
+
+            // The injected failure was never consumed — no storage call.
+            assertTrue(storage.failNextRemove)
+        }
+
+    @Test
+    fun writeWithoutAccountEmailRoundTripsNull() =
+        runTest {
+            val store = DefaultStatusSnapshotStore(InMemoryStatusCacheStorage())
+            val anonymous = snapshot.copy(accountEmail = null)
+
+            store.write(key, 1, TestPayload.serializer(), anonymous)
+
+            assertEquals(anonymous, store.read(key, 1, TestPayload.serializer()))
+        }
+}

--- a/MobileGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/statuscache/StatusSnapshotTest.kt
+++ b/MobileGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/statuscache/StatusSnapshotTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.data.statuscache
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StatusSnapshotTest {
+    private fun snapshotAt(
+        fetchedAt: Long,
+        confirmedAt: Long = fetchedAt,
+    ) = StatusSnapshot(
+        payload = "value",
+        fetchedAtEpochSeconds = fetchedAt,
+        confirmedAtEpochSeconds = confirmedAt,
+    )
+
+    @Test
+    fun ageIsZeroWhenTimestampEqualsNow() {
+        assertEquals(0L, snapshotAt(1000L).fetchedAgeSeconds(nowEpochSeconds = 1000L))
+    }
+
+    @Test
+    fun ageIsElapsedSecondsForPastTimestamp() {
+        assertEquals(500L, snapshotAt(1000L).fetchedAgeSeconds(nowEpochSeconds = 1500L))
+    }
+
+    @Test
+    fun smallFutureSkewIsToleratedAsAgeZero() {
+        // Within CLOCK_SKEW_TOLERANCE_SECONDS: treat as fresh (age 0).
+        assertEquals(
+            0L,
+            snapshotAt(1000L + StatusSnapshot.CLOCK_SKEW_TOLERANCE_SECONDS)
+                .fetchedAgeSeconds(nowEpochSeconds = 1000L),
+        )
+    }
+
+    @Test
+    fun farFutureTimestampIsForcedStale() {
+        // Beyond the tolerance a future timestamp means the wall clock
+        // moved backwards — the snapshot must read as maximally stale
+        // so it can never suppress revalidation.
+        assertEquals(
+            Long.MAX_VALUE,
+            snapshotAt(1000L + StatusSnapshot.CLOCK_SKEW_TOLERANCE_SECONDS + 1)
+                .fetchedAgeSeconds(nowEpochSeconds = 1000L),
+        )
+    }
+
+    @Test
+    fun confirmedAgeUsesConfirmedTimestamp() {
+        val snapshot = snapshotAt(fetchedAt = 1000L, confirmedAt = 1800L)
+        assertEquals(200L, snapshot.confirmedAgeSeconds(nowEpochSeconds = 2000L))
+        assertEquals(1000L, snapshot.fetchedAgeSeconds(nowEpochSeconds = 2000L))
+    }
+}

--- a/MobileGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/UserScopedCache.kt
+++ b/MobileGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/UserScopedCache.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.domain.repository
+
+/**
+ * Locally cached data scoped to the signed-in user.
+ *
+ * Implemented by the status-snapshot cache in `:data`
+ * (see `MobileGarage/docs/STATUS_CACHE_PLAN.md`). This narrow domain
+ * interface exists so the sign-out manager in `:usecase` (which
+ * depends only on `:domain`) can clear per-user cache entries without
+ * a `:usecase` → `:data` dependency — the same layering as the other
+ * repository interfaces here.
+ */
+interface UserScopedCache {
+    /**
+     * Clears every cache entry registered as user-scoped. Called when
+     * the user signs out so cached per-user values (e.g. the feature
+     * allowlist) cannot leak across accounts. Must not throw.
+     */
+    suspend fun clearUserScopedEntries()
+}

--- a/MobileGarage/iosFramework/src/commonMain/kotlin/com/chriscartland/garage/iosframework/NativeComponent.kt
+++ b/MobileGarage/iosFramework/src/commonMain/kotlin/com/chriscartland/garage/iosframework/NativeComponent.kt
@@ -45,10 +45,16 @@ import com.chriscartland.garage.data.repository.NetworkButtonHealthRepository
 import com.chriscartland.garage.data.repository.NetworkDoorRepository
 import com.chriscartland.garage.data.repository.NetworkRemoteButtonRepository
 import com.chriscartland.garage.data.repository.NetworkSnoozeRepository
+import com.chriscartland.garage.data.statuscache.DefaultStatusSnapshotStore
+import com.chriscartland.garage.data.statuscache.DefaultUserScopedCache
+import com.chriscartland.garage.data.statuscache.StatusCacheKeys
+import com.chriscartland.garage.data.statuscache.StatusCacheStorage
+import com.chriscartland.garage.data.statuscache.StatusSnapshotStore
 import com.chriscartland.garage.datalocal.AppDatabase
 import com.chriscartland.garage.datalocal.DataStoreAppSettings
 import com.chriscartland.garage.datalocal.DataStoreDiagnosticsCounters
 import com.chriscartland.garage.datalocal.DataStoreFactory
+import com.chriscartland.garage.datalocal.DataStoreStatusCacheStorage
 import com.chriscartland.garage.datalocal.DatabaseFactory
 import com.chriscartland.garage.datalocal.DatabaseLocalDoorDataSource
 import com.chriscartland.garage.datalocal.RoomAppLoggerRepository
@@ -69,6 +75,7 @@ import com.chriscartland.garage.domain.repository.RemoteButtonRepository
 import com.chriscartland.garage.domain.repository.ServerConfigRepository
 import com.chriscartland.garage.domain.repository.SnoozeRepository
 import com.chriscartland.garage.domain.repository.TestNotificationRepository
+import com.chriscartland.garage.domain.repository.UserScopedCache
 import com.chriscartland.garage.usecase.AppSettingsUseCase
 import com.chriscartland.garage.usecase.AppStartup
 import com.chriscartland.garage.usecase.ApplyButtonHealthFcmUseCase
@@ -108,6 +115,7 @@ import com.chriscartland.garage.usecase.RegisterFcmUseCase
 import com.chriscartland.garage.usecase.RunStartupDiagnosticsMaintenanceUseCase
 import com.chriscartland.garage.usecase.SeedDiagnosticsCountersFromRoomUseCase
 import com.chriscartland.garage.usecase.SignInWithGoogleUseCase
+import com.chriscartland.garage.usecase.SignOutCacheClearManager
 import com.chriscartland.garage.usecase.SignOutUseCase
 import com.chriscartland.garage.usecase.SnoozeNotificationsUseCase
 import com.chriscartland.garage.usecase.SubscribeTestNotificationUseCase
@@ -205,6 +213,10 @@ abstract class NativeComponent(
     abstract val doorResolvedFcmSubscriptionManager: DoorResolvedFcmSubscriptionManager
     abstract val initialDoorFetchManager: InitialDoorFetchManager
     abstract val computeButtonHealthDisplayUseCase: ComputeButtonHealthDisplayUseCase
+    abstract val statusCacheStorage: StatusCacheStorage
+    abstract val statusSnapshotStore: StatusSnapshotStore
+    abstract val userScopedCache: UserScopedCache
+    abstract val signOutCacheClearManager: SignOutCacheClearManager
 
     // --- ViewModels ---
 
@@ -529,6 +541,38 @@ abstract class NativeComponent(
 
     @Provides
     @SharedSingleton
+    fun provideStatusCacheStorage(factory: DataStoreFactory): StatusCacheStorage =
+        DataStoreStatusCacheStorage(factory.createStatusCacheDataStore())
+
+    @Provides
+    @SharedSingleton
+    fun provideStatusSnapshotStore(storage: StatusCacheStorage): StatusSnapshotStore = DefaultStatusSnapshotStore(storage)
+
+    @Provides
+    @SharedSingleton
+    fun provideUserScopedCache(statusSnapshotStore: StatusSnapshotStore): UserScopedCache =
+        DefaultUserScopedCache(
+            statusSnapshotStore = statusSnapshotStore,
+            userScopedKeys = StatusCacheKeys.CLEARED_ON_SIGN_OUT,
+        )
+
+    @Provides
+    @SharedSingleton
+    fun provideSignOutCacheClearManager(
+        authRepository: AuthRepository,
+        userScopedCache: UserScopedCache,
+        applicationScope: CoroutineScope,
+        dispatchers: DispatcherProvider,
+    ): SignOutCacheClearManager =
+        SignOutCacheClearManager(
+            authRepository = authRepository,
+            userScopedCache = userScopedCache,
+            scope = applicationScope,
+            dispatcher = dispatchers.io,
+        )
+
+    @Provides
+    @SharedSingleton
     fun provideAppDatabase(factory: DatabaseFactory): AppDatabase = factory.createDatabase()
 
     @Provides
@@ -799,6 +843,7 @@ abstract class NativeComponent(
         buttonHealthFcmSubscriptionManager: ButtonHealthFcmSubscriptionManager,
         doorResolvedFcmSubscriptionManager: DoorResolvedFcmSubscriptionManager,
         initialDoorFetchManager: InitialDoorFetchManager,
+        signOutCacheClearManager: SignOutCacheClearManager,
         applicationScope: CoroutineScope,
         dispatchers: DispatcherProvider,
     ): AppStartup =
@@ -811,6 +856,7 @@ abstract class NativeComponent(
             buttonHealthFcmSubscriptionManager = buttonHealthFcmSubscriptionManager,
             doorResolvedFcmSubscriptionManager = doorResolvedFcmSubscriptionManager,
             initialDoorFetchManager = initialDoorFetchManager,
+            signOutCacheClearManager = signOutCacheClearManager,
             externalScope = applicationScope,
             dispatchers = dispatchers,
         )

--- a/MobileGarage/iosFramework/src/iosTest/kotlin/com/chriscartland/garage/iosframework/NativeComponentTest.kt
+++ b/MobileGarage/iosFramework/src/iosTest/kotlin/com/chriscartland/garage/iosframework/NativeComponentTest.kt
@@ -119,6 +119,19 @@ class NativeComponentTest {
         )
 
     @Test
+    fun statusCacheStorageIsSingleton() = assertSame(component.statusCacheStorage, component.statusCacheStorage, "statusCacheStorage")
+
+    @Test
+    fun statusSnapshotStoreIsSingleton() = assertSame(component.statusSnapshotStore, component.statusSnapshotStore, "statusSnapshotStore")
+
+    @Test
+    fun userScopedCacheIsSingleton() = assertSame(component.userScopedCache, component.userScopedCache, "userScopedCache")
+
+    @Test
+    fun signOutCacheClearManagerIsSingleton() =
+        assertSame(component.signOutCacheClearManager, component.signOutCacheClearManager, "signOutCacheClearManager")
+
+    @Test
     fun authRepositoryIsSingleton() = assertSame(component.authRepository, component.authRepository, "authRepository")
 
     @Test

--- a/MobileGarage/test-common/build.gradle.kts
+++ b/MobileGarage/test-common/build.gradle.kts
@@ -17,6 +17,9 @@ kotlin {
             implementation(project(":data"))
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.coroutines.test)
+            // FakeStatusSnapshotStore implements the :data store
+            // interface, whose signatures name KSerializer.
+            implementation(libs.kotlinx.serialization.json)
         }
     }
 }

--- a/MobileGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeStatusSnapshotStore.kt
+++ b/MobileGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeStatusSnapshotStore.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.testcommon
+
+import com.chriscartland.garage.data.statuscache.StatusCacheKey
+import com.chriscartland.garage.data.statuscache.StatusSnapshot
+import com.chriscartland.garage.data.statuscache.StatusSnapshotStore
+import kotlinx.serialization.KSerializer
+
+/**
+ * In-memory [StatusSnapshotStore] for tests. Mirrors the production
+ * never-throw contract: failure injection makes reads/writes DEGRADE
+ * ([failNextRead] → null, [failNextWrite] → dropped write), never
+ * throw — matching what `DefaultStatusSnapshotStore` does on storage
+ * or decode failure.
+ *
+ * Entries are held as live [StatusSnapshot] objects (no JSON round
+ * trip); [seed] pre-populates a snapshot as if a previous process had
+ * persisted it. Schema-version mismatch behaves like production: the
+ * read returns null and the entry is deleted.
+ */
+class FakeStatusSnapshotStore : StatusSnapshotStore {
+    private data class Entry(
+        val schemaVersion: Int,
+        val snapshot: StatusSnapshot<*>,
+    )
+
+    private val entries = mutableMapOf<StatusCacheKey, Entry>()
+
+    private var readFailurePending = false
+    private var writeFailurePending = false
+
+    private val _clearCalls = mutableListOf<Set<StatusCacheKey>>()
+
+    /** Every [clear] invocation, in order, with the keys it was given. */
+    val clearCalls: List<Set<StatusCacheKey>> get() = _clearCalls
+
+    private var _writeCount = 0
+    val writeCount: Int get() = _writeCount
+
+    /** Pre-populates [key] as if persisted by a previous process. */
+    fun <T : Any> seed(
+        key: StatusCacheKey,
+        schemaVersion: Int,
+        snapshot: StatusSnapshot<T>,
+    ) {
+        entries[key] = Entry(schemaVersion, snapshot)
+    }
+
+    /** The next [read] returns null (simulates storage/decode failure). */
+    fun failNextRead() {
+        readFailurePending = true
+    }
+
+    /** The next [write] is dropped (simulates storage failure). */
+    fun failNextWrite() {
+        writeFailurePending = true
+    }
+
+    fun contains(key: StatusCacheKey): Boolean = entries.containsKey(key)
+
+    @Suppress("UNCHECKED_CAST")
+    override suspend fun <T : Any> read(
+        key: StatusCacheKey,
+        schemaVersion: Int,
+        payloadSerializer: KSerializer<T>,
+    ): StatusSnapshot<T>? {
+        if (readFailurePending) {
+            readFailurePending = false
+            return null
+        }
+        val entry = entries[key] ?: return null
+        if (entry.schemaVersion != schemaVersion) {
+            entries.remove(key)
+            return null
+        }
+        return entry.snapshot as StatusSnapshot<T>
+    }
+
+    override suspend fun <T : Any> write(
+        key: StatusCacheKey,
+        schemaVersion: Int,
+        payloadSerializer: KSerializer<T>,
+        snapshot: StatusSnapshot<T>,
+    ) {
+        if (writeFailurePending) {
+            writeFailurePending = false
+            return
+        }
+        _writeCount++
+        entries[key] = Entry(schemaVersion, snapshot)
+    }
+
+    override suspend fun clear(keys: Set<StatusCacheKey>) {
+        _clearCalls.add(keys)
+        keys.forEach { entries.remove(it) }
+    }
+}

--- a/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppStartup.kt
+++ b/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/AppStartup.kt
@@ -43,6 +43,7 @@ class AppStartup(
     private val buttonHealthFcmSubscriptionManager: ButtonHealthFcmSubscriptionManager,
     private val doorResolvedFcmSubscriptionManager: DoorResolvedFcmSubscriptionManager,
     private val initialDoorFetchManager: InitialDoorFetchManager,
+    private val signOutCacheClearManager: SignOutCacheClearManager,
     private val externalScope: CoroutineScope,
     private val dispatchers: DispatcherProvider,
 ) {
@@ -77,6 +78,10 @@ class AppStartup(
         Logger.d { "AppStartup: Starting initial door fetch (one-shot per process)" }
         initialDoorFetchManager.start()
         actions.add("startInitialDoorFetch")
+
+        Logger.d { "AppStartup: Starting sign-out cache clear manager" }
+        signOutCacheClearManager.start()
+        actions.add("startSignOutCacheClear")
 
         externalScope.launch(dispatchers.io) {
             logAppEvent(AppLoggerKeys.ON_CREATE_FCM_SUBSCRIBE_TOPIC)

--- a/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SignOutCacheClearManager.kt
+++ b/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SignOutCacheClearManager.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import co.touchlab.kermit.Logger
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.repository.AuthRepository
+import com.chriscartland.garage.domain.repository.UserScopedCache
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+/**
+ * App-scoped manager that clears user-scoped cache entries on sign-out
+ * (ADR-015 Manager pattern; started from [AppStartup]). Part of the
+ * status-snapshot cache — see `MobileGarage/docs/STATUS_CACHE_PLAN.md`.
+ *
+ * Best-effort by design: the persisted-cache safety story for per-user
+ * entries is account-keyed hydration (a snapshot written by a
+ * different account is refused at read time), because this clear can
+ * be missed — StateFlow conflation can skip a transient
+ * `Unauthenticated` emission during a fast account switch, and process
+ * death can land between sign-out and the disk write. This manager
+ * handles the common case promptly; account keying is the guarantee.
+ *
+ * Projects `authState` to a boolean before reacting so token-refresh
+ * writes of new `Authenticated` instances never re-trigger it.
+ */
+class SignOutCacheClearManager(
+    private val authRepository: AuthRepository,
+    private val userScopedCache: UserScopedCache,
+    private val scope: CoroutineScope,
+    private val dispatcher: CoroutineDispatcher,
+) {
+    private var job: Job? = null
+
+    /** Idempotent — calling twice does not start a second collector. */
+    fun start() {
+        if (job?.isActive == true) {
+            Logger.d { "SignOutCacheClearManager: already running" }
+            return
+        }
+        job = scope.launch(dispatcher) {
+            authRepository.authState
+                .map { it is AuthState.Unauthenticated }
+                .distinctUntilChanged()
+                .filter { it }
+                .collect {
+                    Logger.i { "SignOutCacheClearManager: signed out; clearing user-scoped cache entries" }
+                    userScopedCache.clearUserScopedEntries()
+                }
+        }
+    }
+}

--- a/MobileGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SignOutCacheClearManagerTest.kt
+++ b/MobileGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SignOutCacheClearManagerTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.AuthState
+import com.chriscartland.garage.domain.model.DisplayName
+import com.chriscartland.garage.domain.model.Email
+import com.chriscartland.garage.domain.model.User
+import com.chriscartland.garage.domain.repository.UserScopedCache
+import com.chriscartland.garage.testcommon.FakeAuthRepository
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private class RecordingUserScopedCache : UserScopedCache {
+    var clearCount = 0
+
+    override suspend fun clearUserScopedEntries() {
+        clearCount++
+    }
+}
+
+class SignOutCacheClearManagerTest {
+    private val user = User(name = DisplayName("Test User"), email = Email("test@example.com"))
+
+    private fun createManager(
+        scope: TestScope,
+        authRepository: FakeAuthRepository,
+        cache: UserScopedCache,
+    ): SignOutCacheClearManager =
+        SignOutCacheClearManager(
+            authRepository = authRepository,
+            userScopedCache = cache,
+            scope = scope.backgroundScope,
+            dispatcher = UnconfinedTestDispatcher(scope.testScheduler),
+        )
+
+    @Test
+    fun clearsOnSignOut() =
+        runTest {
+            val auth = FakeAuthRepository()
+            val cache = RecordingUserScopedCache()
+            auth.setAuthState(AuthState.Authenticated(user))
+            createManager(this, auth, cache).start()
+            runCurrent()
+
+            auth.setAuthState(AuthState.Unauthenticated)
+            runCurrent()
+
+            assertEquals(1, cache.clearCount)
+        }
+
+    @Test
+    fun doesNotClearWhileSignedInOrUnknown() =
+        runTest {
+            val auth = FakeAuthRepository()
+            val cache = RecordingUserScopedCache()
+            createManager(this, auth, cache).start()
+            runCurrent()
+
+            // Initial Unknown state: no clear.
+            assertEquals(0, cache.clearCount)
+
+            auth.setAuthState(AuthState.Authenticated(user))
+            runCurrent()
+
+            assertEquals(0, cache.clearCount)
+        }
+
+    @Test
+    fun tokenRefreshStyleAuthenticatedRewritesDoNotTrigger() =
+        runTest {
+            val auth = FakeAuthRepository()
+            val cache = RecordingUserScopedCache()
+            auth.setAuthState(AuthState.Authenticated(user))
+            createManager(this, auth, cache).start()
+            runCurrent()
+
+            // A token refresh writes a NEW Authenticated instance; the
+            // manager projects to a boolean so nothing fires.
+            auth.setAuthState(AuthState.Authenticated(user.copy()))
+            runCurrent()
+
+            assertEquals(0, cache.clearCount)
+        }
+
+    @Test
+    fun clearsOncePerSignOutAcrossCycles() =
+        runTest {
+            val auth = FakeAuthRepository()
+            val cache = RecordingUserScopedCache()
+            auth.setAuthState(AuthState.Authenticated(user))
+            createManager(this, auth, cache).start()
+            runCurrent()
+
+            auth.setAuthState(AuthState.Unauthenticated)
+            runCurrent()
+            auth.setAuthState(AuthState.Authenticated(user))
+            runCurrent()
+            auth.setAuthState(AuthState.Unauthenticated)
+            runCurrent()
+
+            assertEquals(2, cache.clearCount)
+        }
+
+    @Test
+    fun startIsIdempotent() =
+        runTest {
+            val auth = FakeAuthRepository()
+            val cache = RecordingUserScopedCache()
+            auth.setAuthState(AuthState.Authenticated(user))
+            val manager = createManager(this, auth, cache)
+            manager.start()
+            manager.start()
+            manager.start()
+            runCurrent()
+
+            auth.setAuthState(AuthState.Unauthenticated)
+            runCurrent()
+
+            // One collector, one clear — not three.
+            assertEquals(1, cache.clearCount)
+        }
+}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -89,6 +89,13 @@ else
     fail "datastore singleton"
 fi
 
+step "DataStore files excluded from cloud backup (M6 — backup_rules + data_extraction_rules)"
+if $GRADLE checkBackupRulesExcludes; then
+    pass "backup rules excludes"
+else
+    fail "backup rules excludes"
+fi
+
 step "No raw Dispatchers (ADR-005 — VM/UseCase must inject DispatcherProvider)"
 if $GRADLE checkNoRawDispatchers; then
     pass "no raw dispatchers"


### PR DESCRIPTION
## Summary
PR 1 of the status-cache rollout — see [`MobileGarage/docs/STATUS_CACHE_PLAN.md`](https://github.com/cartland/SmartGarageDoor/blob/main/MobileGarage/docs/STATUS_CACHE_PLAN.md) §D1 (merged in #1071). **Infrastructure only; no repository behavior changes.** PRs 2–4 will wire button health, snooze, and the feature allowlist onto this store.

### What's here
- **`:data` `statuscache` package** — `StatusSnapshotStore` (public API never throws: reads AND writes degrade instead of crashing the CoroutineExceptionHandler-less `applicationScope`), `DefaultStatusSnapshotStore` (JSON envelope `{schemaVersion, fetchedAt, confirmedAt, accountEmail?, payload}`; any decode failure = treat-as-absent AND delete the corrupt entry, so a bad snapshot can never crash-loop), `StatusSnapshot` freshness helpers with the 60s clock-skew guard (far-future timestamps read as maximally stale), `StatusCacheKeys.CLEARED_ON_SIGN_OUT` registry (empty until PRs 2–4).
- **`:domain` `UserScopedCache`** — narrow interface so the `:usecase` manager can clear per-user entries without adding a `:usecase` → `:data` dependency.
- **`:data-local`** — `createStatusCacheDataStore()` (new `status_cache.preferences_pb`, own file so settings/diagnostics clears can't touch it, `ReplaceFileCorruptionHandler` self-heals corruption to empty) + `DataStoreStatusCacheStorage`.
- **Backup posture (M6)** — new file excluded from cloud backup in both `backup_rules.xml` and `data_extraction_rules.xml`, plus a new `checkBackupRulesExcludes` buildSrc task (in `validate.sh`) asserting every `*_FILE_NAME` constant in `DataStoreFactory.kt` appears in both exclude lists — closes the fail-open class permanently. Verified red-then-green.
- **`checkDataStoreSingleton` hardened** — the red-test for the new `provideStatusCacheStorage` guard exposed a pre-existing false-pass: the 5-line look-back window picked up the *previous* provider's `@Singleton` when providers are adjacent. The task now inspects only the annotation block contiguously attached to the function. Re-verified red-then-green.
- **`SignOutCacheClearManager`** (ADR-015) — clears registered user-scoped keys on `Unauthenticated`; auth-state projected to a boolean (no token-refresh retriggers); idempotent `start()` from `AppStartup`. Best-effort by design — account-keyed hydration (PR 4) is the guarantee.
- **DI** — providers + abstract vals in BOTH `AppComponent` and `NativeComponent`; identity tests added to `ComponentGraphTest` and `NativeComponentTest`; `FakeStatusSnapshotStore` in `test-common`.

### Verification
- `./scripts/validate.sh` — all checks passed (output scanned for FAIL markers).
- `:iosFramework:iosSimulatorArm64Test` — green locally (NativeComponent wiring + new identity tests); iOS CI is not a required check, so this was verified before push.
- 22 new unit tests: store round-trip, corrupt-envelope/schema-mismatch/incompatible-payload self-healing, storage-failure degradation (read/write/clear), unknown-key tolerance, clock-skew forcing, sign-out manager semantics.
- Both new/extended guardrail checks verified red-then-green.

## Merge order
This is PR 1 of 4 in the status-cache rollout. Standalone — no dependencies. PRs 2–4 depend on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)