### PR TITLE
docs: record decision NOT to persist ServerConfig (status cache D5)

### DIFF
--- a/MobileGarage/docs/DECISIONS.md
+++ b/MobileGarage/docs/DECISIONS.md
@@ -1947,13 +1947,14 @@ A persisted last-known-value cache in the KMP layer; repositories **hydrate-then
 
 - Cold launches render last-known verdicts instantly; the Android per-entry snooze fetch + 60s poll is gone (replaced by TTL-gated screen-entry revalidate on both platforms + the door-event hook + the expiry derivation); the pre-existing iOS stale "Snoozing until [past]" label is fixed.
 - Accepted staleness bounds (verified magnitudes): seconds on cold start (revalidate round-trip); ≤ fetch-TTL for server-side snooze voids that happen while the app is dead (fail-safe direction); offline cold start keeps the last confirmed verdict until display-TTL — same posture as the Room-hydrated door state.
-- Every new persisted status must: define its DTO + `StatusCacheKey` beside its repo, pick a hydration shape above, register per-user keys in `CLEARED_ON_SIGN_OUT`, and add both-component DI + identity tests. `ServerConfig` remains unpersisted (deferred; its absence bounds cold-start revalidate at 2–3 RTTs).
+- Every new persisted status must: define its DTO + `StatusCacheKey` beside its repo, pick a hydration shape above, register per-user keys in `CLEARED_ON_SIGN_OUT`, and add both-component DI + identity tests. `ServerConfig` is **deliberately not persisted** (decided 2026-07-18, not deferred — see Alternatives); its absence bounds cold-start revalidate at 2–3 RTTs, an accepted permanent cost.
 
 ### Alternatives considered
 
 - **Room entities per status** — rejected: single-value snapshots, not queryable lists; Preferences DataStore is the right primitive (door events stay in Room).
 - **Fetch-skip TTL for the allowlist** — rejected in review: it removed the only grant-propagation path (restart) with no manual-refresh fallback.
 - **Keeping "Checking…" UI** — rejected: it was prominent UI for a state the user cannot act on; with hydration it would appear exactly when least useful.
+- **Persisting `ServerConfig` as a fourth status** — rejected (2026-07-18). Its only payoff is shortening the *silent* button-health cold-start revalidate (2–3 RTTs → ~1); `ServerConfig` has no UI and button-health display already hydrates instantly (D2), so the gain is invisible. Against that: it holds the `remoteButtonPushKey` secret (persisting writes it to disk — mitigated but a new surface for zero benefit) and adds permanent maintenance weight (DTO, DI, identity tests, sign-out registration). Net-negative; the 2–3-RTT cold-start revalidate is an accepted permanent cost. `STATUS_CACHE_PLAN.md` § D5 has the full reasoning.
 
 ### References
 

--- a/MobileGarage/docs/STATUS_CACHE_PLAN.md
+++ b/MobileGarage/docs/STATUS_CACHE_PLAN.md
@@ -73,9 +73,15 @@ Unifying gap: nothing except door events (Room) and app settings (DataStore) sur
 - Sign-out: key registered with the D1 clearer (account-keying is the real guard).
 - Display unchanged (null allowlist = rows absent); hydration removes the cold-start pop-in. Display-TTL 24h off `confirmedAt`, same skew guard.
 
-### D5. ServerConfig — deferred
+### D5. ServerConfig — decided NOT to persist (2026-07-18)
 
-`CachedServerConfigRepository` stays unpersisted for now. Consequence: the button-health cold-start revalidate is serially gated on a serverConfig fetch + token refresh (2–3 RTTs), so the stale-display window is a few seconds; bounded by the D2 display-TTL. If later persisted, `remoteButtonPushKey` rides in the already-backup-excluded file (and the key alone does not authorize pushes — the server also verifies the ID-token allowlist).
+`CachedServerConfigRepository` stays unpersisted — **this is a settled decision, not a "later" item.** The only payoff would be shortening the *silent* button-health cold-start revalidate (serially gated on a serverConfig fetch + token refresh, 2–3 RTTs → ~1). That window is invisible: `ServerConfig` has no UI of its own, and button-health *display* already hydrates instantly from its own snapshot (D2), so nothing a user sees would change.
+
+Against that zero visible gain sit two real costs the other three statuses don't carry:
+1. **Secret on disk.** `ServerConfig` holds `remoteButtonPushKey` (the `X-RemoteButtonPushKey` shared secret). Persisting it writes that secret to disk — mitigated (rides in the backup-excluded `status_cache.preferences_pb`; the key alone does not authorize a push, the server also verifies the ID-token + email allowlist), but still a new surface for no benefit.
+2. **Permanent maintenance weight** — a fourth persisted status: DTO, `StatusCacheKey`, both-component DI, identity tests, sign-out registration, carried forever.
+
+The only scenario where a cached config could matter is a cold start on a flaky network — but door control needs the network anyway, so a cached key unblocks nothing. Net-negative trade; not doing it. The accepted consequence is the permanent 2–3-RTT cold-start revalidate, bounded by the D2 display-TTL.
 
 ### D6. Platform-side exceptions
 
@@ -99,7 +105,7 @@ Unifying gap: nothing except door events (Room) and app settings (DataStore) sur
 
 ## Accepted tradeoffs (explicit, review-verified magnitudes)
 
-- Cold-start verdict staleness: seconds (revalidate round-trip; 2–3 RTTs while ServerConfig is unpersisted); the ~1-minute stale window after a firmware-rotation reset is closed by the disk-seed rule; offline cold start keeps the last confirmed verdict until the display-TTL — same posture as Room-hydrated door state.
+- Cold-start verdict staleness: seconds (revalidate round-trip; the 2–3-RTT chain is the permanent steady state — ServerConfig is deliberately not persisted, see D5); the ~1-minute stale window after a firmware-rotation reset is closed by the disk-seed rule; offline cold start keeps the last confirmed verdict until the display-TTL — same posture as Room-hydrated door state.
 - Cross-device snooze changes detected at: door-event hook, screen-entry TTL revalidate, manual refresh, cold start. Dominant failure direction fail-safe (unexpected warning rather than a missed one).
 - A stale-pushKey 403 clears the button-health cache → Hidden until next success (fail-safe).
 - In-flight write-through may re-write a just-cleared entry at sign-out (harmless for non-account-keyed entries; allowlist is account-keyed).


### PR DESCRIPTION
## What

Records the decision **not** to persist `ServerConfig` in the status-snapshot cache (STATUS_CACHE_PLAN § D5), replacing the earlier "deferred" framing which read as *maybe-later*.

## Why

Persisting `ServerConfig` would only shorten the **silent** button-health cold-start revalidate (2–3 RTTs → ~1). That window is invisible:
- `ServerConfig` has no UI of its own, and
- button-health *display* already hydrates instantly from its own snapshot (D2).

Against zero visible gain sit two real costs the other three cached statuses don't carry:
1. **Secret on disk** — `ServerConfig` holds `remoteButtonPushKey`; persisting writes it to disk (mitigated by the backup-excluded file + server-side ID-token/allowlist check, but still a new surface for no benefit).
2. **Permanent maintenance weight** — a fourth persisted status (DTO, DI in both components, identity tests, sign-out registration).

Net-negative trade. The 2–3-RTT cold-start revalidate is now recorded as an accepted permanent cost, bounded by the D2 display-TTL.

## Changes (docs only)

- `STATUS_CACHE_PLAN.md` § D5 — heading "deferred" → "decided NOT to persist (2026-07-18)" + full reasoning; accepted-tradeoff bullet reframes the RTT chain as the permanent steady state.
- `DECISIONS.md` ADR-034 — consequence line updated; new "Alternatives considered" bullet documenting the rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)