### PR TITLE
chore: bump versionName to 2.21.1 (Android) and 0.1.5 (Wear)

### DIFF
--- a/MobileGarage/CHANGELOG.md
+++ b/MobileGarage/CHANGELOG.md
@@ -15,6 +15,11 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
 
+## 2.21.1
+
+- **Calmer cold start.** Before the first door status arrives, Home now shows "Connecting…" instead of a gray door with a warning badge labeled "Unknown" — a real server-reported unknown state still shows the warning look. Settings shows a "Checking sign-in…" row instead of briefly flashing a "Sign in with Google" prompt at already-signed-in users while auth resolves. No structural change to either screen's states or flows, only the presentation of the pre-data window.
+- **Internal:** #1101 — `HomeStatusDisplay.hasData` / `AccountRowState.Checking`; `GarageIcon.suppressWarningOverlay` withholds the warning badge only when no door event exists at all. New previews (`HomeContentConnecting`, `SettingsContentChecking`). No new capability; patch.
+
 ## 2.21.0
 
 - Wear OS companion sign-in: the phone now answers the watch's request for

--- a/MobileGarage/version.properties
+++ b/MobileGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.21.0
+versionName=2.21.1

--- a/MobileGarage/wearApp/CHANGELOG.md
+++ b/MobileGarage/wearApp/CHANGELOG.md
@@ -14,6 +14,20 @@ The phone app's history lives in [`../CHANGELOG.md`](../CHANGELOG.md).
 Same rule as the phone app: major = rewrite or core-experience shift;
 minor = added or removed user-facing feature; patch = fixes, polish, refactors.
 
+## 0.1.5
+
+- The hold-to-confirm ring is now centered on the physical screen and hugs
+  the bezel, instead of circling the door image off-center. The screen now
+  stays on for up to 15 seconds while a press is in flight or the door is
+  moving, so you can watch the action complete without the display timing
+  out; it never stays on just because the button is armed. Pressing now
+  allows a little more time before showing "Door did not move," since the
+  watch's network path is less reliable than the phone's.
+- Before the first door status arrives, the screen now shows "Connecting…"
+  with no warning badge, instead of a gray door labeled "Unknown" with a
+  warning triangle — calmer during the first few seconds after opening the
+  app.
+
 ## 0.1.4
 
 - Armed button stays armed while you keep touching the screen: every touch

--- a/MobileGarage/wearApp/version.properties
+++ b/MobileGarage/wearApp/version.properties
@@ -1,1 +1,1 @@
-versionName=0.1.4
+versionName=0.1.5


### PR DESCRIPTION
Patch version bumps for this session's UI-polish batch, cutting a release of both apps.

## Android 2.21.0 → 2.21.1
- #1101 — calm cold-start presentation (Home "Connecting…" instead of "Unknown"+⚠, Settings "Checking sign-in…" instead of flashing the sign-in CTA)

## Wear 0.1.4 → 0.1.5
- #1100 — screen-centered hold ring, scoped keep-screen-on (15s cap while a press is in flight or the door is moving), longer wear-specific door-response grace
- #1103 — calm connecting presentation (mirrors the Android change)

No new capability on either platform; both are bug-fix/polish patch releases. Full `./scripts/validate.sh` passed ("All checks passed", zero FAIL markers) on this branch.

Once merged, both `android/N` and `wear/N` releases will be cut from the merge commit per `CLAUDE.md` § Releasing Android / § Releasing Wear OS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)