### PR TITLE
feat(settings): install-on-watch row with live detection

### DIFF
--- a/MobileGarage/android-screenshot-tests/PREVIEW_COVERAGE.md
+++ b/MobileGarage/android-screenshot-tests/PREVIEW_COVERAGE.md
@@ -3,7 +3,7 @@
 
 # Preview Screenshot Coverage
 
-**100 / 100 (100%)**
+**102 / 102 (100%)**
 
 ## Covered
 
@@ -98,6 +98,8 @@
 - `SettingsContentSignedInBasicPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt`
 - `SettingsContentSignedOutPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt`
 - `SettingsContentSnoozeInFlightPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt`
+- `SettingsContentWatchInstallPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt`
+- `SettingsContentWatchInstalledPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt`
 - `SettingsTabPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/TabPreviews.kt`
 - `SnoozeSheetContentActivePreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/settings/SnoozeBottomSheet.kt`
 - `SnoozeSheetContentOffPreview` — `androidApp/src/main/java/com/chriscartland/garage/ui/settings/SnoozeBottomSheet.kt`

--- a/MobileGarage/android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/SettingsRedesignScreenshotTest.kt
+++ b/MobileGarage/android-screenshot-tests/src/screenshotTest/kotlin/com/chriscartland/garage/screenshottests/SettingsRedesignScreenshotTest.kt
@@ -30,6 +30,8 @@ import com.chriscartland.garage.ui.settings.SettingsContentSignedInAllowlistedPr
 import com.chriscartland.garage.ui.settings.SettingsContentSignedInBasicPreview
 import com.chriscartland.garage.ui.settings.SettingsContentSignedOutPreview
 import com.chriscartland.garage.ui.settings.SettingsContentSnoozeInFlightPreview
+import com.chriscartland.garage.ui.settings.SettingsContentWatchInstallPreview
+import com.chriscartland.garage.ui.settings.SettingsContentWatchInstalledPreview
 import com.chriscartland.garage.ui.settings.SnoozeSheetContentActivePreview
 import com.chriscartland.garage.ui.settings.SnoozeSheetContentOffPreview
 import com.chriscartland.garage.ui.settings.VersionSheetContentPreview
@@ -105,6 +107,30 @@ fun SettingsContentPermissionDeniedPreviewTest() {
 @Composable
 fun SettingsContentSnoozeInFlightPreviewTest() {
     AppTheme { SettingsContentSnoozeInFlightPreview() }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun SettingsContentWatchInstallPreviewTest() {
+    AppTheme { SettingsContentWatchInstallPreview() }
+}
+
+@PreviewTest
+@Preview(showBackground = true, name = "Light")
+@Preview(
+    showBackground = true,
+    name = "Dark",
+    uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun SettingsContentWatchInstalledPreviewTest() {
+    AppTheme { SettingsContentWatchInstalledPreview() }
 }
 
 @PreviewTest

--- a/MobileGarage/androidApp/build.gradle.kts
+++ b/MobileGarage/androidApp/build.gradle.kts
@@ -269,6 +269,12 @@ dependencies {
     implementation(libs.play.services.auth)
     // Wearable Data Layer — answers the watch's auth-relay RPC.
     implementation(libs.play.services.wearable)
+    // Install-on-watch: RemoteActivityHelper opens the Play Store listing
+    // on the paired watch; futures-ktx awaits its ListenableFuture and
+    // coroutines-play-services awaits the Wearable client Tasks.
+    implementation(libs.androidx.wear.remote.interactions)
+    implementation(libs.androidx.concurrent.futures.ktx)
+    implementation(libs.kotlinx.coroutines.play.services)
     // Testing
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -81,6 +81,7 @@ import com.chriscartland.garage.domain.repository.SnoozeDoorEventBridge
 import com.chriscartland.garage.domain.repository.SnoozeRepository
 import com.chriscartland.garage.domain.repository.TestNotificationRepository
 import com.chriscartland.garage.domain.repository.UserScopedCache
+import com.chriscartland.garage.domain.repository.WearCompanionRepository
 import com.chriscartland.garage.fcm.FirebaseMessagingBridge
 import com.chriscartland.garage.usecase.AppSettingsUseCase
 import com.chriscartland.garage.usecase.AppStartup
@@ -114,10 +115,12 @@ import com.chriscartland.garage.usecase.ObserveDiagnosticsCountUseCase
 import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
 import com.chriscartland.garage.usecase.ObserveFeatureAccessUseCase
 import com.chriscartland.garage.usecase.ObserveTestNotificationStateUseCase
+import com.chriscartland.garage.usecase.ObserveWatchAppStatusUseCase
 import com.chriscartland.garage.usecase.PruneDiagnosticsLogUseCase
 import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
 import com.chriscartland.garage.usecase.ReceiveFcmDoorEventUseCase
 import com.chriscartland.garage.usecase.RegisterFcmUseCase
+import com.chriscartland.garage.usecase.RequestWatchAppInstallUseCase
 import com.chriscartland.garage.usecase.RevalidateSnoozeStatusUseCase
 import com.chriscartland.garage.usecase.RunStartupDiagnosticsMaintenanceUseCase
 import com.chriscartland.garage.usecase.SeedDiagnosticsCountersFromRoomUseCase
@@ -133,6 +136,7 @@ import com.chriscartland.garage.viewmodel.DefaultDoorHistoryViewModel
 import com.chriscartland.garage.viewmodel.DefaultFunctionListViewModel
 import com.chriscartland.garage.viewmodel.DefaultHomeViewModel
 import com.chriscartland.garage.viewmodel.DefaultProfileViewModel
+import com.chriscartland.garage.wearrelay.PlayServicesWearCompanionRepository
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -364,6 +368,8 @@ abstract class AppComponent(
         computeEffectiveSnoozeState: ComputeEffectiveSnoozeStateUseCase,
         observeDoorEvents: ObserveDoorEventsUseCase,
         observeFeatureAccess: ObserveFeatureAccessUseCase,
+        observeWatchAppStatus: ObserveWatchAppStatusUseCase,
+        requestWatchAppInstall: RequestWatchAppInstallUseCase,
         signInWithGoogle: SignInWithGoogleUseCase,
         signOut: SignOutUseCase,
         fetchSnoozeStatus: FetchSnoozeStatusUseCase,
@@ -378,6 +384,8 @@ abstract class AppComponent(
             computeEffectiveSnoozeState = computeEffectiveSnoozeState,
             observeDoorEvents = observeDoorEvents,
             observeFeatureAccessUseCase = observeFeatureAccess,
+            observeWatchAppStatusUseCase = observeWatchAppStatus,
+            requestWatchAppInstallUseCase = requestWatchAppInstall,
             signInWithGoogleUseCase = signInWithGoogle,
             signOutUseCase = signOut,
             fetchSnoozeStatusUseCase = fetchSnoozeStatus,
@@ -531,6 +539,24 @@ abstract class AppComponent(
     @Provides
     fun provideObserveFeatureAccessUseCase(featureAllowlistRepository: FeatureAllowlistRepository): ObserveFeatureAccessUseCase =
         ObserveFeatureAccessUseCase(featureAllowlistRepository)
+
+    @Provides
+    fun provideWearCompanionRepository(): WearCompanionRepository =
+        PlayServicesWearCompanionRepository(
+            context = application.applicationContext,
+            // The Play listing identity. Debug/benchmark builds carry an
+            // applicationId suffix that has no listing, so this is the
+            // release id, not BuildConfig.APPLICATION_ID.
+            playStorePackageName = "com.chriscartland.garage",
+        )
+
+    @Provides
+    fun provideObserveWatchAppStatusUseCase(wearCompanionRepository: WearCompanionRepository): ObserveWatchAppStatusUseCase =
+        ObserveWatchAppStatusUseCase(wearCompanionRepository)
+
+    @Provides
+    fun provideRequestWatchAppInstallUseCase(wearCompanionRepository: WearCompanionRepository): RequestWatchAppInstallUseCase =
+        RequestWatchAppInstallUseCase(wearCompanionRepository)
 
     @Provides
     fun provideFetchButtonHealthUseCase(

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
@@ -48,6 +48,7 @@ import com.chriscartland.garage.domain.model.AppLinks
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.SnoozeAction
 import com.chriscartland.garage.domain.model.SnoozeState
+import com.chriscartland.garage.domain.model.WatchInstallAction
 import com.chriscartland.garage.permissions.rememberNotificationPermissionState
 import com.chriscartland.garage.ui.settings.AccountBottomSheet
 import com.chriscartland.garage.ui.settings.AccountRowState
@@ -96,6 +97,8 @@ fun ProfileContent(
     val layoutDebugEnabled by resolved.layoutDebugEnabled.collectAsState()
     val navigationRailItemPosition by resolved.navigationRailItemPosition.collectAsState()
     val navigationRailTopPaddingDp by resolved.navigationRailTopPaddingDp.collectAsState()
+    val watchAppStatus by resolved.watchAppStatus.collectAsState()
+    val watchInstallAction by resolved.watchInstallAction.collectAsState()
     val appConfig = component.appConfig
     val context = LocalContext.current
     // For click-time getString with runtime format args: LocalResources tracks
@@ -149,6 +152,23 @@ fun ProfileContent(
         }
     }
 
+    // Install-on-watch outcome: confirm success, or fall back to the
+    // phone's own Play Store listing (its device picker can target the
+    // watch) when the remote launch fails.
+    val watchInstallOpenedMessage = stringResource(R.string.watch_install_opened_snackbar)
+    val watchInstallFailedMessage = stringResource(R.string.watch_install_failed_snackbar)
+    LaunchedEffect(watchInstallAction) {
+        when (watchInstallAction) {
+            WatchInstallAction.OpenedOnWatch -> snackbarHostState.showSnackbar(watchInstallOpenedMessage)
+            WatchInstallAction.Failed -> {
+                val url = "https://play.google.com/store/apps/details?id=${appVersion.packageName}"
+                context.startActivity(Intent(Intent.ACTION_VIEW, url.toUri()))
+                snackbarHostState.showSnackbar(watchInstallFailedMessage)
+            }
+            WatchInstallAction.Idle, WatchInstallAction.Sending -> Unit
+        }
+    }
+
     val unknownNameFallback = stringResource(R.string.profile_account_name_unknown)
     val accountState = when (val s = authState) {
         is AuthState.Authenticated -> AccountRowState.SignedIn(
@@ -175,12 +195,15 @@ fun ProfileContent(
             showSnoozeRow = appConfig.snoozeNotificationsOption,
             showDeveloperSection = developerAccess == true,
             showFunctionListRow = functionListAccess == true,
+            watchAppStatus = watchAppStatus,
             versionName = appVersion.versionName,
             versionCode = appVersion.versionCode.toString(),
             layoutDebugEnabled = layoutDebugEnabled,
             navigationRailItemPosition = navigationRailItemPosition,
             navigationRailTopPaddingDp = navigationRailTopPaddingDp,
             snoozeInFlight = snoozeAction is SnoozeAction.Sending,
+            watchInstallInFlight = watchInstallAction is WatchInstallAction.Sending,
+            onInstallOnWatchTap = resolved::installOnWatch,
             onAccountTap = { accountSheetOpen = true },
             onSignInTap = { googleSignIn.launchSignIn() },
             onSnoozeTap = {

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/TabPreviews.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/TabPreviews.kt
@@ -45,6 +45,7 @@ import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.domain.model.NavigationRailItemPosition
 import com.chriscartland.garage.domain.model.NavigationRailLayout
 import com.chriscartland.garage.domain.model.RemoteButtonState
+import com.chriscartland.garage.domain.model.WatchAppStatus
 import com.chriscartland.garage.presentation.SinceStatusMapper
 import com.chriscartland.garage.presentation.demoDoorEvents
 import com.chriscartland.garage.ui.home.DeviceCheckIn
@@ -359,6 +360,7 @@ fun SettingsTabPreview() {
             showSnoozeRow = true,
             showDeveloperSection = true,
             showFunctionListRow = true,
+            watchAppStatus = WatchAppStatus.NoWatch,
             versionName = "2.7.1",
             versionCode = "184",
             layoutDebugEnabled = false,

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ThreePaneDashboardPreviews.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ThreePaneDashboardPreviews.kt
@@ -31,6 +31,7 @@ import com.chriscartland.garage.domain.model.LoadingResult
 import com.chriscartland.garage.domain.model.NavigationRailItemPosition
 import com.chriscartland.garage.domain.model.NavigationRailLayout
 import com.chriscartland.garage.domain.model.RemoteButtonState
+import com.chriscartland.garage.domain.model.WatchAppStatus
 import com.chriscartland.garage.presentation.SinceStatusMapper
 import com.chriscartland.garage.presentation.demoDoorEvents
 import com.chriscartland.garage.ui.home.DeviceCheckIn
@@ -191,6 +192,7 @@ private fun SettingsPaneBody(modifier: Modifier) {
         showSnoozeRow = true,
         showDeveloperSection = false,
         showFunctionListRow = false,
+        watchAppStatus = WatchAppStatus.NoWatch,
         versionName = "2.15.3",
         versionCode = "213",
         layoutDebugEnabled = false,

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.automirrored.outlined.List
 import androidx.compose.material.icons.automirrored.outlined.Login
 import androidx.compose.material.icons.automirrored.outlined.OpenInNew
 import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.outlined.Analytics
 import androidx.compose.material.icons.outlined.Description
@@ -41,6 +42,7 @@ import androidx.compose.material.icons.outlined.NotificationsPaused
 import androidx.compose.material.icons.outlined.Palette
 import androidx.compose.material.icons.outlined.Storefront
 import androidx.compose.material.icons.outlined.VerticalAlignCenter
+import androidx.compose.material.icons.outlined.Watch
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -54,6 +56,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -61,8 +64,10 @@ import androidx.compose.ui.unit.dp
 import com.chriscartland.garage.R
 import com.chriscartland.garage.domain.model.NavigationRailItemPosition
 import com.chriscartland.garage.domain.model.NavigationRailLayout
+import com.chriscartland.garage.domain.model.WatchAppStatus
 import com.chriscartland.garage.ui.theme.AppAnimatedVisibility
 import com.chriscartland.garage.ui.theme.DividerInset
+import com.chriscartland.garage.ui.theme.DoorStatusTheme
 import com.chriscartland.garage.ui.theme.PreviewScreenSurface
 import com.chriscartland.garage.ui.theme.Spacing
 import com.chriscartland.garage.ui.theme.safeListContentPadding
@@ -117,6 +122,7 @@ fun SettingsContent(
     showSnoozeRow: Boolean,
     showDeveloperSection: Boolean,
     showFunctionListRow: Boolean,
+    watchAppStatus: WatchAppStatus,
     versionName: String,
     versionCode: String,
     layoutDebugEnabled: Boolean,
@@ -124,9 +130,11 @@ fun SettingsContent(
     navigationRailTopPaddingDp: Int,
     modifier: Modifier = Modifier,
     snoozeInFlight: Boolean = false,
+    watchInstallInFlight: Boolean = false,
     onAccountTap: () -> Unit = {},
     onSignInTap: () -> Unit = {},
     onSnoozeTap: () -> Unit = {},
+    onInstallOnWatchTap: () -> Unit = {},
     onFunctionListTap: () -> Unit = {},
     onVersionTap: () -> Unit = {},
     onPlayStoreTap: () -> Unit = {},
@@ -196,6 +204,42 @@ fun SettingsContent(
                         onClick = onSnoozeTap,
                         inFlight = snoozeInFlight,
                     )
+                }
+            }
+        }
+
+        item {
+            // Only rendered when a watch is actually detected — phone-only
+            // users never see the section. Unknown/Unavailable/NoWatch all
+            // hide it; the poll flips it live if a watch connects.
+            AppAnimatedVisibility(
+                visible = watchAppStatus == WatchAppStatus.WatchNeedsApp ||
+                    watchAppStatus == WatchAppStatus.InstalledOnWatch,
+                label = "Watch section",
+            ) {
+                SettingsSection(label = stringResource(R.string.settings_section_watch)) {
+                    if (watchAppStatus == WatchAppStatus.InstalledOnWatch) {
+                        SettingsRow(
+                            icon = Icons.Outlined.Watch,
+                            title = stringResource(R.string.settings_watch_installed_title),
+                            subtitle = stringResource(R.string.settings_watch_installed_subtitle),
+                            showChevron = false,
+                            onClick = {},
+                            trailingIcon = Icons.Filled.CheckCircle,
+                            // The app's canonical green (door-closed), theme-aware.
+                            trailingIconTint = DoorStatusTheme.colorScheme.closedFresh,
+                        )
+                    } else {
+                        SettingsRow(
+                            icon = Icons.Outlined.Watch,
+                            title = stringResource(R.string.settings_watch_install_title),
+                            subtitle = stringResource(R.string.settings_watch_install_subtitle),
+                            showChevron = false,
+                            onClick = onInstallOnWatchTap,
+                            trailingIcon = Icons.AutoMirrored.Outlined.OpenInNew,
+                            inFlight = watchInstallInFlight,
+                        )
+                    }
                 }
             }
         }
@@ -329,6 +373,7 @@ private fun SettingsRow(
     showChevron: Boolean,
     onClick: () -> Unit,
     trailingIcon: ImageVector? = null,
+    trailingIconTint: Color? = null,
     inFlight: Boolean = false,
 ) {
     ListItem(
@@ -363,7 +408,7 @@ private fun SettingsRow(
                     Icon(
                         imageVector = trailingIcon,
                         contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        tint = trailingIconTint ?: MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }
@@ -433,6 +478,7 @@ fun SettingsContentSignedOutPreview() {
             showSnoozeRow = true,
             showDeveloperSection = false,
             showFunctionListRow = false,
+            watchAppStatus = WatchAppStatus.NoWatch,
             versionName = "2.6.1",
             versionCode = "182",
             layoutDebugEnabled = false,
@@ -454,6 +500,7 @@ fun SettingsContentCheckingPreview() {
             showSnoozeRow = true,
             showDeveloperSection = false,
             showFunctionListRow = false,
+            watchAppStatus = WatchAppStatus.NoWatch,
             versionName = "2.6.1",
             versionCode = "182",
             layoutDebugEnabled = false,
@@ -476,6 +523,7 @@ fun SettingsContentSignedInBasicPreview() {
             showSnoozeRow = true,
             showDeveloperSection = false,
             showFunctionListRow = false,
+            watchAppStatus = WatchAppStatus.NoWatch,
             versionName = "2.6.1",
             versionCode = "182",
             layoutDebugEnabled = false,
@@ -498,6 +546,7 @@ fun SettingsContentSignedInAllowlistedPreview() {
             showSnoozeRow = true,
             showDeveloperSection = true,
             showFunctionListRow = true,
+            watchAppStatus = WatchAppStatus.NoWatch,
             versionName = "2.6.1",
             versionCode = "182",
             layoutDebugEnabled = false,
@@ -520,6 +569,57 @@ fun SettingsContentPermissionDeniedPreview() {
             showSnoozeRow = true,
             showDeveloperSection = false,
             showFunctionListRow = false,
+            watchAppStatus = WatchAppStatus.NoWatch,
+            versionName = "2.6.1",
+            versionCode = "182",
+            layoutDebugEnabled = false,
+            navigationRailItemPosition = NavigationRailItemPosition.CenteredVertically,
+            navigationRailTopPaddingDp = NavigationRailLayout.DEFAULT_TOP_PADDING_DP,
+        )
+    }
+}
+
+// A connected watch without the app: the Watch section shows the
+// install call-to-action row.
+@Preview
+@Composable
+fun SettingsContentWatchInstallPreview() {
+    PreviewScreenSurface {
+        SettingsContent(
+            accountState = AccountRowState.SignedIn(
+                displayName = "Chris Cartland",
+                email = "chris@example.com",
+            ),
+            snoozeState = SnoozeRowState.Off,
+            showSnoozeRow = true,
+            showDeveloperSection = false,
+            showFunctionListRow = false,
+            watchAppStatus = WatchAppStatus.WatchNeedsApp,
+            versionName = "2.6.1",
+            versionCode = "182",
+            layoutDebugEnabled = false,
+            navigationRailItemPosition = NavigationRailItemPosition.CenteredVertically,
+            navigationRailTopPaddingDp = NavigationRailLayout.DEFAULT_TOP_PADDING_DP,
+        )
+    }
+}
+
+// Watch app detected: the Watch section shows the installed row with a
+// green check.
+@Preview
+@Composable
+fun SettingsContentWatchInstalledPreview() {
+    PreviewScreenSurface {
+        SettingsContent(
+            accountState = AccountRowState.SignedIn(
+                displayName = "Chris Cartland",
+                email = "chris@example.com",
+            ),
+            snoozeState = SnoozeRowState.Off,
+            showSnoozeRow = true,
+            showDeveloperSection = false,
+            showFunctionListRow = false,
+            watchAppStatus = WatchAppStatus.InstalledOnWatch,
             versionName = "2.6.1",
             versionCode = "182",
             layoutDebugEnabled = false,
@@ -545,6 +645,7 @@ fun SettingsContentSnoozeInFlightPreview() {
             showSnoozeRow = true,
             showDeveloperSection = false,
             showFunctionListRow = false,
+            watchAppStatus = WatchAppStatus.NoWatch,
             versionName = "2.6.1",
             versionCode = "182",
             layoutDebugEnabled = false,

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/wearrelay/PlayServicesWearCompanionRepository.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/wearrelay/PlayServicesWearCompanionRepository.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.wearrelay
+
+import android.content.Context
+import android.content.Intent
+import androidx.concurrent.futures.await
+import androidx.core.net.toUri
+import androidx.wear.remote.interactions.RemoteActivityHelper
+import co.touchlab.kermit.Logger
+import com.chriscartland.garage.domain.model.WatchAppStatus
+import com.chriscartland.garage.domain.model.WatchInstallResult
+import com.chriscartland.garage.domain.repository.WearCompanionRepository
+import com.google.android.gms.wearable.CapabilityClient
+import com.google.android.gms.wearable.Wearable
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.tasks.await
+
+/**
+ * [WearCompanionRepository] over the Play services Wearable API.
+ *
+ * Detection: the watch app declares
+ * [WearCompanionRepository.WATCH_APP_CAPABILITY] in its Wear resources;
+ * any node advertising it means the app is installed. A connected node
+ * without it means a watch that needs the app. Polls while collected
+ * (same cadence rationale as the watch side's `RelayFallbackAuthBridge`)
+ * so an install completing on the watch flips the row live, and a watch
+ * connecting mid-screen is picked up without re-entering.
+ *
+ * Install: `RemoteActivityHelper` launches the app's Play Store listing
+ * directly on the watch — the supported "install from your phone" flow.
+ * Falls back to [WatchInstallResult.Failed] on any error; the UI then
+ * opens the phone's own Play Store listing instead.
+ */
+class PlayServicesWearCompanionRepository(
+    private val context: Context,
+    private val playStorePackageName: String,
+) : WearCompanionRepository {
+    override fun observeWatchAppStatus(): Flow<WatchAppStatus> =
+        flow {
+            while (true) {
+                val status = queryStatus()
+                emit(status)
+                if (status == WatchAppStatus.Unavailable) {
+                    // No Wearable module on this device — terminal, stop polling.
+                    return@flow
+                }
+                delay(STATUS_POLL_MILLIS)
+            }
+        }
+
+    // Play services surfaces failures as a mix of ApiException, runtime
+    // exceptions, and wrapped Task errors; this is a best-effort boundary
+    // where any failure maps to Unavailable, so the generic catch is the
+    // design (same posture as FirebaseAuthBridge).
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun queryStatus(): WatchAppStatus =
+        try {
+            val capabilityNodes = Wearable
+                .getCapabilityClient(context)
+                .getCapability(
+                    WearCompanionRepository.WATCH_APP_CAPABILITY,
+                    CapabilityClient.FILTER_ALL,
+                ).await()
+                .nodes
+            if (capabilityNodes.isNotEmpty()) {
+                WatchAppStatus.InstalledOnWatch
+            } else {
+                val connected = Wearable.getNodeClient(context).connectedNodes.await()
+                if (connected.isEmpty()) WatchAppStatus.NoWatch else WatchAppStatus.WatchNeedsApp
+            }
+        } catch (e: Exception) {
+            Logger.d { "WearCompanion: wearable status query failed: $e" }
+            WatchAppStatus.Unavailable
+        }
+
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun requestInstallOnWatch(): WatchInstallResult =
+        try {
+            val connected = Wearable.getNodeClient(context).connectedNodes.await()
+            if (connected.isEmpty()) {
+                WatchInstallResult.NoWatchReachable
+            } else {
+                val opened = launchPlayStoreOnNodes(connected.map { it.id to it.displayName })
+                if (opened > 0) WatchInstallResult.OpenedOnWatch else WatchInstallResult.Failed
+            }
+        } catch (e: Exception) {
+            Logger.w { "WearCompanion: install request failed: $e" }
+            WatchInstallResult.Failed
+        }
+
+    /** Returns how many nodes the Play Store listing was launched on. */
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun launchPlayStoreOnNodes(nodes: List<Pair<String, String>>): Int {
+        val helper = RemoteActivityHelper(context)
+        val intent = Intent(Intent.ACTION_VIEW)
+            .addCategory(Intent.CATEGORY_BROWSABLE)
+            .setData("market://details?id=$playStorePackageName".toUri())
+        var opened = 0
+        nodes.forEach { (nodeId, displayName) ->
+            try {
+                helper.startRemoteActivity(intent, nodeId).await()
+                opened++
+            } catch (e: Exception) {
+                Logger.w { "WearCompanion: remote launch failed on $displayName: $e" }
+            }
+        }
+        return opened
+    }
+
+    private companion object {
+        /** Re-query cadence while the Settings screen is collecting. */
+        const val STATUS_POLL_MILLIS: Long = 15_000L
+    }
+}

--- a/MobileGarage/androidApp/src/main/res/values/strings.xml
+++ b/MobileGarage/androidApp/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <!-- Settings screen — section labels (uppercased at render time). -->
     <string name="settings_section_account">Account</string>
     <string name="settings_section_notifications">Notifications</string>
+    <string name="settings_section_watch">Watch</string>
     <string name="settings_section_about">About</string>
     <string name="settings_section_developer">Developer</string>
 
@@ -35,6 +36,14 @@
     <string name="settings_notifications_subtitle_off">Notifications enabled</string>
     <!-- Notifications row subtitle when a snooze is active. %1$s is the time the snooze ends. -->
     <string name="settings_notifications_subtitle_snoozing_until">Snoozing until %1$s</string>
+
+    <!-- Settings — Watch section (shown only when a watch is connected). -->
+    <string name="settings_watch_installed_title">Watch app installed</string>
+    <string name="settings_watch_installed_subtitle">The app is on your watch</string>
+    <string name="settings_watch_install_title">Install on your watch</string>
+    <string name="settings_watch_install_subtitle">Open the Play Store on your watch</string>
+    <string name="watch_install_opened_snackbar">Check your watch to finish installing</string>
+    <string name="watch_install_failed_snackbar">Couldn\'t reach your watch. Opening the Play Store here instead.</string>
 
     <!-- Settings — About section rows. -->
     <string name="settings_about_version_title">Version</string>

--- a/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/UnavailableWearCompanionRepository.kt
+++ b/MobileGarage/data/src/commonMain/kotlin/com/chriscartland/garage/data/repository/UnavailableWearCompanionRepository.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.data.repository
+
+import com.chriscartland.garage.domain.model.WatchAppStatus
+import com.chriscartland.garage.domain.model.WatchInstallResult
+import com.chriscartland.garage.domain.repository.WearCompanionRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+/**
+ * [WearCompanionRepository] for platforms with no companion-watch concept
+ * (iOS wires this in `NativeComponent`). Terminal [WatchAppStatus.Unavailable]
+ * means consumers never render watch UI.
+ */
+class UnavailableWearCompanionRepository : WearCompanionRepository {
+    override fun observeWatchAppStatus(): Flow<WatchAppStatus> = flowOf(WatchAppStatus.Unavailable)
+
+    override suspend fun requestInstallOnWatch(): WatchInstallResult = WatchInstallResult.Failed
+}

--- a/MobileGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/WatchAppStatus.kt
+++ b/MobileGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/WatchAppStatus.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.domain.model
+
+/**
+ * Whether the paired watch has the Wear OS app installed.
+ *
+ * Detection is capability-based: the watch app declares
+ * `WearCompanionRepository.WATCH_APP_CAPABILITY` in its Wear resources, and
+ * the phone queries the Wearable Data Layer for nodes advertising it.
+ */
+sealed interface WatchAppStatus {
+    /** Initial state before the first Data Layer query resolves. */
+    data object Unknown : WatchAppStatus
+
+    /**
+     * This platform cannot query watches at all (iOS, or a device without
+     * the Play services Wearable module). Terminal — no watch UI shown.
+     */
+    data object Unavailable : WatchAppStatus
+
+    /** The Wearable API works but no watch is currently connected. */
+    data object NoWatch : WatchAppStatus
+
+    /** A watch is connected but does not have the app installed. */
+    data object WatchNeedsApp : WatchAppStatus
+
+    /** At least one paired watch has the app installed. */
+    data object InstalledOnWatch : WatchAppStatus
+}
+
+/**
+ * Result of asking the platform to open the app's Play Store listing on
+ * the paired watch (remote install flow).
+ */
+sealed interface WatchInstallResult {
+    /** The Play Store listing was launched on at least one watch. */
+    data object OpenedOnWatch : WatchInstallResult
+
+    /** No connected watch to target. */
+    data object NoWatchReachable : WatchInstallResult
+
+    /** The remote launch was attempted but failed. */
+    data object Failed : WatchInstallResult
+}
+
+/**
+ * UI-facing state for the install-on-watch action, owned by the Settings
+ * screen ViewModel. Mirrors the [SnoozeAction] transient-action pattern:
+ * `Idle -> Sending -> (OpenedOnWatch | Failed) -> Idle` (auto-reset).
+ */
+sealed interface WatchInstallAction {
+    data object Idle : WatchInstallAction
+
+    data object Sending : WatchInstallAction
+
+    data object OpenedOnWatch : WatchInstallAction
+
+    /** Remote launch failed or no watch was reachable. */
+    data object Failed : WatchInstallAction
+}

--- a/MobileGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/WearCompanionRepository.kt
+++ b/MobileGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/repository/WearCompanionRepository.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.domain.repository
+
+import com.chriscartland.garage.domain.model.WatchAppStatus
+import com.chriscartland.garage.domain.model.WatchInstallResult
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Companion-watch integration: whether the paired watch has the Wear OS
+ * app, and a remote-install action that opens the app's Play Store
+ * listing directly on the watch.
+ *
+ * Like [RemoteButtonRepository], this performs remote actions and holds
+ * no storage. Android implements it over the Play services Wearable API
+ * (`PlayServicesWearCompanionRepository`); iOS wires the terminal no-op
+ * (`UnavailableWearCompanionRepository`) since there is no Wear OS
+ * concept there.
+ */
+interface WearCompanionRepository {
+    /**
+     * Observe the watch-app install status. Emits [WatchAppStatus.Unknown]
+     * consumers should hide watch UI for, then live status while collected
+     * (the Android implementation re-polls so an install completing on the
+     * watch flips the status without leaving the screen). Emits
+     * [WatchAppStatus.Unavailable] and completes when the platform cannot
+     * query watches at all.
+     */
+    fun observeWatchAppStatus(): Flow<WatchAppStatus>
+
+    /**
+     * Open the app's Play Store listing on the connected watch(es) that
+     * don't have the app. Best effort; never throws.
+     */
+    suspend fun requestInstallOnWatch(): WatchInstallResult
+
+    companion object {
+        /**
+         * Wearable Data Layer capability the WATCH app declares (in
+         * `wearApp/src/main/res/values/wear.xml`) so the phone can detect
+         * the app is installed on a paired watch. The phone's own relay
+         * capability is `WearAuthRelayProtocol.PHONE_AUTH_CAPABILITY` —
+         * same mechanism, opposite direction. Pinned to the XML by
+         * `WearCapabilityDeclarationTest` in `:wearApp`.
+         */
+        const val WATCH_APP_CAPABILITY: String = "garage_watch_app"
+    }
+}

--- a/MobileGarage/gradle/libs.versions.toml
+++ b/MobileGarage/gradle/libs.versions.toml
@@ -57,6 +57,8 @@ lifecycle = "2.9.1"
 mockito = "5.23.0"
 playServicesAuth = "21.6.0"
 playServicesWearable = "20.0.1"
+wearRemoteInteractions = "1.0.0"
+concurrentFuturesKtx = "1.3.0"
 room = "2.7.2"
 # sqlite is PINNED at 2.5.0 (same as kermit/datastore above: 2.7.0's iOS KLIBs
 # are built with Kotlin 2.3.20, rejected by Kotlin 2.1.20). Unpin with the
@@ -137,6 +139,8 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
 play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version.ref = "playServicesAuth" }
 play-services-wearable = { group = "com.google.android.gms", name = "play-services-wearable", version.ref = "playServicesWearable" }
+androidx-wear-remote-interactions = { group = "androidx.wear", name = "wear-remote-interactions", version.ref = "wearRemoteInteractions" }
+androidx-concurrent-futures-ktx = { group = "androidx.concurrent", name = "concurrent-futures-ktx", version.ref = "concurrentFuturesKtx" }
 kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "coroutines" }
 screenshot-validation-api = { group = "com.android.tools.screenshot", name = "screenshot-validation-api", version.ref = "screenshot" }
 androidx-credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }

--- a/MobileGarage/iosFramework/src/commonMain/kotlin/com/chriscartland/garage/iosframework/NativeComponent.kt
+++ b/MobileGarage/iosFramework/src/commonMain/kotlin/com/chriscartland/garage/iosframework/NativeComponent.kt
@@ -45,6 +45,7 @@ import com.chriscartland.garage.data.repository.NetworkButtonHealthRepository
 import com.chriscartland.garage.data.repository.NetworkDoorRepository
 import com.chriscartland.garage.data.repository.NetworkRemoteButtonRepository
 import com.chriscartland.garage.data.repository.NetworkSnoozeRepository
+import com.chriscartland.garage.data.repository.UnavailableWearCompanionRepository
 import com.chriscartland.garage.data.statuscache.DefaultStatusSnapshotStore
 import com.chriscartland.garage.data.statuscache.DefaultUserScopedCache
 import com.chriscartland.garage.data.statuscache.StatusCacheKeys
@@ -77,6 +78,7 @@ import com.chriscartland.garage.domain.repository.SnoozeDoorEventBridge
 import com.chriscartland.garage.domain.repository.SnoozeRepository
 import com.chriscartland.garage.domain.repository.TestNotificationRepository
 import com.chriscartland.garage.domain.repository.UserScopedCache
+import com.chriscartland.garage.domain.repository.WearCompanionRepository
 import com.chriscartland.garage.usecase.AppSettingsUseCase
 import com.chriscartland.garage.usecase.AppStartup
 import com.chriscartland.garage.usecase.ApplyButtonHealthFcmUseCase
@@ -109,10 +111,12 @@ import com.chriscartland.garage.usecase.ObserveDiagnosticsCountUseCase
 import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
 import com.chriscartland.garage.usecase.ObserveFeatureAccessUseCase
 import com.chriscartland.garage.usecase.ObserveTestNotificationStateUseCase
+import com.chriscartland.garage.usecase.ObserveWatchAppStatusUseCase
 import com.chriscartland.garage.usecase.PruneDiagnosticsLogUseCase
 import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
 import com.chriscartland.garage.usecase.ReceiveFcmDoorEventUseCase
 import com.chriscartland.garage.usecase.RegisterFcmUseCase
+import com.chriscartland.garage.usecase.RequestWatchAppInstallUseCase
 import com.chriscartland.garage.usecase.RevalidateSnoozeStatusUseCase
 import com.chriscartland.garage.usecase.RunStartupDiagnosticsMaintenanceUseCase
 import com.chriscartland.garage.usecase.SeedDiagnosticsCountersFromRoomUseCase
@@ -326,6 +330,8 @@ abstract class NativeComponent(
         computeEffectiveSnoozeState: ComputeEffectiveSnoozeStateUseCase,
         observeDoorEvents: ObserveDoorEventsUseCase,
         observeFeatureAccess: ObserveFeatureAccessUseCase,
+        observeWatchAppStatus: ObserveWatchAppStatusUseCase,
+        requestWatchAppInstall: RequestWatchAppInstallUseCase,
         signInWithGoogle: SignInWithGoogleUseCase,
         signOut: SignOutUseCase,
         fetchSnoozeStatus: FetchSnoozeStatusUseCase,
@@ -340,6 +346,8 @@ abstract class NativeComponent(
             computeEffectiveSnoozeState = computeEffectiveSnoozeState,
             observeDoorEvents = observeDoorEvents,
             observeFeatureAccessUseCase = observeFeatureAccess,
+            observeWatchAppStatusUseCase = observeWatchAppStatus,
+            requestWatchAppInstallUseCase = requestWatchAppInstall,
             signInWithGoogleUseCase = signInWithGoogle,
             signOutUseCase = signOut,
             fetchSnoozeStatusUseCase = fetchSnoozeStatus,
@@ -519,6 +527,17 @@ abstract class NativeComponent(
     @Provides
     fun provideObserveFeatureAccessUseCase(featureAllowlistRepository: FeatureAllowlistRepository): ObserveFeatureAccessUseCase =
         ObserveFeatureAccessUseCase(featureAllowlistRepository)
+
+    @Provides
+    fun provideWearCompanionRepository(): WearCompanionRepository = UnavailableWearCompanionRepository()
+
+    @Provides
+    fun provideObserveWatchAppStatusUseCase(wearCompanionRepository: WearCompanionRepository): ObserveWatchAppStatusUseCase =
+        ObserveWatchAppStatusUseCase(wearCompanionRepository)
+
+    @Provides
+    fun provideRequestWatchAppInstallUseCase(wearCompanionRepository: WearCompanionRepository): RequestWatchAppInstallUseCase =
+        RequestWatchAppInstallUseCase(wearCompanionRepository)
 
     @Provides
     fun provideFetchButtonHealthUseCase(

--- a/MobileGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeWearCompanionRepository.kt
+++ b/MobileGarage/test-common/src/commonMain/kotlin/com/chriscartland/garage/testcommon/FakeWearCompanionRepository.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.testcommon
+
+import com.chriscartland.garage.domain.model.WatchAppStatus
+import com.chriscartland.garage.domain.model.WatchInstallResult
+import com.chriscartland.garage.domain.repository.WearCompanionRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Fake [WearCompanionRepository] for unit testing.
+ *
+ * Configure with `setX()` methods; observe calls via read-only counters.
+ */
+class FakeWearCompanionRepository : WearCompanionRepository {
+    private val status = MutableStateFlow<WatchAppStatus>(WatchAppStatus.Unknown)
+    private var installResult: WatchInstallResult = WatchInstallResult.OpenedOnWatch
+
+    var installRequestCount: Int = 0
+        private set
+
+    fun setWatchAppStatus(value: WatchAppStatus) {
+        status.value = value
+    }
+
+    fun setInstallResult(value: WatchInstallResult) {
+        installResult = value
+    }
+
+    override fun observeWatchAppStatus(): Flow<WatchAppStatus> = status
+
+    override suspend fun requestInstallOnWatch(): WatchInstallResult {
+        installRequestCount++
+        return installResult
+    }
+}

--- a/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveWatchAppStatusUseCase.kt
+++ b/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ObserveWatchAppStatusUseCase.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.WatchAppStatus
+import com.chriscartland.garage.domain.repository.WearCompanionRepository
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Observes whether the paired watch has the Wear OS app installed.
+ * Cold pass-through of the repository flow (matches the upstream shape —
+ * the repo owns polling; there is no cached StateFlow to pass by
+ * reference here).
+ */
+class ObserveWatchAppStatusUseCase(
+    private val wearCompanionRepository: WearCompanionRepository,
+) {
+    operator fun invoke(): Flow<WatchAppStatus> = wearCompanionRepository.observeWatchAppStatus()
+}

--- a/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RequestWatchAppInstallUseCase.kt
+++ b/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RequestWatchAppInstallUseCase.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.WatchInstallResult
+import com.chriscartland.garage.domain.repository.WearCompanionRepository
+
+/**
+ * Opens the app's Play Store listing on the paired watch so the user can
+ * install the Wear OS app from their wrist. No auth involved — this is a
+ * purely local companion-device action.
+ */
+class RequestWatchAppInstallUseCase(
+    private val wearCompanionRepository: WearCompanionRepository,
+) {
+    suspend operator fun invoke(): WatchInstallResult = wearCompanionRepository.requestInstallOnWatch()
+}

--- a/MobileGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/ProfileViewModel.kt
+++ b/MobileGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/ProfileViewModel.kt
@@ -32,6 +32,9 @@ import com.chriscartland.garage.domain.model.NavigationRailLayout
 import com.chriscartland.garage.domain.model.SnoozeAction
 import com.chriscartland.garage.domain.model.SnoozeDurationUIOption
 import com.chriscartland.garage.domain.model.SnoozeState
+import com.chriscartland.garage.domain.model.WatchAppStatus
+import com.chriscartland.garage.domain.model.WatchInstallAction
+import com.chriscartland.garage.domain.model.WatchInstallResult
 import com.chriscartland.garage.domain.model.toServer
 import com.chriscartland.garage.usecase.AppSettingsUseCase
 import com.chriscartland.garage.usecase.ComputeEffectiveSnoozeStateUseCase
@@ -40,6 +43,8 @@ import com.chriscartland.garage.usecase.LogAppEventUseCase
 import com.chriscartland.garage.usecase.ObserveAuthStateUseCase
 import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
 import com.chriscartland.garage.usecase.ObserveFeatureAccessUseCase
+import com.chriscartland.garage.usecase.ObserveWatchAppStatusUseCase
+import com.chriscartland.garage.usecase.RequestWatchAppInstallUseCase
 import com.chriscartland.garage.usecase.RevalidateSnoozeStatusUseCase
 import com.chriscartland.garage.usecase.SignInWithGoogleUseCase
 import com.chriscartland.garage.usecase.SignOutUseCase
@@ -50,6 +55,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 private const val SNOOZE_ACTION_RESET_DELAY_MS = 10_000L
+private const val WATCH_INSTALL_ACTION_RESET_DELAY_MS = 10_000L
 
 /**
  * Drives the Settings screen — one VM per screen (ADR-026). Aggregates the
@@ -108,7 +114,25 @@ interface ProfileViewModel {
      */
     val navigationRailTopPaddingDp: StateFlow<Int>
 
+    /**
+     * Whether the paired watch has the Wear OS app. Drives the Settings
+     * "Watch" section: hidden until a connected watch is detected, then a
+     * green check (installed) or an install call-to-action.
+     */
+    val watchAppStatus: StateFlow<WatchAppStatus>
+
+    /**
+     * Transient state of the install-on-watch action ([installOnWatch]).
+     * `Idle -> Sending -> (OpenedOnWatch | Failed) -> Idle` with auto-reset,
+     * mirroring [snoozeAction]. The UI surfaces OpenedOnWatch/Failed once
+     * (snackbar; Failed also falls back to the phone Play Store).
+     */
+    val watchInstallAction: StateFlow<WatchInstallAction>
+
     fun signInWithGoogle(idToken: GoogleIdToken)
+
+    /** Open the app's Play Store listing on the connected watch. */
+    fun installOnWatch()
 
     fun signOut()
 
@@ -140,6 +164,8 @@ class DefaultProfileViewModel(
     computeEffectiveSnoozeState: ComputeEffectiveSnoozeStateUseCase,
     private val observeDoorEvents: ObserveDoorEventsUseCase,
     private val observeFeatureAccessUseCase: ObserveFeatureAccessUseCase,
+    private val observeWatchAppStatusUseCase: ObserveWatchAppStatusUseCase,
+    private val requestWatchAppInstallUseCase: RequestWatchAppInstallUseCase,
     private val signInWithGoogleUseCase: SignInWithGoogleUseCase,
     private val signOutUseCase: SignOutUseCase,
     private val fetchSnoozeStatusUseCase: FetchSnoozeStatusUseCase,
@@ -179,6 +205,12 @@ class DefaultProfileViewModel(
         MutableStateFlow(NavigationRailLayout.DEFAULT_TOP_PADDING_DP)
     override val navigationRailTopPaddingDp: StateFlow<Int> = _navigationRailTopPaddingDp
 
+    private val _watchAppStatus = MutableStateFlow<WatchAppStatus>(WatchAppStatus.Unknown)
+    override val watchAppStatus: StateFlow<WatchAppStatus> = _watchAppStatus
+
+    private val _watchInstallAction = MutableStateFlow<WatchInstallAction>(WatchInstallAction.Idle)
+    override val watchInstallAction: StateFlow<WatchInstallAction> = _watchInstallAction
+
     // Cached so the snooze action can attach the latest door change time
     // without the UI having to thread it through.
     private val currentDoorEvent = MutableStateFlow<DoorEvent?>(null)
@@ -205,6 +237,24 @@ class DefaultProfileViewModel(
             appSettings.observeNavigationRailTopPaddingDp().collect {
                 _navigationRailTopPaddingDp.value = it
             }
+        }
+        viewModelScope.launch(dispatchers.io) {
+            observeWatchAppStatusUseCase().collect { _watchAppStatus.value = it }
+        }
+    }
+
+    override fun installOnWatch() {
+        // Guard double-taps: the row stays tappable while Sending renders
+        // the in-flight ring, so a second tap must not queue another launch.
+        if (_watchInstallAction.value is WatchInstallAction.Sending) return
+        _watchInstallAction.value = WatchInstallAction.Sending
+        viewModelScope.launch(dispatchers.io) {
+            _watchInstallAction.value = when (requestWatchAppInstallUseCase()) {
+                WatchInstallResult.OpenedOnWatch -> WatchInstallAction.OpenedOnWatch
+                WatchInstallResult.NoWatchReachable -> WatchInstallAction.Failed
+                WatchInstallResult.Failed -> WatchInstallAction.Failed
+            }
+            scheduleWatchInstallActionReset()
         }
     }
 
@@ -300,6 +350,13 @@ class DefaultProfileViewModel(
         viewModelScope.launch {
             delay(SNOOZE_ACTION_RESET_DELAY_MS)
             _snoozeAction.value = SnoozeAction.Idle
+        }
+    }
+
+    private fun scheduleWatchInstallActionReset() {
+        viewModelScope.launch {
+            delay(WATCH_INSTALL_ACTION_RESET_DELAY_MS)
+            _watchInstallAction.value = WatchInstallAction.Idle
         }
     }
 }

--- a/MobileGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/ProfileViewModelTest.kt
+++ b/MobileGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/ProfileViewModelTest.kt
@@ -32,6 +32,9 @@ import com.chriscartland.garage.domain.model.SnoozeAction
 import com.chriscartland.garage.domain.model.SnoozeDurationUIOption
 import com.chriscartland.garage.domain.model.SnoozeState
 import com.chriscartland.garage.domain.model.User
+import com.chriscartland.garage.domain.model.WatchAppStatus
+import com.chriscartland.garage.domain.model.WatchInstallAction
+import com.chriscartland.garage.domain.model.WatchInstallResult
 import com.chriscartland.garage.testcommon.FakeAppLoggerRepository
 import com.chriscartland.garage.testcommon.FakeAppSettingsRepository
 import com.chriscartland.garage.testcommon.FakeAuthRepository
@@ -39,6 +42,7 @@ import com.chriscartland.garage.testcommon.FakeDiagnosticsCountersRepository
 import com.chriscartland.garage.testcommon.FakeDoorRepository
 import com.chriscartland.garage.testcommon.FakeFeatureAllowlistRepository
 import com.chriscartland.garage.testcommon.FakeSnoozeRepository
+import com.chriscartland.garage.testcommon.FakeWearCompanionRepository
 import com.chriscartland.garage.testcommon.TestDispatcherProvider
 import com.chriscartland.garage.usecase.AppSettingsUseCase
 import com.chriscartland.garage.usecase.ComputeEffectiveSnoozeStateUseCase
@@ -48,6 +52,8 @@ import com.chriscartland.garage.usecase.LogAppEventUseCase
 import com.chriscartland.garage.usecase.ObserveAuthStateUseCase
 import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
 import com.chriscartland.garage.usecase.ObserveFeatureAccessUseCase
+import com.chriscartland.garage.usecase.ObserveWatchAppStatusUseCase
+import com.chriscartland.garage.usecase.RequestWatchAppInstallUseCase
 import com.chriscartland.garage.usecase.RevalidateSnoozeStatusUseCase
 import com.chriscartland.garage.usecase.SignInWithGoogleUseCase
 import com.chriscartland.garage.usecase.SignOutUseCase
@@ -77,6 +83,7 @@ class ProfileViewModelTest {
     private lateinit var snoozeRepository: FakeSnoozeRepository
     private lateinit var featureAllowlistRepository: FakeFeatureAllowlistRepository
     private lateinit var appLoggerRepository: FakeAppLoggerRepository
+    private lateinit var wearCompanionRepository: FakeWearCompanionRepository
 
     private val testUser = User(
         name = DisplayName("User"),
@@ -91,6 +98,7 @@ class ProfileViewModelTest {
         snoozeRepository = FakeSnoozeRepository()
         featureAllowlistRepository = FakeFeatureAllowlistRepository()
         appLoggerRepository = FakeAppLoggerRepository()
+        wearCompanionRepository = FakeWearCompanionRepository()
     }
 
     @AfterTest
@@ -113,6 +121,8 @@ class ProfileViewModelTest {
             ),
             observeDoorEvents = ObserveDoorEventsUseCase(doorRepository),
             observeFeatureAccessUseCase = ObserveFeatureAccessUseCase(featureAllowlistRepository),
+            observeWatchAppStatusUseCase = ObserveWatchAppStatusUseCase(wearCompanionRepository),
+            requestWatchAppInstallUseCase = RequestWatchAppInstallUseCase(wearCompanionRepository),
             signInWithGoogleUseCase = SignInWithGoogleUseCase(authRepository),
             signOutUseCase = SignOutUseCase(authRepository),
             fetchSnoozeStatusUseCase = FetchSnoozeStatusUseCase(snoozeRepository),
@@ -292,6 +302,70 @@ class ProfileViewModelTest {
                 SnoozeAction.Failed.EventChanged,
                 viewModel.snoozeAction.value,
                 "ActionError.SnoozeEventChanged must map to Failed.EventChanged",
+            )
+        }
+
+    @Test
+    fun watchAppStatusPassesThroughFromRepository() =
+        runTest {
+            val viewModel = createViewModel()
+            assertEquals(WatchAppStatus.Unknown, viewModel.watchAppStatus.value)
+
+            wearCompanionRepository.setWatchAppStatus(WatchAppStatus.WatchNeedsApp)
+            advanceUntilIdle()
+            assertEquals(WatchAppStatus.WatchNeedsApp, viewModel.watchAppStatus.value)
+
+            wearCompanionRepository.setWatchAppStatus(WatchAppStatus.InstalledOnWatch)
+            advanceUntilIdle()
+            assertEquals(WatchAppStatus.InstalledOnWatch, viewModel.watchAppStatus.value)
+        }
+
+    @Test
+    fun installOnWatchSuccessSetsOpenedThenAutoResets() =
+        runTest {
+            val viewModel = createViewModel()
+            wearCompanionRepository.setInstallResult(WatchInstallResult.OpenedOnWatch)
+
+            viewModel.installOnWatch()
+            // Don't `advanceUntilIdle` — that fires the 10s reset delay too.
+            testDispatcher.scheduler.runCurrent()
+
+            assertEquals(WatchInstallAction.OpenedOnWatch, viewModel.watchInstallAction.value)
+            assertEquals(1, wearCompanionRepository.installRequestCount)
+
+            advanceUntilIdle()
+            assertEquals(
+                WatchInstallAction.Idle,
+                viewModel.watchInstallAction.value,
+                "Action must auto-reset to Idle after the reset delay",
+            )
+        }
+
+    @Test
+    fun installOnWatchFailureSetsFailed() =
+        runTest {
+            val viewModel = createViewModel()
+            wearCompanionRepository.setInstallResult(WatchInstallResult.Failed)
+
+            viewModel.installOnWatch()
+            testDispatcher.scheduler.runCurrent()
+
+            assertEquals(WatchInstallAction.Failed, viewModel.watchInstallAction.value)
+        }
+
+    @Test
+    fun installOnWatchNoWatchReachableMapsToFailed() =
+        runTest {
+            val viewModel = createViewModel()
+            wearCompanionRepository.setInstallResult(WatchInstallResult.NoWatchReachable)
+
+            viewModel.installOnWatch()
+            testDispatcher.scheduler.runCurrent()
+
+            assertEquals(
+                WatchInstallAction.Failed,
+                viewModel.watchInstallAction.value,
+                "NoWatchReachable surfaces as Failed so the UI falls back to the phone store",
             )
         }
 }

--- a/MobileGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/RealNetworkSnoozeRepositoryPropagationTest.kt
+++ b/MobileGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/RealNetworkSnoozeRepositoryPropagationTest.kt
@@ -42,6 +42,7 @@ import com.chriscartland.garage.testcommon.FakeNetworkButtonDataSource
 import com.chriscartland.garage.testcommon.FakeNetworkConfigDataSource
 import com.chriscartland.garage.testcommon.FakeRemoteButtonRepository
 import com.chriscartland.garage.testcommon.FakeStatusSnapshotStore
+import com.chriscartland.garage.testcommon.FakeWearCompanionRepository
 import com.chriscartland.garage.testcommon.TestDispatcherProvider
 import com.chriscartland.garage.usecase.AppSettingsUseCase
 import com.chriscartland.garage.usecase.ComputeEffectiveSnoozeStateUseCase
@@ -51,6 +52,8 @@ import com.chriscartland.garage.usecase.LogAppEventUseCase
 import com.chriscartland.garage.usecase.ObserveAuthStateUseCase
 import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
 import com.chriscartland.garage.usecase.ObserveFeatureAccessUseCase
+import com.chriscartland.garage.usecase.ObserveWatchAppStatusUseCase
+import com.chriscartland.garage.usecase.RequestWatchAppInstallUseCase
 import com.chriscartland.garage.usecase.RevalidateSnoozeStatusUseCase
 import com.chriscartland.garage.usecase.SignInWithGoogleUseCase
 import com.chriscartland.garage.usecase.SignOutUseCase
@@ -208,6 +211,8 @@ class RealNetworkSnoozeRepositoryPropagationTest {
                 ),
                 observeDoorEvents = ObserveDoorEventsUseCase(doorRepository),
                 observeFeatureAccessUseCase = ObserveFeatureAccessUseCase(featureAllowlistRepository),
+                observeWatchAppStatusUseCase = ObserveWatchAppStatusUseCase(FakeWearCompanionRepository()),
+                requestWatchAppInstallUseCase = RequestWatchAppInstallUseCase(FakeWearCompanionRepository()),
                 signInWithGoogleUseCase = SignInWithGoogleUseCase(authRepository),
                 signOutUseCase = SignOutUseCase(authRepository),
                 fetchSnoozeStatusUseCase = FetchSnoozeStatusUseCase(snoozeRepository),
@@ -314,6 +319,8 @@ class RealNetworkSnoozeRepositoryPropagationTest {
                 ),
                 observeDoorEvents = ObserveDoorEventsUseCase(doorRepository),
                 observeFeatureAccessUseCase = ObserveFeatureAccessUseCase(featureAllowlistRepository),
+                observeWatchAppStatusUseCase = ObserveWatchAppStatusUseCase(FakeWearCompanionRepository()),
+                requestWatchAppInstallUseCase = RequestWatchAppInstallUseCase(FakeWearCompanionRepository()),
                 signInWithGoogleUseCase = SignInWithGoogleUseCase(authRepository),
                 signOutUseCase = SignOutUseCase(authRepository),
                 fetchSnoozeStatusUseCase = FetchSnoozeStatusUseCase(snoozeRepository),

--- a/MobileGarage/wearApp/src/main/res/values/wear.xml
+++ b/MobileGarage/wearApp/src/main/res/values/wear.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2026 Chris Cartland. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+<resources>
+    <!-- Wearable Data Layer capability so the PHONE can detect that the
+         watch app is installed (Settings "Watch" row). Must match
+         WearCompanionRepository.WATCH_APP_CAPABILITY — pinned by
+         WearCapabilityDeclarationTest. The phone's own relay capability
+         is declared in androidApp/src/main/res/values/wear.xml. -->
+    <string-array
+        name="android_wear_capabilities"
+        translatable="false">
+        <item>garage_watch_app</item>
+    </string-array>
+</resources>

--- a/MobileGarage/wearApp/src/test/java/com/chriscartland/garage/wear/WearCapabilityDeclarationTest.kt
+++ b/MobileGarage/wearApp/src/test/java/com/chriscartland/garage/wear/WearCapabilityDeclarationTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.wear
+
+import com.chriscartland.garage.domain.repository.WearCompanionRepository
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Pins the Wear capability declaration (`res/values/wear.xml`) to the
+ * shared constant the phone queries. XML can't reference a Kotlin const,
+ * so the two are kept in sync by hand — this test catches drift (same
+ * pattern as `RoomSchemaTest` parsing source files).
+ */
+class WearCapabilityDeclarationTest {
+    @Test
+    fun wearXmlDeclaresTheWatchAppCapability() {
+        val wearXml = File("src/main/res/values/wear.xml")
+        assertTrue("wear.xml missing at ${wearXml.absolutePath}", wearXml.exists())
+        val content = wearXml.readText()
+        assertTrue(
+            "wear.xml must declare the '${WearCompanionRepository.WATCH_APP_CAPABILITY}' capability " +
+                "(WearCompanionRepository.WATCH_APP_CAPABILITY) so the phone can detect the watch app.",
+            content.contains("<item>${WearCompanionRepository.WATCH_APP_CAPABILITY}</item>"),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Settings gains a **Watch** section, visible only when a paired watch is connected: a **green check** when the Wear OS app is already installed, or an **Install on your watch** call-to-action that opens the app's Play Store listing directly on the watch via `RemoteActivityHelper` (the supported "install from your phone" flow — better than a notification, one less tap). If the remote launch fails, the phone's own Play Store listing opens as the fallback, with a snackbar either way.
- Detection is capability-based and **live**: the watch app now declares `garage_watch_app` in `wear.xml` (mirror of the phone's `garage_phone_auth_relay`), and the phone polls `CapabilityClient` every 15s while the screen is open — completing the install on the watch flips the row to the green check without leaving Settings.

## Architecture
- `WearCompanionRepository` interface in `:domain` (RemoteButtonRepository-style: remote actions, no storage); `PlayServicesWearCompanionRepository` in `:androidApp`; `UnavailableWearCompanionRepository` terminal no-op for iOS.
- `ObserveWatchAppStatusUseCase` + `RequestWatchAppInstallUseCase` → `ProfileViewModel` (`watchAppStatus`, `watchInstallAction` with the SnoozeAction-style transient lifecycle). UI goes through the VM only (ADR-033).
- **Both DI components updated** (`AppComponent` + `NativeComponent`) in the same PR; `:iosFramework:iosSimulatorArm64Test` run locally — BUILD SUCCESSFUL.
- `WearCapabilityDeclarationTest` pins `wear.xml` to the shared constant (RoomSchemaTest source-parsing pattern).

## Verification
- Full `./scripts/validate.sh` — **All checks passed** (0 FAIL markers).
- `:iosFramework:iosSimulatorArm64Test` — BUILD SUCCESSFUL (NativeComponent wiring).
- New ProfileViewModel tests: status pass-through, install success → OpenedOnWatch → auto-reset, Failed, NoWatchReachable → Failed.
- New previews (`SettingsContentWatchInstall`, `SettingsContentWatchInstalled`) wired into the screenshot test (light+dark). Reference PNGs not regenerated — local Layoutlib renders blank on this machine; they refresh on the next regen in a working environment.

## Rollout note
Existing watch installs (0.1.5 and older) predate the capability declaration, so the phone will show the install CTA even though the app is installed, until the watch updates to the next wear release; tapping just opens the watch Play Store listing (harmless, self-heals). The next `wear/N` release ships the declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)