### PR TITLE
feat(cache): allowlist hydrates with account-keyed auth-gated seeding (PR 4)

### DIFF
--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -702,11 +702,15 @@ abstract class AppComponent(
     fun provideFeatureAllowlistRepository(
         networkFeatureAllowlistDataSource: NetworkFeatureAllowlistDataSource,
         authRepository: AuthRepository,
+        statusSnapshotStore: StatusSnapshotStore,
+        appClock: AppClock,
         applicationScope: CoroutineScope,
     ): FeatureAllowlistRepository =
         CachedFeatureAllowlistRepository(
             networkDataSource = networkFeatureAllowlistDataSource,
             authRepository = authRepository,
+            statusSnapshotStore = statusSnapshotStore,
+            appClock = appClock,
             externalScope = applicationScope,
         )
 

--- a/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/CachedFeatureAllowlistRepository.kt
+++ b/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/CachedFeatureAllowlistRepository.kt
@@ -20,6 +20,11 @@ package com.chriscartland.garage.data.repository
 import co.touchlab.kermit.Logger
 import com.chriscartland.garage.data.NetworkFeatureAllowlistDataSource
 import com.chriscartland.garage.data.NetworkResult
+import com.chriscartland.garage.data.statuscache.AllowlistSnapshot
+import com.chriscartland.garage.data.statuscache.AllowlistSnapshotDto
+import com.chriscartland.garage.data.statuscache.StatusSnapshot
+import com.chriscartland.garage.data.statuscache.StatusSnapshotStore
+import com.chriscartland.garage.domain.coroutines.AppClock
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.FeatureAllowlist
 import com.chriscartland.garage.domain.repository.AuthRepository
@@ -27,6 +32,7 @@ import com.chriscartland.garage.domain.repository.FeatureAllowlistRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -43,10 +49,32 @@ import kotlinx.coroutines.sync.withLock
  * Network errors during fetch leave the previous successful value in
  * place (matching `CachedServerConfigRepository`'s behavior). Sign-out
  * always clears, even after a successful fetch — security boundary.
+ *
+ * Persisted last-known allowlist (STATUS_CACHE_PLAN.md D4): hydration
+ * removes the cold-start pop-in of the Developer/Function-List rows,
+ * and the repo still ALWAYS revalidates on the Authenticated emission
+ * — no fetch-skip TTL, because app restart is the only
+ * grant-propagation path (Settings has no pull-to-refresh) and
+ * skipping the fetch would trade one tiny request for a stuck grant.
+ *
+ * Account-keyed hydration is the cross-account guard: the keyed check
+ * runs INSIDE the auth gate (`authState.first { it !is Unknown }`) —
+ * at construction the auth state is typically `Unknown`, so there is
+ * no email to compare yet; `Unknown` must never seed and never delete.
+ * A snapshot whose `accountEmail` differs from the signed-in user is
+ * deleted (confirmed mismatch — covers a sign-out clear missed by
+ * StateFlow conflation or process death); a snapshot with NO email is
+ * treated as absent but not deleted (never destroy data on missing
+ * information). Only after the keyed hydration does the ordinary auth
+ * collector start — it replays the current value, so the Authenticated
+ * fetch still fires after the seed (hydrate-before-fetch, sequenced in
+ * one coroutine).
  */
 class CachedFeatureAllowlistRepository(
     private val networkDataSource: NetworkFeatureAllowlistDataSource,
     private val authRepository: AuthRepository,
+    private val statusSnapshotStore: StatusSnapshotStore,
+    private val appClock: AppClock,
     externalScope: CoroutineScope,
 ) : FeatureAllowlistRepository {
     private val _allowlist = MutableStateFlow<FeatureAllowlist?>(null)
@@ -56,6 +84,12 @@ class CachedFeatureAllowlistRepository(
 
     init {
         externalScope.launch {
+            // Keyed hydration inside the auth gate — see class KDoc.
+            when (val first = authRepository.authState.first { it !is AuthState.Unknown }) {
+                is AuthState.Authenticated -> hydrate(signedInEmail = first.user.email.asString())
+                AuthState.Unauthenticated -> statusSnapshotStore.clear(setOf(AllowlistSnapshot.KEY))
+                AuthState.Unknown -> Unit // unreachable: filtered above
+            }
             authRepository.authState.collect { state ->
                 when (state) {
                     is AuthState.Authenticated -> fetchAllowlist()
@@ -64,6 +98,9 @@ class CachedFeatureAllowlistRepository(
                             Logger.i { "allowlist cleared on sign-out" }
                             _allowlist.value = null
                         }
+                        // Best-effort disk clear (account-keying is the
+                        // guarantee; SignOutCacheClearManager also clears).
+                        statusSnapshotStore.clear(setOf(AllowlistSnapshot.KEY))
                     }
                     AuthState.Unknown -> Unit
                 }
@@ -71,15 +108,46 @@ class CachedFeatureAllowlistRepository(
         }
     }
 
+    /** Seeds the in-memory cache from a snapshot owned by [signedInEmail]. */
+    private suspend fun hydrate(signedInEmail: String) {
+        val snapshot = statusSnapshotStore.read(
+            AllowlistSnapshot.KEY,
+            AllowlistSnapshot.SCHEMA_VERSION,
+            AllowlistSnapshotDto.serializer(),
+        ) ?: return
+        val snapshotEmail = snapshot.accountEmail
+        if (snapshotEmail == null) {
+            // No owner recorded: treat as absent, but never delete on
+            // missing information.
+            Logger.w { "allowlist snapshot has no accountEmail; ignoring" }
+            return
+        }
+        if (snapshotEmail != signedInEmail) {
+            // Confirmed cross-account snapshot (a sign-out clear missed by
+            // conflation or process death) — refuse AND delete.
+            Logger.w { "allowlist snapshot belongs to another account; deleting" }
+            statusSnapshotStore.clear(setOf(AllowlistSnapshot.KEY))
+            return
+        }
+        if (snapshot.confirmedAgeSeconds(appClock.nowEpochSeconds()) > DISPLAY_TTL_SECONDS) {
+            Logger.i { "allowlist snapshot older than display-TTL; not seeding" }
+            return
+        }
+        // CAS: only seed if the collector's fetch hasn't landed yet (it
+        // can't have — the collector starts after hydration — but keep
+        // the guard).
+        if (_allowlist.value == null) {
+            val seeded = snapshot.payload.toDomain()
+            _allowlist.value = seeded
+            Logger.i { "allowlist <- $seeded (source=disk seed)" }
+        }
+    }
+
     /**
-     * Force-refresh the allowlist. Captures the email at fetch start and
-     * re-checks after the network call — if the user switched mid-fetch,
-     * the result is for the previous user and is discarded. This is the
-     * only place the user-switch race is closed: the auth-listener path
-     * clears `_allowlist` on `Unauthenticated` but does not acquire the
-     * mutex, so an in-flight fetch with user A's token can resolve while
-     * user B is signing in. The post-fetch email check ensures A's
-     * answer is never written under B's session.
+     * Force-fetch from the server. On success the value is written to
+     * [allowlist] and persisted (keyed to the fetching account). The
+     * user-switch guard discards a response that raced a sign-out or
+     * account change.
      */
     override suspend fun fetchAllowlist(): FeatureAllowlist? =
         fetchMutex.withLock {
@@ -114,8 +182,37 @@ class CachedFeatureAllowlistRepository(
             }
             if (result != null) {
                 _allowlist.value = result
+                persistAllowlist(result, accountEmail = initialEmail.asString())
                 Logger.i { "allowlist <- $result (source=GET)" }
             }
             result
         }
+
+    private suspend fun persistAllowlist(
+        allowlist: FeatureAllowlist,
+        accountEmail: String,
+    ) {
+        val now = appClock.nowEpochSeconds()
+        statusSnapshotStore.write(
+            AllowlistSnapshot.KEY,
+            AllowlistSnapshot.SCHEMA_VERSION,
+            AllowlistSnapshotDto.serializer(),
+            StatusSnapshot(
+                payload = AllowlistSnapshotDto.fromDomain(allowlist),
+                fetchedAtEpochSeconds = now,
+                confirmedAtEpochSeconds = now,
+                accountEmail = accountEmail,
+            ),
+        )
+    }
+
+    private companion object {
+        /**
+         * Never seed an allowlist whose last server confirmation is
+         * older than this — access grants/revocations must not ride a
+         * week-old snapshot (the always-revalidate fetch corrects it
+         * seconds later anyway; this bounds the wrong-rows window).
+         */
+        const val DISPLAY_TTL_SECONDS: Long = 24L * 60L * 60L
+    }
 }

--- a/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/statuscache/AllowlistSnapshot.kt
+++ b/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/statuscache/AllowlistSnapshot.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.data.statuscache
+
+import com.chriscartland.garage.domain.model.FeatureAllowlist
+import kotlinx.serialization.Serializable
+
+/**
+ * Persisted shape of the per-user feature allowlist
+ * (STATUS_CACHE_PLAN.md D4). The envelope's `accountEmail` MUST be set
+ * on every write — hydration refuses a snapshot written by a different
+ * account, which is the actual cross-account guard (the sign-out clear
+ * is best-effort; see `SignOutCacheClearManager`).
+ */
+@Serializable
+data class AllowlistSnapshotDto(
+    val functionList: Boolean = false,
+    val developer: Boolean = false,
+) {
+    fun toDomain(): FeatureAllowlist =
+        FeatureAllowlist(
+            functionList = functionList,
+            developer = developer,
+        )
+
+    companion object {
+        fun fromDomain(allowlist: FeatureAllowlist): AllowlistSnapshotDto =
+            AllowlistSnapshotDto(
+                functionList = allowlist.functionList,
+                developer = allowlist.developer,
+            )
+    }
+}
+
+/** Cache identity + versioning for the allowlist snapshot. */
+object AllowlistSnapshot {
+    val KEY = StatusCacheKey("featureAllowlist")
+
+    /** Bump to deliberately invalidate all persisted allowlist entries. */
+    const val SCHEMA_VERSION: Int = 1
+}

--- a/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/statuscache/StatusCacheKey.kt
+++ b/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/statuscache/StatusCacheKey.kt
@@ -54,5 +54,9 @@ object StatusCacheKeys {
         // clearing on sign-out keeps the cache free of anything the
         // signed-out UI can't show (STATUS_CACHE_PLAN.md D3).
         SnoozeSnapshot.KEY,
+        // Genuinely per-user: Developer/Function-List access must not
+        // leak across accounts. The clear here is best-effort; the
+        // account-keyed hydration is the guarantee (STATUS_CACHE_PLAN.md D4).
+        AllowlistSnapshot.KEY,
     )
 }

--- a/MobileGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/CachedFeatureAllowlistRepositoryTest.kt
+++ b/MobileGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/CachedFeatureAllowlistRepositoryTest.kt
@@ -18,6 +18,10 @@
 package com.chriscartland.garage.data.repository
 
 import com.chriscartland.garage.data.NetworkResult
+import com.chriscartland.garage.data.statuscache.AllowlistSnapshot
+import com.chriscartland.garage.data.statuscache.AllowlistSnapshotDto
+import com.chriscartland.garage.data.statuscache.StatusSnapshot
+import com.chriscartland.garage.domain.coroutines.AppClock
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.DisplayName
 import com.chriscartland.garage.domain.model.Email
@@ -26,6 +30,7 @@ import com.chriscartland.garage.domain.model.FirebaseIdToken
 import com.chriscartland.garage.domain.model.User
 import com.chriscartland.garage.testcommon.FakeAuthRepository
 import com.chriscartland.garage.testcommon.FakeNetworkFeatureAllowlistDataSource
+import com.chriscartland.garage.testcommon.FakeStatusSnapshotStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
@@ -71,7 +76,7 @@ class CachedFeatureAllowlistRepositoryTest {
             }
             val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
 
-            val repo = CachedFeatureAllowlistRepository(ds, authRepo, externalScope)
+            val repo = CachedFeatureAllowlistRepository(ds, authRepo, FakeStatusSnapshotStore(), AppClock { 1_000L }, externalScope)
             advanceUntilIdle()
             // Initial state is Unknown — no fetch yet.
             assertEquals(0, ds.fetchCount)
@@ -99,7 +104,7 @@ class CachedFeatureAllowlistRepositoryTest {
             }
             val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
 
-            val repo = CachedFeatureAllowlistRepository(ds, authRepo, externalScope)
+            val repo = CachedFeatureAllowlistRepository(ds, authRepo, FakeStatusSnapshotStore(), AppClock { 1_000L }, externalScope)
             advanceUntilIdle()
             assertEquals(sampleAllowlist, repo.allowlist.value)
 
@@ -123,7 +128,7 @@ class CachedFeatureAllowlistRepositoryTest {
             }
             val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
 
-            val repo = CachedFeatureAllowlistRepository(ds, authRepo, externalScope)
+            val repo = CachedFeatureAllowlistRepository(ds, authRepo, FakeStatusSnapshotStore(), AppClock { 1_000L }, externalScope)
             advanceUntilIdle()
 
             // The init collector saw Unauthenticated, so the cache is null and
@@ -151,7 +156,7 @@ class CachedFeatureAllowlistRepositoryTest {
             }
             val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
 
-            val repo = CachedFeatureAllowlistRepository(ds, authRepo, externalScope)
+            val repo = CachedFeatureAllowlistRepository(ds, authRepo, FakeStatusSnapshotStore(), AppClock { 1_000L }, externalScope)
             advanceUntilIdle()
             assertEquals(sampleAllowlist, repo.allowlist.value)
 
@@ -196,7 +201,7 @@ class CachedFeatureAllowlistRepositoryTest {
             ds.swapAuthDuringFetch = { authRepo.setAuthState(bobState) }
 
             val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
-            val repo = CachedFeatureAllowlistRepository(ds, authRepo, externalScope)
+            val repo = CachedFeatureAllowlistRepository(ds, authRepo, FakeStatusSnapshotStore(), AppClock { 1_000L }, externalScope)
             advanceUntilIdle()
 
             // After init: A's fetch fired, mid-fetch swapped to Bob. Result
@@ -225,7 +230,7 @@ class CachedFeatureAllowlistRepositoryTest {
             }
             val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
 
-            val repo = CachedFeatureAllowlistRepository(ds, authRepo, externalScope)
+            val repo = CachedFeatureAllowlistRepository(ds, authRepo, FakeStatusSnapshotStore(), AppClock { 1_000L }, externalScope)
             advanceUntilIdle()
             assertEquals(FeatureAllowlist(functionList = true, developer = false), repo.allowlist.value)
             assertEquals(listOf("alice-token"), ds.fetchIdTokens)
@@ -246,6 +251,172 @@ class CachedFeatureAllowlistRepositoryTest {
                 "fetch must have been called with both tokens, was: ${ds.fetchIdTokens}",
             )
 
+            externalScope.cancel()
+        }
+
+    // Persisted-snapshot tests (STATUS_CACHE_PLAN.md D4) — auth-gated
+    // account-keyed hydration + write-through.
+
+    private fun seededStore(
+        allowlist: FeatureAllowlist,
+        accountEmail: String?,
+        confirmedAtSeconds: Long = 900L,
+    ): FakeStatusSnapshotStore =
+        FakeStatusSnapshotStore().apply {
+            seed(
+                AllowlistSnapshot.KEY,
+                AllowlistSnapshot.SCHEMA_VERSION,
+                StatusSnapshot(
+                    payload = AllowlistSnapshotDto.fromDomain(allowlist),
+                    fetchedAtEpochSeconds = confirmedAtSeconds,
+                    confirmedAtEpochSeconds = confirmedAtSeconds,
+                    accountEmail = accountEmail,
+                ),
+            )
+        }
+
+    @Test
+    fun hydrationSeedsMatchingAccountBeforeTheFetchLands() =
+        runTest {
+            // The data source has no result configured, so the collector's
+            // fetch writes nothing — the observable value is the seed: the
+            // cold-start pop-in fix.
+            val ds = FakeNetworkFeatureAllowlistDataSource()
+            val authRepo = FakeAuthRepository().apply {
+                setIdTokenResult(FirebaseIdToken(idToken = "t", exp = Long.MAX_VALUE))
+                setAuthState(authenticatedState(email = "test@example.com"))
+            }
+            val store = seededStore(sampleAllowlist, accountEmail = "test@example.com")
+            val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+
+            val repo = CachedFeatureAllowlistRepository(ds, authRepo, store, AppClock { 1_000L }, externalScope)
+            advanceUntilIdle()
+
+            assertEquals(sampleAllowlist, repo.allowlist.value)
+            externalScope.cancel()
+        }
+
+    @Test
+    fun hydrationRefusesAndDeletesAnotherAccountsSnapshot() =
+        runTest {
+            val ds = FakeNetworkFeatureAllowlistDataSource()
+            val authRepo = FakeAuthRepository().apply {
+                setIdTokenResult(FirebaseIdToken(idToken = "t", exp = Long.MAX_VALUE))
+                setAuthState(authenticatedState(email = "bob@example.com"))
+            }
+            // Alice's snapshot survived (conflation-skipped clear / process
+            // death) — Bob must never see her Developer access.
+            val store = seededStore(sampleAllowlist, accountEmail = "alice@example.com")
+            val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+
+            val repo = CachedFeatureAllowlistRepository(ds, authRepo, store, AppClock { 1_000L }, externalScope)
+            advanceUntilIdle()
+
+            assertNull(repo.allowlist.value)
+            assertEquals(false, store.contains(AllowlistSnapshot.KEY), "confirmed mismatch must delete")
+            externalScope.cancel()
+        }
+
+    @Test
+    fun hydrationIgnoresButKeepsSnapshotWithNoAccountEmail() =
+        runTest {
+            val ds = FakeNetworkFeatureAllowlistDataSource()
+            val authRepo = FakeAuthRepository().apply {
+                setIdTokenResult(FirebaseIdToken(idToken = "t", exp = Long.MAX_VALUE))
+                setAuthState(authenticatedState())
+            }
+            val store = seededStore(sampleAllowlist, accountEmail = null)
+            val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+
+            val repo = CachedFeatureAllowlistRepository(ds, authRepo, store, AppClock { 1_000L }, externalScope)
+            advanceUntilIdle()
+
+            assertNull(repo.allowlist.value)
+            // Never destroy data on missing information.
+            assertTrue(store.contains(AllowlistSnapshot.KEY))
+            externalScope.cancel()
+        }
+
+    @Test
+    fun hydrationSkipsSnapshotOlderThanDisplayTtl() =
+        runTest {
+            val ds = FakeNetworkFeatureAllowlistDataSource()
+            val authRepo = FakeAuthRepository().apply {
+                setIdTokenResult(FirebaseIdToken(idToken = "t", exp = Long.MAX_VALUE))
+                setAuthState(authenticatedState())
+            }
+            val now = 200_000L
+            val store = seededStore(
+                sampleAllowlist,
+                accountEmail = "test@example.com",
+                confirmedAtSeconds = now - (24L * 60L * 60L) - 1L,
+            )
+            val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+
+            val repo = CachedFeatureAllowlistRepository(ds, authRepo, store, AppClock { now }, externalScope)
+            advanceUntilIdle()
+
+            assertNull(repo.allowlist.value)
+            externalScope.cancel()
+        }
+
+    @Test
+    fun unknownAuthNeverSeedsAndNeverDeletes() =
+        runTest {
+            val ds = FakeNetworkFeatureAllowlistDataSource()
+            val authRepo = FakeAuthRepository() // stays Unknown
+            val store = seededStore(sampleAllowlist, accountEmail = "test@example.com")
+            val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+
+            val repo = CachedFeatureAllowlistRepository(ds, authRepo, store, AppClock { 1_000L }, externalScope)
+            advanceUntilIdle()
+
+            // No email to compare yet — nothing seeded, nothing destroyed.
+            assertNull(repo.allowlist.value)
+            assertTrue(store.contains(AllowlistSnapshot.KEY))
+            externalScope.cancel()
+        }
+
+    @Test
+    fun unauthenticatedFirstEmissionClearsPersistedSnapshot() =
+        runTest {
+            val ds = FakeNetworkFeatureAllowlistDataSource()
+            val authRepo = FakeAuthRepository().apply { setAuthState(AuthState.Unauthenticated) }
+            val store = seededStore(sampleAllowlist, accountEmail = "test@example.com")
+            val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+
+            val repo = CachedFeatureAllowlistRepository(ds, authRepo, store, AppClock { 1_000L }, externalScope)
+            advanceUntilIdle()
+
+            assertNull(repo.allowlist.value)
+            assertEquals(false, store.contains(AllowlistSnapshot.KEY))
+            externalScope.cancel()
+        }
+
+    @Test
+    fun successfulFetchPersistsSnapshotKeyedToTheAccount() =
+        runTest {
+            val ds = FakeNetworkFeatureAllowlistDataSource().apply {
+                setFetchResult(NetworkResult.Success(sampleAllowlist))
+            }
+            val authRepo = FakeAuthRepository().apply {
+                setIdTokenResult(FirebaseIdToken(idToken = "t", exp = Long.MAX_VALUE))
+                setAuthState(authenticatedState(email = "test@example.com"))
+            }
+            val store = FakeStatusSnapshotStore()
+            val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+
+            val repo = CachedFeatureAllowlistRepository(ds, authRepo, store, AppClock { 1_000L }, externalScope)
+            advanceUntilIdle()
+
+            assertEquals(sampleAllowlist, repo.allowlist.value)
+            val persisted = store.read(
+                AllowlistSnapshot.KEY,
+                AllowlistSnapshot.SCHEMA_VERSION,
+                AllowlistSnapshotDto.serializer(),
+            )
+            assertEquals(AllowlistSnapshotDto.fromDomain(sampleAllowlist), persisted?.payload)
+            assertEquals("test@example.com", persisted?.accountEmail)
             externalScope.cancel()
         }
 }

--- a/MobileGarage/iosFramework/src/commonMain/kotlin/com/chriscartland/garage/iosframework/NativeComponent.kt
+++ b/MobileGarage/iosFramework/src/commonMain/kotlin/com/chriscartland/garage/iosframework/NativeComponent.kt
@@ -666,11 +666,15 @@ abstract class NativeComponent(
     fun provideFeatureAllowlistRepository(
         networkFeatureAllowlistDataSource: NetworkFeatureAllowlistDataSource,
         authRepository: AuthRepository,
+        statusSnapshotStore: StatusSnapshotStore,
+        appClock: AppClock,
         applicationScope: CoroutineScope,
     ): FeatureAllowlistRepository =
         CachedFeatureAllowlistRepository(
             networkDataSource = networkFeatureAllowlistDataSource,
             authRepository = authRepository,
+            statusSnapshotStore = statusSnapshotStore,
+            appClock = appClock,
             externalScope = applicationScope,
         )
 


### PR DESCRIPTION
## Summary
PR 4 — the final implementation PR of [`MobileGarage/docs/STATUS_CACHE_PLAN.md`](https://github.com/cartland/SmartGarageDoor/blob/main/MobileGarage/docs/STATUS_CACHE_PLAN.md) (§D4). Fixes the reported Developer-section reload: the `developerAccess`/`functionListAccess` gates now render instantly from the persisted last-known allowlist instead of popping in after a network round-trip on every cold start.

### Design (round-2-reviewed shape)
- **Hydration runs INSIDE the auth gate**: the init coroutine awaits the first non-`Unknown` auth state (at construction there is no email to compare), runs the keyed check, THEN starts the existing collector — which replays the current value, so the Authenticated fetch still fires after the seed (hydrate-before-fetch, one sequenced coroutine).
- **Account-keying is the cross-account guard**: a snapshot owned by a different email is refused **and deleted** (covers a sign-out clear missed by StateFlow conflation or process death — the exact holes round 1's verifier identified); a snapshot with no email is ignored but never deleted; `Unknown` never seeds and never deletes.
- **Always revalidate on Authenticated** — no fetch-skip TTL: app restart stays the grant-propagation path (round 1 showed a TTL here would strand mid-day grants with no fallback).
- 24h display-TTL off `confirmedAt` bounds seeded-verdict age; write-through is keyed to the fetching account (safe under the fetch's existing user-switch guard).
- `Unauthenticated` also clears the persisted entry; key registered in `CLEARED_ON_SIGN_OUT`.

### Verification
`./scripts/validate.sh` all-green (output scanned for plain `FAIL` markers); `:iosFramework:iosSimulatorArm64Test` green; 13/13 allowlist repo tests (7 new: seed-before-fetch, cross-account refuse+delete, no-email ignore-keep, display-TTL skip, Unknown never-seeds/never-deletes, Unauthenticated disk clear, keyed write-through). DI updated in both components.

## Merge order
Depends on #1072 (merged). Disjoint from #1077 (merged/in-flight). Last implementation PR — the ADR + plan-status docs PR follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)