### PR TITLE
feat(ui-gallery): density rework — all states at a glance, wrap, width caps

### DIFF
--- a/MobileGarage/ui-gallery/README.md
+++ b/MobileGarage/ui-gallery/README.md
@@ -22,7 +22,7 @@ the committed PNGs by relative path, so it works from a fresh clone.
 | Keys | Action |
 | --- | --- |
 | `↑` `↓` (or `k` `j`) | previous / next row (wraps) |
-| `←` `→` (or `h` `l`) | previous / next variant within the row (wraps, remembered per row) |
+| `←` `→` (or `h` `l`) | previous / next variant within the row (no-op today — all rows show every state at once) |
 | `Space` | switch platform (Android ↔ iOS) |
 | `t` | toggle light / dark theme |
 | `Home` / `End` | first / last row |
@@ -39,22 +39,22 @@ Every image cell is addressed by four dimensions:
 
 - **Row** (up/down) — a named collection inside a section. The whole feed is
   always rendered; up/down moves the selection and scrolls to it.
-- **Variant** (left/right) — a row-specific axis, one axis per row (e.g. the
-  Home row's axis is door *state*; the snooze sheet's axis is *selection*).
-  All tiles in the row swap together when the variant changes.
+- **Variant** (left/right) — a row-specific flip-in-place axis. Present in
+  the schema but **deliberately unused by the current curation** (see below).
 - **Platform** (Space) — global. `platformCycle` in the manifest defines what
   Space cycles through. Rows captured only on a platform outside the cycle
   (Wear OS) are **pinned**: they always show their platform, with a badge.
 - **Theme** (t) — global light/dark.
 
-**Items vs variants — the curation rule.** `items` are what you compare side
-by side at a glance; `variants` are what you flip in place:
+**Density first — show everything, no pills.** Every row puts ALL of its
+states in `items`, side by side, wrapping onto as many lines as the width
+needs — the page never scrolls horizontally. Eight Home states in one glance
+beats one image plus seven chips. Reach for `variants` only if a future row
+genuinely cannot show its states simultaneously; nothing today qualifies.
 
-- Small components put their *states* in `items` — nine door-canvas states in
-  one row is more useful than flipping through them one at a time.
-- Full screens put their states in `variants` — one big image flipped in
-  place, so Android and iOS renders of the same state sit under your eyes as
-  you hit Space.
+**Sizing.** `height` is the row's nominal tile height; `maxw` (default 420)
+caps display width, so wide components (pills, full-width sections) scale
+*down* to fit instead of dominating the page.
 
 A missing combination renders as a labeled placeholder ("No dark capture",
 "Not captured on iOS") rather than silently substituting — the gaps are
@@ -97,19 +97,21 @@ sections:
     rows:
       - id: home              # unique, stable (used in URLs + saved state)
         title: Home
-        axis: State           # label for the left/right dimension
-        height: 420           # tile display height in px
+        height: 300           # nominal tile height in px
+        maxw: 420             # optional width cap (default 420)
         note: Optional caption under the row header.
-        variants:             # omit entirely for a single implicit variant
-          - {id: closed, label: Closed}
-        items:
-          - id: screen
-            label: Phone
+        items:                # every state side by side (wraps to fit)
+          - id: closed
+            label: Closed
             images:
-              closed:                          # variant id
-                android: ${ref}/..._{theme}_*.png
-                ios: {light: "${ios}/Home-closed.1.png"}
+              android: ${ref}/..._{theme}_*.png
+              ios: {light: "${ios}/Home-closed.1.png"}
 ```
+
+A row may also declare `variants` (with an `axis` label) to make ←/→ flip
+all tiles in place; the current curation intentionally has none. With
+variants, each item's `images` gains a variant-id level above the platform
+keys.
 
 Image value idioms (one per platform, by design):
 

--- a/MobileGarage/ui-gallery/index.html
+++ b/MobileGarage/ui-gallery/index.html
@@ -151,7 +151,8 @@
   }
   .chip.active { background: var(--accent-dim); border-color: var(--accent); color: #fff; }
   .row-note { margin: 4px 0 0; color: var(--muted); font-size: 12px; }
-  .strip { display: flex; gap: 12px; overflow-x: auto; padding-top: 10px; align-items: flex-start; }
+  /* Rows WRAP to fit the width — the page never scrolls horizontally. */
+  .strip { display: flex; gap: 12px; flex-wrap: wrap; padding-top: 10px; align-items: flex-start; }
   .cell { margin: 0; flex: none; }
   .cell .frame {
     display: block;
@@ -302,6 +303,21 @@
   function rowIndex() {
     for (var i = 0; i < rows.length; i++) if (rows[i].id === state.rowId) return i;
     return 0;
+  }
+
+  // Tile display size: nominal row height, but wide images are capped at the
+  // row's maxw (default 420) and scale DOWN proportionally — wide pills and
+  // full-width sections must not dominate the page.
+  var DEFAULT_MAX_TILE_W = 420;
+  function tileSize(row, imgW, imgH) {
+    var h = row.height;
+    var w = Math.round(h * imgW / imgH);
+    var maxW = row.maxw || DEFAULT_MAX_TILE_W;
+    if (w > maxW) {
+      h = Math.round(h * maxW / w);
+      w = maxW;
+    }
+    return { w: w, h: h };
   }
 
   // ---- Cell resolution ----
@@ -524,10 +540,9 @@
         var res = cellFor(row, cell.item);
         if (res) {
           anyImage = true;
-          var displayH = row.height;
-          var displayW = Math.round(displayH * res.img.w / res.img.h);
-          cell.link.style.width = displayW + "px";
-          cell.link.style.height = displayH + "px";
+          var size = tileSize(row, res.img.w, res.img.h);
+          cell.link.style.width = size.w + "px";
+          cell.link.style.height = size.h + "px";
           var src = encodeURI(res.img.src);
           if (cell.img.getAttribute("src") !== src) cell.img.setAttribute("src", src);
           cell.img.hidden = false;
@@ -539,10 +554,9 @@
           if (res.pinned) cell.badge.textContent = M.platformLabels[res.platform] || res.platform;
         } else {
           var info = placeholderInfo(row, cell.item);
-          var phH = row.height;
-          var phW = Math.round(phH * info.w / info.h);
-          cell.link.style.width = phW + "px";
-          cell.link.style.height = phH + "px";
+          var phSize = tileSize(row, info.w, info.h);
+          cell.link.style.width = phSize.w + "px";
+          cell.link.style.height = phSize.h + "px";
           cell.img.hidden = true;
           cell.img.removeAttribute("src");
           cell.ph.hidden = false;

--- a/MobileGarage/ui-gallery/manifest.js
+++ b/MobileGarage/ui-gallery/manifest.js
@@ -22,158 +22,199 @@ window.UI_GALLERY = {
     {
      "id": "home",
      "title": "Home",
-     "axis": "State",
+     "axis": null,
      "note": null,
-     "height": 420,
+     "height": 300,
+     "maxw": null,
      "variants": [
       {
-       "id": "closed",
-       "label": "Closed"
-      },
-      {
-       "id": "open",
-       "label": "Open"
-      },
-      {
-       "id": "confirming",
-       "label": "Confirming"
-      },
-      {
-       "id": "sending",
-       "label": "Sending"
-      },
-      {
-       "id": "warning",
-       "label": "Open too long"
-      },
-      {
-       "id": "stale",
-       "label": "Stale data"
-      },
-      {
-       "id": "alerts",
-       "label": "Alerts"
-      },
-      {
-       "id": "signed-out",
-       "label": "Signed out"
+       "id": "default",
+       "label": "Default"
       }
      ],
      "items": [
       {
-       "id": "screen",
-       "label": "Phone",
+       "id": "closed",
+       "label": "Closed",
        "platforms": [
         "android",
         "ios"
        ],
        "images": {
-        "closed|android|light": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentClosedSignedInPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "closed|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentClosedSignedInPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
         },
-        "closed|ios|light": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/Home-closed-signed-out.1.png",
          "w": 1125,
          "h": 2436
-        },
-        "open|android|light": {
+        }
+       }
+      },
+      {
+       "id": "open",
+       "label": "Open",
+       "platforms": [
+        "android",
+        "ios"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentOpenSignedInPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "open|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentOpenSignedInPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
         },
-        "open|ios|light": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/Home-open-signed-in.1.png",
          "w": 1125,
          "h": 2436
-        },
-        "confirming|android|light": {
+        }
+       }
+      },
+      {
+       "id": "confirming",
+       "label": "Confirming",
+       "platforms": [
+        "android",
+        "ios"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentAwaitingConfirmationPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "confirming|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentAwaitingConfirmationPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
         },
-        "confirming|ios|light": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/Home-confirm-state.1.png",
          "w": 1125,
          "h": 2436
-        },
-        "sending|android|light": {
+        }
+       }
+      },
+      {
+       "id": "sending",
+       "label": "Sending",
+       "platforms": [
+        "android"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentSendingToDoorPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "sending|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentSendingToDoorPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
-        },
-        "warning|android|light": {
+        }
+       }
+      },
+      {
+       "id": "warning",
+       "label": "Open too long",
+       "platforms": [
+        "android",
+        "ios"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentOpeningTooLongPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "warning|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentOpeningTooLongPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
         },
-        "warning|ios|light": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/Home-opening-too-long-warning.1.png",
          "w": 1125,
          "h": 2436
-        },
-        "stale|android|light": {
+        }
+       }
+      },
+      {
+       "id": "stale",
+       "label": "Stale data",
+       "platforms": [
+        "android"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentStaleBannerPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "stale|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentStaleBannerPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
-        },
-        "alerts|android|light": {
+        }
+       }
+      },
+      {
+       "id": "alerts",
+       "label": "Alerts",
+       "platforms": [
+        "android",
+        "ios"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentPermissionMissingPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "alerts|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentPermissionMissingPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
         },
-        "alerts|ios|light": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/Home-with-alerts.1.png",
          "w": 1125,
          "h": 2436
-        },
-        "signed-out|android|light": {
+        }
+       }
+      },
+      {
+       "id": "signed-out",
+       "label": "Signed out",
+       "platforms": [
+        "android",
+        "ios"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentSignedOutPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "signed-out|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentSignedOutPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
         },
-        "signed-out|ios|light": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/Home-sign-in-row.1.png",
          "w": 1125,
          "h": 2436
@@ -185,71 +226,87 @@ window.UI_GALLERY = {
     {
      "id": "home-remote-pill",
      "title": "Home, remote pill states",
-     "axis": "Pill state",
-     "note": "Same Home screen flipped through the remote-button health pill states.",
-     "height": 420,
+     "axis": null,
+     "note": "Same Home screen across the remote-button health pill states.",
+     "height": 300,
+     "maxw": null,
      "variants": [
       {
-       "id": "online",
-       "label": "Online"
-      },
-      {
-       "id": "offline",
-       "label": "Offline"
-      },
-      {
-       "id": "unauthorized",
-       "label": "Unauthorized"
-      },
-      {
-       "id": "unknown",
-       "label": "Unknown"
+       "id": "default",
+       "label": "Default"
       }
      ],
      "items": [
       {
-       "id": "screen",
-       "label": "Phone",
+       "id": "online",
+       "label": "Online",
        "platforms": [
         "android"
        ],
        "images": {
-        "online|android|light": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentRemotePillOnlinePreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "online|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentRemotePillOnlinePreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
-        },
-        "offline|android|light": {
+        }
+       }
+      },
+      {
+       "id": "offline",
+       "label": "Offline",
+       "platforms": [
+        "android"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentRemotePillOfflinePreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "offline|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentRemotePillOfflinePreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
-        },
-        "unauthorized|android|light": {
+        }
+       }
+      },
+      {
+       "id": "unauthorized",
+       "label": "Unauthorized",
+       "platforms": [
+        "android"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentRemotePillUnauthorizedPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "unauthorized|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentRemotePillUnauthorizedPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
-        },
-        "unknown|android|light": {
+        }
+       }
+      },
+      {
+       "id": "unknown",
+       "label": "Unknown",
+       "platforms": [
+        "android"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentRemotePillUnknownPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "unknown|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HomeRedesignScreenshotTestKt/HomeContentRemotePillUnknownPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
@@ -261,100 +318,128 @@ window.UI_GALLERY = {
     {
      "id": "history",
      "title": "History",
-     "axis": "State",
+     "axis": null,
      "note": null,
-     "height": 420,
+     "height": 300,
+     "maxw": null,
      "variants": [
       {
-       "id": "recent",
-       "label": "Recent events"
-      },
-      {
-       "id": "closed-days",
-       "label": "Closed days"
-      },
-      {
-       "id": "empty",
-       "label": "Empty"
-      },
-      {
-       "id": "loading-older",
-       "label": "Loading older"
-      },
-      {
-       "id": "reached-beginning",
-       "label": "Reached beginning"
-      },
-      {
-       "id": "stale",
-       "label": "Stale banner"
+       "id": "default",
+       "label": "Default"
       }
      ],
      "items": [
       {
-       "id": "screen",
-       "label": "Phone",
+       "id": "recent",
+       "label": "Recent events",
        "platforms": [
         "android",
         "ios"
        ],
        "images": {
-        "recent|android|light": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HistoryRedesignScreenshotTestKt/HistoryContentMultiDayPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "recent|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HistoryRedesignScreenshotTestKt/HistoryContentMultiDayPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
         },
-        "recent|ios|light": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/History-recent-events.1.png",
          "w": 1125,
          "h": 2436
-        },
-        "closed-days|android|light": {
+        }
+       }
+      },
+      {
+       "id": "closed-days",
+       "label": "Closed days",
+       "platforms": [
+        "android",
+        "ios"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HistoryRedesignScreenshotTestKt/HistoryContentMultiDayClosedPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "closed-days|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HistoryRedesignScreenshotTestKt/HistoryContentMultiDayClosedPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
         },
-        "closed-days|ios|light": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/History-closed-states.1.png",
          "w": 1125,
          "h": 2436
-        },
-        "empty|android|light": {
+        }
+       }
+      },
+      {
+       "id": "empty",
+       "label": "Empty",
+       "platforms": [
+        "android",
+        "ios"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HistoryRedesignScreenshotTestKt/HistoryContentEmptyPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "empty|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/HistoryRedesignScreenshotTestKt/HistoryContentEmptyPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
         },
-        "empty|ios|light": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/History-empty.1.png",
          "w": 1125,
          "h": 2436
-        },
-        "loading-older|ios|light": {
+        }
+       }
+      },
+      {
+       "id": "loading-older",
+       "label": "Loading older",
+       "platforms": [
+        "ios"
+       ],
+       "images": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/History-loading-older-page.1.png",
          "w": 1125,
          "h": 2436
-        },
-        "reached-beginning|ios|light": {
+        }
+       }
+      },
+      {
+       "id": "reached-beginning",
+       "label": "Reached beginning",
+       "platforms": [
+        "ios"
+       ],
+       "images": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/History-reached-beginning.1.png",
          "w": 1125,
          "h": 2436
-        },
-        "stale|ios|light": {
+        }
+       }
+      },
+      {
+       "id": "stale",
+       "label": "Stale banner",
+       "platforms": [
+        "ios"
+       ],
+       "images": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/History-stale-banner.1.png",
          "w": 1125,
          "h": 2436
@@ -366,106 +451,130 @@ window.UI_GALLERY = {
     {
      "id": "settings",
      "title": "Settings",
-     "axis": "State",
+     "axis": null,
      "note": null,
-     "height": 420,
+     "height": 300,
+     "maxw": null,
      "variants": [
       {
-       "id": "signed-in",
-       "label": "Signed in (allowlisted)"
-      },
-      {
-       "id": "signed-in-basic",
-       "label": "Signed in (basic)"
-      },
-      {
-       "id": "signed-out",
-       "label": "Signed out"
-      },
-      {
-       "id": "permission-denied",
-       "label": "Notifications off"
-      },
-      {
-       "id": "snooze-sending",
-       "label": "Snooze sending"
+       "id": "default",
+       "label": "Default"
       }
      ],
      "items": [
       {
-       "id": "screen",
-       "label": "Phone",
+       "id": "signed-in",
+       "label": "Signed in (allowlisted)",
        "platforms": [
         "android",
         "ios"
        ],
        "images": {
-        "signed-in|android|light": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/SettingsRedesignScreenshotTestKt/SettingsContentSignedInAllowlistedPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "signed-in|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/SettingsRedesignScreenshotTestKt/SettingsContentSignedInAllowlistedPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
         },
-        "signed-in|ios|light": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/Settings-signed-in-developer.1.png",
          "w": 1125,
          "h": 2436
-        },
-        "signed-in-basic|android|light": {
+        }
+       }
+      },
+      {
+       "id": "signed-in-basic",
+       "label": "Signed in (basic)",
+       "platforms": [
+        "android"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/SettingsRedesignScreenshotTestKt/SettingsContentSignedInBasicPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "signed-in-basic|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/SettingsRedesignScreenshotTestKt/SettingsContentSignedInBasicPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
-        },
-        "signed-out|android|light": {
+        }
+       }
+      },
+      {
+       "id": "signed-out",
+       "label": "Signed out",
+       "platforms": [
+        "android",
+        "ios"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/SettingsRedesignScreenshotTestKt/SettingsContentSignedOutPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "signed-out|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/SettingsRedesignScreenshotTestKt/SettingsContentSignedOutPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
         },
-        "signed-out|ios|light": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/Settings-signed-out.1.png",
          "w": 1125,
          "h": 2436
-        },
-        "permission-denied|android|light": {
+        }
+       }
+      },
+      {
+       "id": "permission-denied",
+       "label": "Notifications off",
+       "platforms": [
+        "android",
+        "ios"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/SettingsRedesignScreenshotTestKt/SettingsContentPermissionDeniedPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "permission-denied|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/SettingsRedesignScreenshotTestKt/SettingsContentPermissionDeniedPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
         },
-        "permission-denied|ios|light": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/Settings-notifications-disabled.1.png",
          "w": 1125,
          "h": 2436
-        },
-        "snooze-sending|android|light": {
+        }
+       }
+      },
+      {
+       "id": "snooze-sending",
+       "label": "Snooze sending",
+       "platforms": [
+        "android",
+        "ios"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/SettingsRedesignScreenshotTestKt/SettingsContentSnoozeInFlightPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "snooze-sending|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/SettingsRedesignScreenshotTestKt/SettingsContentSnoozeInFlightPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
         },
-        "snooze-sending|ios|light": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/Settings-snooze-sending.1.png",
          "w": 1125,
          "h": 2436
@@ -477,63 +586,75 @@ window.UI_GALLERY = {
     {
      "id": "functions",
      "title": "Function list",
-     "axis": "Access",
+     "axis": null,
      "note": null,
-     "height": 420,
+     "height": 300,
+     "maxw": null,
      "variants": [
       {
-       "id": "granted",
-       "label": "Granted"
-      },
-      {
-       "id": "denied",
-       "label": "Denied"
-      },
-      {
-       "id": "test-notifications",
-       "label": "Test notifications"
+       "id": "default",
+       "label": "Default"
       }
      ],
      "items": [
       {
-       "id": "screen",
-       "label": "Phone",
+       "id": "granted",
+       "label": "Granted",
        "platforms": [
         "android",
         "ios"
        ],
        "images": {
-        "granted|android|light": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ScreensScreenshotTestKt/FunctionListContentPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "granted|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ScreensScreenshotTestKt/FunctionListContentPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
         },
-        "granted|ios|light": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/Functions-granted.1.png",
          "w": 1125,
          "h": 2436
-        },
-        "denied|android|light": {
+        }
+       }
+      },
+      {
+       "id": "denied",
+       "label": "Denied",
+       "platforms": [
+        "android",
+        "ios"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ScreensScreenshotTestKt/FunctionListContentDeniedPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "denied|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ScreensScreenshotTestKt/FunctionListContentDeniedPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
         },
-        "denied|ios|light": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/Functions-locked.1.png",
          "w": 1125,
          "h": 2436
-        },
-        "test-notifications|ios|light": {
+        }
+       }
+      },
+      {
+       "id": "test-notifications",
+       "label": "Test notifications",
+       "platforms": [
+        "ios"
+       ],
+       "images": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/Functions-test-notifications.1.png",
          "w": 1125,
          "h": 2436
@@ -545,23 +666,20 @@ window.UI_GALLERY = {
     {
      "id": "diagnostics",
      "title": "Diagnostics",
-     "axis": "State",
+     "axis": null,
      "note": null,
-     "height": 420,
+     "height": 300,
+     "maxw": null,
      "variants": [
       {
        "id": "default",
-       "label": "Counters"
-      },
-      {
-       "id": "clearing",
-       "label": "Clear in flight"
+       "label": "Default"
       }
      ],
      "items": [
       {
-       "id": "screen",
-       "label": "Phone",
+       "id": "counters",
+       "label": "Counters",
        "platforms": [
         "android",
         "ios"
@@ -581,13 +699,22 @@ window.UI_GALLERY = {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/Diagnostics-counters.1.png",
          "w": 1125,
          "h": 2436
-        },
-        "clearing|android|light": {
+        }
+       }
+      },
+      {
+       "id": "clearing",
+       "label": "Clear in flight",
+       "platforms": [
+        "android"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/SettingsRedesignScreenshotTestKt/DiagnosticsContentClearInFlightPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 2400
         },
-        "clearing|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/SettingsRedesignScreenshotTestKt/DiagnosticsContentClearInFlightPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 2400
@@ -604,54 +731,61 @@ window.UI_GALLERY = {
     {
      "id": "sheet-snooze",
      "title": "Snooze sheet",
-     "axis": "State",
+     "axis": null,
      "note": null,
-     "height": 300,
+     "height": 240,
+     "maxw": 300,
      "variants": [
       {
-       "id": "off",
-       "label": "Nothing selected"
-      },
-      {
-       "id": "active",
-       "label": "Option selected"
+       "id": "default",
+       "label": "Default"
       }
      ],
      "items": [
       {
-       "id": "sheet",
-       "label": "Sheet",
+       "id": "off",
+       "label": "Nothing selected",
        "platforms": [
         "android",
         "ios"
        ],
        "images": {
-        "off|android|light": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/SettingsRedesignScreenshotTestKt/SnoozeSheetContentOffPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 1519
         },
-        "off|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/SettingsRedesignScreenshotTestKt/SnoozeSheetContentOffPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 1519
         },
-        "off|ios|light": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/Snooze-sheet-nothing-selected.1.png",
          "w": 1125,
          "h": 2436
-        },
-        "active|android|light": {
+        }
+       }
+      },
+      {
+       "id": "active",
+       "label": "Option selected",
+       "platforms": [
+        "android",
+        "ios"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/SettingsRedesignScreenshotTestKt/SnoozeSheetContentActivePreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 1519
         },
-        "active|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/SettingsRedesignScreenshotTestKt/SnoozeSheetContentActivePreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 1519
         },
-        "active|ios|light": {
+        "default|ios|light": {
          "src": "../iosApp/SnapshotTests/__Snapshots__/PreviewTests.generated/Snooze-sheet-option-selected.1.png",
          "w": 1125,
          "h": 2436
@@ -665,7 +799,8 @@ window.UI_GALLERY = {
      "title": "Account & version sheets",
      "axis": null,
      "note": null,
-     "height": 300,
+     "height": 240,
+     "maxw": 300,
      "variants": [
       {
        "id": "default",
@@ -724,7 +859,8 @@ window.UI_GALLERY = {
      "title": "Info sheets",
      "axis": null,
      "note": null,
-     "height": 300,
+     "height": 240,
+     "maxw": 300,
      "variants": [
       {
        "id": "default",
@@ -789,7 +925,8 @@ window.UI_GALLERY = {
      "title": "Clear diagnostics dialog",
      "axis": null,
      "note": null,
-     "height": 240,
+     "height": 200,
+     "maxw": 300,
      "variants": [
       {
        "id": "default",
@@ -828,7 +965,8 @@ window.UI_GALLERY = {
      "title": "Home dashboard by width",
      "axis": null,
      "note": null,
-     "height": 280,
+     "height": 230,
+     "maxw": 520,
      "variants": [
       {
        "id": "default",
@@ -938,7 +1076,8 @@ window.UI_GALLERY = {
      "title": "Navigation rail",
      "axis": null,
      "note": null,
-     "height": 280,
+     "height": 230,
+     "maxw": 520,
      "variants": [
       {
        "id": "default",
@@ -1010,7 +1149,8 @@ window.UI_GALLERY = {
      "title": "Three-pane dashboard",
      "axis": null,
      "note": null,
-     "height": 280,
+     "height": 230,
+     "maxw": 520,
      "variants": [
       {
        "id": "default",
@@ -1106,7 +1246,8 @@ window.UI_GALLERY = {
      "title": "Door canvas",
      "axis": null,
      "note": "The shared door drawing. iOS renders the same geometry from the KMP constants.",
-     "height": 170,
+     "height": 130,
+     "maxw": null,
      "variants": [
       {
        "id": "default",
@@ -1304,7 +1445,8 @@ window.UI_GALLERY = {
      "title": "Door states grid (iOS)",
      "axis": null,
      "note": "The iOS snapshot gallery captures all door states as one composite.",
-     "height": 320,
+     "height": 260,
+     "maxw": null,
      "variants": [
       {
        "id": "default",
@@ -1333,7 +1475,8 @@ window.UI_GALLERY = {
      "title": "Garage icon",
      "axis": null,
      "note": null,
-     "height": 120,
+     "height": 110,
+     "maxw": null,
      "variants": [
       {
        "id": "default",
@@ -1372,7 +1515,8 @@ window.UI_GALLERY = {
      "title": "Garage door button",
      "axis": null,
      "note": "The round remote button, one tile per ButtonStateMachine state.",
-     "height": 150,
+     "height": 130,
+     "maxw": null,
      "variants": [
       {
        "id": "default",
@@ -1558,7 +1702,8 @@ window.UI_GALLERY = {
      "title": "Remote button states grid (iOS)",
      "axis": null,
      "note": null,
-     "height": 320,
+     "height": 260,
+     "maxw": null,
      "variants": [
       {
        "id": "default",
@@ -1585,141 +1730,182 @@ window.UI_GALLERY = {
     {
      "id": "remote-section",
      "title": "Remote control section",
-     "axis": "Button state",
-     "note": "The full-width Home section that hosts the button, flipped through states.",
-     "height": 240,
+     "axis": null,
+     "note": "The full-width Home section that hosts the button, one tile per state.",
+     "height": 180,
+     "maxw": 340,
      "variants": [
       {
-       "id": "ready",
-       "label": "Ready"
-      },
-      {
-       "id": "preparing",
-       "label": "Preparing"
-      },
-      {
-       "id": "awaiting",
-       "label": "Awaiting confirmation"
-      },
-      {
-       "id": "sending-server",
-       "label": "Sending to server"
-      },
-      {
-       "id": "sending-door",
-       "label": "Sending to door"
-      },
-      {
-       "id": "succeeded",
-       "label": "Succeeded"
-      },
-      {
-       "id": "cancelled",
-       "label": "Cancelled"
-      },
-      {
-       "id": "server-failed",
-       "label": "Server failed"
-      },
-      {
-       "id": "door-failed",
-       "label": "Door failed"
+       "id": "default",
+       "label": "Default"
       }
      ],
      "items": [
       {
-       "id": "section",
-       "label": "Section",
+       "id": "ready",
+       "label": "Ready",
        "platforms": [
         "android"
        ],
        "images": {
-        "ready|android|light": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 295
         },
-        "ready|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 295
-        },
-        "preparing|android|light": {
+        }
+       }
+      },
+      {
+       "id": "preparing",
+       "label": "Preparing",
+       "platforms": [
+        "android"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentPreparingPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 295
         },
-        "preparing|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentPreparingPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 295
-        },
-        "awaiting|android|light": {
+        }
+       }
+      },
+      {
+       "id": "awaiting",
+       "label": "Awaiting confirmation",
+       "platforms": [
+        "android"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentAwaitingConfirmationPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 295
         },
-        "awaiting|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentAwaitingConfirmationPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 295
-        },
-        "sending-server|android|light": {
+        }
+       }
+      },
+      {
+       "id": "sending-server",
+       "label": "Sending to server",
+       "platforms": [
+        "android"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentSendingToServerPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 295
         },
-        "sending-server|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentSendingToServerPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 295
-        },
-        "sending-door|android|light": {
+        }
+       }
+      },
+      {
+       "id": "sending-door",
+       "label": "Sending to door",
+       "platforms": [
+        "android"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentSendingToDoorPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 295
         },
-        "sending-door|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentSendingToDoorPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 295
-        },
-        "succeeded|android|light": {
+        }
+       }
+      },
+      {
+       "id": "succeeded",
+       "label": "Succeeded",
+       "platforms": [
+        "android"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentSucceededPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 295
         },
-        "succeeded|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentSucceededPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 295
-        },
-        "cancelled|android|light": {
+        }
+       }
+      },
+      {
+       "id": "cancelled",
+       "label": "Cancelled",
+       "platforms": [
+        "android"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentCancelledPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 295
         },
-        "cancelled|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentCancelledPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 295
-        },
-        "server-failed|android|light": {
+        }
+       }
+      },
+      {
+       "id": "server-failed",
+       "label": "Server failed",
+       "platforms": [
+        "android"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentServerFailedPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 295
         },
-        "server-failed|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentServerFailedPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 295
-        },
-        "door-failed|android|light": {
+        }
+       }
+      },
+      {
+       "id": "door-failed",
+       "label": "Door failed",
+       "platforms": [
+        "android"
+       ],
+       "images": {
+        "default|android|light": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentDoorFailedPreviewTest_Light_fc5b723e_0.png",
          "w": 1080,
          "h": 295
         },
-        "door-failed|android|dark": {
+        "default|android|dark": {
          "src": "../android-screenshot-tests/src/screenshotTestDebug/reference/com/chriscartland/garage/screenshottests/ComponentsScreenshotTestKt/RemoteButtonContentDoorFailedPreviewTest_Dark_77106447_0.png",
          "w": 1080,
          "h": 295
@@ -1733,7 +1919,8 @@ window.UI_GALLERY = {
      "title": "Network diagram",
      "axis": null,
      "note": "The phone-to-server-to-door progress diagram shown while a press is in flight.",
-     "height": 150,
+     "height": 120,
+     "maxw": 320,
      "variants": [
       {
        "id": "default",
@@ -1867,7 +2054,8 @@ window.UI_GALLERY = {
      "title": "Device check-in pill",
      "axis": null,
      "note": null,
-     "height": 100,
+     "height": 80,
+     "maxw": 240,
      "variants": [
       {
        "id": "default",
@@ -1958,7 +2146,8 @@ window.UI_GALLERY = {
      "title": "Remote button health pill",
      "axis": null,
      "note": null,
-     "height": 100,
+     "height": 80,
+     "maxw": 240,
      "variants": [
       {
        "id": "default",
@@ -2049,7 +2238,8 @@ window.UI_GALLERY = {
      "title": "Remote offline pill",
      "axis": null,
      "note": null,
-     "height": 100,
+     "height": 80,
+     "maxw": 240,
      "variants": [
       {
        "id": "default",
@@ -2140,7 +2330,8 @@ window.UI_GALLERY = {
      "title": "Door status card",
      "axis": null,
      "note": null,
-     "height": 190,
+     "height": 160,
+     "maxw": 320,
      "variants": [
       {
        "id": "default",
@@ -2174,7 +2365,8 @@ window.UI_GALLERY = {
      "title": "Error card",
      "axis": null,
      "note": null,
-     "height": 190,
+     "height": 160,
+     "maxw": 320,
      "variants": [
       {
        "id": "default",
@@ -2251,7 +2443,8 @@ window.UI_GALLERY = {
      "title": "Hero flow",
      "axis": null,
      "note": "The single wear screen through the press narrative. Emulator captures, clock pinned to 10:10.",
-     "height": 220,
+     "height": 190,
+     "maxw": null,
      "variants": [
       {
        "id": "default",
@@ -2361,7 +2554,8 @@ window.UI_GALLERY = {
      "title": "Sign-in",
      "axis": null,
      "note": null,
-     "height": 220,
+     "height": 190,
+     "maxw": null,
      "variants": [
       {
        "id": "default",

--- a/MobileGarage/ui-gallery/manifest.yaml
+++ b/MobileGarage/ui-gallery/manifest.yaml
@@ -4,11 +4,15 @@
 # Regenerate manifest.js after editing:  python3 scripts/generate-ui-gallery.py
 # Schema + curation philosophy: MobileGarage/ui-gallery/README.md
 #
-# The two per-row dimensions:
-#   items    = what you compare SIDE BY SIDE at a glance (up/down selects the row)
-#   variants = what you FLIP IN PLACE with left/right (one axis per row)
-# Small components put their states in `items` (see everything at once);
-# full screens put their states in `variants` (flip one big image).
+# Density-first curation: every row shows ALL of its states side by side
+# (`items`), wrapping onto multiple lines — never a horizontal scroll and
+# never a flip-through. The `variants` axis (left/right keys) exists in the
+# schema but is deliberately unused today: nothing in the current content
+# earns a flip when everything fits on screen at once.
+#
+# Sizing: `height` is the nominal tile height; `maxw` (default 420) caps the
+# display width so wide components (pills, full-width sections) scale DOWN
+# to fit instead of blowing up.
 #
 # Global dimensions (apply to every row):
 #   platform = Space key cycles `platformCycle`. Rows captured only on a
@@ -18,15 +22,17 @@
 # Image value idioms (one per platform, by design):
 #   android: ${ref}/...Foo_{theme}_*.png   # {theme} -> Light/Dark; * absorbs the
 #                                          # AGP content hash that changes on regen
-#   ios:     {light: "${ios}/Bar.1.png"}     # explicit: iOS snapshots are light-only
+#   ios:     {light: "${ios}/Bar.1.png"}   # explicit: iOS snapshots are light-only
 #   wear:    ${wear}/wear-baz.png          # plain string = all themes (the wear UI
 #                                          # has a single theme; same capture both)
+# Quote YAML boolean-like ids ("off", "on", "yes", "no") — YAML 1.1 parses
+# them as booleans and the generator rejects non-string ids.
 #
 # Deliberately omitted (curation, not exhaustiveness): synthetic fixtures
-# (SafeListContentPaddingCanary, SpacingTokensReference), *Screen/*Tab wrappers
-# that duplicate their *Content previews, framed marketing shots, and store
-# composites. Add a row when a state matters for design review, not merely
-# because a PNG exists.
+# (SafeListContentPaddingCanary, SpacingTokensReference), *Screen/*Tab
+# wrappers that duplicate their *Content previews, framed marketing shots,
+# and store composites. Add a row when a state matters for design review,
+# not merely because a PNG exists.
 
 version: 1
 
@@ -48,189 +54,185 @@ sections:
     rows:
       - id: home
         title: Home
-        axis: State
-        height: 420
-        variants:
-          - {id: closed, label: Closed}
-          - {id: open, label: Open}
-          - {id: confirming, label: Confirming}
-          - {id: sending, label: Sending}
-          - {id: warning, label: Open too long}
-          - {id: stale, label: Stale data}
-          - {id: alerts, label: Alerts}
-          - {id: signed-out, label: Signed out}
+        height: 300
         items:
-          - id: screen
-            label: Phone
+          - id: closed
+            label: Closed
             images:
-              closed:
-                android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentClosedSignedInPreviewTest_{theme}_*.png
-                ios: {light: "${ios}/Home-closed-signed-out.1.png"}
-              open:
-                android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentOpenSignedInPreviewTest_{theme}_*.png
-                ios: {light: "${ios}/Home-open-signed-in.1.png"}
-              confirming:
-                android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentAwaitingConfirmationPreviewTest_{theme}_*.png
-                ios: {light: "${ios}/Home-confirm-state.1.png"}
-              sending:
-                android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentSendingToDoorPreviewTest_{theme}_*.png
-              warning:
-                android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentOpeningTooLongPreviewTest_{theme}_*.png
-                ios: {light: "${ios}/Home-opening-too-long-warning.1.png"}
-              stale:
-                android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentStaleBannerPreviewTest_{theme}_*.png
-              alerts:
-                android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentPermissionMissingPreviewTest_{theme}_*.png
-                ios: {light: "${ios}/Home-with-alerts.1.png"}
-              signed-out:
-                android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentSignedOutPreviewTest_{theme}_*.png
-                ios: {light: "${ios}/Home-sign-in-row.1.png"}
+              android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentClosedSignedInPreviewTest_{theme}_*.png
+              ios: {light: "${ios}/Home-closed-signed-out.1.png"}
+          - id: open
+            label: Open
+            images:
+              android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentOpenSignedInPreviewTest_{theme}_*.png
+              ios: {light: "${ios}/Home-open-signed-in.1.png"}
+          - id: confirming
+            label: Confirming
+            images:
+              android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentAwaitingConfirmationPreviewTest_{theme}_*.png
+              ios: {light: "${ios}/Home-confirm-state.1.png"}
+          - id: sending
+            label: Sending
+            images:
+              android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentSendingToDoorPreviewTest_{theme}_*.png
+          - id: warning
+            label: Open too long
+            images:
+              android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentOpeningTooLongPreviewTest_{theme}_*.png
+              ios: {light: "${ios}/Home-opening-too-long-warning.1.png"}
+          - id: stale
+            label: Stale data
+            images:
+              android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentStaleBannerPreviewTest_{theme}_*.png
+          - id: alerts
+            label: Alerts
+            images:
+              android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentPermissionMissingPreviewTest_{theme}_*.png
+              ios: {light: "${ios}/Home-with-alerts.1.png"}
+          - id: signed-out
+            label: Signed out
+            images:
+              android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentSignedOutPreviewTest_{theme}_*.png
+              ios: {light: "${ios}/Home-sign-in-row.1.png"}
 
       - id: home-remote-pill
         title: Home, remote pill states
-        axis: Pill state
-        height: 420
-        note: Same Home screen flipped through the remote-button health pill states.
-        variants:
-          - {id: online, label: Online}
-          - {id: offline, label: Offline}
-          - {id: unauthorized, label: Unauthorized}
-          - {id: unknown, label: Unknown}
+        height: 300
+        note: Same Home screen across the remote-button health pill states.
         items:
-          - id: screen
-            label: Phone
+          - id: online
+            label: Online
             images:
-              online:
-                android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentRemotePillOnlinePreviewTest_{theme}_*.png
-              offline:
-                android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentRemotePillOfflinePreviewTest_{theme}_*.png
-              unauthorized:
-                android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentRemotePillUnauthorizedPreviewTest_{theme}_*.png
-              unknown:
-                android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentRemotePillUnknownPreviewTest_{theme}_*.png
+              android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentRemotePillOnlinePreviewTest_{theme}_*.png
+          - id: offline
+            label: Offline
+            images:
+              android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentRemotePillOfflinePreviewTest_{theme}_*.png
+          - id: unauthorized
+            label: Unauthorized
+            images:
+              android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentRemotePillUnauthorizedPreviewTest_{theme}_*.png
+          - id: unknown
+            label: Unknown
+            images:
+              android: ${ref}/HomeRedesignScreenshotTestKt/HomeContentRemotePillUnknownPreviewTest_{theme}_*.png
 
       - id: history
         title: History
-        axis: State
-        height: 420
-        variants:
-          - {id: recent, label: Recent events}
-          - {id: closed-days, label: Closed days}
-          - {id: empty, label: Empty}
-          - {id: loading-older, label: Loading older}
-          - {id: reached-beginning, label: Reached beginning}
-          - {id: stale, label: Stale banner}
+        height: 300
         items:
-          - id: screen
-            label: Phone
+          - id: recent
+            label: Recent events
             images:
-              recent:
-                android: ${ref}/HistoryRedesignScreenshotTestKt/HistoryContentMultiDayPreviewTest_{theme}_*.png
-                ios: {light: "${ios}/History-recent-events.1.png"}
-              closed-days:
-                android: ${ref}/HistoryRedesignScreenshotTestKt/HistoryContentMultiDayClosedPreviewTest_{theme}_*.png
-                ios: {light: "${ios}/History-closed-states.1.png"}
-              empty:
-                android: ${ref}/HistoryRedesignScreenshotTestKt/HistoryContentEmptyPreviewTest_{theme}_*.png
-                ios: {light: "${ios}/History-empty.1.png"}
-              loading-older:
-                ios: {light: "${ios}/History-loading-older-page.1.png"}
-              reached-beginning:
-                ios: {light: "${ios}/History-reached-beginning.1.png"}
-              stale:
-                ios: {light: "${ios}/History-stale-banner.1.png"}
+              android: ${ref}/HistoryRedesignScreenshotTestKt/HistoryContentMultiDayPreviewTest_{theme}_*.png
+              ios: {light: "${ios}/History-recent-events.1.png"}
+          - id: closed-days
+            label: Closed days
+            images:
+              android: ${ref}/HistoryRedesignScreenshotTestKt/HistoryContentMultiDayClosedPreviewTest_{theme}_*.png
+              ios: {light: "${ios}/History-closed-states.1.png"}
+          - id: empty
+            label: Empty
+            images:
+              android: ${ref}/HistoryRedesignScreenshotTestKt/HistoryContentEmptyPreviewTest_{theme}_*.png
+              ios: {light: "${ios}/History-empty.1.png"}
+          - id: loading-older
+            label: Loading older
+            images:
+              ios: {light: "${ios}/History-loading-older-page.1.png"}
+          - id: reached-beginning
+            label: Reached beginning
+            images:
+              ios: {light: "${ios}/History-reached-beginning.1.png"}
+          - id: stale
+            label: Stale banner
+            images:
+              ios: {light: "${ios}/History-stale-banner.1.png"}
 
       - id: settings
         title: Settings
-        axis: State
-        height: 420
-        variants:
-          - {id: signed-in, label: Signed in (allowlisted)}
-          - {id: signed-in-basic, label: Signed in (basic)}
-          - {id: signed-out, label: Signed out}
-          - {id: permission-denied, label: Notifications off}
-          - {id: snooze-sending, label: Snooze sending}
+        height: 300
         items:
-          - id: screen
-            label: Phone
+          - id: signed-in
+            label: Signed in (allowlisted)
             images:
-              signed-in:
-                android: ${ref}/SettingsRedesignScreenshotTestKt/SettingsContentSignedInAllowlistedPreviewTest_{theme}_*.png
-                ios: {light: "${ios}/Settings-signed-in-developer.1.png"}
-              signed-in-basic:
-                android: ${ref}/SettingsRedesignScreenshotTestKt/SettingsContentSignedInBasicPreviewTest_{theme}_*.png
-              signed-out:
-                android: ${ref}/SettingsRedesignScreenshotTestKt/SettingsContentSignedOutPreviewTest_{theme}_*.png
-                ios: {light: "${ios}/Settings-signed-out.1.png"}
-              permission-denied:
-                android: ${ref}/SettingsRedesignScreenshotTestKt/SettingsContentPermissionDeniedPreviewTest_{theme}_*.png
-                ios: {light: "${ios}/Settings-notifications-disabled.1.png"}
-              snooze-sending:
-                android: ${ref}/SettingsRedesignScreenshotTestKt/SettingsContentSnoozeInFlightPreviewTest_{theme}_*.png
-                ios: {light: "${ios}/Settings-snooze-sending.1.png"}
+              android: ${ref}/SettingsRedesignScreenshotTestKt/SettingsContentSignedInAllowlistedPreviewTest_{theme}_*.png
+              ios: {light: "${ios}/Settings-signed-in-developer.1.png"}
+          - id: signed-in-basic
+            label: Signed in (basic)
+            images:
+              android: ${ref}/SettingsRedesignScreenshotTestKt/SettingsContentSignedInBasicPreviewTest_{theme}_*.png
+          - id: signed-out
+            label: Signed out
+            images:
+              android: ${ref}/SettingsRedesignScreenshotTestKt/SettingsContentSignedOutPreviewTest_{theme}_*.png
+              ios: {light: "${ios}/Settings-signed-out.1.png"}
+          - id: permission-denied
+            label: Notifications off
+            images:
+              android: ${ref}/SettingsRedesignScreenshotTestKt/SettingsContentPermissionDeniedPreviewTest_{theme}_*.png
+              ios: {light: "${ios}/Settings-notifications-disabled.1.png"}
+          - id: snooze-sending
+            label: Snooze sending
+            images:
+              android: ${ref}/SettingsRedesignScreenshotTestKt/SettingsContentSnoozeInFlightPreviewTest_{theme}_*.png
+              ios: {light: "${ios}/Settings-snooze-sending.1.png"}
 
       - id: functions
         title: Function list
-        axis: Access
-        height: 420
-        variants:
-          - {id: granted, label: Granted}
-          - {id: denied, label: Denied}
-          - {id: test-notifications, label: Test notifications}
+        height: 300
         items:
-          - id: screen
-            label: Phone
+          - id: granted
+            label: Granted
             images:
-              granted:
-                android: ${ref}/ScreensScreenshotTestKt/FunctionListContentPreviewTest_{theme}_*.png
-                ios: {light: "${ios}/Functions-granted.1.png"}
-              denied:
-                android: ${ref}/ScreensScreenshotTestKt/FunctionListContentDeniedPreviewTest_{theme}_*.png
-                ios: {light: "${ios}/Functions-locked.1.png"}
-              test-notifications:
-                ios: {light: "${ios}/Functions-test-notifications.1.png"}
+              android: ${ref}/ScreensScreenshotTestKt/FunctionListContentPreviewTest_{theme}_*.png
+              ios: {light: "${ios}/Functions-granted.1.png"}
+          - id: denied
+            label: Denied
+            images:
+              android: ${ref}/ScreensScreenshotTestKt/FunctionListContentDeniedPreviewTest_{theme}_*.png
+              ios: {light: "${ios}/Functions-locked.1.png"}
+          - id: test-notifications
+            label: Test notifications
+            images:
+              ios: {light: "${ios}/Functions-test-notifications.1.png"}
 
       - id: diagnostics
         title: Diagnostics
-        axis: State
-        height: 420
-        variants:
-          - {id: default, label: Counters}
-          - {id: clearing, label: Clear in flight}
+        height: 300
         items:
-          - id: screen
-            label: Phone
+          - id: counters
+            label: Counters
             images:
-              default:
-                android: ${ref}/SettingsRedesignScreenshotTestKt/DiagnosticsContentPreviewTest_{theme}_*.png
-                ios: {light: "${ios}/Diagnostics-counters.1.png"}
-              clearing:
-                android: ${ref}/SettingsRedesignScreenshotTestKt/DiagnosticsContentClearInFlightPreviewTest_{theme}_*.png
+              android: ${ref}/SettingsRedesignScreenshotTestKt/DiagnosticsContentPreviewTest_{theme}_*.png
+              ios: {light: "${ios}/Diagnostics-counters.1.png"}
+          - id: clearing
+            label: Clear in flight
+            images:
+              android: ${ref}/SettingsRedesignScreenshotTestKt/DiagnosticsContentClearInFlightPreviewTest_{theme}_*.png
 
   - title: Sheets & dialogs
     rows:
       - id: sheet-snooze
         title: Snooze sheet
-        axis: State
-        height: 300
-        variants:
-          # "off"/"on"/"yes"/"no" must stay quoted: YAML 1.1 parses them as booleans.
-          - {id: "off", label: Nothing selected}
-          - {id: active, label: Option selected}
+        height: 240
+        maxw: 300
         items:
-          - id: sheet
-            label: Sheet
+          - id: "off"
+            label: Nothing selected
             images:
-              "off":
-                android: ${ref}/SettingsRedesignScreenshotTestKt/SnoozeSheetContentOffPreviewTest_{theme}_*.png
-                ios: {light: "${ios}/Snooze-sheet-nothing-selected.1.png"}
-              active:
-                android: ${ref}/SettingsRedesignScreenshotTestKt/SnoozeSheetContentActivePreviewTest_{theme}_*.png
-                ios: {light: "${ios}/Snooze-sheet-option-selected.1.png"}
+              android: ${ref}/SettingsRedesignScreenshotTestKt/SnoozeSheetContentOffPreviewTest_{theme}_*.png
+              ios: {light: "${ios}/Snooze-sheet-nothing-selected.1.png"}
+          - id: active
+            label: Option selected
+            images:
+              android: ${ref}/SettingsRedesignScreenshotTestKt/SnoozeSheetContentActivePreviewTest_{theme}_*.png
+              ios: {light: "${ios}/Snooze-sheet-option-selected.1.png"}
 
       - id: sheet-account
         title: Account & version sheets
-        height: 300
+        height: 240
+        maxw: 300
         items:
           - id: account
             label: Account
@@ -244,7 +246,8 @@ sections:
 
       - id: info-sheets
         title: Info sheets
-        height: 300
+        height: 240
+        maxw: 300
         items:
           - id: door-status
             label: Door status
@@ -259,7 +262,8 @@ sections:
 
       - id: dialog-clear
         title: Clear diagnostics dialog
-        height: 240
+        height: 200
+        maxw: 300
         items:
           - id: dialog
             label: Dialog
@@ -270,7 +274,8 @@ sections:
     rows:
       - id: dashboard-widths
         title: Home dashboard by width
-        height: 280
+        height: 230
+        maxw: 520
         items:
           - id: tablet-home
             label: Home on tablet
@@ -295,7 +300,8 @@ sections:
 
       - id: rail
         title: Navigation rail
-        height: 280
+        height: 230
+        maxw: 520
         items:
           - id: home-700
             label: Home + rail (700 dp)
@@ -312,7 +318,8 @@ sections:
 
       - id: three-pane
         title: Three-pane dashboard
-        height: 280
+        height: 230
+        maxw: 520
         items:
           - id: phone-landscape
             label: Phone landscape
@@ -335,7 +342,7 @@ sections:
     rows:
       - id: door-canvas
         title: Door canvas
-        height: 170
+        height: 130
         note: The shared door drawing. iOS renders the same geometry from the KMP constants.
         items:
           - id: closed
@@ -379,7 +386,7 @@ sections:
 
       - id: door-grid-ios
         title: Door states grid (iOS)
-        height: 320
+        height: 260
         note: The iOS snapshot gallery captures all door states as one composite.
         items:
           - id: grid
@@ -389,7 +396,7 @@ sections:
 
       - id: garage-icon
         title: Garage icon
-        height: 120
+        height: 110
         items:
           - id: icon
             label: Icon
@@ -400,7 +407,7 @@ sections:
     rows:
       - id: door-button
         title: Garage door button
-        height: 150
+        height: 130
         note: The round remote button, one tile per ButtonStateMachine state.
         items:
           - id: ready
@@ -442,7 +449,7 @@ sections:
 
       - id: button-grid-ios
         title: Remote button states grid (iOS)
-        height: 320
+        height: 260
         items:
           - id: grid
             label: All states
@@ -451,45 +458,51 @@ sections:
 
       - id: remote-section
         title: Remote control section
-        axis: Button state
-        height: 240
-        note: The full-width Home section that hosts the button, flipped through states.
-        variants:
-          - {id: ready, label: Ready}
-          - {id: preparing, label: Preparing}
-          - {id: awaiting, label: Awaiting confirmation}
-          - {id: sending-server, label: Sending to server}
-          - {id: sending-door, label: Sending to door}
-          - {id: succeeded, label: Succeeded}
-          - {id: cancelled, label: Cancelled}
-          - {id: server-failed, label: Server failed}
-          - {id: door-failed, label: Door failed}
+        height: 180
+        maxw: 340
+        note: The full-width Home section that hosts the button, one tile per state.
         items:
-          - id: section
-            label: Section
+          - id: ready
+            label: Ready
             images:
-              ready:
-                android: ${ref}/ComponentsScreenshotTestKt/RemoteButtonContentPreviewTest_{theme}_*.png
-              preparing:
-                android: ${ref}/ComponentsScreenshotTestKt/RemoteButtonContentPreparingPreviewTest_{theme}_*.png
-              awaiting:
-                android: ${ref}/ComponentsScreenshotTestKt/RemoteButtonContentAwaitingConfirmationPreviewTest_{theme}_*.png
-              sending-server:
-                android: ${ref}/ComponentsScreenshotTestKt/RemoteButtonContentSendingToServerPreviewTest_{theme}_*.png
-              sending-door:
-                android: ${ref}/ComponentsScreenshotTestKt/RemoteButtonContentSendingToDoorPreviewTest_{theme}_*.png
-              succeeded:
-                android: ${ref}/ComponentsScreenshotTestKt/RemoteButtonContentSucceededPreviewTest_{theme}_*.png
-              cancelled:
-                android: ${ref}/ComponentsScreenshotTestKt/RemoteButtonContentCancelledPreviewTest_{theme}_*.png
-              server-failed:
-                android: ${ref}/ComponentsScreenshotTestKt/RemoteButtonContentServerFailedPreviewTest_{theme}_*.png
-              door-failed:
-                android: ${ref}/ComponentsScreenshotTestKt/RemoteButtonContentDoorFailedPreviewTest_{theme}_*.png
+              android: ${ref}/ComponentsScreenshotTestKt/RemoteButtonContentPreviewTest_{theme}_*.png
+          - id: preparing
+            label: Preparing
+            images:
+              android: ${ref}/ComponentsScreenshotTestKt/RemoteButtonContentPreparingPreviewTest_{theme}_*.png
+          - id: awaiting
+            label: Awaiting confirmation
+            images:
+              android: ${ref}/ComponentsScreenshotTestKt/RemoteButtonContentAwaitingConfirmationPreviewTest_{theme}_*.png
+          - id: sending-server
+            label: Sending to server
+            images:
+              android: ${ref}/ComponentsScreenshotTestKt/RemoteButtonContentSendingToServerPreviewTest_{theme}_*.png
+          - id: sending-door
+            label: Sending to door
+            images:
+              android: ${ref}/ComponentsScreenshotTestKt/RemoteButtonContentSendingToDoorPreviewTest_{theme}_*.png
+          - id: succeeded
+            label: Succeeded
+            images:
+              android: ${ref}/ComponentsScreenshotTestKt/RemoteButtonContentSucceededPreviewTest_{theme}_*.png
+          - id: cancelled
+            label: Cancelled
+            images:
+              android: ${ref}/ComponentsScreenshotTestKt/RemoteButtonContentCancelledPreviewTest_{theme}_*.png
+          - id: server-failed
+            label: Server failed
+            images:
+              android: ${ref}/ComponentsScreenshotTestKt/RemoteButtonContentServerFailedPreviewTest_{theme}_*.png
+          - id: door-failed
+            label: Door failed
+            images:
+              android: ${ref}/ComponentsScreenshotTestKt/RemoteButtonContentDoorFailedPreviewTest_{theme}_*.png
 
       - id: network-diagram
         title: Network diagram
-        height: 150
+        height: 120
+        maxw: 320
         note: The phone-to-server-to-door progress diagram shown while a press is in flight.
         items:
           - id: idle
@@ -521,7 +534,8 @@ sections:
     rows:
       - id: checkin-pill
         title: Device check-in pill
-        height: 100
+        height: 80
+        maxw: 240
         items:
           - id: fresh
             label: Fresh
@@ -542,7 +556,8 @@ sections:
 
       - id: health-pill
         title: Remote button health pill
-        height: 100
+        height: 80
+        maxw: 240
         items:
           - id: available
             label: Available
@@ -563,7 +578,8 @@ sections:
 
       - id: offline-pill
         title: Remote offline pill
-        height: 100
+        height: 80
+        maxw: 240
         items:
           - id: fresh
             label: Fresh
@@ -584,7 +600,8 @@ sections:
 
       - id: status-card
         title: Door status card
-        height: 190
+        height: 160
+        maxw: 320
         items:
           - id: card
             label: Card
@@ -593,7 +610,8 @@ sections:
 
       - id: error-card
         title: Error card
-        height: 190
+        height: 160
+        maxw: 320
         items:
           - id: default
             label: Default
@@ -612,7 +630,7 @@ sections:
     rows:
       - id: wear-hero
         title: Hero flow
-        height: 220
+        height: 190
         note: The single wear screen through the press narrative. Emulator captures, clock pinned to 10:10.
         items:
           - id: closed
@@ -638,7 +656,7 @@ sections:
 
       - id: wear-signin
         title: Sign-in
-        height: 220
+        height: 190
         items:
           - id: signed-out
             label: Signed out

--- a/scripts/generate-ui-gallery.py
+++ b/scripts/generate-ui-gallery.py
@@ -218,6 +218,7 @@ def build_manifest(doc):
                     "axis": row.get("axis"),
                     "note": row.get("note"),
                     "height": row.get("height", 360),
+                    "maxw": row.get("maxw"),
                     "variants": variants,
                     "items": items,
                 }


### PR DESCRIPTION
Gallery feedback round:

- **No more variant pills.** Every row now shows ALL of its states side by side as captioned items — 8 Home states in one glance instead of 1 image + 8 chips. The `variants` axis stays in the schema/viewer for a future row that genuinely can't show everything at once; the current curation uses none.
- **No horizontal scrolling.** Row strips wrap to the window width (`flex-wrap`); a "row" is a logical grouping, not a literal single line.
- **Width caps.** New row-level `maxw` (default 420px): wide images scale DOWN proportionally instead of blowing up — the Remote offline pill now renders at 240px, the Remote control section at 340px.
- Tile heights reduced across the board for density (screens 420→300, pills →80, etc.).

Verified with headless-Chrome renders: Home row shows all 8 states on one wrapped line, the 9-state Remote control section wraps to two lines, pills are compact, zero horizontal scrollbars.

On the Android/iOS parity notes from the feedback: iOS-only states (History paging, Functions test-notifications) show as honest placeholders under the Android platform toggle. Closing those gaps means adding Android previews for the missing states — deferred, since new Android reference PNGs can only render in a working Layoutlib env (local renders blank), and per the feedback we'd conform to Android structure where the structures differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)