### PR TITLE
fix(wear): surface sign-in failures instead of a silently dead button (0.1.2)

### DIFF
--- a/MobileGarage/wearApp/CHANGELOG.md
+++ b/MobileGarage/wearApp/CHANGELOG.md
@@ -14,6 +14,15 @@ The phone app's history lives in [`../CHANGELOG.md`](../CHANGELOG.md).
 Same rule as the phone app: major = rewrite or core-experience shift;
 minor = added or removed user-facing feature; patch = fixes, polish, refactors.
 
+## 0.1.2
+
+- Sign-in failures now show a transient "Sign-in failed" message under the
+  button instead of silently doing nothing (the 0.1.1 button appeared
+  unresponsive when Credential Manager failed, e.g. watches whose Play
+  services lack the Identity Sign-In module).
+- Slightly smaller door in the signed-out layout so the sign-in button and
+  failure message fit the round screen.
+
 ## 0.1.1
 
 - No app changes. First release through the fully automated CI to Play

--- a/MobileGarage/wearApp/src/debug/java/com/chriscartland/garage/wear/debug/ScreenshotStagesActivity.kt
+++ b/MobileGarage/wearApp/src/debug/java/com/chriscartland/garage/wear/debug/ScreenshotStagesActivity.kt
@@ -64,6 +64,7 @@ class ScreenshotStagesActivity : ComponentActivity() {
                         ),
                         buttonState = fixture.buttonState,
                         isHolding = false,
+                        signInError = false,
                         onDoorTap = {},
                         onHoldStart = {},
                         onHoldEnd = {},

--- a/MobileGarage/wearApp/src/main/java/com/chriscartland/garage/wear/ui/HeroScreen.kt
+++ b/MobileGarage/wearApp/src/main/java/com/chriscartland/garage/wear/ui/HeroScreen.kt
@@ -85,6 +85,7 @@ fun HeroScreen(
     val doorEvent by viewModel.currentDoorEvent.collectAsStateWithLifecycle()
     val buttonState by viewModel.buttonState.collectAsStateWithLifecycle()
     val isHolding by viewModel.isHolding.collectAsStateWithLifecycle()
+    val signInError by viewModel.signInError.collectAsStateWithLifecycle()
 
     // Foreground-only refresh: poll while the screen is visible, stop when hidden.
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -115,15 +116,15 @@ fun HeroScreen(
         onDoorTap = viewModel::onDoorTap,
         onHoldStart = viewModel::onHoldStart,
         onHoldEnd = viewModel::onHoldEnd,
+        signInError = signInError,
         onSignInClick = {
+            viewModel.onSignInStarted()
             scope.launch {
                 val token = WearGoogleSignIn.requestGoogleIdToken(
                     context = context,
                     serverClientId = signInConfig.googleServerClientId,
                 )
-                if (token != null) {
-                    viewModel.signIn(token)
-                }
+                viewModel.onSignInResult(token)
             }
         },
         modifier = modifier,
@@ -142,6 +143,7 @@ fun HeroScreenContent(
     authState: AuthState,
     buttonState: RemoteButtonState,
     isHolding: Boolean,
+    signInError: Boolean,
     onDoorTap: () -> Unit,
     onHoldStart: () -> Unit,
     onHoldEnd: () -> Unit,
@@ -180,7 +182,17 @@ fun HeroScreenContent(
                 onDoorTap = onDoorTap,
                 onHoldStart = onHoldStart,
                 onHoldEnd = onHoldEnd,
-                modifier = Modifier.fillMaxWidth(DOOR_WIDTH_FRACTION),
+                // The signed-out layout also carries the button + error
+                // caption; a slightly smaller door keeps the whole column
+                // inside the round viewport (0.1.2 fix — the caption used
+                // to overflow into the screen's clipped bottom edge).
+                modifier = Modifier.fillMaxWidth(
+                    if (authState is AuthState.Authenticated) {
+                        DOOR_WIDTH_FRACTION
+                    } else {
+                        DOOR_WIDTH_FRACTION_SIGNED_OUT
+                    },
+                ),
             )
             Text(
                 text = HeroScreenMappers.doorStateLabel(doorPosition),
@@ -214,6 +226,16 @@ fun HeroScreenContent(
                     ) {
                         Text(text = stringResource(R.string.sign_in))
                     }
+                    // Reserved caption slot: empty text keeps the height
+                    // stable so the transient failure message (auto-cleared
+                    // by the ViewModel) never reflows the column.
+                    Text(
+                        text = if (signInError) stringResource(R.string.sign_in_failed) else "",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                        textAlign = TextAlign.Center,
+                        minLines = 1,
+                    )
                 }
             }
         }
@@ -339,6 +361,7 @@ private fun HeroScreenContentArmedPreview() {
             ),
             buttonState = RemoteButtonState.AwaitingConfirmation,
             isHolding = false,
+            signInError = false,
             onDoorTap = {},
             onHoldStart = {},
             onHoldEnd = {},
@@ -357,6 +380,7 @@ private fun HeroScreenContentSignedOutPreview() {
             authState = AuthState.Unauthenticated,
             buttonState = RemoteButtonState.Ready,
             isHolding = false,
+            signInError = false,
             onDoorTap = {},
             onHoldStart = {},
             onHoldEnd = {},
@@ -366,6 +390,7 @@ private fun HeroScreenContentSignedOutPreview() {
 }
 
 private const val DOOR_WIDTH_FRACTION = 0.62f
+private const val DOOR_WIDTH_FRACTION_SIGNED_OUT = 0.54f
 private const val DOOR_INSIDE_RING_FRACTION = 0.78f
 private const val RING_STROKE_DP = 5
 private const val RING_RELEASE_MILLIS = 150

--- a/MobileGarage/wearApp/src/main/java/com/chriscartland/garage/wear/ui/WearHomeViewModel.kt
+++ b/MobileGarage/wearApp/src/main/java/com/chriscartland/garage/wear/ui/WearHomeViewModel.kt
@@ -87,8 +87,14 @@ class WearHomeViewModel(
     /** True while a hold-to-confirm countdown is running (drives the radial indicator). */
     val isHolding: StateFlow<Boolean> = _isHolding
 
+    private val _signInError = MutableStateFlow(false)
+
+    /** True after a failed sign-in attempt; cleared by [onSignInStarted]. */
+    val signInError: StateFlow<Boolean> = _signInError
+
     private var holdJob: Job? = null
     private var refreshJob: Job? = null
+    private var signInErrorJob: Job? = null
 
     /** First tap on the door: arm the button. Gated on auth and `Ready`. */
     fun onDoorTap() {
@@ -146,9 +152,39 @@ class WearHomeViewModel(
         refreshJob = null
     }
 
-    fun signIn(googleIdToken: GoogleIdToken) {
+    /** A sign-in attempt is starting: clear any stale failure message. */
+    fun onSignInStarted() {
+        _signInError.value = false
+    }
+
+    /**
+     * Result of the platform sign-in flow. `null` means Credential Manager
+     * failed or was dismissed (e.g. `NoCredentialException:
+     * Auth.Api.Identity.SignIn.API is not available` on watches whose Play
+     * services lack the Identity module) — surface it instead of silently
+     * doing nothing, which reads as an unresponsive button (0.1.1 bug).
+     * The error is transient ([SIGN_IN_ERROR_DISPLAY_MILLIS]) because the
+     * UI renders it as a bottom-edge overlay on the round screen.
+     */
+    fun onSignInResult(googleIdToken: GoogleIdToken?) {
+        if (googleIdToken == null) {
+            showSignInError()
+            return
+        }
         viewModelScope.launch(dispatchers.io) {
-            signInWithGoogleUseCase(googleIdToken)
+            val result = signInWithGoogleUseCase(googleIdToken)
+            if (result !is AuthState.Authenticated) {
+                showSignInError()
+            }
+        }
+    }
+
+    private fun showSignInError() {
+        _signInError.value = true
+        signInErrorJob?.cancel()
+        signInErrorJob = viewModelScope.launch(dispatchers.default) {
+            delay(SIGN_IN_ERROR_DISPLAY_MILLIS)
+            _signInError.value = false
         }
     }
 
@@ -178,5 +214,8 @@ class WearHomeViewModel(
 
         /** Foreground poll cadence while a press is waiting on the door. */
         const val ACTIVE_POLL_MILLIS: Long = 2_000L
+
+        /** How long the transient sign-in failure message stays visible. */
+        const val SIGN_IN_ERROR_DISPLAY_MILLIS: Long = 5_000L
     }
 }

--- a/MobileGarage/wearApp/src/main/res/values/strings.xml
+++ b/MobileGarage/wearApp/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <!-- Auth. -->
     <string name="sign_in">Sign in</string>
     <string name="sign_in_hint">Sign in to control the door</string>
+    <string name="sign_in_failed">Sign-in failed</string>
     <string name="checking_sign_in">Checking sign-in…</string>
 
     <!-- Content descriptions. -->

--- a/MobileGarage/wearApp/src/test/java/com/chriscartland/garage/wear/ui/WearHomeViewModelTest.kt
+++ b/MobileGarage/wearApp/src/test/java/com/chriscartland/garage/wear/ui/WearHomeViewModelTest.kt
@@ -247,9 +247,53 @@ class WearHomeViewModelTest {
     fun signInDelegatesToUseCase() =
         runTest {
             val viewModel = createViewModel()
-            viewModel.signIn(GoogleIdToken("test-google-token"))
+            authRepository.setSignInResult(
+                AuthState.Authenticated(
+                    User(name = DisplayName("Test User"), email = Email("test@example.com")),
+                ),
+            )
+            viewModel.onSignInResult(GoogleIdToken("test-google-token"))
             advanceUntilIdle()
             assertEquals(1, authRepository.signInCount)
+            assertFalse(viewModel.signInError.value)
+        }
+
+    @Test
+    fun nullSignInResultShowsTransientError() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.onSignInResult(null)
+            runCurrent()
+            assertTrue(viewModel.signInError.value)
+            assertEquals(0, authRepository.signInCount)
+            advanceTimeBy(WearHomeViewModel.SIGN_IN_ERROR_DISPLAY_MILLIS + 1)
+            runCurrent()
+            assertFalse(viewModel.signInError.value)
+        }
+
+    @Test
+    fun failedFirebaseSignInShowsTransientError() =
+        runTest {
+            val viewModel = createViewModel()
+            authRepository.setSignInResult(AuthState.Unauthenticated)
+            viewModel.onSignInResult(GoogleIdToken("test-google-token"))
+            runCurrent()
+            assertEquals(1, authRepository.signInCount)
+            assertTrue(viewModel.signInError.value)
+            advanceTimeBy(WearHomeViewModel.SIGN_IN_ERROR_DISPLAY_MILLIS + 1)
+            runCurrent()
+            assertFalse(viewModel.signInError.value)
+        }
+
+    @Test
+    fun signInStartedClearsError() =
+        runTest {
+            val viewModel = createViewModel()
+            viewModel.onSignInResult(null)
+            runCurrent()
+            assertTrue(viewModel.signInError.value)
+            viewModel.onSignInStarted()
+            assertFalse(viewModel.signInError.value)
         }
 
     companion object {

--- a/MobileGarage/wearApp/version.properties
+++ b/MobileGarage/wearApp/version.properties
@@ -1,1 +1,1 @@
-versionName=0.1.1
+versionName=0.1.2


### PR DESCRIPTION
## Summary
- **Bug** (reported on a real Pixel Watch 4, reproduced on a Wear OS 5 emulator): tapping Sign in did nothing. Root cause: `getCredential` throws instantly (`NoCredentialException: Auth.Api.Identity.SignIn.API is not available on this device`, `API_UNAVAILABLE`) and 0.1.1 swallowed the exception with only a logcat line — an invisible failure that reads as an unresponsive button.
- **Fix**: `WearHomeViewModel` gains a transient `signInError` state (set on null token or failed Firebase sign-in, auto-cleared after 5s, reset on a new attempt). The hero screen shows "Sign-in failed" in a **reserved caption slot** under the button — reserved so the message never reflows the layout — and the signed-out layout uses a slightly smaller door so the full column fits the round viewport (the first two iterations clipped against the circle's bottom chord; final layout verified visually on the reproducing emulator).
- Bumps to 0.1.2 with changelog so `wear/3` can ship immediately after merge.
- Note: this makes the failure *visible*; whether Credential Manager can *succeed* on the Pixel Watch 4 is still under investigation (watch logcat pending; phone-relay fallback is the documented plan B).

## Test plan
- [x] `./scripts/validate.sh` — full suite passes
- [x] 13 wear unit tests including the transient-error lifecycle (shown → auto-cleared → cleared on retry)
- [x] Emulator verification on the image that reproduces the failure: 0.1.1 behavior = silent nothing; this build = "Sign-in failed" caption fully visible inside the round screen, stable layout before/during/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)