### PR TITLE
feat(onboarding): calm cold-start presentation on Home and Settings

### DIFF
--- a/MobileGarage/android-screenshot-tests/PREVIEW_COVERAGE.md
+++ b/MobileGarage/android-screenshot-tests/PREVIEW_COVERAGE.md
@@ -3,7 +3,7 @@
 
 # Preview Screenshot Coverage
 
-**98 / 98 (100%)**
+**100 / 100 (100%)**
 
 ## Covered
 
@@ -47,6 +47,7 @@
 - `HistoryTabPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/TabPreviews.kt`
 - `HomeContentAwaitingConfirmationPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt`
 - `HomeContentClosedSignedInPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt`
+- `HomeContentConnectingPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt`
 - `HomeContentOnTabletPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt`
 - `HomeContentOpenSignedInPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt`
 - `HomeContentOpeningTooLongPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt`
@@ -91,6 +92,7 @@
 - `RemoteOfflinePillStalePreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/RemoteOfflinePill.kt`
 - `RemoteOfflinePillVeryStalePreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/RemoteOfflinePill.kt`
 - `SafeListContentPaddingCanaryPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/HomeDashboardPreviews.kt`
+- `SettingsContentCheckingPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt`
 - `SettingsContentPermissionDeniedPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt`
 - `SettingsContentSignedInAllowlistedPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt`
 - `SettingsContentSignedInBasicPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt`

--- a/MobileGarage/android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTest.kt
+++ b/MobileGarage/android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTest.kt
@@ -24,6 +24,7 @@ import com.chriscartland.garage.ui.DoorStatusInfoSheetContentPreview
 import com.chriscartland.garage.ui.RemoteControlInfoSheetContentPreview
 import com.chriscartland.garage.ui.home.HomeContentAwaitingConfirmationPreview
 import com.chriscartland.garage.ui.home.HomeContentClosedSignedInPreview
+import com.chriscartland.garage.ui.home.HomeContentConnectingPreview
 import com.chriscartland.garage.ui.home.HomeContentOnTabletPreview
 import com.chriscartland.garage.ui.home.HomeContentOpenSignedInPreview
 import com.chriscartland.garage.ui.home.HomeContentOpeningTooLongPreview
@@ -60,6 +61,18 @@ fun HomeContentOpenSignedInPreviewTest() {
 @Composable
 fun HomeContentClosedSignedInPreviewTest() {
     AppTheme { HomeContentClosedSignedInPreview() }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun HomeContentConnectingPreviewTest() {
+    AppTheme { HomeContentConnectingPreview() }
 }
 
 @PreviewTest

--- a/MobileGarage/android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/SettingsRedesignScreenshotTest.kt
+++ b/MobileGarage/android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/SettingsRedesignScreenshotTest.kt
@@ -24,6 +24,7 @@ import com.chriscartland.garage.ui.settings.AccountSheetContentSignedInPreview
 import com.chriscartland.garage.ui.settings.ClearDiagnosticsDialogPreview
 import com.chriscartland.garage.ui.settings.DiagnosticsContentClearInFlightPreview
 import com.chriscartland.garage.ui.settings.DiagnosticsContentPreview
+import com.chriscartland.garage.ui.settings.SettingsContentCheckingPreview
 import com.chriscartland.garage.ui.settings.SettingsContentPermissionDeniedPreview
 import com.chriscartland.garage.ui.settings.SettingsContentSignedInAllowlistedPreview
 import com.chriscartland.garage.ui.settings.SettingsContentSignedInBasicPreview
@@ -44,6 +45,18 @@ import com.chriscartland.garage.ui.theme.AppTheme
 @Composable
 fun SettingsContentSignedOutPreviewTest() {
     AppTheme { SettingsContentSignedOutPreview() }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun SettingsContentCheckingPreviewTest() {
+    AppTheme { SettingsContentCheckingPreview() }
 }
 
 @PreviewTest

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/GarageIcon.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/GarageIcon.kt
@@ -68,6 +68,10 @@ import java.time.Duration
  *   screenshot tests) so reference PNGs are deterministic — Layoutlib can't
  *   advance `LaunchedEffect`, so an animated `OPENING` would otherwise
  *   render at the start frame and look identical to `CLOSED`.
+ * @param suppressWarningOverlay set `true` only for the no-data cold-start
+ *   presentation: the door shape still renders (gray, midway) but the ⚠
+ *   badge is withheld — nothing is wrong, the app just hasn't heard from
+ *   the server yet. Real UNKNOWN events (with data) keep the badge.
  */
 @Composable
 fun GarageIcon(
@@ -77,6 +81,7 @@ fun GarageIcon(
     color: Color = LocalDoorStatusColorScheme.current.openFresh,
     duration: Duration = DEFAULT_GARAGE_DOOR_ANIMATION_DURATION,
     lastChangeTimeSeconds: Long? = null,
+    suppressWarningOverlay: Boolean = false,
 ) {
     if (static || LocalInspectionMode.current) {
         DoorIconBox(
@@ -84,6 +89,7 @@ fun GarageIcon(
             doorPosition = doorPosition,
             modifier = modifier,
             color = color,
+            suppressWarningOverlay = suppressWarningOverlay,
         )
     } else {
         AnimatedDoorIcon(
@@ -92,6 +98,7 @@ fun GarageIcon(
             modifier = modifier,
             color = color,
             duration = duration,
+            suppressWarningOverlay = suppressWarningOverlay,
         )
     }
 }
@@ -103,6 +110,7 @@ private fun AnimatedDoorIcon(
     modifier: Modifier,
     color: Color,
     duration: Duration,
+    suppressWarningOverlay: Boolean,
 ) {
     // Decide ONCE per fresh composition whether this icon should replay the
     // full slide from the "from" end. True only for a motion state whose event
@@ -155,6 +163,7 @@ private fun AnimatedDoorIcon(
         doorPosition = doorPosition,
         modifier = modifier,
         color = color,
+        suppressWarningOverlay = suppressWarningOverlay,
     )
 }
 
@@ -175,6 +184,7 @@ private fun DoorIconBox(
     doorPosition: DoorPosition,
     modifier: Modifier,
     color: Color,
+    suppressWarningOverlay: Boolean = false,
 ) {
     Box(
         modifier = modifier
@@ -191,7 +201,7 @@ private fun DoorIconBox(
             DoorOverlayKind.NONE -> Unit
             DoorOverlayKind.ARROW_UP -> DirectionOverlay(-90f, "Up Arrow")
             DoorOverlayKind.ARROW_DOWN -> DirectionOverlay(90f, "Down Arrow")
-            DoorOverlayKind.WARNING -> WarningOverlay()
+            DoorOverlayKind.WARNING -> if (!suppressWarningOverlay) WarningOverlay()
         }
     }
 }

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
@@ -157,7 +157,9 @@ fun ProfileContent(
                 .ifBlank { unknownNameFallback },
             email = s.user.email.asString(),
         )
-        AuthState.Unauthenticated, AuthState.Unknown -> AccountRowState.SignedOut
+        AuthState.Unauthenticated -> AccountRowState.SignedOut
+        // Cold start: don't flash the sign-in CTA before Firebase resolves.
+        AuthState.Unknown -> AccountRowState.Checking
     }
     val notificationsGranted = notificationPermissionState.status.isGranted
     val snoozeRowState = if (notificationsGranted) {

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
@@ -114,6 +114,14 @@ data class HomeStatusDisplay(
     val warning: DoorWarning? = null,
     /** Drives the muted "stale" door color and disables animation when true. */
     val isStale: Boolean = false,
+    /**
+     * False only while no door event exists at all (cold start, empty cache).
+     * The card then renders the calm connecting presentation — "Connecting…"
+     * headline, waiting sub-line, no ⚠ badge — instead of the alarming
+     * "Unknown" + warning look. A real server-reported UNKNOWN (an actual
+     * event) keeps the full warning presentation.
+     */
+    val hasData: Boolean = true,
 )
 
 /** Auth-gated bottom card variant. */
@@ -329,6 +337,7 @@ private fun HomeStatusCardBody(
                 // event (cold-open / first view) rather than on every fresh
                 // composition. See DoorAnimationMemory.
                 lastChangeTimeSeconds = status.lastChangeTimeSeconds,
+                suppressWarningOverlay = !status.hasData,
             )
         }
         Column(
@@ -336,12 +345,20 @@ private fun HomeStatusCardBody(
             verticalArrangement = Arrangement.spacedBy(Spacing.Tight),
         ) {
             Text(
-                text = doorStateLabel(status.doorPosition),
+                text = if (status.hasData) {
+                    doorStateLabel(status.doorPosition)
+                } else {
+                    stringResource(R.string.home_door_state_connecting)
+                },
                 style = MaterialTheme.typography.titleLarge,
                 color = MaterialTheme.colorScheme.onSurface,
             )
             Text(
-                text = sinceLine,
+                text = if (status.hasData) {
+                    sinceLine
+                } else {
+                    stringResource(R.string.home_since_connecting)
+                },
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
@@ -630,6 +647,11 @@ private object HomePreviewData {
         doorPosition = DoorPosition.CLOSED,
         lastChangeTimeSeconds = null,
     )
+    val connectingStatus = HomeStatusDisplay(
+        doorPosition = DoorPosition.UNKNOWN,
+        lastChangeTimeSeconds = null,
+        hasData = false,
+    )
     val openingTooLongStatus = HomeStatusDisplay(
         doorPosition = DoorPosition.OPENING_TOO_LONG,
         lastChangeTimeSeconds = null,
@@ -649,6 +671,13 @@ private object HomePreviewData {
     val staleCheckIn = DeviceCheckInDisplay(
         durationLabel = "23 min ago",
         isStale = true,
+    )
+
+    // Cold-start pill: label must equal DeviceCheckIn's no-data output so the
+    // pill hides its text exactly like production before the first event.
+    val noDataCheckIn = DeviceCheckInDisplay(
+        durationLabel = "No data yet",
+        isStale = false,
     )
 }
 
@@ -769,6 +798,22 @@ fun HomeContentSignedOutPreview() =
             authState = HomeAuthState.SignedOut,
             deviceCheckIn = HomePreviewData.freshCheckIn,
             buttonHealthDisplay = ButtonHealthDisplay.Online,
+            modifier = Modifier.padding(horizontal = Spacing.Screen),
+        )
+    }
+
+// Cold start, nothing heard yet: calm connecting presentation (no ⚠ badge,
+// "Connecting…" headline) + "Checking sign-in…" card + bare check-in pill.
+@Preview(heightDp = 900)
+@Composable
+fun HomeContentConnectingPreview() =
+    PreviewScreenSurface {
+        HomeContent(
+            status = HomePreviewData.connectingStatus,
+            sinceLine = "",
+            authState = HomeAuthState.Unknown,
+            deviceCheckIn = HomePreviewData.noDataCheckIn,
+            buttonHealthDisplay = ButtonHealthDisplay.Hidden,
             modifier = Modifier.padding(horizontal = Spacing.Screen),
         )
     }

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeMapper.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeMapper.kt
@@ -66,6 +66,9 @@ object HomeMapper {
             doorPosition = doorPosition,
             lastChangeTimeSeconds = event?.lastChangeTimeSeconds,
             isStale = isCheckInStale,
+            // No event at all (cold start, empty cache) renders the calm
+            // connecting presentation instead of "Unknown" + warning badge.
+            hasData = event != null,
         )
     }
 

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
@@ -72,6 +72,13 @@ import com.chriscartland.garage.ui.theme.safeListContentPadding
  * CTA or the signed-in user identity.
  */
 sealed interface AccountRowState {
+    /**
+     * Auth listener still resolving at cold start. Renders a calm
+     * "Checking sign-in…" row — NOT the sign-in CTA, which used to flash
+     * for already-signed-in users before Firebase resolved.
+     */
+    data object Checking : AccountRowState
+
     data object SignedOut : AccountRowState
 
     data class SignedIn(
@@ -136,6 +143,13 @@ fun SettingsContent(
         item {
             SettingsSection(label = stringResource(R.string.settings_section_account)) {
                 when (accountState) {
+                    AccountRowState.Checking -> SettingsRow(
+                        icon = Icons.Filled.AccountCircle,
+                        title = stringResource(R.string.settings_account_checking),
+                        subtitle = null,
+                        showChevron = false,
+                        onClick = {},
+                    )
                     AccountRowState.SignedOut -> SettingsRow(
                         icon = Icons.AutoMirrored.Outlined.Login,
                         title = stringResource(R.string.settings_account_sign_in),
@@ -416,6 +430,27 @@ fun SettingsContentSignedOutPreview() {
         SettingsContent(
             accountState = AccountRowState.SignedOut,
             snoozeState = SnoozeRowState.Off,
+            showSnoozeRow = true,
+            showDeveloperSection = false,
+            showFunctionListRow = false,
+            versionName = "2.6.1",
+            versionCode = "182",
+            layoutDebugEnabled = false,
+            navigationRailItemPosition = NavigationRailItemPosition.CenteredVertically,
+            navigationRailTopPaddingDp = NavigationRailLayout.DEFAULT_TOP_PADDING_DP,
+        )
+    }
+}
+
+// Cold start: auth still resolving — calm "Checking sign-in…" row instead of
+// a flashed sign-in CTA.
+@Preview
+@Composable
+fun SettingsContentCheckingPreview() {
+    PreviewScreenSurface {
+        SettingsContent(
+            accountState = AccountRowState.Checking,
+            snoozeState = SnoozeRowState.Loading,
             showSnoozeRow = true,
             showDeveloperSection = false,
             showFunctionListRow = false,

--- a/MobileGarage/androidApp/src/main/res/values/strings.xml
+++ b/MobileGarage/androidApp/src/main/res/values/strings.xml
@@ -26,6 +26,7 @@
 
     <!-- Settings — Account section rows. -->
     <string name="settings_account_sign_in">Sign in with Google</string>
+    <string name="settings_account_checking">Checking sign-in…</string>
 
     <!-- Settings — Notifications section row + subtitle states. -->
     <string name="settings_notifications_row_title">Door open notifications</string>
@@ -152,6 +153,8 @@
 
     <!-- Home → Status card "Since X · Y" line + duration formatting. -->
     <string name="home_since_unknown">Last change time unknown</string>
+    <string name="home_door_state_connecting">Connecting…</string>
+    <string name="home_since_connecting">Waiting for the latest door status</string>
     <!-- "Since X · Y" line. %1$s is a time (e.g. "9:47 AM"); %2$s is a duration (e.g. "2 hr 14 min"). -->
     <string name="home_since_format">Since %1$s · %2$s</string>
     <!-- Duration when hours and minutes are both shown ("2 hr 14 min"). -->

--- a/MobileGarage/androidApp/src/test/java/com/chriscartland/garage/ui/home/HomeMapperTest.kt
+++ b/MobileGarage/androidApp/src/test/java/com/chriscartland/garage/ui/home/HomeMapperTest.kt
@@ -79,6 +79,20 @@ class HomeMapperTest {
         val display = HomeMapper.toHomeStatusDisplay(LoadingResult.Complete(null))
         assertEquals(DoorPosition.UNKNOWN, display.doorPosition)
         assertNull(display.lastChangeTimeSeconds)
+        // No event at all → the calm connecting presentation, not the
+        // alarming "Unknown" + warning-badge look.
+        assertEquals(false, display.hasData)
+    }
+
+    @Test
+    fun toHomeStatusDisplay_real_unknown_event_keeps_warning_presentation() {
+        // A server-reported UNKNOWN is an actual event: hasData stays true so
+        // the full warning presentation (badge + "Unknown" label) renders.
+        val display = HomeMapper.toHomeStatusDisplay(
+            LoadingResult.Complete(event(DoorPosition.UNKNOWN)),
+        )
+        assertEquals(DoorPosition.UNKNOWN, display.doorPosition)
+        assertEquals(true, display.hasData)
     }
 
     @Test


### PR DESCRIPTION
Startup used to read as broken; this improves only the *presentation* of the pre-data window — same states, same flows, no structural change (per the feedback constraint).

## Home: connecting, not "Unknown" + ⚠
`HomeStatusDisplay.hasData` is false only when NO door event exists at all (cold start, empty cache). The status card then renders **"Connecting…"** with **"Waiting for the latest door status"** and suppresses the door's warning-triangle overlay (new `GarageIcon.suppressWarningOverlay`, default off). A real server-reported `UNKNOWN` event keeps the full warning presentation — pinned by `HomeMapperTest.toHomeStatusDisplay_real_unknown_event_keeps_warning_presentation`.

## Settings: no more sign-in flash
Auth `Unknown` used to collapse into `SignedOut`, flashing a **"Sign in with Google"** row for already-signed-in users while Firebase resolved. New `AccountRowState.Checking` renders a non-interactive **"Checking sign-in…"** row instead. (Home already had a proper Unknown branch; it's unchanged.)

## Fixtures
New previews `HomeContentConnectingPreview` + `SettingsContentCheckingPreview`, wired into the screenshot tests (preview-coverage check passes; `PREVIEW_COVERAGE.md` regenerated). Reference PNGs render on the next working-env screenshot regen — local Layoutlib renders blank on this machine (known repo limitation).

Validation: full `./scripts/validate.sh` — All checks passed.

Follow-ups (not in this PR): the wear app gets the same connecting treatment next (separate PR — same files as the in-flight wear PR #1100), and iOS should mirror the connecting labels for parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)