### PR TITLE
chore: bump versionName to 2.22.0 (Android) and 0.1.6 (Wear)

### DIFF
--- a/MobileGarage/CHANGELOG.md
+++ b/MobileGarage/CHANGELOG.md
@@ -15,6 +15,11 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
 
+## 2.22.0
+
+- **Install the watch app from your phone.** Settings gains a "Watch" section that appears when a paired watch is connected: a green check when the Wear OS app is already on the watch, or an "Install on your watch" action that opens the Play Store listing directly on the watch so you can finish the install from your wrist. If the watch can't be reached, the phone's own Play Store listing opens instead. The status updates live while the screen is open, so completing the install on the watch flips the row to the green check.
+- **Internal:** #1107 — `WearCompanionRepository` (domain) + `PlayServicesWearCompanionRepository` (CapabilityClient detection, 15s poll while collected; `RemoteActivityHelper` remote launch); watch app declares the `garage_watch_app` capability (needs wear 0.1.6+ on the watch for detection — older installs show the install CTA, which harmlessly opens the watch's own listing). New minor: a user-facing capability that didn't exist before.
+
 ## 2.21.1
 
 - **Calmer cold start.** Before the first door status arrives, Home now shows "Connecting…" instead of a gray door with a warning badge labeled "Unknown" — a real server-reported unknown state still shows the warning look. Settings shows a "Checking sign-in…" row instead of briefly flashing a "Sign in with Google" prompt at already-signed-in users while auth resolves. No structural change to either screen's states or flows, only the presentation of the pre-data window.

--- a/MobileGarage/distribution/whatsnew/whatsnew-en-US
+++ b/MobileGarage/distribution/whatsnew/whatsnew-en-US
@@ -1,3 +1,3 @@
-Wear OS companion support: the phone now shares its sign-in with the Garage watch app, so your watch can check the door and operate it without a separate sign-in.
+Install the watch app from your phone: Settings now shows whether the Garage app is on your paired watch, with a green check when installed or a one-tap action that opens the Play Store right on the watch.
 
-Garage door notifications remain cleaner: the "left open" alert updates in place to a single "Resolved" notification once the door closes.
+Wear OS companion support: the phone now shares its sign-in with the Garage watch app, so your watch can check the door and operate it without a separate sign-in.

--- a/MobileGarage/version.properties
+++ b/MobileGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.21.1
+versionName=2.22.0

--- a/MobileGarage/wearApp/CHANGELOG.md
+++ b/MobileGarage/wearApp/CHANGELOG.md
@@ -14,6 +14,13 @@ The phone app's history lives in [`../CHANGELOG.md`](../CHANGELOG.md).
 Same rule as the phone app: major = rewrite or core-experience shift;
 minor = added or removed user-facing feature; patch = fixes, polish, refactors.
 
+## 0.1.6
+
+- The watch app now announces itself to the paired phone, so the phone's
+  new Settings "Watch" row (phone app 2.22.0+) can show a green check
+  when the app is installed instead of offering to install it again. No
+  visible change on the watch itself.
+
 ## 0.1.5
 
 - The hold-to-confirm ring is now centered on the physical screen and hugs

--- a/MobileGarage/wearApp/version.properties
+++ b/MobileGarage/wearApp/version.properties
@@ -1,1 +1,1 @@
-versionName=0.1.5
+versionName=0.1.6


### PR DESCRIPTION
## Summary
- Android `2.21.1` → `2.22.0` (minor: the install-on-watch Settings capability, #1107) + changelog entry + whatsnew line.
- Wear `0.1.5` → `0.1.6` (patch: declares the `garage_watch_app` capability so the phone's detection works; no visible watch change) + changelog entry.

Precedes the `android/261` + `wear/7` releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)