### PR TITLE
feat(wear): phone auth relay — watch signs in via the paired phone

### DIFF
--- a/MobileGarage/CHANGELOG.md
+++ b/MobileGarage/CHANGELOG.md
@@ -15,6 +15,14 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
 
+## 2.21.0
+
+- Wear OS companion sign-in: the phone now answers the watch's request for
+  the signed-in account and a Firebase ID token over the Wearable Data
+  Layer, so the watch app can operate the door without watch-local Google
+  sign-in (which Play services rejects on Wear OS). Additive background
+  service; no phone UI or behavior changes.
+
 ## 2.20.4
 - **Statuses appear instantly when the app opens.** The remote-control availability, the notification snooze status, and the Developer-section access now remember their last-known values across app restarts and render immediately on launch, refreshing silently in the background. The prominent "Checking…" indicator is gone: while a status is genuinely unresolved (first run only, in practice) the app shows nothing, and the verdict appears once known.
 - **Fewer network requests and wakeups.** The Settings screen no longer re-fetches the snooze status on every visit or polls every minute. It now refreshes at most every ~5 minutes on entry, when a door event arrives that could have voided a snooze, or when the snooze sheet is opened. A snooze that reaches its end time now flips to "not snoozing" on screen at that moment instead of waiting for the next refresh.

--- a/MobileGarage/androidApp/build.gradle.kts
+++ b/MobileGarage/androidApp/build.gradle.kts
@@ -267,6 +267,8 @@ dependencies {
     implementation(libs.androidx.navigation3.ui)
     implementation(libs.androidx.lifecycle.viewmodel.navigation3)
     implementation(libs.play.services.auth)
+    // Wearable Data Layer — answers the watch's auth-relay RPC.
+    implementation(libs.play.services.wearable)
     // Testing
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/MobileGarage/androidApp/src/main/AndroidManifest.xml
+++ b/MobileGarage/androidApp/src/main/AndroidManifest.xml
@@ -56,6 +56,24 @@
             </intent-filter>
         </service>
 
+        <!-- Wear auth relay: answers the watch's RPC for the phone's
+             signed-in identity + a Firebase ID token (Wearable Data Layer).
+             Play services starts and binds it on demand; the path filter
+             matches WearAuthRelayProtocol.ID_TOKEN_PATH. exported=true is
+             the documented WearableListenerService pattern (only Play
+             services can deliver these intents). -->
+        <service
+            android:name=".wearrelay.WearAuthRelayService"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.android.gms.wearable.REQUEST_RECEIVED" />
+                <data
+                    android:host="*"
+                    android:pathPrefix="/garage/auth"
+                    android:scheme="wear" />
+            </intent-filter>
+        </service>
+
         <!--
           FCM: render OS-shown (background) open-door warnings on the app-owned
           "Garage door" channel + garage icon, instead of FCM's default

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/wearrelay/WearAuthRelayService.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/wearrelay/WearAuthRelayService.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.wearrelay
+
+import co.touchlab.kermit.Logger
+import com.chriscartland.garage.data.wearrelay.WearAuthRelayProtocol
+import com.chriscartland.garage.data.wearrelay.WearAuthRelayResponse
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.TaskCompletionSource
+import com.google.android.gms.tasks.Tasks
+import com.google.android.gms.wearable.WearableListenerService
+import com.google.firebase.Firebase
+import com.google.firebase.auth.auth
+
+/**
+ * Answers the watch's auth-relay RPC (Wearable Data Layer) with the phone's
+ * signed-in identity and a Firebase ID token.
+ *
+ * This is Google's documented secondary auth method for Wear ("token
+ * sharing from the companion app"): watches whose Play services cannot
+ * complete Credential Manager sign-in (observed on Pixel Watch 4 /
+ * Wear OS 7, 2026-07-22) still authenticate as long as the phone app is
+ * signed in and reachable over Bluetooth or Wi-Fi.
+ *
+ * Play services starts this service on demand — it has no UI, holds no
+ * state, and mirrors `FirebaseAuthBridge`'s token access. The payload
+ * shape is pinned by the shared `WearAuthRelayProtocol` codec (`:data`),
+ * used verbatim by the watch client. ID tokens expire after ~1 hour; the
+ * watch re-requests per call, so nothing long-lived crosses the wire.
+ */
+class WearAuthRelayService : WearableListenerService() {
+    override fun onRequest(
+        nodeId: String,
+        path: String,
+        request: ByteArray,
+    ): Task<ByteArray>? {
+        if (path != WearAuthRelayProtocol.ID_TOKEN_PATH) {
+            return null
+        }
+        val relayRequest = WearAuthRelayProtocol.decodeRequest(request)
+        if (relayRequest == null) {
+            Logger.w { "WearAuthRelay: malformed request from $nodeId" }
+            return Tasks.forResult(
+                WearAuthRelayProtocol.encodeResponse(WearAuthRelayResponse(signedIn = false)),
+            )
+        }
+        val user = Firebase.auth.currentUser
+        if (user == null) {
+            Logger.d { "WearAuthRelay: request while signed out" }
+            return Tasks.forResult(
+                WearAuthRelayProtocol.encodeResponse(WearAuthRelayResponse(signedIn = false)),
+            )
+        }
+        val source = TaskCompletionSource<ByteArray>()
+        user
+            .getIdToken(relayRequest.forceRefresh)
+            .addOnSuccessListener { result ->
+                Logger.d { "WearAuthRelay: served ID token (forceRefresh=${relayRequest.forceRefresh})" }
+                source.setResult(
+                    WearAuthRelayProtocol.encodeResponse(
+                        WearAuthRelayResponse(
+                            signedIn = true,
+                            displayName = user.displayName,
+                            email = user.email,
+                            idToken = result.token,
+                            idTokenExp = result.expirationTimestamp,
+                        ),
+                    ),
+                )
+            }.addOnFailureListener { exception ->
+                Logger.w { "WearAuthRelay: token fetch failed: $exception" }
+                // Identity without a token: the watch shows signed-in state
+                // but the push will fail its auth gate until a token succeeds.
+                source.setResult(
+                    WearAuthRelayProtocol.encodeResponse(
+                        WearAuthRelayResponse(
+                            signedIn = true,
+                            displayName = user.displayName,
+                            email = user.email,
+                        ),
+                    ),
+                )
+            }
+        return source.task
+    }
+}

--- a/MobileGarage/androidApp/src/main/res/values/wear.xml
+++ b/MobileGarage/androidApp/src/main/res/values/wear.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2026 Chris Cartland. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+<resources>
+    <!-- Wearable Data Layer capability so the watch can locate the phone
+         node that answers the auth relay RPC. Must match
+         WearAuthRelayProtocol.PHONE_AUTH_CAPABILITY. -->
+    <string-array
+        name="android_wear_capabilities"
+        translatable="false">
+        <item>garage_phone_auth_relay</item>
+    </string-array>
+</resources>

--- a/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/wearrelay/WearAuthRelayProtocol.kt
+++ b/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/wearrelay/WearAuthRelayProtocol.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.data.wearrelay
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+
+/**
+ * Wire protocol for the phone → watch auth relay over the Wearable Data
+ * Layer (`MessageClient.sendRequest` RPC).
+ *
+ * The watch cannot always complete Credential Manager sign-in (e.g. Play
+ * services on some watches lack the Identity Sign-In module), so the phone
+ * app answers requests for the signed-in user's identity and a fresh
+ * Firebase ID token — Google's documented secondary auth method for Wear.
+ *
+ * Both sides (`:androidApp` `WearAuthRelayService`, `:wearApp`
+ * `DataLayerWearAuthRelayClient`) use THIS codec so the payload shape
+ * cannot drift unilaterally. Decoding is lenient (`ignoreUnknownKeys`) for
+ * forward compatibility and returns null on malformed payloads.
+ */
+@Serializable
+data class WearAuthRelayRequest(
+    val forceRefresh: Boolean = false,
+)
+
+@Serializable
+data class WearAuthRelayResponse(
+    /** False when no user is signed in on the phone. */
+    val signedIn: Boolean,
+    val displayName: String? = null,
+    val email: String? = null,
+    /** Null when signed out, or when the phone's token fetch failed. */
+    val idToken: String? = null,
+    /** Token expiry (epoch seconds), when [idToken] is present. */
+    val idTokenExp: Long? = null,
+)
+
+object WearAuthRelayProtocol {
+    /** MessageClient RPC path the phone's WearableListenerService answers. */
+    const val ID_TOKEN_PATH = "/garage/auth/id_token"
+
+    /** Capability the phone app declares so the watch can find its node. */
+    const val PHONE_AUTH_CAPABILITY = "garage_phone_auth_relay"
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun encodeRequest(request: WearAuthRelayRequest): ByteArray =
+        json.encodeToString(WearAuthRelayRequest.serializer(), request).encodeToByteArray()
+
+    fun decodeRequest(bytes: ByteArray): WearAuthRelayRequest? =
+        try {
+            json.decodeFromString(WearAuthRelayRequest.serializer(), bytes.decodeToString())
+        } catch (e: SerializationException) {
+            null
+        } catch (e: IllegalArgumentException) {
+            null
+        }
+
+    fun encodeResponse(response: WearAuthRelayResponse): ByteArray =
+        json.encodeToString(WearAuthRelayResponse.serializer(), response).encodeToByteArray()
+
+    fun decodeResponse(bytes: ByteArray): WearAuthRelayResponse? =
+        try {
+            json.decodeFromString(WearAuthRelayResponse.serializer(), bytes.decodeToString())
+        } catch (e: SerializationException) {
+            null
+        } catch (e: IllegalArgumentException) {
+            null
+        }
+}

--- a/MobileGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/WearAuthRelayProtocolTest.kt
+++ b/MobileGarage/data/src/commonTest/kotlin/com/chriscartland/garage/data/WearAuthRelayProtocolTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.data
+
+import com.chriscartland.garage.data.wearrelay.WearAuthRelayProtocol
+import com.chriscartland.garage.data.wearrelay.WearAuthRelayRequest
+import com.chriscartland.garage.data.wearrelay.WearAuthRelayResponse
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class WearAuthRelayProtocolTest {
+    @Test
+    fun requestRoundTrips() {
+        val request = WearAuthRelayRequest(forceRefresh = true)
+        val decoded = WearAuthRelayProtocol.decodeRequest(WearAuthRelayProtocol.encodeRequest(request))
+        assertEquals(request, decoded)
+    }
+
+    @Test
+    fun signedInResponseRoundTrips() {
+        val response = WearAuthRelayResponse(
+            signedIn = true,
+            displayName = "Test User",
+            email = "test@example.com",
+            idToken = "token-abc",
+            idTokenExp = 1_234_567L,
+        )
+        val decoded = WearAuthRelayProtocol.decodeResponse(WearAuthRelayProtocol.encodeResponse(response))
+        assertEquals(response, decoded)
+    }
+
+    @Test
+    fun signedOutResponseRoundTrips() {
+        val response = WearAuthRelayResponse(signedIn = false)
+        val decoded = WearAuthRelayProtocol.decodeResponse(WearAuthRelayProtocol.encodeResponse(response))
+        assertEquals(response, decoded)
+    }
+
+    @Test
+    fun decodeToleratesUnknownKeys() {
+        val decoded = WearAuthRelayProtocol.decodeResponse(
+            """{"signedIn":true,"email":"a@b.c","futureField":42}""".encodeToByteArray(),
+        )
+        assertEquals(
+            WearAuthRelayResponse(signedIn = true, email = "a@b.c"),
+            decoded,
+        )
+    }
+
+    @Test
+    fun decodeReturnsNullOnMalformedPayload() {
+        assertNull(WearAuthRelayProtocol.decodeResponse("not json".encodeToByteArray()))
+        assertNull(WearAuthRelayProtocol.decodeRequest(byteArrayOf(0x00, 0x01)))
+        assertNull(WearAuthRelayProtocol.decodeResponse("""{"noSignedInKey":1}""".encodeToByteArray()))
+    }
+}

--- a/MobileGarage/distribution/wear-whatsnew/whatsnew-en-US
+++ b/MobileGarage/distribution/wear-whatsnew/whatsnew-en-US
@@ -1,1 +1,1 @@
-First Wear OS release. See your garage door status at a glance with a live animated door, and control it from your wrist: tap the door to arm, then press and hold for two seconds to operate the door. The deliberate hold prevents accidental presses.
+Sign in now works through your phone: keep the phone app signed in and nearby, and the watch signs in automatically. Tap the door to arm, then press and hold for two seconds to operate the door.

--- a/MobileGarage/distribution/whatsnew/whatsnew-en-US
+++ b/MobileGarage/distribution/whatsnew/whatsnew-en-US
@@ -1,3 +1,3 @@
-Garage door notifications are now cleaner. When the door is left open too long, that alert updates in place to a single "Resolved: open for X minutes" notification once the door closes, instead of leaving a second card behind.
+Wear OS companion support: the phone now shares its sign-in with the Garage watch app, so your watch can check the door and operate it without a separate sign-in.
 
-You can also load older door history by scrolling to the bottom of the list.
+Garage door notifications remain cleaner: the "left open" alert updates in place to a single "Resolved" notification once the door closes.

--- a/MobileGarage/gradle/libs.versions.toml
+++ b/MobileGarage/gradle/libs.versions.toml
@@ -56,6 +56,7 @@ ksp = "2.1.20-1.0.32"
 lifecycle = "2.9.1"
 mockito = "5.23.0"
 playServicesAuth = "21.6.0"
+playServicesWearable = "20.0.1"
 room = "2.7.2"
 # sqlite is PINNED at 2.5.0 (same as kermit/datastore above: 2.7.0's iOS KLIBs
 # are built with Kotlin 2.3.20, rejected by Kotlin 2.1.20). Unpin with the
@@ -135,6 +136,8 @@ kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }
 mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
 play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version.ref = "playServicesAuth" }
+play-services-wearable = { group = "com.google.android.gms", name = "play-services-wearable", version.ref = "playServicesWearable" }
+kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "coroutines" }
 screenshot-validation-api = { group = "com.android.tools.screenshot", name = "screenshot-validation-api", version.ref = "screenshot" }
 androidx-credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }
 androidx-credentials-play-services-auth = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "credentials"}

--- a/MobileGarage/version.properties
+++ b/MobileGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.20.4
+versionName=2.21.0

--- a/MobileGarage/wearApp/CHANGELOG.md
+++ b/MobileGarage/wearApp/CHANGELOG.md
@@ -14,6 +14,16 @@ The phone app's history lives in [`../CHANGELOG.md`](../CHANGELOG.md).
 Same rule as the phone app: major = rewrite or core-experience shift;
 minor = added or removed user-facing feature; patch = fixes, polish, refactors.
 
+## 0.1.3
+
+- Sign in with your phone: while the watch is signed out, the app now uses
+  the paired phone's signed-in account over Bluetooth or Wi-Fi (requires
+  phone app 2.21.0). Play services rejects watch-local Google sign-in on
+  Wear OS ("Google Identity Services do not support this Android
+  Credential Manager API on Wear OS", captured on a Pixel Watch 4), so the
+  phone relay is the working path; the Sign in button remains for watches
+  where it works.
+
 ## 0.1.2
 
 - Sign-in failures now show a transient "Sign-in failed" message under the

--- a/MobileGarage/wearApp/build.gradle.kts
+++ b/MobileGarage/wearApp/build.gradle.kts
@@ -182,6 +182,10 @@ dependencies {
     implementation(libs.androidx.credentials)
     implementation(libs.androidx.credentials.play.services.auth)
     implementation(libs.googleId)
+    // Phone auth relay over the Wearable Data Layer (secondary auth —
+    // Credential Manager sign-in fails on some watches).
+    implementation(libs.play.services.wearable)
+    implementation(libs.kotlinx.coroutines.play.services)
     // Testing
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/MobileGarage/wearApp/src/main/java/com/chriscartland/garage/wear/GarageWearApplication.kt
+++ b/MobileGarage/wearApp/src/main/java/com/chriscartland/garage/wear/GarageWearApplication.kt
@@ -18,7 +18,9 @@
 package com.chriscartland.garage.wear
 
 import android.app.Application
+import com.chriscartland.garage.wear.auth.DataLayerWearAuthRelayClient
 import com.chriscartland.garage.wear.auth.FirebaseAuthBridge
+import com.chriscartland.garage.wear.auth.RelayFallbackAuthBridge
 import com.chriscartland.garage.wear.config.WearAppConfigFactory
 import com.chriscartland.garage.wear.di.WearComponent
 import com.chriscartland.garage.wear.di.WearSignInConfig
@@ -31,7 +33,13 @@ import com.chriscartland.garage.wear.di.create
 class GarageWearApplication : Application() {
     val component: WearComponent by lazy {
         WearComponent::class.create(
-            authBridge = FirebaseAuthBridge(),
+            // Local Firebase auth wins when present; otherwise the phone
+            // relay supplies identity + tokens (Credential Manager sign-in
+            // fails on some watches — see docs/WEAR_OS.md).
+            authBridge = RelayFallbackAuthBridge(
+                local = FirebaseAuthBridge(),
+                relay = DataLayerWearAuthRelayClient(this),
+            ),
             appConfig = WearAppConfigFactory.create(),
             signInConfig = WearSignInConfig(
                 googleServerClientId = BuildConfig.GOOGLE_WEB_CLIENT_ID,

--- a/MobileGarage/wearApp/src/main/java/com/chriscartland/garage/wear/auth/RelayFallbackAuthBridge.kt
+++ b/MobileGarage/wearApp/src/main/java/com/chriscartland/garage/wear/auth/RelayFallbackAuthBridge.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.wear.auth
+
+import com.chriscartland.garage.data.AuthBridge
+import com.chriscartland.garage.data.AuthUserInfo
+import com.chriscartland.garage.domain.model.FirebaseIdToken
+import com.chriscartland.garage.domain.model.GoogleIdToken
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+
+/**
+ * [AuthBridge] that prefers watch-local Firebase auth and falls back to the
+ * phone auth relay.
+ *
+ * - When the watch itself is signed in (Credential Manager succeeded),
+ *   [local] is authoritative and the relay is never consulted.
+ * - While the watch is signed out, the relay is polled: if the paired
+ *   phone's app is signed in and reachable, its identity flows through and
+ *   `getIdToken` fetches fresh tokens from the phone per call.
+ *
+ * This is Google's documented secondary auth for Wear — required in
+ * practice because Credential Manager sign-in fails on some watches
+ * (Pixel Watch 4 / Wear OS 7, observed 2026-07-22). The shared
+ * `FirebaseAuthRepository` consumes this bridge unchanged.
+ *
+ * Polling only runs while the flow is collected AND the local user is
+ * absent; each poll is one lightweight Data Layer RPC. Gating the poll on
+ * screen visibility is a noted follow-up (docs/WEAR_OS.md).
+ */
+class RelayFallbackAuthBridge(
+    private val local: AuthBridge,
+    private val relay: WearAuthRelayClient,
+    private val relayPollMillis: Long = DEFAULT_RELAY_POLL_MILLIS,
+) : AuthBridge {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun observeAuthUser(): Flow<AuthUserInfo?> =
+        local.observeAuthUser().flatMapLatest { localUser ->
+            if (localUser != null) {
+                flowOf(localUser)
+            } else {
+                relayUserFlow()
+            }
+        }
+
+    private fun relayUserFlow(): Flow<AuthUserInfo?> =
+        flow {
+            emit(null)
+            while (true) {
+                val response = relay.requestAuth(forceRefresh = false)
+                if (response?.signedIn == true) {
+                    emit(
+                        AuthUserInfo(
+                            displayName = response.displayName ?: "",
+                            email = response.email ?: "",
+                        ),
+                    )
+                } else {
+                    emit(null)
+                }
+                delay(relayPollMillis)
+            }
+        }
+
+    override suspend fun signInWithGoogleToken(idToken: GoogleIdToken): Boolean = local.signInWithGoogleToken(idToken)
+
+    override fun getCurrentUser(): AuthUserInfo? = local.getCurrentUser()
+
+    override suspend fun getIdToken(forceRefresh: Boolean): FirebaseIdToken? {
+        val localToken = local.getIdToken(forceRefresh)
+        if (localToken != null) {
+            return localToken
+        }
+        val response = relay.requestAuth(forceRefresh = forceRefresh) ?: return null
+        val relayToken = response.idToken ?: return null
+        return FirebaseIdToken(idToken = relayToken, exp = response.idTokenExp ?: 0L)
+    }
+
+    override suspend fun signOut() {
+        local.signOut()
+    }
+
+    companion object {
+        /** Relay poll cadence while signed out and the bridge flow is collected. */
+        const val DEFAULT_RELAY_POLL_MILLIS: Long = 15_000L
+    }
+}

--- a/MobileGarage/wearApp/src/main/java/com/chriscartland/garage/wear/auth/WearAuthRelayClient.kt
+++ b/MobileGarage/wearApp/src/main/java/com/chriscartland/garage/wear/auth/WearAuthRelayClient.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.wear.auth
+
+import android.content.Context
+import co.touchlab.kermit.Logger
+import com.chriscartland.garage.data.wearrelay.WearAuthRelayProtocol
+import com.chriscartland.garage.data.wearrelay.WearAuthRelayRequest
+import com.chriscartland.garage.data.wearrelay.WearAuthRelayResponse
+import com.google.android.gms.wearable.CapabilityClient
+import com.google.android.gms.wearable.Wearable
+import kotlinx.coroutines.tasks.await
+
+/**
+ * Watch-side client for the phone auth relay. Interface + default impl so
+ * the composing bridge is unit-testable without Play services.
+ */
+interface WearAuthRelayClient {
+    /**
+     * Ask the paired phone for the signed-in user's identity and a Firebase
+     * ID token. Null when no phone is reachable, the phone app is missing,
+     * or the RPC fails.
+     */
+    suspend fun requestAuth(forceRefresh: Boolean): WearAuthRelayResponse?
+}
+
+/** [WearAuthRelayClient] over the Wearable Data Layer (MessageClient RPC). */
+class DataLayerWearAuthRelayClient(
+    private val context: Context,
+) : WearAuthRelayClient {
+    override suspend fun requestAuth(forceRefresh: Boolean): WearAuthRelayResponse? =
+        try {
+            val capability = Wearable
+                .getCapabilityClient(context)
+                .getCapability(
+                    WearAuthRelayProtocol.PHONE_AUTH_CAPABILITY,
+                    CapabilityClient.FILTER_REACHABLE,
+                ).await()
+            val node = capability.nodes.firstOrNull { it.isNearby } ?: capability.nodes.firstOrNull()
+            if (node == null) {
+                Logger.d { "WearAuthRelay: no reachable phone node" }
+                null
+            } else {
+                val responseBytes = Wearable
+                    .getMessageClient(context)
+                    .sendRequest(
+                        node.id,
+                        WearAuthRelayProtocol.ID_TOKEN_PATH,
+                        WearAuthRelayProtocol.encodeRequest(WearAuthRelayRequest(forceRefresh = forceRefresh)),
+                    ).await()
+                WearAuthRelayProtocol.decodeResponse(responseBytes).also { response ->
+                    Logger.d { "WearAuthRelay: response signedIn=${response?.signedIn} hasToken=${response?.idToken != null}" }
+                }
+            }
+        } catch (e: Exception) {
+            Logger.w { "WearAuthRelay: request failed: $e" }
+            null
+        }
+}

--- a/MobileGarage/wearApp/src/test/java/com/chriscartland/garage/wear/auth/RelayFallbackAuthBridgeTest.kt
+++ b/MobileGarage/wearApp/src/test/java/com/chriscartland/garage/wear/auth/RelayFallbackAuthBridgeTest.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.wear.auth
+
+import com.chriscartland.garage.data.AuthUserInfo
+import com.chriscartland.garage.data.wearrelay.WearAuthRelayResponse
+import com.chriscartland.garage.domain.model.FirebaseIdToken
+import com.chriscartland.garage.testcommon.FakeAuthBridge
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Unit tests for the local-first / relay-fallback auth composition.
+ *
+ * Motivating platform fact (captured from a Pixel Watch 4, 2026-07-22):
+ * GMS rejects Credential Manager Sign in with Google on Wear OS
+ * ("Google Identity Services do not support this Android Credential
+ * Manager API on Wear OS"), so the phone relay is the working path.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class RelayFallbackAuthBridgeTest {
+    private class FakeRelayClient : WearAuthRelayClient {
+        var response: WearAuthRelayResponse? = null
+        var requestCount = 0
+            private set
+        var lastForceRefresh: Boolean? = null
+            private set
+
+        override suspend fun requestAuth(forceRefresh: Boolean): WearAuthRelayResponse? {
+            requestCount++
+            lastForceRefresh = forceRefresh
+            return response
+        }
+    }
+
+    private val localBridge = FakeAuthBridge()
+    private val relayClient = FakeRelayClient()
+    private val bridge = RelayFallbackAuthBridge(
+        local = localBridge,
+        relay = relayClient,
+        relayPollMillis = 1_000L,
+    )
+
+    @Test
+    fun localUserWinsAndRelayIsNotConsulted() =
+        runTest {
+            localBridge.setAuthUser(AuthUserInfo(displayName = "Local", email = "local@example.com"))
+            val latest = MutableStateFlow<AuthUserInfo?>(null)
+            backgroundScope.launch { bridge.observeAuthUser().collect { latest.value = it } }
+            runCurrent()
+            assertEquals("local@example.com", latest.value?.email)
+            advanceTimeBy(5_000L)
+            assertEquals(0, relayClient.requestCount)
+            coroutineContext.cancelChildren()
+        }
+
+    @Test
+    fun relayIdentityFlowsThroughWhileSignedOutLocally() =
+        runTest {
+            relayClient.response = WearAuthRelayResponse(
+                signedIn = true,
+                displayName = "Phone User",
+                email = "phone@example.com",
+            )
+            val latest = MutableStateFlow<AuthUserInfo?>(null)
+            backgroundScope.launch { bridge.observeAuthUser().collect { latest.value = it } }
+            runCurrent()
+            assertEquals("phone@example.com", latest.value?.email)
+            assertEquals(1, relayClient.requestCount)
+            coroutineContext.cancelChildren()
+        }
+
+    @Test
+    fun relaySignedOutPhoneYieldsNullAndKeepsPolling() =
+        runTest {
+            relayClient.response = WearAuthRelayResponse(signedIn = false)
+            val latest = MutableStateFlow<AuthUserInfo?>(AuthUserInfo("seed", "seed@example.com"))
+            backgroundScope.launch { bridge.observeAuthUser().collect { latest.value = it } }
+            runCurrent()
+            assertNull(latest.value)
+            advanceTimeBy(3_001L)
+            assertEquals(4, relayClient.requestCount)
+            coroutineContext.cancelChildren()
+        }
+
+    @Test
+    fun idTokenPrefersLocalThenRelay() =
+        runTest {
+            localBridge.setIdTokenResult(FirebaseIdToken(idToken = "local-token", exp = 1L))
+            relayClient.response = WearAuthRelayResponse(
+                signedIn = true,
+                idToken = "relay-token",
+                idTokenExp = 2L,
+            )
+            assertEquals("local-token", bridge.getIdToken(forceRefresh = true)?.asString())
+            assertEquals(0, relayClient.requestCount)
+
+            localBridge.setIdTokenResult(null)
+            val relayToken = bridge.getIdToken(forceRefresh = true)
+            assertEquals("relay-token", relayToken?.asString())
+            assertEquals(2L, relayToken?.exp)
+            assertEquals(true, relayClient.lastForceRefresh)
+        }
+
+    @Test
+    fun idTokenNullWhenNeitherSourceHasOne() =
+        runTest {
+            localBridge.setIdTokenResult(null)
+            relayClient.response = WearAuthRelayResponse(signedIn = true, idToken = null)
+            assertNull(bridge.getIdToken(forceRefresh = false))
+            relayClient.response = null
+            assertNull(bridge.getIdToken(forceRefresh = false))
+        }
+}

--- a/MobileGarage/wearApp/version.properties
+++ b/MobileGarage/wearApp/version.properties
@@ -1,1 +1,1 @@
-versionName=0.1.2
+versionName=0.1.3

--- a/docs/WEAR_OS.md
+++ b/docs/WEAR_OS.md
@@ -57,13 +57,21 @@ early release never submits, signed-out is inert).
   while visible, tightening to 2s while a press is waiting on the door so
   the machine's door-moved success detection fires promptly. No FCM, no
   background work, zero battery cost while the app is closed.
-- **Auth**: Firebase Auth directly on the watch. Sign-in uses Credential
-  Manager's Sign in with Google (`GetSignInWithGoogleOption`), the
-  recommended Wear OS 5.1+ flow, feeding the same
-  `SignInWithGoogleUseCase → FirebaseAuthRepository` chain as the phone.
-  On watches without Credential Manager support the sign-in chip simply
-  fails gracefully (token relay from the phone over the Data Layer is the
-  documented fallback, not yet built).
+- **Auth**: local-first with a phone relay fallback, composed in
+  `RelayFallbackAuthBridge` (consumed unchanged by the shared
+  `FirebaseAuthRepository`). Watch-local Credential Manager Sign in with
+  Google is attempted via the Sign in button — but **GMS hard-rejects it on
+  Wear OS** ("Google Identity Services do not support this Android
+  Credential Manager API on Wear OS", captured via logcat on a Pixel
+  Watch 4 / Wear OS 7 / GMS 26.28, 2026-07-22), so in practice auth comes
+  from the **phone relay**: while signed out, the watch polls the paired
+  phone over the Wearable Data Layer (`MessageClient.sendRequest` RPC,
+  wire shape pinned by `:data`'s `WearAuthRelayProtocol` codec + tests);
+  the phone's `WearAuthRelayService` (`:androidApp`, 2.21.0+) answers with
+  the signed-in identity and a fresh Firebase ID token per call. Requires
+  the phone reachable over Bluetooth/Wi-Fi for pushes — door *status*
+  needs no auth. Poll cadence: 15s, only while signed out and the app
+  process is alive.
 
 ## Build / CI integration
 


### PR DESCRIPTION
## Summary
- **Root cause, captured from the real device**: GMS on the Pixel Watch 4 (Wear OS 7, GMS 26.28) rejects Credential Manager Sign in with Google outright — logcat: `Google Identity Services do not support this Android Credential Manager API on Wear OS`. Watch-local sign-in is a dead end on this hardware; this PR implements Google's documented secondary auth for Wear: **token sharing from the companion app** over the Wearable Data Layer.
- **`:data` (commonMain)**: `WearAuthRelayProtocol` — one RPC path, capability name, lenient JSON codec used verbatim by both apps so the wire shape can't drift (5 tests: round-trips, unknown-key tolerance, malformed → null).
- **`:androidApp` (2.21.0)**: `WearAuthRelayService`, a `WearableListenerService` answering the RPC with the phone's signed-in identity + a fresh Firebase ID token (mirrors `FirebaseAuthBridge` token access; started on demand by Play services; additive — no phone UI/behavior changes). `wear.xml` declares the `garage_phone_auth_relay` capability.
- **`:wearApp` (0.1.3)**: `DataLayerWearAuthRelayClient` (interface + Data Layer impl) and `RelayFallbackAuthBridge` — watch-local Firebase auth is authoritative when present; while signed out, the relay polls every 15s for identity and fetches tokens per call. The shared `FirebaseAuthRepository`, use cases, and the remote button's auth gate are untouched. The Sign in button remains for watches where Credential Manager works.
- Changelogs + Play whatsnew for both apps; `docs/WEAR_OS.md` auth section rewritten around the captured GMS rejection.

## Test plan
- [x] `./scripts/validate.sh` — full suite passes (all androidApp lints/tests/builds + wearApp build/tests + :data tests)
- [x] New tests: `WearAuthRelayProtocolTest` (5), `RelayFallbackAuthBridgeTest` (5 — local-wins/relay-never-consulted, relay identity flows through, signed-out keeps polling, token local-then-relay preference, null when neither)
- [x] Real-watch evidence gathered over Wi-Fi adb (paired Pixel Watch 4): 0.1.2 renders correctly; sign-in tap reproduces the GMS rejection verbatim
- [ ] End-to-end relay (phone 2.21.0 + watch 0.1.3 both from internal track): will verify on the paired watch after both releases — expected: watch flips to signed-in automatically within ~15s of app open with the phone nearby

🤖 Generated with [Claude Code](https://claude.com/claude-code)