### PR TITLE
chore(wear): bump versionName to 0.1.1 for the first automated CI release

### DIFF
--- a/MobileGarage/wearApp/CHANGELOG.md
+++ b/MobileGarage/wearApp/CHANGELOG.md
@@ -14,6 +14,12 @@ The phone app's history lives in [`../CHANGELOG.md`](../CHANGELOG.md).
 Same rule as the phone app: major = rewrite or core-experience shift;
 minor = added or removed user-facing feature; patch = fixes, polish, refactors.
 
+## 0.1.1
+
+- No app changes. First release through the fully automated CI to Play
+  pipeline (wear/N tag to Wear internal track), now including Play release
+  notes from `distribution/wear-whatsnew/`.
+
 ## 0.1.0
 
 - Initial Wear OS release: animated garage door status with tap-to-arm and a

--- a/MobileGarage/wearApp/version.properties
+++ b/MobileGarage/wearApp/version.properties
@@ -1,1 +1,1 @@
-versionName=0.1.0
+versionName=0.1.1


### PR DESCRIPTION
## Summary
- Bumps `wearApp/version.properties` to 0.1.1 with a matching `wearApp/CHANGELOG.md` entry (release-script gate).
- No app changes — `wear/2` (versionCode 1000002) will be the first release through the fully automated lane: CI build → automatic upload to the Play `wear:internal` track with release notes, now that `WEAR_PLAY_UPLOAD_ENABLED=true`.
- Patch bump keeps Play's version history tidy instead of shipping 0.1.0 under a second versionCode.

## Test plan
- [x] Version/changelog only; the release gates (`release-wear.sh --check`) validate both before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)