### PR TITLE
fix(cache): harden allowlist hydration — session recheck, blank-email ownership, serialized seed

### DIFF
--- a/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/CachedFeatureAllowlistRepository.kt
+++ b/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/CachedFeatureAllowlistRepository.kt
@@ -110,36 +110,58 @@ class CachedFeatureAllowlistRepository(
 
     /** Seeds the in-memory cache from a snapshot owned by [signedInEmail]. */
     private suspend fun hydrate(signedInEmail: String) {
-        val snapshot = statusSnapshotStore.read(
-            AllowlistSnapshot.KEY,
-            AllowlistSnapshot.SCHEMA_VERSION,
-            AllowlistSnapshotDto.serializer(),
-        ) ?: return
-        val snapshotEmail = snapshot.accountEmail
-        if (snapshotEmail == null) {
-            // No owner recorded: treat as absent, but never delete on
-            // missing information.
-            Logger.w { "allowlist snapshot has no accountEmail; ignoring" }
+        // Ownership needs a usable identity: FirebaseAuthBridge maps a
+        // missing email to "", and "" == "" must not let two email-less
+        // accounts match each other's snapshots.
+        if (signedInEmail.isBlank()) {
+            Logger.w { "allowlist hydrate: signed-in user has no email; skipping" }
             return
         }
-        if (snapshotEmail != signedInEmail) {
-            // Confirmed cross-account snapshot (a sign-out clear missed by
-            // conflation or process death) — refuse AND delete.
-            Logger.w { "allowlist snapshot belongs to another account; deleting" }
-            statusSnapshotStore.clear(setOf(AllowlistSnapshot.KEY))
-            return
-        }
-        if (snapshot.confirmedAgeSeconds(appClock.nowEpochSeconds()) > DISPLAY_TTL_SECONDS) {
-            Logger.i { "allowlist snapshot older than display-TTL; not seeding" }
-            return
-        }
-        // CAS: only seed if the collector's fetch hasn't landed yet (it
-        // can't have — the collector starts after hydration — but keep
-        // the guard).
-        if (_allowlist.value == null) {
-            val seeded = snapshot.payload.toDomain()
-            _allowlist.value = seeded
-            Logger.i { "allowlist <- $seeded (source=disk seed)" }
+        // Under fetchMutex so the seed's check-then-act can never
+        // interleave with a concurrent public fetchAllowlist() write
+        // (latent today — init sequences hydrate before the collector —
+        // but the public API permits it).
+        fetchMutex.withLock {
+            val snapshot = statusSnapshotStore.read(
+                AllowlistSnapshot.KEY,
+                AllowlistSnapshot.SCHEMA_VERSION,
+                AllowlistSnapshotDto.serializer(),
+            ) ?: return
+            val snapshotEmail = snapshot.accountEmail
+            if (snapshotEmail.isNullOrBlank()) {
+                // No usable owner recorded: treat as absent, but never
+                // delete on missing information.
+                Logger.w { "allowlist snapshot has no accountEmail; ignoring" }
+                return
+            }
+            if (snapshotEmail != signedInEmail) {
+                // Confirmed cross-account snapshot (a sign-out clear missed by
+                // conflation or process death) — refuse AND delete.
+                Logger.w { "allowlist snapshot belongs to another account; deleting" }
+                statusSnapshotStore.clear(setOf(AllowlistSnapshot.KEY))
+                return
+            }
+            if (snapshot.confirmedAgeSeconds(appClock.nowEpochSeconds()) > DISPLAY_TTL_SECONDS) {
+                Logger.i { "allowlist snapshot older than display-TTL; not seeding" }
+                return
+            }
+            // Post-read session recheck (mirrors fetchAllowlist's guard):
+            // the disk read suspended, and a fast A→B account switch can be
+            // conflated into never showing Unauthenticated — the seed must
+            // not publish A's rows into B's live session.
+            val auth = authRepository.authState.value
+            if (auth !is AuthState.Authenticated || auth.user.email.asString() != signedInEmail) {
+                Logger.w { "allowlist hydrate: session changed during read; not seeding" }
+                return
+            }
+            // CAS: only seed if the collector's fetch hasn't landed yet (it
+            // can't have — the collector starts after hydration — but keep
+            // the guard).
+            if (_allowlist.value == null) {
+                val seeded = snapshot.payload.toDomain()
+                _allowlist.value = seeded
+                Logger.i { "allowlist <- $seeded (source=disk seed)" }
+            }
         }
     }
 
@@ -192,6 +214,13 @@ class CachedFeatureAllowlistRepository(
         allowlist: FeatureAllowlist,
         accountEmail: String,
     ) {
+        if (accountEmail.isBlank()) {
+            // Can't establish ownership for an email-less account —
+            // don't persist rather than write an entry a different
+            // email-less account could later match.
+            Logger.w { "allowlist: no email to key the snapshot; not persisting" }
+            return
+        }
         val now = appClock.nowEpochSeconds()
         statusSnapshotStore.write(
             AllowlistSnapshot.KEY,

--- a/MobileGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/CachedFeatureAllowlistRepositoryTest.kt
+++ b/MobileGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/repository/CachedFeatureAllowlistRepositoryTest.kt
@@ -419,4 +419,49 @@ class CachedFeatureAllowlistRepositoryTest {
             assertEquals("test@example.com", persisted?.accountEmail)
             externalScope.cancel()
         }
+
+    @Test
+    fun blankEmailNeverMatchesASnapshotOwner() =
+        runTest {
+            // FirebaseAuthBridge maps a missing email to "" — two email-less
+            // accounts must not match each other's snapshots via "" == "".
+            val ds = FakeNetworkFeatureAllowlistDataSource()
+            val authRepo = FakeAuthRepository().apply {
+                setIdTokenResult(FirebaseIdToken(idToken = "t", exp = Long.MAX_VALUE))
+                setAuthState(authenticatedState(email = ""))
+            }
+            val store = seededStore(sampleAllowlist, accountEmail = "")
+            val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+
+            val repo = CachedFeatureAllowlistRepository(ds, authRepo, store, AppClock { 1_000L }, externalScope)
+            advanceUntilIdle()
+
+            assertNull(repo.allowlist.value)
+            // Not a confirmed mismatch either — the entry is kept.
+            assertTrue(store.contains(AllowlistSnapshot.KEY))
+            externalScope.cancel()
+        }
+
+    @Test
+    fun fetchForEmaillessAccountDoesNotPersist() =
+        runTest {
+            val ds = FakeNetworkFeatureAllowlistDataSource().apply {
+                setFetchResult(NetworkResult.Success(sampleAllowlist))
+            }
+            val authRepo = FakeAuthRepository().apply {
+                setIdTokenResult(FirebaseIdToken(idToken = "t", exp = Long.MAX_VALUE))
+                setAuthState(authenticatedState(email = ""))
+            }
+            val store = FakeStatusSnapshotStore()
+            val externalScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+
+            val repo = CachedFeatureAllowlistRepository(ds, authRepo, store, AppClock { 1_000L }, externalScope)
+            advanceUntilIdle()
+
+            // In-memory value works normally; only the persisted snapshot
+            // is skipped (no ownable key to write).
+            assertEquals(sampleAllowlist, repo.allowlist.value)
+            assertEquals(false, store.contains(AllowlistSnapshot.KEY))
+            externalScope.cancel()
+        }
 }


### PR DESCRIPTION
## Summary
Fix-forward for the confirmed findings from the 2-angle adversarial review of #1078 (both reviewers independently converged on the first item).

- **Post-read session recheck** (mirrors `fetchAllowlist`'s guard): the hydrate disk read suspends, and a fast A→B account switch can be conflated into never emitting `Unauthenticated` — without the recheck, A's seeded rows could publish into B's live session memory (disk was keyed; memory wasn't re-guarded at write time).
- **Blank emails are not ownership**: `FirebaseAuthBridge` maps a missing email to `""`, so `"" == ""` let two email-less accounts match each other's snapshots. Now: a blank signed-in email never hydrates, a blank snapshot owner is ignored-but-kept (like null), and a fetch for an email-less account is not persisted at all.
- **Seed serialized with the public API**: hydrate's check-then-act now runs under `fetchMutex`, so it can never interleave with a concurrent `fetchAllowlist()` write (latent today — init sequences hydrate before the collector — but the public API permits it).

Accepted as inherent to hydrate-then-revalidate (no change): the revoke-direction flicker (seeded rows disappear when the always-on revalidate lands — visibility only; the server independently authorizes every real action) and the offline-session stale-rows window (bounded by the 24h display-TTL, same posture as every other cached status).

## Verification
15/15 allowlist repo tests (2 new); `./scripts/validate.sh` all-green (0 plain-`FAIL` markers); `:iosFramework:iosSimulatorArm64Test` green.

## Merge order
Standalone follow-up to #1078 (merged). Closes out the status-cache rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)