### PR TITLE
feat(wear): armed button stays armed while touched, disarm after quiet period

### DIFF
--- a/MobileGarage/distribution/wear-whatsnew/whatsnew-en-US
+++ b/MobileGarage/distribution/wear-whatsnew/whatsnew-en-US
@@ -1,1 +1,1 @@
-Sign in now works through your phone: keep the phone app signed in and nearby, and the watch signs in automatically. Tap the door to arm, then press and hold for two seconds to operate the door.
+The armed button now stays armed while you keep touching the screen and only disarms after a few quiet seconds. Operating the door still requires the full two-second press and hold.

--- a/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ButtonStateMachine.kt
+++ b/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ButtonStateMachine.kt
@@ -58,7 +58,8 @@ import kotlinx.coroutines.launch
  *     --(displayMillis)--> Ready
  *
  * Failure paths:
- *   AwaitingConfirmation --(confirmationTimeoutMillis)--> Cancelled
+ *   AwaitingConfirmation --(confirmationTimeoutMillis since the last
+ *     [onUserInteraction], if any)--> Cancelled
  *     --(cancelledDisplayMillis)--> Ready
  *   SendingToServer --(networkTimeoutMillis)--> ServerFailed
  *     --(displayMillis)--> Ready
@@ -105,6 +106,19 @@ class ButtonStateMachine(
     /** Force back to [RemoteButtonState.Ready]. Cancels any pending timers. */
     fun reset() {
         events.trySend(Event.Reset)
+    }
+
+    /**
+     * User touched the controlling surface. While in
+     * [RemoteButtonState.AwaitingConfirmation] this restarts the confirmation
+     * timeout, so the armed window counts from the LAST touch rather than the
+     * arming tap — an engaged user (partial taps, aborted holds) stays armed
+     * and the window expires only after a quiet period with no touches.
+     * Ignored in every other state; in particular it must never disturb the
+     * Preparing or network timers (the machine has a single timer slot).
+     */
+    fun onUserInteraction() {
+        events.trySend(Event.UserInteraction)
     }
 
     /**
@@ -160,6 +174,11 @@ class ButtonStateMachine(
             Event.PreparingComplete -> if (current == RemoteButtonState.Preparing) {
                 transitionTo(RemoteButtonState.AwaitingConfirmation)
                 scheduleTimer(confirmationTimeoutMillis, Event.ConfirmationTimedOut)
+            }
+            Event.UserInteraction -> {
+                if (current == RemoteButtonState.AwaitingConfirmation) {
+                    scheduleTimer(confirmationTimeoutMillis, Event.ConfirmationTimedOut)
+                }
             }
             Event.ConfirmationTimedOut -> {
                 if (current == RemoteButtonState.AwaitingConfirmation) {
@@ -256,6 +275,9 @@ class ButtonStateMachine(
 
         /** ViewModel: network request failed (server error, connection failure). */
         data object NetworkFailed : Event
+
+        /** UI: user touched the controlling surface (extends the armed window). */
+        data object UserInteraction : Event
 
         /** External flow: door position changed. */
         data object DoorMoved : Event

--- a/MobileGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ButtonStateMachineTest.kt
+++ b/MobileGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ButtonStateMachineTest.kt
@@ -267,6 +267,82 @@ class ButtonStateMachineTest {
             assertEquals(RemoteButtonState.Ready, sm.state.value)
         }
 
+    // --- Armed-window extension (onUserInteraction) ---
+
+    @Test
+    fun userInteractionWhileArmedRestartsConfirmationTimeout() =
+        runTest {
+            val sm = create()
+            sm.onTap()
+            testScheduler.runCurrent()
+            advanceTimeBy(PREPARING_DELAY + 1)
+            testScheduler.runCurrent()
+            assertEquals(RemoteButtonState.AwaitingConfirmation, sm.state.value)
+
+            // Late in the window, a touch restarts it.
+            advanceTimeBy(CONFIRMATION_TIMEOUT - 1_000)
+            sm.onUserInteraction()
+            testScheduler.runCurrent()
+
+            // Still armed well past the ORIGINAL expiry — the restart worked.
+            advanceTimeBy(CONFIRMATION_TIMEOUT - 1_000)
+            testScheduler.runCurrent()
+            assertEquals(RemoteButtonState.AwaitingConfirmation, sm.state.value)
+
+            // A quiet period with no touches still disarms: 1s remained on
+            // the restarted window, so +1.5s lands inside Cancelled's display.
+            advanceTimeBy(1_500)
+            testScheduler.runCurrent()
+            assertEquals(RemoteButtonState.Cancelled, sm.state.value)
+
+            advanceTimeBy(CANCELLED_DISPLAY + 1)
+            testScheduler.runCurrent()
+            assertEquals(RemoteButtonState.Ready, sm.state.value)
+        }
+
+    @Test
+    fun userInteractionDuringPreparingDoesNotDisturbArming() =
+        runTest {
+            val sm = create()
+            sm.onTap()
+            testScheduler.runCurrent()
+            assertEquals(RemoteButtonState.Preparing, sm.state.value)
+
+            // The machine has ONE timer slot; a naive reschedule here would
+            // cancel the Preparing timer and strand the machine. Must no-op.
+            sm.onUserInteraction()
+            testScheduler.runCurrent()
+            advanceTimeBy(PREPARING_DELAY + 1)
+            testScheduler.runCurrent()
+            assertEquals(RemoteButtonState.AwaitingConfirmation, sm.state.value)
+        }
+
+    @Test
+    fun userInteractionInReadyIsIgnored() =
+        runTest {
+            val sm = create()
+            sm.onUserInteraction()
+            testScheduler.runCurrent()
+            assertEquals(RemoteButtonState.Ready, sm.state.value)
+        }
+
+    @Test
+    fun userInteractionDuringSendingDoesNotDisturbNetworkTimeout() =
+        runTest {
+            val sm = prepareAndConfirm()
+            sm.onNetworkStarted()
+            testScheduler.runCurrent()
+
+            sm.onUserInteraction()
+            testScheduler.runCurrent()
+            assertEquals(RemoteButtonState.SendingToServer, sm.state.value)
+
+            // The network timeout must still fire on schedule.
+            advanceTimeBy(NETWORK_TIMEOUT + 1)
+            testScheduler.runCurrent()
+            assertEquals(RemoteButtonState.ServerFailed, sm.state.value)
+        }
+
     // --- Full happy path ---
 
     @Test

--- a/MobileGarage/wearApp/CHANGELOG.md
+++ b/MobileGarage/wearApp/CHANGELOG.md
@@ -14,6 +14,16 @@ The phone app's history lives in [`../CHANGELOG.md`](../CHANGELOG.md).
 Same rule as the phone app: major = rewrite or core-experience shift;
 minor = added or removed user-facing feature; patch = fixes, polish, refactors.
 
+## 0.1.4
+
+- Armed button stays armed while you keep touching the screen: every touch
+  (down and up, anywhere on the screen) restarts the disarm timer, so
+  partial taps and aborted holds no longer let the button quietly disarm.
+  It now disarms only after ~8 seconds with no touches. Also fixes a
+  mid-hold disarm edge where a hold started late in the armed window could
+  visually complete but never fire. Operating the door still requires the
+  full continuous 2-second hold, and a quick tap still never triggers it.
+
 ## 0.1.3
 
 - Sign in with your phone: while the watch is signed out, the app now uses

--- a/MobileGarage/wearApp/src/debug/java/com/chriscartland/garage/wear/debug/ScreenshotStagesActivity.kt
+++ b/MobileGarage/wearApp/src/debug/java/com/chriscartland/garage/wear/debug/ScreenshotStagesActivity.kt
@@ -68,6 +68,7 @@ class ScreenshotStagesActivity : ComponentActivity() {
                         onDoorTap = {},
                         onHoldStart = {},
                         onHoldEnd = {},
+                        onAnyTouch = {},
                         onSignInClick = {},
                     )
                 }

--- a/MobileGarage/wearApp/src/main/java/com/chriscartland/garage/wear/ui/HeroScreen.kt
+++ b/MobileGarage/wearApp/src/main/java/com/chriscartland/garage/wear/ui/HeroScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -34,12 +36,14 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -116,6 +120,7 @@ fun HeroScreen(
         onDoorTap = viewModel::onDoorTap,
         onHoldStart = viewModel::onHoldStart,
         onHoldEnd = viewModel::onHoldEnd,
+        onAnyTouch = viewModel::onScreenTouch,
         signInError = signInError,
         onSignInClick = {
             viewModel.onSignInStarted()
@@ -134,7 +139,10 @@ fun HeroScreen(
 /**
  * Stateless hero layout (previewable): the animated door with the radial
  * hold-to-confirm indicator, the door state label, and the button hint or
- * sign-in chip.
+ * sign-in chip. [onAnyTouch] fires for every pointer down AND up anywhere
+ * on the screen (observed on the Initial pass, never consumed) — the
+ * ViewModel uses it to keep the armed window alive while the user keeps
+ * interacting.
  */
 @Composable
 fun HeroScreenContent(
@@ -147,6 +155,7 @@ fun HeroScreenContent(
     onDoorTap: () -> Unit,
     onHoldStart: () -> Unit,
     onHoldEnd: () -> Unit,
+    onAnyTouch: () -> Unit,
     onSignInClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -167,9 +176,29 @@ fun HeroScreenContent(
         label = "holdProgress",
     )
 
+    val currentOnAnyTouch by rememberUpdatedState(onAnyTouch)
     ScreenScaffold(modifier = modifier) {
         Column(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) {
+                    // Observe (never consume) every gesture's down and up on
+                    // the Initial pass, so touches anywhere on the screen —
+                    // including ones handled by the door's own tap detector —
+                    // reach the ViewModel and restart the armed window.
+                    awaitEachGesture {
+                        awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+                        currentOnAnyTouch()
+                        var anyPressed = true
+                        while (anyPressed) {
+                            val event = awaitPointerEvent(PointerEventPass.Initial)
+                            anyPressed = event.changes.any { it.pressed }
+                        }
+                        // Release counts too: the quiet period runs from the
+                        // LAST touch, so it starts at finger-up.
+                        currentOnAnyTouch()
+                    }
+                },
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {
@@ -365,6 +394,7 @@ private fun HeroScreenContentArmedPreview() {
             onDoorTap = {},
             onHoldStart = {},
             onHoldEnd = {},
+            onAnyTouch = {},
             onSignInClick = {},
         )
     }
@@ -384,6 +414,7 @@ private fun HeroScreenContentSignedOutPreview() {
             onDoorTap = {},
             onHoldStart = {},
             onHoldEnd = {},
+            onAnyTouch = {},
             onSignInClick = {},
         )
     }

--- a/MobileGarage/wearApp/src/main/java/com/chriscartland/garage/wear/ui/WearHomeViewModel.kt
+++ b/MobileGarage/wearApp/src/main/java/com/chriscartland/garage/wear/ui/WearHomeViewModel.kt
@@ -50,11 +50,20 @@ import kotlinx.coroutines.launch
  *     ([HOLD_TO_CONFIRM_MILLIS]). If the finger stays down the whole time,
  *     the machine's second tap fires and the press is submitted.
  *  3. [onHoldEnd] (finger lifted early) cancels the countdown; the machine
- *     stays in `AwaitingConfirmation` until its own timeout cancels it.
+ *     stays armed. Every touch on the screen — [onScreenTouch] from the
+ *     UI's screen-wide observer, plus the hold callbacks themselves —
+ *     restarts the machine's confirmation timeout, so the armed window
+ *     counts from the LAST touch and expires only after a quiet period
+ *     with no touches. Because finger-down restarts the window, a hold
+ *     started at the last instant can always run its full 2 seconds; the
+ *     machine can never disarm mid-hold.
  *
- * A quick tap while armed does nothing — only a completed hold confirms.
- * This is deliberately stricter than the phone's second-tap confirm; a
- * watch face is far easier to touch accidentally.
+ * A quick tap while armed never submits — it only keeps the button armed.
+ * Only a completed continuous hold confirms. This is deliberately stricter
+ * than the phone's second-tap confirm; a watch face is far easier to touch
+ * accidentally. There is deliberately no hard cap on how long touches can
+ * keep the button armed: the execute gate is the continuous hold, not the
+ * window length, and the quiet-period timeout handles abandonment.
  *
  * Freshness: the watch has no FCM registration, so [onVisible] starts a
  * foreground-only refresh loop (stopped by [onHidden]). While a press is
@@ -111,6 +120,8 @@ class WearHomeViewModel(
      * re-checked against `AwaitingConfirmation` when the countdown completes.
      */
     fun onHoldStart() {
+        // Any touch keeps the armed window alive (machine no-ops unless armed).
+        stateMachine.onUserInteraction()
         val state = buttonState.value
         val armedOrArming = state is RemoteButtonState.AwaitingConfirmation || state is RemoteButtonState.Preparing
         if (!armedOrArming) return
@@ -128,9 +139,21 @@ class WearHomeViewModel(
 
     /** Finger lifted: cancel an incomplete hold (no-op after a completed one). */
     fun onHoldEnd() {
+        // The quiet period runs from the LAST touch, so release also resets it.
+        stateMachine.onUserInteraction()
         holdJob?.cancel()
         holdJob = null
         _isHolding.value = false
+    }
+
+    /**
+     * Any touch observed anywhere on the screen (the UI's non-consuming
+     * screen-wide observer). While armed this restarts the machine's
+     * confirmation timeout so the button stays armed while the user keeps
+     * interacting; no-op in every other state.
+     */
+    fun onScreenTouch() {
+        stateMachine.onUserInteraction()
     }
 
     /** Screen became visible: start the foreground refresh loop. */

--- a/MobileGarage/wearApp/src/test/java/com/chriscartland/garage/wear/ui/WearHomeViewModelTest.kt
+++ b/MobileGarage/wearApp/src/test/java/com/chriscartland/garage/wear/ui/WearHomeViewModelTest.kt
@@ -29,6 +29,7 @@ import com.chriscartland.garage.testcommon.FakeAuthRepository
 import com.chriscartland.garage.testcommon.FakeDoorRepository
 import com.chriscartland.garage.testcommon.FakeRemoteButtonRepository
 import com.chriscartland.garage.testcommon.TestDispatcherProvider
+import com.chriscartland.garage.usecase.ButtonStateMachine
 import com.chriscartland.garage.usecase.FetchCurrentDoorEventUseCase
 import com.chriscartland.garage.usecase.ObserveAuthStateUseCase
 import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
@@ -59,6 +60,8 @@ import org.junit.Test
  *  - a quick tap while armed never submits a press (only a completed hold does)
  *  - releasing before the hold completes never submits
  *  - nothing arms or submits while signed out
+ *  - touches keep the button armed (window counts from the last touch);
+ *    only a quiet period with no touches disarms it
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class WearHomeViewModelTest {
@@ -180,6 +183,77 @@ class WearHomeViewModelTest {
             viewModel.onDoorTap()
             runCurrent()
             assertEquals(RemoteButtonState.AwaitingConfirmation, viewModel.buttonState.value)
+            assertEquals(0, remoteButtonRepository.pushCount)
+        }
+
+    @Test
+    fun partialTapsKeepButtonArmed() =
+        runTest {
+            val viewModel = createViewModel()
+            signIn()
+            arm(viewModel)
+            // Repeated aborted holds spanning well past the original window:
+            // every touch (down and up) restarts the disarm timer.
+            repeat(3) {
+                advanceTimeBy(ButtonStateMachine.DEFAULT_CONFIRMATION_TIMEOUT - 1_000L)
+                viewModel.onHoldStart()
+                advanceTimeBy(200L)
+                viewModel.onHoldEnd()
+                runCurrent()
+                assertEquals(RemoteButtonState.AwaitingConfirmation, viewModel.buttonState.value)
+            }
+            assertEquals(0, remoteButtonRepository.pushCount)
+            // A quiet period with no touches disarms.
+            advanceTimeBy(ButtonStateMachine.DEFAULT_CONFIRMATION_TIMEOUT + 1)
+            runCurrent()
+            assertEquals(RemoteButtonState.Cancelled, viewModel.buttonState.value)
+            assertEquals(0, remoteButtonRepository.pushCount)
+        }
+
+    @Test
+    fun screenTouchKeepsButtonArmed() =
+        runTest {
+            val viewModel = createViewModel()
+            signIn()
+            arm(viewModel)
+            // A touch anywhere on the screen (not just the door) keeps it armed.
+            advanceTimeBy(ButtonStateMachine.DEFAULT_CONFIRMATION_TIMEOUT - 1_000L)
+            viewModel.onScreenTouch()
+            runCurrent()
+            advanceTimeBy(ButtonStateMachine.DEFAULT_CONFIRMATION_TIMEOUT - 1_000L)
+            runCurrent()
+            assertEquals(RemoteButtonState.AwaitingConfirmation, viewModel.buttonState.value)
+            assertEquals(0, remoteButtonRepository.pushCount)
+        }
+
+    @Test
+    fun holdStartedLateInArmedWindowStillSubmits() =
+        runTest {
+            val viewModel = createViewModel()
+            signIn()
+            arm(viewModel)
+            // Finger down just before the original window would have expired:
+            // the touch restarts the timer, so the hold always gets its full
+            // 2 seconds. (Previously the machine could disarm mid-hold and a
+            // visually completed ring fired into a dead state.)
+            advanceTimeBy(ButtonStateMachine.DEFAULT_CONFIRMATION_TIMEOUT - 500L)
+            viewModel.onHoldStart()
+            runCurrent()
+            advanceTimeBy(WearHomeViewModel.HOLD_TO_CONFIRM_MILLIS + 1)
+            runCurrent()
+            assertEquals(1, remoteButtonRepository.pushCount)
+            assertEquals(RemoteButtonState.SendingToDoor, viewModel.buttonState.value)
+        }
+
+    @Test
+    fun armedDisarmsAfterQuietPeriod() =
+        runTest {
+            val viewModel = createViewModel()
+            signIn()
+            arm(viewModel)
+            advanceTimeBy(ButtonStateMachine.DEFAULT_CONFIRMATION_TIMEOUT + 1)
+            runCurrent()
+            assertEquals(RemoteButtonState.Cancelled, viewModel.buttonState.value)
             assertEquals(0, remoteButtonRepository.pushCount)
         }
 

--- a/MobileGarage/wearApp/version.properties
+++ b/MobileGarage/wearApp/version.properties
@@ -1,1 +1,1 @@
-versionName=0.1.3
+versionName=0.1.4

--- a/docs/WEAR_OS.md
+++ b/docs/WEAR_OS.md
@@ -22,13 +22,27 @@ and palette as phone/iOS) with the door state label under it.
    ring sweeps around the door; when it completes, the machine's second tap
    fires and the press is submitted (`SendingToServer → SendingToDoor →
    Succeeded` when the door actually moves).
-3. **Release early** → the ring resets, nothing is sent. The machine's own
-   8s confirmation timeout eventually disarms (`Cancelled → Ready`).
+3. **Release early** → the ring resets, nothing is sent, and the button
+   **stays armed**. Every touch anywhere on the screen (down and up, seen by
+   a non-consuming Initial-pass observer) restarts the machine's
+   confirmation timeout via `ButtonStateMachine.onUserInteraction()`, so
+   the armed window counts from the **last touch**: partial taps and
+   aborted holds keep it armed, and only ~8s with no touches disarms it
+   (`Cancelled → Ready`). Because finger-down restarts the window, a hold
+   started at the last instant always gets its full 2 seconds — the machine
+   can never disarm mid-hold (pre-0.1.4, a late hold could visually
+   complete its ring and then fire into an already-cancelled state).
 
-A quick tap while armed does nothing — deliberately stricter than the phone's
-second-tap confirm, because a watch face is much easier to touch accidentally.
-`WearHomeViewModelTest` pins these safety properties (stray tap never submits,
-early release never submits, signed-out is inert).
+A quick tap while armed never submits — it only keeps the window alive.
+This is deliberately stricter than the phone's second-tap confirm, because
+a watch face is much easier to touch accidentally. There is deliberately no
+hard cap on how long touches can keep the button armed: the execute gate is
+the continuous 2s hold, not the window length, and the quiet-period timeout
+handles abandonment. `WearHomeViewModelTest` pins these safety properties
+(stray tap never submits, early release never submits, signed-out is inert,
+late hold still completes, quiet period disarms); `ButtonStateMachineTest`
+pins that `onUserInteraction` extends only the armed window and never
+disturbs the machine's other timers (it has a single timer slot).
 
 ## Architecture
 


### PR DESCRIPTION
## What

The watch's armed window now counts from the **last touch**, not the arming tap. Any touch anywhere on the screen (finger-down AND finger-up) restarts the disarm timer, so partial taps and aborted holds keep the button armed; only ~8s with **no** touches disarms it (`Cancelled → Ready`). Executing still requires the full continuous 2-second hold, and a quick tap still never submits.

## How

- **`ButtonStateMachine.onUserInteraction()`** (shared `usecase`): new event that restarts the confirmation timeout — gated on `AwaitingConfirmation` inside the machine. The gate is load-bearing: the machine has a single timer slot, so a naive reschedule during `Preparing` would cancel the arming timer and strand the machine (test-pinned). Ignored in all other states, so the network timers are untouchable too.
- **`WearHomeViewModel`**: `onHoldStart`/`onHoldEnd` and a new `onScreenTouch()` all feed the event; the quiet period runs from finger-up.
- **`HeroScreen`**: screen-wide non-consuming Initial-pass pointer observer reports every down/up (including touches the door's own tap detector handles) — sign-in button and door gestures unaffected.

## Fixes a real edge

Previously a hold started late in the 8s window could be disarmed by the machine **mid-hold** — the ring visually completed, then fired into an already-cancelled state. Finger-down now restarts the window (8s ≫ 2s hold), so a started hold always completes. Pinned by `holdStartedLateInArmedWindowStillSubmits`.

## Deliberate choices

- No hard cap on how long touches keep it armed: the execute gate is the continuous hold, not the window length; the quiet-period timeout handles abandonment.
- Only down/up reset the timer (not move events): a resting finger is a hold — it either completes or its release resets the timer.
- Phone/iOS behavior unchanged — nothing there calls the new event (additive shared API, no DI changes).

## Tests

4 new `ButtonStateMachineTest` + 4 new `WearHomeViewModelTest` cases (armed-window restart, Preparing/network timer isolation, partial taps keep armed, screen touch keeps armed, late hold still submits, quiet period disarms). Full `validate.sh` green.

Wear versionName → 0.1.4 (changelog + whatsnew drafted); `docs/WEAR_OS.md` hero section updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)