### PR TITLE
feat(wear): wear/N release lane — CI-built AAB, gated Play upload to Wear internal

### DIFF
--- a/.claude/hooks/git-guardrails.sh
+++ b/.claude/hooks/git-guardrails.sh
@@ -96,7 +96,7 @@ fi
 # --- Block tag creation (use release scripts instead) ---
 if echo "$STRIPPED" | grep -qE '\bgit\s+tag\b'; then
   if ! echo "$STRIPPED" | grep -qE '\bgit\s+tag\b.*(-l\b|--list\b)'; then
-    deny "BLOCKED: Never create or push tags directly. Use ./scripts/release-android.sh or ./scripts/release-firebase.sh for releases. Use git tag -l to list tags."
+    deny "BLOCKED: Never create or push tags directly. Use the release scripts (./scripts/release-android.sh, release-ios.sh, release-firebase.sh, release-wear.sh). Use git tag -l to list tags."
   fi
 fi
 
@@ -119,10 +119,10 @@ fi
 PUSH_SEGMENTS=$(echo "$COMMAND" | sed '/<<.*EOF/,/^EOF/d' | grep -oE 'git[[:space:]]+push\b[^;&|]*' | sed -E "s/[\"']//g")
 if [ -n "$PUSH_SEGMENTS" ]; then
   if echo "$PUSH_SEGMENTS" | grep -qE -- '--tags\b|refs/tags/|(^|[[:space:]])tag[[:space:]]'; then
-    deny "BLOCKED: Never push tags directly (--tags, refs/tags/, or the 'push <remote> tag <name>' form). Use ./scripts/release-android.sh, ./scripts/release-ios.sh, or ./scripts/release-firebase.sh -- they push release tags as part of a gated release."
+    deny "BLOCKED: Never push tags directly (--tags, refs/tags/, or the 'push <remote> tag <name>' form). Use ./scripts/release-android.sh, ./scripts/release-ios.sh, ./scripts/release-firebase.sh, or ./scripts/release-wear.sh -- they push release tags as part of a gated release."
   fi
-  if echo "$PUSH_SEGMENTS" | grep -qE '(^|[[:space:]:])(android|ios|server)/[0-9]+([[:space:]:]|$)'; then
-    deny "BLOCKED: Never push an android/N, ios/N, or server/N ref directly. Use ./scripts/release-android.sh, ./scripts/release-ios.sh, or ./scripts/release-firebase.sh -- they push release tags as part of a gated release."
+  if echo "$PUSH_SEGMENTS" | grep -qE '(^|[[:space:]:])(android|ios|server|wear)/[0-9]+([[:space:]:]|$)'; then
+    deny "BLOCKED: Never push an android/N, ios/N, server/N, or wear/N ref directly. Use ./scripts/release-android.sh, ./scripts/release-ios.sh, ./scripts/release-firebase.sh, or ./scripts/release-wear.sh -- they push release tags as part of a gated release."
   fi
 fi
 

--- a/.github/scripts/play-track-snapshot.mjs
+++ b/.github/scripts/play-track-snapshot.mjs
@@ -36,22 +36,33 @@ if (!saJson) {
   process.exit(1)
 }
 
+// Wear artifacts share the package with an offset versionCode: wear/N is
+// released as versionCode 1000000 + N (see wearApp/build.gradle.kts).
+const WEAR_VERSION_CODE_OFFSET = 1000000
+
 const versionNameCache = new Map()
 function resolveVersionName(vc) {
   if (versionNameCache.has(vc)) return versionNameCache.get(vc)
   let name = '(no tag)'
-  // The module dir was renamed AndroidGarage -> MobileGarage (2026-07). Tags cut
-  // before the rename keep version.properties at the OLD path, so try the current
-  // path first and fall back to the old one — otherwise historical versionCodes
-  // (android/<=255) stop resolving.
-  for (const path of ['MobileGarage/version.properties', 'AndroidGarage/version.properties']) {
+  // Candidate [tag, path] pairs for this versionCode. Phone codes map to
+  // android/N. The module dir was renamed AndroidGarage -> MobileGarage
+  // (2026-07): tags cut before the rename keep version.properties at the OLD
+  // path, so try the current path first and fall back — otherwise historical
+  // versionCodes (android/<=255) stop resolving.
+  const candidates = vc > WEAR_VERSION_CODE_OFFSET
+    ? [[`wear/${vc - WEAR_VERSION_CODE_OFFSET}`, 'MobileGarage/wearApp/version.properties']]
+    : [
+        [`android/${vc}`, 'MobileGarage/version.properties'],
+        [`android/${vc}`, 'AndroidGarage/version.properties'],
+      ]
+  for (const [tag, path] of candidates) {
     try {
-      const out = execFileSync('git', ['show', `android/${vc}:${path}`], { encoding: 'utf8' })
+      const out = execFileSync('git', ['show', `${tag}:${path}`], { encoding: 'utf8' })
       const m = out.match(/versionName=(.+)/)
       name = m ? m[1].trim() : '(unknown)'
       break
     } catch {
-      // path absent at this tag; try the next
+      // tag or path absent; try the next candidate
     }
   }
   versionNameCache.set(vc, name)

--- a/.github/workflows/release-wear.yml
+++ b/.github/workflows/release-wear.yml
@@ -1,0 +1,132 @@
+name: Wear OS Release
+
+# Triggered by wear/N tags pushed by scripts/release-wear.sh
+# Builds the Wear AAB (versionCode = 1000000 + N) and uploads it as a
+# 1-day CI artifact. When the repo Actions variable WEAR_PLAY_UPLOAD_ENABLED
+# is 'true', also deploys to the Play Store WEAR INTERNAL track — never
+# production.
+#
+# Bootstrap: the variable stays unset until the one-time manual Play Console
+# steps are done (Wear OS form-factor opt-in + first manual AAB upload).
+# See docs/WEAR_OS.md § Releasing.
+# To retry a failed release, use "Re-run all jobs" in the Actions UI.
+on:
+  push:
+    tags:
+      - 'wear/[0-9]*'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  release:
+    name: Wear Release Build (and Deploy to Wear Internal when enabled)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Validate tag format
+        id: validate
+        run: |
+          REF="${GITHUB_REF}"
+          if [[ ! "$REF" =~ ^refs/tags/ ]]; then
+            echo "::error::This workflow must be run on a tag."
+            exit 1
+          fi
+
+          TAG="${REF#refs/tags/}"
+          if [[ ! "$TAG" =~ ^wear/[0-9]+$ ]]; then
+            echo "::error::Tag must match 'wear/N' pattern, got: $TAG"
+            exit 1
+          fi
+
+          TAG_NUMBER="${TAG#wear/}"
+          VERSION_CODE=$((1000000 + TAG_NUMBER))
+          echo "tag_number=$TAG_NUMBER" >> $GITHUB_OUTPUT
+          echo "version_code=$VERSION_CODE" >> $GITHUB_OUTPUT
+          echo "Validated: tag=$TAG, tagNumber=$TAG_NUMBER, versionCode=$VERSION_CODE"
+
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # full history so the mainline check below can walk ancestry
+
+      # Server-side re-assertion that this is a mainline commit. The release
+      # script already refuses to tag anything off `main` locally, and a
+      # Claude hook blocks pushing a tag ref directly -- but neither of those
+      # is enforced here, on the runner, which is the one place this
+      # workflow can't be argued with. This closes that gap independent of
+      # who cut the tag or how the ref was pushed.
+      - name: Verify tagged commit is on main
+        run: |
+          git fetch origin main --quiet
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" FETCH_HEAD; then
+            echo "::error::Tag ${GITHUB_REF_NAME} points to commit $GITHUB_SHA, which is not reachable from origin/main. Refusing to release a commit that hasn't gone through the required main-branch checks."
+            exit 1
+          fi
+          echo "Verified: $GITHUB_SHA is on origin/main."
+
+      - uses: ./.github/actions/setup-android
+        with:
+          encrypt-key: ${{ secrets.ENCRYPT_KEY }}
+
+      - name: Build Wear Release AAB
+        working-directory: MobileGarage
+        env:
+          SERVER_CONFIG_KEY: ${{ secrets.SERVER_CONFIG_KEY }}
+          GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
+          GARAGE_RELEASE_KEYSTORE_PWD: ${{ secrets.GARAGE_RELEASE_KEYSTORE_PWD }}
+          GARAGE_RELEASE_KEY_PWD: ${{ secrets.GARAGE_RELEASE_KEY_PWD }}
+        run: ./gradlew :wearApp:bundleRelease -PWEAR_VERSION_CODE=${{ steps.validate.outputs.tag_number }} -PSERVER_CONFIG_KEY="$SERVER_CONFIG_KEY" -PGOOGLE_WEB_CLIENT_ID="$GOOGLE_WEB_CLIENT_ID" -PGARAGE_RELEASE_KEYSTORE_PWD="$GARAGE_RELEASE_KEYSTORE_PWD" -PGARAGE_RELEASE_KEY_PWD="$GARAGE_RELEASE_KEY_PWD"
+
+      - name: Clean secrets
+        if: always()
+        working-directory: MobileGarage
+        run: ./release/clean-secrets.sh
+
+      # Short retention because the signed AAB embeds BuildConfig.SERVER_CONFIG_KEY
+      # and is publicly fetchable for the retention window via the GitHub Actions
+      # artifacts API on a public repo. Play Store is the source of truth for the
+      # binary; this 1-day artifact exists for the one-time manual upload flow and
+      # same-day release-debugging.
+      - name: Upload release AAB artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: wear-release-aab-${{ steps.validate.outputs.version_code }}
+          path: MobileGarage/wearApp/build/outputs/bundle/release/
+          retention-days: 1
+
+      - name: Deploy to Google Play (Wear Internal Track)
+        if: vars.WEAR_PLAY_UPLOAD_ENABLED == 'true'
+        # Pinned to the v1.1.5 commit SHA (audit M4), same as release-android.yml.
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.chriscartland.garage
+          releaseFiles: MobileGarage/wearApp/build/outputs/bundle/release/*.aab
+          tracks: wear:internal
+
+      - name: Manual upload instructions (Play upload disabled)
+        if: vars.WEAR_PLAY_UPLOAD_ENABLED != 'true'
+        run: |
+          echo "::notice title=Wear Release (manual upload)::Play upload is disabled (WEAR_PLAY_UPLOAD_ENABLED != 'true'). Download the 'wear-release-aab-${{ steps.validate.outputs.version_code }}' artifact from this run (1-day retention) and upload it in Play Console -> Wear OS internal testing. After the first manual upload succeeds, set the repo Actions variable WEAR_PLAY_UPLOAD_ENABLED=true to automate future wear/N releases."
+
+      - name: Release summary
+        run: |
+          TAG="wear/${{ steps.validate.outputs.tag_number }}"
+          echo "::notice title=Wear OS Release::Built $TAG (versionCode=${{ steps.validate.outputs.version_code }}, package=com.chriscartland.garage). Play upload enabled: ${{ vars.WEAR_PLAY_UPLOAD_ENABLED == 'true' }}"
+
+  # Track release failures via a single GitHub issue (auto-create on failure,
+  # auto-close on the next successful release). Mirrors the Android release pattern.
+  track-failure:
+    name: Track Wear Release Failure
+    if: always()
+    needs: [release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/ci-failure-tracker
+        with:
+          label: release-failure/wear
+          result: ${{ needs.release.result == 'success' && 'success' || 'failure' }}
+          workflow-name: "Wear OS Release (tag: ${{ github.ref_name }})"

--- a/MobileGarage/wearApp/CHANGELOG.md
+++ b/MobileGarage/wearApp/CHANGELOG.md
@@ -1,0 +1,22 @@
+---
+category: reference
+status: active
+last_verified: 2026-07-22
+---
+# Wear OS App Changelog
+
+Internal release history for the Wear OS app. Releases are cut with
+`./scripts/release-wear.sh` as `wear/N` tags (versionCode = 1000000 + N).
+The phone app's history lives in [`../CHANGELOG.md`](../CHANGELOG.md).
+
+## Versioning
+
+Same rule as the phone app: major = rewrite or core-experience shift;
+minor = added or removed user-facing feature; patch = fixes, polish, refactors.
+
+## 0.1.0
+
+- Initial Wear OS release: animated garage door status with tap-to-arm and a
+  2-second hold-to-confirm remote button.
+- Standalone watch app: Sign in with Google via Credential Manager,
+  foreground-only status refresh, shared door animation spec with phone/iOS.

--- a/MobileGarage/wearApp/build.gradle.kts
+++ b/MobileGarage/wearApp/build.gradle.kts
@@ -32,6 +32,11 @@ val localProperties = Properties().apply {
     }
 }
 
+// Wear artifact versionCodes share the phone's applicationId and must be
+// globally unique against android/N (= N) codes. wear/N maps to
+// WEAR_VERSION_CODE_OFFSET + N, keeping the two sequences disjoint.
+val wearVersionCodeOffset = 1_000_000
+
 android {
     namespace = "com.chriscartland.garage.wear"
     compileSdk = 36
@@ -46,11 +51,17 @@ android {
         // Wear OS 3 (API 30) and newer.
         minSdk = 30
         targetSdk = 36
-        // Wear releases are not wired into release-android.sh yet. When they
-        // are, versionCode must be globally unique vs the phone artifacts —
-        // use a large offset (e.g. 1_000_000 + N). See docs/WEAR_OS.md.
-        versionCode = 1
-        versionName = "0.1.0"
+        // versionCode comes from the wear/N tag via -PWEAR_VERSION_CODE=N
+        // (release-wear.yml), offset per wearVersionCodeOffset above.
+        // Local builds fall back to N=0, always below any real release.
+        val tagVersionCode = (project.findProperty("WEAR_VERSION_CODE") as? String)?.toIntOrNull()
+        versionCode = wearVersionCodeOffset + (tagVersionCode ?: 0)
+        // versionName from wearApp/version.properties (manually bumped, semver).
+        // release-wear.sh gates on a matching wearApp/CHANGELOG.md heading.
+        val versionProps = Properties().apply {
+            project.file("version.properties").inputStream().use { load(it) }
+        }
+        versionName = versionProps.getProperty("versionName")
         setProperty("archivesBaseName", "$applicationId-wear-$versionName-$versionCode")
 
         val serverConfigKey = "SERVER_CONFIG_KEY".let {

--- a/MobileGarage/wearApp/version.properties
+++ b/MobileGarage/wearApp/version.properties
@@ -1,0 +1,1 @@
+versionName=0.1.0

--- a/docs/RELEASE_STRATEGY.md
+++ b/docs/RELEASE_STRATEGY.md
@@ -1,7 +1,7 @@
 ---
 category: reference
 status: active
-last_verified: 2026-07-03
+last_verified: 2026-07-22
 ---
 
 # Release & Deployment Strategy
@@ -398,6 +398,12 @@ A multi-component repository:
 - An **iOS** app (the shared CMP codebase) — released to TestFlight **Internal** by
   `ios/N` tags, mirroring the Android model; production App Store promotion is manual.
   *Composes: Foundations + App + iOS.*
+- A **Wear OS** app (same package as the phone app) — released by `wear/N` tags
+  (versionCode = 1000000 + N, disjoint from phone codes) to the Play **Wear internal**
+  track. Bootstrap state: the CI Play-upload step is gated behind the
+  `WEAR_PLAY_UPLOAD_ENABLED` repo variable until the one-time manual Console upload +
+  Wear form-factor opt-in is done; until then CI produces a 1-day AAB artifact for
+  manual upload. *Composes: Foundations + App + Android (§5 applies to both artifacts).*
 - **ESP32 firmware** — flashed manually; outside this strategy (§8).
 
 There is **no web frontend**, so the Web layer (§7) does not apply.

--- a/docs/WEAR_OS.md
+++ b/docs/WEAR_OS.md
@@ -1,7 +1,7 @@
 ---
 category: reference
 status: active
-last_verified: 2026-07-21
+last_verified: 2026-07-22
 ---
 
 # Wear OS App (`MobileGarage/wearApp/`)
@@ -78,6 +78,39 @@ early release never submits, signed-out is inert).
 - Secrets: same `SERVER_CONFIG_KEY` / `GOOGLE_WEB_CLIENT_ID` from
   `local.properties` (or `-P` properties in CI).
 
+## Releasing (`wear/N` tags)
+
+Mirrors the phone release model. Use `./scripts/release-wear.sh` — never
+create or push `wear/N` tags directly (the guardrails hook blocks them).
+
+```bash
+./scripts/validate.sh                        # writes the validation marker
+./scripts/release-wear.sh --check            # prints the exact next command
+./scripts/release-wear.sh --confirm-tag wear/N
+```
+
+- **Version mapping:** tag `wear/N` builds versionCode `1000000 + N` (offset
+  keeps Wear codes unique vs the phone's `android/N` codes in the shared
+  applicationId). versionName comes from `wearApp/version.properties`; the
+  script gates on a matching `wearApp/CHANGELOG.md` heading, same as the
+  phone/Firebase gates.
+- **Workflow** (`release-wear.yml`): builds + signs the Wear AAB on CI and
+  always uploads it as a 1-day artifact (`wear-release-aab-<code>`). When the
+  repo Actions variable `WEAR_PLAY_UPLOAD_ENABLED` is `'true'`, it also
+  uploads to the Play **Wear internal** track (`tracks: wear:internal`,
+  same pinned uploader action and service account as the phone).
+- **One-time bootstrap (manual, Play Console):** the variable stays unset for
+  the first release. Cut `wear/1`, download the artifact, then in Play
+  Console: opt in to the **Wear OS form factor** (Setup → Advanced settings →
+  Form factors), create a **Wear OS internal testing** release, upload the
+  AAB, add testers. After it's accepted, run the `play-track-snapshot`
+  workflow and check the track-state issue: the wear track's API name should
+  read `wear:internal` — if it differs, fix `release-wear.yml` first. Then set
+  `WEAR_PLAY_UPLOAD_ENABLED=true` (repo Settings → Secrets and variables →
+  Actions → Variables) and every later `wear/N` release deploys automatically.
+- The `play-track-snapshot` renderer resolves wear versionCodes back to
+  `wear/N` tags, so the track-state log stays readable.
+
 ## Deliberately not included (follow-ups, in rough priority order)
 
 1. **On-device verification.** Nothing here has run on a watch or emulator —
@@ -90,11 +123,11 @@ early release never submits, signed-out is inert).
    operates the physical door.** The signed-out app is inert
    (`PushRemoteButtonUseCase` gates on `Authenticated` before any network
    call), so UI/layout verification while signed out is always safe.
-2. **Release plumbing.** No `wear/N` tag flow, no Play upload workflow,
-   versionCode hardcoded to 1. When wiring releases: Wear versionCodes must
-   not collide with phone artifact codes (use a large offset), R8 must be
-   enabled + ADR-020 keep rules ported (minification is off in this first
-   cut), and the Wear track in Play Console needs the standalone APK.
+2. **R8 for the Wear release build.** Minification is deliberately OFF in
+   the release build type — the phone needed hand-tuned keep rules for
+   kotlinx.serialization (ADR-020) and there is no CLI way to verify a
+   minified Wear build end-to-end yet. Fine for internal testing; enable +
+   port the keep rules (and verify on a device) before any wider rollout.
 3. **FCM push on the watch** (replace/augment polling; the shared
    `FcmRegistrationManager` + `MessagingBridge` seam already exists).
 4. **Tiles + complications** — the natural Wear surfaces for door status

--- a/scripts/release-wear.sh
+++ b/scripts/release-wear.sh
@@ -1,0 +1,642 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Release the Wear OS app by creating and pushing a wear/N tag.
+# This triggers release-wear.yml to build the Wear AAB on CI.
+#
+# IMPORTANT: We only publish to the Play INTERNAL track, never production.
+# Users promote from internal to production manually in Play Console.
+#
+# The tag number maps to versionCode = 1000000 + N (offset keeps Wear
+# artifact codes unique vs the phone's android/N codes in the shared
+# applicationId).
+#
+# BOOTSTRAP NOTE: until the repo Actions variable WEAR_PLAY_UPLOAD_ENABLED
+# is set to 'true', the workflow only uploads the signed AAB as a CI
+# artifact (1-day retention) for MANUAL upload in Play Console. Set the
+# variable after the one-time manual upload + Wear form-factor opt-in has
+# succeeded; from then on CI uploads to the Wear internal track
+# automatically, like release-android.yml does for the phone.
+#
+# USAGE
+#
+# Start with --check. It prints the exact command(s) you should run next,
+# with real values (SHAs, tag names) already filled in. Copy-paste, don't
+# re-type from memory; seeing the concrete values is the whole point.
+#
+#   ./scripts/release-wear.sh --check
+#
+# Normal release (validation marker matches HEAD):
+#   ./scripts/release-wear.sh --confirm-tag wear/N
+#
+# Emergency release (validation has not passed for HEAD):
+#   ./scripts/release-wear.sh \
+#       --confirm-tag wear/N \
+#       --confirm-unvalidated-release <40-char-sha>
+#
+# Rollback release (detached HEAD on an older tag):
+#   git checkout wear/M               # older tag you want to re-release
+#   ./scripts/release-wear.sh --check     # prints the rollback command
+#   ./scripts/release-wear.sh \
+#       --confirm-tag wear/N \
+#       --confirm-hash <40-char-sha-of-target> \
+#       --confirm-rollback-from <40-char-sha-of-previous-latest>
+#
+# DESIGN PRINCIPLE
+#
+# Every override asks you to state a value from reality (a SHA, a tag).
+# The script fails if the value does not match. This makes correct usage
+# easy (read from --check output) and accidental usage hard (you would
+# have to type the right value for the wrong situation).
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+# Parse flags.
+MODE="interactive"
+CONFIRM_TAG=""
+CONFIRM_HASH=""
+CONFIRM_ROLLBACK_FROM=""
+CONFIRM_UNVALIDATED_RELEASE=""
+CONFIRM_NO_CHANGELOG=""
+DRY_RUN=false
+
+show_help() {
+    cat <<'EOF'
+Usage: ./scripts/release-wear.sh [OPTIONS]
+
+Recommended workflow: run with --check first. It prints the exact
+command to run next, with SHAs filled in. Copy-paste that command.
+
+Modes:
+  (no args)                 Interactive mode — prompts for confirmation
+  --check                   Print state + recommended next command, then exit
+  --confirm-tag <tag>       Non-interactive release. Tag must match computed next tag.
+  --dry-run                 Show what would happen without creating tags
+
+Override flags (all require a specific value from --check output):
+  --confirm-hash <sha>              Release a specific commit. SHA must match
+                                    exactly (recommend 40-char full SHA).
+  --confirm-rollback-from <sha>     Required for rollback releases. Must match
+                                    the SHA the latest tag currently points to.
+  --confirm-unvalidated-release <sha>
+                                    Release without validation marker match.
+                                    SHA must equal the target commit.
+  --confirm-no-changelog <sha>      Release without a CHANGELOG entry for the
+                                    current versionName. SHA must equal the
+                                    target commit. Add the entry retroactively.
+
+Help:
+  -h, --help                Show this help
+
+Examples:
+  ./scripts/release-wear.sh --check
+  ./scripts/release-wear.sh --confirm-tag wear/1
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --check)
+            MODE="check"
+            shift
+            ;;
+        --confirm-tag)
+            MODE="confirm"
+            CONFIRM_TAG="$2"
+            shift 2
+            ;;
+        --confirm-hash)
+            CONFIRM_HASH="$2"
+            shift 2
+            ;;
+        --confirm-rollback-from)
+            CONFIRM_ROLLBACK_FROM="$2"
+            shift 2
+            ;;
+        --confirm-unvalidated-release)
+            CONFIRM_UNVALIDATED_RELEASE="$2"
+            shift 2
+            ;;
+        --confirm-no-changelog)
+            CONFIRM_NO_CHANGELOG="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Error: Unknown option: $1${RESET}"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+# Fetch tags.
+git fetch origin --tags --quiet
+
+# Compute latest tag number and its SHA.
+HIGHEST_VERSION=$(git tag -l 'wear/[0-9]*' | \
+    sed 's|wear/||' | \
+    grep -E '^[0-9]+$' || true)
+HIGHEST_VERSION=$(echo "$HIGHEST_VERSION" | sort -n | tail -1)
+
+if [ -z "$HIGHEST_VERSION" ]; then
+    NEXT_VERSION=1
+    LATEST_TAG="(none)"
+    LATEST_TAG_SHA="(none)"
+else
+    NEXT_VERSION=$((HIGHEST_VERSION + 1))
+    LATEST_TAG="wear/$HIGHEST_VERSION"
+    LATEST_TAG_SHA=$(git rev-parse "$LATEST_TAG" 2>/dev/null || echo "(missing)")
+fi
+
+NEW_TAG="wear/$NEXT_VERSION"
+
+# Resolve target commit.
+if [ -n "$CONFIRM_HASH" ]; then
+    TARGET_COMMIT=$(git rev-parse --verify "$CONFIRM_HASH" 2>/dev/null) || {
+        echo -e "${RED}Error: --confirm-hash '$CONFIRM_HASH' is not a valid git ref.${RESET}"
+        exit 1
+    }
+    TARGET_COMMIT_SHORT=$(git rev-parse --short "$TARGET_COMMIT")
+    TARGET_SOURCE="--confirm-hash $CONFIRM_HASH -> $TARGET_COMMIT_SHORT"
+else
+    TARGET_COMMIT=$(git rev-parse HEAD)
+    TARGET_COMMIT_SHORT=$(git rev-parse --short HEAD)
+    TARGET_SOURCE="HEAD ($TARGET_COMMIT_SHORT)"
+fi
+
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+if [ -z "$CURRENT_BRANCH" ]; then
+    CURRENT_BRANCH="(detached)"
+fi
+
+# Validation marker state.
+#   matches : marker exists and matches TARGET_COMMIT
+#   stale   : marker exists but matches some other commit
+#   missing : marker file does not exist
+# validate.sh builds + tests :wearApp too, so the shared marker covers Wear.
+VALIDATION_FILE="$REPO_ROOT/.claude/.validation-passed"
+VALIDATION_STATE="missing"
+VALIDATED_COMMIT=""
+if [ -f "$VALIDATION_FILE" ]; then
+    VALIDATED_COMMIT=$(cat "$VALIDATION_FILE" 2>/dev/null | tr -d '[:space:]')
+    if [ "$VALIDATED_COMMIT" = "$TARGET_COMMIT" ]; then
+        VALIDATION_STATE="matches"
+    else
+        VALIDATION_STATE="stale"
+    fi
+fi
+
+# versionName from wearApp/version.properties on the target commit.
+# wearApp/CHANGELOG.md uses the human-readable X.Y.Z heading (not the
+# wear/N tag), so this is the key we look up.
+#
+# Parser tolerates `versionName=0.1.0` and `versionName = 0.1.0` (.properties
+# files allow whitespace around `=`). The trailing tr removes surrounding
+# whitespace, including CR from CRLF line endings.
+VERSION_PROPERTIES="$REPO_ROOT/MobileGarage/wearApp/version.properties"
+VERSION_NAME=""
+if [ -f "$VERSION_PROPERTIES" ]; then
+    VERSION_NAME=$(awk -F= '/^[[:space:]]*versionName[[:space:]]*=/ {
+        sub(/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*/, "")
+        gsub(/[[:space:]]/, "")
+        print
+        exit
+    }' "$VERSION_PROPERTIES")
+fi
+
+# Escape regex special chars in versionName so values like `0.1.0` or
+# `0.1.0-rc.1` are matched literally in awk's extended-regex pattern.
+VERSION_NAME_RE=""
+if [ -n "$VERSION_NAME" ]; then
+    # shellcheck disable=SC2001
+    VERSION_NAME_RE=$(echo "$VERSION_NAME" | sed 's/[][\\.+*?(){}^$|]/\\&/g')
+fi
+
+# CHANGELOG state for the versionName we're about to release.
+#   present  : `## X.Y.Z` heading exists and has non-empty body
+#   empty    : heading exists but body is whitespace-only
+#   missing  : no heading for this versionName
+#   no_file  : MobileGarage/wearApp/CHANGELOG.md does not exist
+#   no_ver   : versionName could not be parsed from version.properties
+#              — treated as a hard failure in the gate (can't ship a
+#              release whose version we can't read)
+#
+# Matching rules:
+# - Lines inside fenced code blocks (```...```) are ignored, in case the
+#   docs intro ever embeds an example release heading.
+# - Heading must be `^## X.Y.Z` followed by end-of-line or whitespace, so
+#   `## 0.1` does not falsely match `0.1.1`. Dots are escaped in the
+#   pattern so the match is literal.
+CHANGELOG_FILE="$REPO_ROOT/MobileGarage/wearApp/CHANGELOG.md"
+CHANGELOG_STATE="no_file"
+CHANGELOG_BODY=""
+if [ -z "$VERSION_NAME" ]; then
+    CHANGELOG_STATE="no_ver"
+elif [ -f "$CHANGELOG_FILE" ]; then
+    CHANGELOG_BODY=$(awk -v ver="$VERSION_NAME_RE" '
+        BEGIN { in_fence = 0; found = 0 }
+        /^```/ { in_fence = !in_fence; next }
+        in_fence { next }
+        $0 ~ ("^## "ver"([ ]|$)") { found = 1; next }
+        found && /^## / { exit }
+        found { print }
+    ' "$CHANGELOG_FILE")
+    HEADING_FOUND=$(awk -v ver="$VERSION_NAME_RE" '
+        BEGIN { in_fence = 0 }
+        /^```/ { in_fence = !in_fence; next }
+        in_fence { next }
+        $0 ~ ("^## "ver"([ ]|$)") { print "yes"; exit }
+    ' "$CHANGELOG_FILE")
+    if [ -n "$(echo "$CHANGELOG_BODY" | tr -d '[:space:]')" ]; then
+        CHANGELOG_STATE="present"
+    elif [ "$HEADING_FOUND" = "yes" ]; then
+        CHANGELOG_STATE="empty"
+    else
+        CHANGELOG_STATE="missing"
+    fi
+fi
+
+# Rollback detection: target commit is already tagged (not the latest),
+# usually because the user ran `git checkout wear/M` on an older tag.
+EXISTING_TAGS_ON_TARGET=$(git tag -l 'wear/[0-9]*' --points-at "$TARGET_COMMIT" 2>/dev/null | sort -t/ -k2 -n || true)
+IS_ROLLBACK="false"
+if [ -n "$EXISTING_TAGS_ON_TARGET" ]; then
+    NEWEST_TAG_ON_TARGET=$(echo "$EXISTING_TAGS_ON_TARGET" | tail -1)
+    if [ "$NEWEST_TAG_ON_TARGET" != "$LATEST_TAG" ]; then
+        IS_ROLLBACK="true"
+    fi
+fi
+
+# === --check mode ===
+if [ "$MODE" = "check" ]; then
+    echo "Latest tag:   $LATEST_TAG (sha: $LATEST_TAG_SHA)"
+    echo "Next tag:     $NEW_TAG (versionCode $((1000000 + NEXT_VERSION)))"
+    echo "HEAD:         $TARGET_COMMIT"
+    echo "Branch:       $CURRENT_BRANCH"
+
+    case "$VALIDATION_STATE" in
+        matches)
+            echo -e "Validation:   ${GREEN}PASSED${RESET} on $VALIDATED_COMMIT"
+            ;;
+        stale)
+            echo -e "Validation:   ${YELLOW}STALE${RESET} (marker is for $VALIDATED_COMMIT, not HEAD)"
+            ;;
+        missing)
+            echo -e "Validation:   ${YELLOW}MISSING${RESET} — run ./scripts/validate.sh first"
+            ;;
+    esac
+
+    if [ -n "$VERSION_NAME" ]; then
+        echo "versionName:  $VERSION_NAME"
+    else
+        echo -e "versionName:  ${YELLOW}NOT FOUND${RESET} (could not parse MobileGarage/wearApp/version.properties)"
+    fi
+
+    case "$CHANGELOG_STATE" in
+        present) echo -e "Changelog:    ${GREEN}PRESENT${RESET} (entry for $VERSION_NAME in MobileGarage/wearApp/CHANGELOG.md)" ;;
+        empty)   echo -e "Changelog:    ${YELLOW}EMPTY${RESET} (heading for $VERSION_NAME has no body)" ;;
+        missing) echo -e "Changelog:    ${YELLOW}MISSING${RESET} (no heading for $VERSION_NAME in MobileGarage/wearApp/CHANGELOG.md)" ;;
+        no_file) echo -e "Changelog:    ${YELLOW}NO FILE${RESET} (MobileGarage/wearApp/CHANGELOG.md does not exist)" ;;
+        no_ver)  echo -e "Changelog:    ${YELLOW}SKIPPED${RESET} (versionName not found in version.properties)" ;;
+    esac
+
+    if [ -n "$EXISTING_TAGS_ON_TARGET" ]; then
+        echo "Target tags:  $(echo "$EXISTING_TAGS_ON_TARGET" | tr '\n' ' ')"
+    fi
+
+    echo ""
+
+    if [ "$IS_ROLLBACK" = "true" ]; then
+        echo -e "${BOLD}Detected ROLLBACK${RESET} (HEAD is on $NEWEST_TAG_ON_TARGET, older than $LATEST_TAG)."
+        echo ""
+        echo "Copy and run this command to proceed:"
+        echo ""
+        echo "  ./scripts/release-wear.sh \\"
+        echo "      --confirm-tag $NEW_TAG \\"
+        echo "      --confirm-hash $TARGET_COMMIT \\"
+        echo "      --confirm-rollback-from $LATEST_TAG_SHA"
+        echo ""
+        EXTRAS=()
+        if [ "$VALIDATION_STATE" != "matches" ]; then
+            EXTRAS+=("--confirm-unvalidated-release $TARGET_COMMIT")
+        fi
+        if [ "$CHANGELOG_STATE" != "present" ] && [ "$CHANGELOG_STATE" != "no_ver" ]; then
+            EXTRAS+=("--confirm-no-changelog $TARGET_COMMIT")
+        fi
+        if [ ${#EXTRAS[@]} -gt 0 ]; then
+            echo "Append the following for the conditions flagged above:"
+            for extra in "${EXTRAS[@]}"; do
+                echo "      $extra"
+            done
+            echo ""
+        fi
+    elif [ "$CHANGELOG_STATE" = "no_ver" ]; then
+        echo -e "${RED}Cannot release: versionName not found in MobileGarage/wearApp/version.properties.${RESET}"
+        echo ""
+        echo "Fix version.properties — expected a line like:"
+        echo "    versionName=X.Y.Z"
+        echo ""
+        echo "Then re-run: ./scripts/release-wear.sh --check"
+        echo ""
+    elif [ "$VALIDATION_STATE" != "matches" ]; then
+        echo "Validation is not passing for HEAD. Two options:"
+        echo ""
+        echo "(1) Run validation, then re-run --check (recommended):"
+        echo "    ./scripts/validate.sh && ./scripts/release-wear.sh --check"
+        echo ""
+        echo "(2) Release WITHOUT validation (emergency only):"
+        echo ""
+        echo "    ./scripts/release-wear.sh \\"
+        echo "        --confirm-tag $NEW_TAG \\"
+        echo "        --confirm-unvalidated-release $TARGET_COMMIT"
+        echo ""
+    elif [ "$CHANGELOG_STATE" != "present" ]; then
+        echo "No CHANGELOG entry for $VERSION_NAME. Two options:"
+        echo ""
+        echo "(1) Add an entry, commit, push, re-run --check (recommended):"
+        echo ""
+        echo "    Edit MobileGarage/wearApp/CHANGELOG.md and add at the top"
+        echo "    (above the previous version):"
+        echo ""
+        echo "      ## $VERSION_NAME"
+        echo "      - <one or more bullets describing user-facing changes>"
+        echo ""
+        echo "    Then: git commit + push, ./scripts/validate.sh, ./scripts/release-wear.sh --check"
+        echo ""
+        echo "(2) Release WITHOUT a changelog entry (emergency only):"
+        echo ""
+        echo "    ./scripts/release-wear.sh \\"
+        echo "        --confirm-tag $NEW_TAG \\"
+        echo "        --confirm-no-changelog $TARGET_COMMIT"
+        echo ""
+    else
+        echo "Copy and run this command to release:"
+        echo ""
+        echo "  ./scripts/release-wear.sh --confirm-tag $NEW_TAG"
+        echo ""
+    fi
+
+    exit 0
+fi
+
+# === Interactive mode guard ===
+if [ "$MODE" = "interactive" ]; then
+    if [ ! -t 0 ] || [ ! -t 1 ]; then
+        echo -e "${RED}Error: Interactive mode requires a TTY.${RESET}"
+        echo ""
+        echo "Run --check to see the exact command for this state:"
+        echo "  ./scripts/release-wear.sh --check"
+        exit 1
+    fi
+fi
+
+echo -e "${BOLD}=== Wear OS Release ===${RESET}"
+echo ""
+
+# === Gate: Clean working tree (only when tagging HEAD) ===
+if [ -z "$CONFIRM_HASH" ]; then
+    # Reconcile git's stat-cache before the fast dirty check. validate.sh touches
+    # tracked files (Gradle outputs, the validation marker), bumping their mtime
+    # without changing content; the stale cached lstat then makes diff-index report
+    # a false "dirty" even though `git status` is clean. --refresh re-stats every
+    # file and clears mtime-only false positives. It NEVER masks a real change: a
+    # file whose content differs from HEAD stays flagged. (CLAUDE.md § "Stat-cache
+    # stale after validate.sh".)
+    git update-index -q --refresh > /dev/null 2>&1 || true
+    if ! git diff-index --quiet HEAD --; then
+        echo -e "${RED}Error: Working tree has uncommitted changes.${RESET}"
+        echo "Commit or stash changes before releasing."
+        exit 1
+    fi
+
+    UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null)
+    if [ -n "$UNTRACKED" ]; then
+        echo -e "${YELLOW}Warning: Untracked files detected:${RESET}"
+        echo "$UNTRACKED" | head -10
+        UNTRACKED_COUNT=$(echo "$UNTRACKED" | wc -l | tr -d ' ')
+        if [ "$UNTRACKED_COUNT" -gt 10 ]; then
+            echo "  ... and $((UNTRACKED_COUNT - 10)) more"
+        fi
+        echo ""
+        if [ "$MODE" = "interactive" ]; then
+            read -p "Continue with untracked files? (y/N) " -n 1 -r
+            echo
+            if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+                echo "Aborted. Remove or .gitignore untracked files before releasing."
+                exit 1
+            fi
+        else
+            echo -e "${YELLOW}Non-interactive: proceeding with untracked files.${RESET}"
+        fi
+    fi
+fi
+
+# === Gate: Must be on main (when tagging HEAD) — override via --confirm-hash ===
+if [ -z "$CONFIRM_HASH" ] && [ "$CURRENT_BRANCH" != "main" ]; then
+    echo -e "${RED}Error: Not on main branch (on '$CURRENT_BRANCH').${RESET}"
+    echo ""
+    echo "Run --check to see the exact command for this state:"
+    echo "  ./scripts/release-wear.sh --check"
+    exit 1
+fi
+
+if [ -n "$CONFIRM_HASH" ]; then
+    echo -e "${YELLOW}Releasing specific commit: $TARGET_COMMIT_SHORT${RESET}"
+    echo "  Resolved from: $CONFIRM_HASH"
+    echo "  Full SHA:      $TARGET_COMMIT"
+    echo ""
+fi
+
+# === Gate: Rollback confirmation ===
+# If --confirm-rollback-from is provided, validate it matches the latest tag's
+# current commit. If the target looks like a rollback but this flag is not
+# provided, require it (prevents accidental "rollback" by forgetting to
+# re-checkout main).
+if [ -n "$CONFIRM_ROLLBACK_FROM" ]; then
+    if [ "$CONFIRM_ROLLBACK_FROM" != "$LATEST_TAG_SHA" ]; then
+        echo -e "${RED}Error: --confirm-rollback-from does not match the latest tag's commit.${RESET}"
+        echo "  Expected (sha of $LATEST_TAG): $LATEST_TAG_SHA"
+        echo "  Got:                           $CONFIRM_ROLLBACK_FROM"
+        echo ""
+        echo "Run --check to see the correct value."
+        exit 1
+    fi
+    echo -e "${YELLOW}Rollback confirmed: $LATEST_TAG -> $NEW_TAG at $TARGET_COMMIT_SHORT${RESET}"
+    echo ""
+elif [ "$IS_ROLLBACK" = "true" ]; then
+    echo -e "${RED}Error: Target commit is on tag $NEWEST_TAG_ON_TARGET, older than $LATEST_TAG.${RESET}"
+    echo "  This looks like a rollback but --confirm-rollback-from was not provided."
+    echo ""
+    echo "Run --check to see the correct command."
+    exit 1
+fi
+
+# === Gate: Validation ===
+# Two acceptable paths:
+#   A. Validation marker matches target commit (normal)
+#   B. --confirm-unvalidated-release matches target commit (emergency)
+if [ "$VALIDATION_STATE" = "matches" ]; then
+    echo -e "${GREEN}Validation passed for this commit.${RESET}"
+elif [ -n "$CONFIRM_UNVALIDATED_RELEASE" ]; then
+    if [ "$CONFIRM_UNVALIDATED_RELEASE" != "$TARGET_COMMIT" ]; then
+        echo -e "${RED}Error: --confirm-unvalidated-release SHA does not match target commit.${RESET}"
+        echo "  Expected (target commit): $TARGET_COMMIT"
+        echo "  Got:                      $CONFIRM_UNVALIDATED_RELEASE"
+        echo ""
+        echo "Run --check to see the correct value."
+        exit 1
+    fi
+    echo -e "${YELLOW}WARNING: Releasing without validation (--confirm-unvalidated-release).${RESET}"
+    echo "  This is intended for emergencies (hotfixes, rollbacks of old tags)."
+    echo ""
+else
+    if [ "$MODE" = "interactive" ]; then
+        if [ "$VALIDATION_STATE" = "stale" ]; then
+            echo -e "${YELLOW}Warning: validation marker is stale.${RESET}"
+            echo "  Marker SHA:    $VALIDATED_COMMIT"
+            echo "  Target SHA:    $TARGET_COMMIT"
+        else
+            echo -e "${YELLOW}Warning: no validation marker — run ./scripts/validate.sh first.${RESET}"
+        fi
+        read -p "Continue without validation? (y/N) " -n 1 -r
+        echo ""
+        [[ $REPLY =~ ^[Yy]$ ]] || { echo "Aborted. Run ./scripts/validate.sh first, or run --check for options."; exit 1; }
+    else
+        echo -e "${RED}Error: validation has not passed for this commit.${RESET}"
+        echo ""
+        echo "Run --check to see the exact command for this state:"
+        echo "  ./scripts/release-wear.sh --check"
+        exit 1
+    fi
+fi
+
+# === Gate: CHANGELOG entry ===
+# MobileGarage/wearApp/CHANGELOG.md must have a `## X.Y.Z` heading with a
+# non-empty body for the current versionName. Mirrors the phone and
+# Firebase changelog gates: the changelog is the permanent history, every
+# version (patch included).
+#
+# If versionName cannot be parsed (no_ver), this is a hard failure — can't
+# ship a release whose version we can't read.
+if [ "$CHANGELOG_STATE" = "present" ]; then
+    FIRST_LINE=$(echo "$CHANGELOG_BODY" | grep -m1 -E '[^[:space:]]' || echo "")
+    echo -e "${GREEN}Changelog entry found for $VERSION_NAME.${RESET}"
+    if [ -n "$FIRST_LINE" ]; then
+        echo "  First line: $(echo "$FIRST_LINE" | head -c 120)"
+    fi
+elif [ "$CHANGELOG_STATE" = "no_ver" ]; then
+    echo -e "${RED}Error: versionName could not be parsed from MobileGarage/wearApp/version.properties.${RESET}"
+    echo "  Expected a line like: versionName=X.Y.Z"
+    echo "  Fix version.properties before releasing — do not use --confirm-no-changelog for this."
+    exit 1
+elif [ -n "$CONFIRM_NO_CHANGELOG" ]; then
+    if [ "$CONFIRM_NO_CHANGELOG" != "$TARGET_COMMIT" ]; then
+        echo -e "${RED}Error: --confirm-no-changelog SHA does not match target commit.${RESET}"
+        echo "  Expected (target commit): $TARGET_COMMIT"
+        echo "  Got:                      $CONFIRM_NO_CHANGELOG"
+        echo ""
+        echo "Run --check to see the correct value."
+        exit 1
+    fi
+    echo -e "${YELLOW}WARNING: Releasing without CHANGELOG entry (--confirm-no-changelog).${RESET}"
+    echo "  Add an entry to MobileGarage/wearApp/CHANGELOG.md after the fact."
+    echo ""
+else
+    case "$CHANGELOG_STATE" in
+        missing) REASON="no heading for $VERSION_NAME in MobileGarage/wearApp/CHANGELOG.md" ;;
+        empty)   REASON="heading for $VERSION_NAME exists but body is empty" ;;
+        no_file) REASON="MobileGarage/wearApp/CHANGELOG.md does not exist" ;;
+        *)       REASON="unknown" ;;
+    esac
+    echo -e "${RED}Error: CHANGELOG gate failed ($REASON).${RESET}"
+    echo ""
+    echo "Run --check to see how to fix (write the entry, or emergency override)."
+    exit 1
+fi
+
+# Existing tags on this commit (informational).
+if [ -n "$EXISTING_TAGS_ON_TARGET" ]; then
+    NEWEST_TAG_ON_COMMIT=$(echo "$EXISTING_TAGS_ON_TARGET" | tail -1)
+    if [ "$NEWEST_TAG_ON_COMMIT" = "$LATEST_TAG" ]; then
+        echo -e "${YELLOW}Note: This commit already has $LATEST_TAG.${RESET}"
+        echo "  Creating $NEW_TAG on the same commit (version bump, no code change)."
+    else
+        echo -e "${YELLOW}Note: This commit previously released as: $(echo "$EXISTING_TAGS_ON_TARGET" | tr '\n' ' ')${RESET}"
+    fi
+fi
+
+# Release details.
+echo ""
+echo "=== Release Details ==="
+echo "  Target:      $TARGET_SOURCE"
+echo "  Branch:      $CURRENT_BRANCH"
+echo "  Latest tag:  $LATEST_TAG ($LATEST_TAG_SHA)"
+echo "  New tag:     $NEW_TAG"
+echo "  versionCode: $((1000000 + NEXT_VERSION))"
+echo "  Commit:      $TARGET_COMMIT_SHORT ($TARGET_COMMIT)"
+echo ""
+
+# Confirmation.
+if [ "$MODE" = "confirm" ]; then
+    if [ "$CONFIRM_TAG" != "$NEW_TAG" ]; then
+        echo -e "${RED}Error: --confirm-tag does not match computed next tag.${RESET}"
+        echo "  Provided: $CONFIRM_TAG"
+        echo "  Expected: $NEW_TAG"
+        echo ""
+        echo "--confirm-tag is a safety check, not an override."
+        echo "The next tag is always computed as highest existing + 1."
+        exit 1
+    fi
+    echo "--confirm-tag matches, proceeding..."
+elif [ "$MODE" = "interactive" ]; then
+    echo -e "${YELLOW}This will create tag '$NEW_TAG' and push it to origin.${RESET}"
+    read -p "Proceed with release? (y/N) " -n 1 -r
+    echo ""
+    [[ $REPLY =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
+fi
+
+# Dry run.
+if [ "$DRY_RUN" = true ]; then
+    echo -e "${YELLOW}=== Dry Run ===${RESET}"
+    echo "Would create tag $NEW_TAG on commit $TARGET_COMMIT_SHORT"
+    echo "Would push tag to origin"
+    echo "No tags were created or pushed."
+    exit 0
+fi
+
+# Create and push tag.
+echo ""
+echo "Creating tag $NEW_TAG on $TARGET_COMMIT_SHORT..."
+git tag "$NEW_TAG" "$TARGET_COMMIT"
+
+echo "Pushing tag to origin..."
+if git push origin "$NEW_TAG"; then
+    echo ""
+    echo -e "${GREEN}=== Release Initiated ===${RESET}"
+    echo ""
+    echo "Tag $NEW_TAG pushed to origin."
+    echo "Monitor: https://github.com/cartland/SmartGarageDoor/actions"
+    echo ""
+    echo "If WEAR_PLAY_UPLOAD_ENABLED is not set to 'true' in repo Actions"
+    echo "variables, download the AAB artifact from the workflow run (1-day"
+    echo "retention) and upload it manually in Play Console (Wear internal)."
+else
+    echo -e "${RED}Error: Failed to push tag.${RESET}"
+    echo "Removing local tag..."
+    git tag -d "$NEW_TAG"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds the `wear/N` release lane, mirroring `android/N`: `scripts/release-wear.sh` (same `--check` / `--confirm-tag` / rollback UX, validation-marker gate, changelog gate against the new `wearApp/CHANGELOG.md`) plus `release-wear.yml` (tag → mainline verification → signed AAB build).
- Tag `wear/N` maps to `versionCode 1000000 + N` (offset keeps Wear artifact codes disjoint from the phone's `android/N` codes within the shared `com.chriscartland.garage` package). versionName now comes from `wearApp/version.properties`.
- **Bootstrap design:** the workflow *always* uploads the signed AAB as a 1-day CI artifact; the Play-upload step (`tracks: wear:internal`, same pinned uploader action + service account as the phone lane) only runs when the repo Actions variable `WEAR_PLAY_UPLOAD_ENABLED` is `'true'`. First release: download the artifact and upload manually in Play Console (one-time Wear OS form-factor opt-in), verify the track name via the `play-track-snapshot` log, then set the variable — every later `wear/N` release deploys automatically.
- Guardrails hook now blocks direct `wear/N` tag pushes (same as android/ios/server); the play-track-snapshot resolver maps wear versionCodes back to `wear/N` tags so the track-state issue stays readable.
- Runbook: `docs/WEAR_OS.md` § Releasing; conformance note added to `docs/RELEASE_STRATEGY.md` §9.1.

## Test plan
- [x] `./scripts/validate.sh` — full suite passes (includes `:wearApp:assembleDebug` + `:wearApp:testDebugUnitTest`)
- [x] `shellcheck scripts/release-wear.sh` — clean
- [x] `./scripts/release-wear.sh --check` — correctly computes `wear/1` (versionCode 1000001), parses versionName `0.1.0`, finds the changelog entry, flags the stale validation marker
- [x] `:wearApp:assembleDebug -PWEAR_VERSION_CODE=7` — produces `com.chriscartland.garage-wear-0.1.0-1000007-debug.apk` (property + version.properties plumbing verified)
- [x] `node --test '.github/scripts/**/*.test.mjs'` — 9/9 pass; `node --check` on the edited snapshot script
- [ ] `wear:internal` track identifier is the documented Play Developer API form-factor name but unverified against this app's listing — deliberately gated behind `WEAR_PLAY_UPLOAD_ENABLED` until the first manual upload confirms it via the play-track-snapshot log

🤖 Generated with [Claude Code](https://claude.com/claude-code)