### PR TITLE
fix(cache): address confirmed review findings from PR #1072

### DIFF
--- a/MobileGarage/build.gradle.kts
+++ b/MobileGarage/build.gradle.kts
@@ -216,8 +216,9 @@ tasks.register<architecture.DataStoreSingletonCheckTask>("checkDataStoreSingleto
 }
 
 tasks.register<architecture.BackupRulesExcludeCheckTask>("checkBackupRulesExcludes") {
-    dataStoreFactoryFile =
-        "$rootDir/data-local/src/commonMain/kotlin/com/chriscartland/garage/datalocal/DataStoreFactory.kt"
+    // The whole source tree (all source sets), so inline filenames in a
+    // platform `actual` are caught, not just commonMain constants.
+    dataStoreSourceDir = "$rootDir/data-local/src"
     backupRulesFiles = listOf(
         "$rootDir/androidApp/src/main/res/xml/backup_rules.xml",
         "$rootDir/androidApp/src/main/res/xml/data_extraction_rules.xml",

--- a/MobileGarage/buildSrc/src/main/kotlin/architecture/BackupRulesExcludeCheckTask.kt
+++ b/MobileGarage/buildSrc/src/main/kotlin/architecture/BackupRulesExcludeCheckTask.kt
@@ -18,44 +18,53 @@ import java.io.File
  * `DataStoreFactory.kt` without the matching `<exclude>` entries
  * breaks the build with instructions.
  *
- * Parsing contract (library-coupled check rule): the constants are
- * matched as `*_FILE_NAME = "<value>"` in [dataStoreFactoryFile]. If
- * ZERO constants parse, the task fails loudly — that means the
- * factory's shape changed and this check needs updating, not that
- * everything is excluded.
+ * Parsing contract (library-coupled check rule): every Kotlin source
+ * under [dataStoreSourceDir] is scanned for BOTH `*_FILE_NAME = "<value>"`
+ * constants AND any quoted `"*.preferences_pb"` literal, and the union
+ * is checked. The literal scan closes the partial-parse fail-open: a
+ * store whose constant deviates from the `_FILE_NAME` convention, or an
+ * inline filename in a platform `actual`, is still caught. If ZERO file
+ * names parse, the task fails loudly — that means the factory's shape
+ * changed and this check needs updating, not that everything is
+ * excluded.
  */
 abstract class BackupRulesExcludeCheckTask : DefaultTask() {
-    /** Path to data-local's commonMain DataStoreFactory.kt. */
+    /** Root of data-local's sources (all source sets), e.g. data-local/src. */
     @get:Input
-    var dataStoreFactoryFile: String = ""
+    var dataStoreSourceDir: String = ""
 
     /** backup_rules.xml + data_extraction_rules.xml paths. */
     @get:Input
     var backupRulesFiles: List<String> = emptyList()
 
     private val fileNameConstPattern = Regex("""\w*_FILE_NAME\s*=\s*"([^"]+)"""")
+    private val preferencesLiteralPattern = Regex(""""([\w.\-]+\.preferences_pb)"""")
 
     @TaskAction
     fun check() {
-        val factory = File(dataStoreFactoryFile)
-        if (!factory.exists()) {
+        val sourceRoot = File(dataStoreSourceDir)
+        if (!sourceRoot.exists()) {
             throw GradleException(
-                "BackupRulesExcludeCheck FAILED: DataStoreFactory not found at $dataStoreFactoryFile.\n" +
-                    "The file moved — update `dataStoreFactoryFile` in MobileGarage/build.gradle.kts.",
+                "BackupRulesExcludeCheck FAILED: source dir not found at $dataStoreSourceDir.\n" +
+                    "The directory moved — update `dataStoreSourceDir` in MobileGarage/build.gradle.kts.",
             )
         }
 
-        val fileNames = fileNameConstPattern
-            .findAll(factory.readText())
-            .map { it.groupValues[1] }
-            .toList()
+        val fileNames = sourceRoot
+            .walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .flatMap { file ->
+                val text = file.readText()
+                fileNameConstPattern.findAll(text).map { it.groupValues[1] } +
+                    preferencesLiteralPattern.findAll(text).map { it.groupValues[1] }
+            }.toSortedSet()
 
         if (fileNames.isEmpty()) {
             throw GradleException(
-                "BackupRulesExcludeCheck FAILED: no `*_FILE_NAME = \"...\"` constants parsed from\n" +
-                    "$dataStoreFactoryFile.\n" +
+                "BackupRulesExcludeCheck FAILED: no `*_FILE_NAME = \"...\"` constants and no\n" +
+                    "\"*.preferences_pb\" literals parsed under $dataStoreSourceDir.\n" +
                     "This is a check-assumption failure, not a clean pass: the factory's constant\n" +
-                    "naming changed and this task's regex needs updating to match it.",
+                    "naming changed and this task's regexes need updating to match it.",
             )
         }
 

--- a/MobileGarage/buildSrc/src/main/kotlin/architecture/DataStoreSingletonCheckTask.kt
+++ b/MobileGarage/buildSrc/src/main/kotlin/architecture/DataStoreSingletonCheckTask.kt
@@ -101,6 +101,16 @@ abstract class DataStoreSingletonCheckTask : DefaultTask() {
                         var lookback = index - 1
                         while (lookback >= 0) {
                             val t = lines[lookback].trim()
+                            // Blank lines don't end attachment: skipping them
+                            // is safe because the previous declaration's
+                            // `fun`/body line is always a non-annotation
+                            // barrier, and ktlint (standard:annotation, run
+                            // via spotless in CI) forbids the shapes where
+                            // skipping could mis-attach.
+                            if (t.isEmpty()) {
+                                lookback--
+                                continue
+                            }
                             val isAttached = t.startsWith("@") ||
                                 t.startsWith("//") ||
                                 t.startsWith("*") ||

--- a/MobileGarage/data-local/src/androidMain/kotlin/com/chriscartland/garage/datalocal/DataStoreFactory.android.kt
+++ b/MobileGarage/data-local/src/androidMain/kotlin/com/chriscartland/garage/datalocal/DataStoreFactory.android.kt
@@ -47,15 +47,13 @@ actual class DataStoreFactory(
     private val statusCacheInstance: DataStore<Preferences> by lazy {
         // Corruption handler: a corrupted cache file self-heals to empty
         // instead of throwing on every launch — the cache is re-earned
-        // from the network, so losing it is always safe.
-        PreferenceDataStoreFactory.createWithPath(
+        // from the network, so losing it is always safe. The two stores
+        // above deliberately have NO handler: they are the source of
+        // truth for their data, so silently discarding them on
+        // corruption is a different product tradeoff.
+        createPreferences(
+            STATUS_CACHE_FILE_NAME,
             corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
-            produceFile = {
-                context.filesDir
-                    .resolve(STATUS_CACHE_FILE_NAME)
-                    .absolutePath
-                    .toPath()
-            },
         )
     }
 
@@ -65,8 +63,12 @@ actual class DataStoreFactory(
 
     actual fun createStatusCacheDataStore(): DataStore<Preferences> = statusCacheInstance
 
-    private fun createPreferences(fileName: String): DataStore<Preferences> =
+    private fun createPreferences(
+        fileName: String,
+        corruptionHandler: ReplaceFileCorruptionHandler<Preferences>? = null,
+    ): DataStore<Preferences> =
         PreferenceDataStoreFactory.createWithPath(
+            corruptionHandler = corruptionHandler,
             produceFile = {
                 context.filesDir
                     .resolve(fileName)

--- a/MobileGarage/data-local/src/iosMain/kotlin/com/chriscartland/garage/datalocal/DataStoreFactory.ios.kt
+++ b/MobileGarage/data-local/src/iosMain/kotlin/com/chriscartland/garage/datalocal/DataStoreFactory.ios.kt
@@ -31,12 +31,13 @@ actual class DataStoreFactory {
     private val statusCacheInstance: DataStore<Preferences> by lazy {
         // Corruption handler: a corrupted cache file self-heals to empty
         // instead of throwing on every launch — the cache is re-earned
-        // from the network, so losing it is always safe.
-        PreferenceDataStoreFactory.createWithPath(
+        // from the network, so losing it is always safe. The two stores
+        // above deliberately have NO handler: they are the source of
+        // truth for their data, so silently discarding them on
+        // corruption is a different product tradeoff.
+        createPreferences(
+            STATUS_CACHE_FILE_NAME,
             corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
-            produceFile = {
-                "${iosDocumentsDirectory()}/$STATUS_CACHE_FILE_NAME".toPath()
-            },
         )
     }
 
@@ -46,8 +47,12 @@ actual class DataStoreFactory {
 
     actual fun createStatusCacheDataStore(): DataStore<Preferences> = statusCacheInstance
 
-    private fun createPreferences(fileName: String): DataStore<Preferences> =
+    private fun createPreferences(
+        fileName: String,
+        corruptionHandler: ReplaceFileCorruptionHandler<Preferences>? = null,
+    ): DataStore<Preferences> =
         PreferenceDataStoreFactory.createWithPath(
+            corruptionHandler = corruptionHandler,
             produceFile = {
                 "${iosDocumentsDirectory()}/$fileName".toPath()
             },

--- a/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/statuscache/DefaultStatusSnapshotStore.kt
+++ b/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/statuscache/DefaultStatusSnapshotStore.kt
@@ -18,6 +18,7 @@
 package com.chriscartland.garage.data.statuscache
 
 import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -50,6 +51,10 @@ class DefaultStatusSnapshotStore(
     ): StatusSnapshot<T>? {
         val raw = runCatching { storage.get(key.storageKey) }
             .getOrElse { t ->
+                // Cancellation is a control signal, not an IO failure — it
+                // must unwind the caller, or a cancelled hydration keeps
+                // running and publishes a spurious cache-absent state.
+                if (t is CancellationException) throw t
                 Logger.w(t) { "StatusSnapshotStore: read failed for ${key.storageKey}; treating as absent" }
                 return null
             } ?: return null
@@ -99,6 +104,7 @@ class DefaultStatusSnapshotStore(
             )
             storage.put(key.storageKey, json.encodeToString(StatusSnapshotEnvelope.serializer(), envelope))
         }.onFailure { t ->
+            if (t is CancellationException) throw t
             Logger.w(t) { "StatusSnapshotStore: write failed for ${key.storageKey}; value not persisted" }
         }
     }
@@ -108,6 +114,7 @@ class DefaultStatusSnapshotStore(
         runCatching {
             storage.remove(keys.map { it.storageKey }.toSet())
         }.onFailure { t ->
+            if (t is CancellationException) throw t
             Logger.w(t) { "StatusSnapshotStore: clear failed for ${keys.map { it.storageKey }}" }
         }
     }

--- a/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/statuscache/StatusSnapshotStore.kt
+++ b/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/statuscache/StatusSnapshotStore.kt
@@ -29,10 +29,10 @@ import kotlinx.serialization.KSerializer
  * write arbitration, and hydration ordering belong to the consuming
  * repository.
  *
- * **The API never throws.** Callers run on the
- * `CoroutineExceptionHandler`-less `applicationScope`, where an
- * uncaught exception crashes the process — and a bad on-disk snapshot
- * would crash it on EVERY launch. So:
+ * **The API never throws — except coroutine cancellation, which
+ * propagates.** Callers run on the `CoroutineExceptionHandler`-less
+ * `applicationScope`, where an uncaught exception crashes the process —
+ * and a bad on-disk snapshot would crash it on EVERY launch. So:
  *  - [read] returns null for missing entries AND for every failure
  *    (envelope parse, schema-version mismatch, payload decode, storage
  *    IO); decode-level failures also delete the corrupt entry so the

--- a/MobileGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/statuscache/DefaultStatusSnapshotStoreTest.kt
+++ b/MobileGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/statuscache/DefaultStatusSnapshotStoreTest.kt
@@ -17,10 +17,12 @@
 
 package com.chriscartland.garage.data.statuscache
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -47,8 +49,10 @@ private class InMemoryStatusCacheStorage : StatusCacheStorage {
     var failNextGet = false
     var failNextPut = false
     var failNextRemove = false
+    var cancelNextCall = false
 
     override suspend fun get(key: String): String? {
+        throwIfInjected()
         if (failNextGet) {
             failNextGet = false
             throw RuntimeException("injected get failure")
@@ -60,6 +64,7 @@ private class InMemoryStatusCacheStorage : StatusCacheStorage {
         key: String,
         value: String,
     ) {
+        throwIfInjected()
         if (failNextPut) {
             failNextPut = false
             throw RuntimeException("injected put failure")
@@ -68,11 +73,19 @@ private class InMemoryStatusCacheStorage : StatusCacheStorage {
     }
 
     override suspend fun remove(keys: Set<String>) {
+        throwIfInjected()
         if (failNextRemove) {
             failNextRemove = false
             throw RuntimeException("injected remove failure")
         }
         keys.forEach { map.remove(it) }
+    }
+
+    private fun throwIfInjected() {
+        if (cancelNextCall) {
+            cancelNextCall = false
+            throw CancellationException("injected cancellation")
+        }
     }
 }
 
@@ -228,6 +241,45 @@ class DefaultStatusSnapshotStoreTest {
 
             // The injected failure was never consumed — no storage call.
             assertTrue(storage.failNextRemove)
+        }
+
+    @Test
+    fun readPropagatesCancellation() =
+        runTest {
+            val storage = InMemoryStatusCacheStorage()
+            val store = DefaultStatusSnapshotStore(storage)
+            storage.cancelNextCall = true
+
+            // Cancellation must unwind the caller, never degrade to
+            // cache-absent (a cancelled hydration would otherwise keep
+            // running and publish a spurious null).
+            assertFailsWith<CancellationException> {
+                store.read(key, 1, TestPayload.serializer())
+            }
+        }
+
+    @Test
+    fun writePropagatesCancellation() =
+        runTest {
+            val storage = InMemoryStatusCacheStorage()
+            val store = DefaultStatusSnapshotStore(storage)
+            storage.cancelNextCall = true
+
+            assertFailsWith<CancellationException> {
+                store.write(key, 1, TestPayload.serializer(), snapshot)
+            }
+        }
+
+    @Test
+    fun clearPropagatesCancellation() =
+        runTest {
+            val storage = InMemoryStatusCacheStorage()
+            val store = DefaultStatusSnapshotStore(storage)
+            storage.cancelNextCall = true
+
+            assertFailsWith<CancellationException> {
+                store.clear(setOf(key))
+            }
         }
 
     @Test


### PR DESCRIPTION
## Summary
Fix-forward for the findings confirmed by the 8-angle adversarial code review of #1072 (28 candidates → 12 verified → 3 confirmed + 1 safe hardening; everything else refuted or accepted-as-designed).

- **`DefaultStatusSnapshotStore`** — rethrow `CancellationException` in `read`/`write`/`clear` instead of swallowing it via `runCatching` (a cancelled hydration otherwise kept running and published a spurious cache-absent state). 3 new tests pin the propagation; interface KDoc updated (never-throw contract now explicitly excepts cancellation).
- **`DataStoreFactory` (android + ios actuals)** — `createPreferences` gains an optional `corruptionHandler` param; the status-cache store routes through it instead of a copy-pasted bespoke block (4 path-construction copies → 2). Behavior-preserving; the two older stores deliberately keep no handler (they're sources of truth, not re-earnable caches — documented inline).
- **`BackupRulesExcludeCheckTask`** — now scans ALL `data-local/src` Kotlin sources for `*_FILE_NAME` constants ∪ quoted `*.preferences_pb` literals, closing the partial-parse fail-open (a differently-named constant or inline filename in a platform `actual` could previously enter cloud backup unchecked). Re-verified red-then-green.
- **`DataStoreSingletonCheckTask`** — the attached-annotation walk now skips blank lines (verifier-confirmed safe: the previous declaration's `fun`/body line is a hard barrier, and ktlint `standard:annotation` forbids the ambiguous shapes).

## Verification
- `./scripts/validate.sh` — all checks passed
- `:iosFramework:iosSimulatorArm64Test` — green
- `:data:testDebugUnitTest` — 15/15 (incl. 3 new cancellation tests)
- Backup-excludes guardrail re-verified red-then-green after the hardening

## Merge order
Standalone follow-up to #1072 (merged). PR 2 of the status-cache rollout (button health) comes next and touches disjoint files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)