### PR TITLE
feat(settings): experimental voice-input playground (speech to text, display only)

### DIFF
--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
@@ -17,10 +17,15 @@
 
 package com.chriscartland.garage.ui
 
+import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.os.Build
+import android.speech.RecognizerIntent
 import android.widget.Toast
 import androidx.activity.compose.ReportDrawn
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -57,6 +62,7 @@ import com.chriscartland.garage.ui.settings.SettingsContent
 import com.chriscartland.garage.ui.settings.SnoozeBottomSheet
 import com.chriscartland.garage.ui.settings.SnoozeRowState
 import com.chriscartland.garage.ui.settings.VersionBottomSheet
+import com.chriscartland.garage.ui.settings.VoiceInputBottomSheet
 import com.chriscartland.garage.version.AppVersion
 import com.chriscartland.garage.viewmodel.ProfileViewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -117,6 +123,41 @@ fun ProfileContent(
     var accountSheetOpen by rememberSaveable { mutableStateOf(false) }
     var versionSheetOpen by rememberSaveable { mutableStateOf(false) }
     var navRailSheetOpen by rememberSaveable { mutableStateOf(false) }
+    var voiceSheetOpen by rememberSaveable { mutableStateOf(false) }
+
+    // Experimental voice-input playground (Settings → Developer → Voice
+    // input). The system speech dialog (RecognizerIntent) records and
+    // recognizes — this app never touches audio and needs no microphone
+    // permission. The transcript goes to the ViewModel's in-memory state
+    // and nowhere else; launching a new capture clears the previous one.
+    val voiceExperimentState by resolved.voiceExperimentState.collectAsState()
+    val voiceLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        val transcript = if (result.resultCode == Activity.RESULT_OK) {
+            result.data
+                ?.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
+                ?.firstOrNull()
+        } else {
+            null
+        }
+        resolved.reportVoiceExperimentTranscript(transcript)
+    }
+    val voicePrompt = stringResource(R.string.voice_experiment_prompt)
+    val onVoiceSpeakTap = {
+        resolved.clearVoiceExperiment()
+        val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH)
+            .putExtra(
+                RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+                RecognizerIntent.LANGUAGE_MODEL_FREE_FORM,
+            ).putExtra(RecognizerIntent.EXTRA_PROMPT, voicePrompt)
+            .putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
+        try {
+            voiceLauncher.launch(intent)
+        } catch (_: ActivityNotFoundException) {
+            resolved.reportVoiceExperimentUnavailable()
+        }
+    }
 
     // TTL-gated revalidate, once per screen entry (STATUS_CACHE_PLAN.md
     // D3). The cached snooze state renders instantly (hydrated across
@@ -231,6 +272,7 @@ fun ProfileContent(
             onDiagnosticsTap = onNavigateToDiagnostics,
             onLayoutDebugChange = resolved::setLayoutDebugEnabled,
             onNavRailTap = { navRailSheetOpen = true },
+            onVoiceInputTap = { voiceSheetOpen = true },
         )
         SnackbarHost(
             hostState = snackbarHostState,
@@ -280,6 +322,14 @@ fun ProfileContent(
                 }
             },
             onDismiss = { versionSheetOpen = false },
+        )
+    }
+
+    if (voiceSheetOpen) {
+        VoiceInputBottomSheet(
+            state = voiceExperimentState,
+            onSpeakTap = onVoiceSpeakTap,
+            onDismiss = { voiceSheetOpen = false },
         )
     }
 

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.outlined.Analytics
 import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.NotificationsOff
 import androidx.compose.material.icons.outlined.NotificationsPaused
@@ -142,6 +143,7 @@ fun SettingsContent(
     onDiagnosticsTap: () -> Unit = {},
     onLayoutDebugChange: (Boolean) -> Unit = {},
     onNavRailTap: () -> Unit = {},
+    onVoiceInputTap: () -> Unit = {},
 ) {
     LazyColumn(
         modifier = modifier.fillMaxSize(),
@@ -326,6 +328,14 @@ fun SettingsContent(
                         ),
                         showChevron = true,
                         onClick = onNavRailTap,
+                    )
+                    HorizontalDivider(modifier = Modifier.padding(start = DividerInset.ListItem))
+                    SettingsRow(
+                        icon = Icons.Outlined.Mic,
+                        title = stringResource(R.string.settings_developer_voice_input_title),
+                        subtitle = stringResource(R.string.settings_developer_voice_input_subtitle),
+                        showChevron = true,
+                        onClick = onVoiceInputTap,
                     )
                 }
             }

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/VoiceInputBottomSheet.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/VoiceInputBottomSheet.kt
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Mic
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.chriscartland.garage.R
+import com.chriscartland.garage.viewmodel.VoiceExperimentState
+
+/**
+ * Experimental voice-input playground (Settings → Developer → Voice
+ * input). One tap on Speak launches the system speech prompt
+ * (`RecognizerIntent` — the launch lives in `ProfileContent`, which
+ * owns the activity-result plumbing); the transcript renders here and
+ * nowhere else. Deliberately NOT wired to any door action, and the
+ * state is ViewModel-memory only — leaving the screen discards it.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun VoiceInputBottomSheet(
+    state: VoiceExperimentState,
+    onSpeakTap: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        modifier = modifier,
+    ) {
+        VoiceInputSheetContent(
+            state = state,
+            onSpeakTap = onSpeakTap,
+        )
+    }
+}
+
+/**
+ * Sheet content extracted so previews can render it directly (the
+ * ModalBottomSheet show animation doesn't run under previews).
+ */
+@Composable
+fun VoiceInputSheetContent(
+    state: VoiceExperimentState,
+    onSpeakTap: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 24.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.voice_experiment_sheet_title),
+            style = MaterialTheme.typography.titleLarge,
+        )
+        Text(
+            text = stringResource(R.string.voice_experiment_disclaimer),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        FilledTonalButton(
+            onClick = onSpeakTap,
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Mic,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+            )
+            Text(
+                text = stringResource(R.string.voice_experiment_speak_button),
+                modifier = Modifier.padding(start = 8.dp),
+            )
+        }
+        when (state) {
+            VoiceExperimentState.Idle -> Text(
+                text = stringResource(R.string.voice_experiment_hint),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            is VoiceExperimentState.Transcript -> Surface(
+                color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                shape = MaterialTheme.shapes.medium,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    text = state.text,
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(16.dp),
+                )
+            }
+            VoiceExperimentState.NoSpeech -> Text(
+                text = stringResource(R.string.voice_experiment_no_speech),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            VoiceExperimentState.Unavailable -> Text(
+                text = stringResource(R.string.voice_experiment_unavailable),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+            )
+        }
+    }
+}
+
+// `private` so `checkPreviewCoverage` exempts them (same rationale as
+// NavRailBottomSheet: developer-gated sheet verified on a real device;
+// these are Android Studio references only).
+@Preview
+@Composable
+private fun VoiceInputSheetContentIdlePreview() {
+    Surface {
+        VoiceInputSheetContent(
+            state = VoiceExperimentState.Idle,
+            onSpeakTap = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun VoiceInputSheetContentTranscriptPreview() {
+    Surface {
+        VoiceInputSheetContent(
+            state = VoiceExperimentState.Transcript("open the garage door"),
+            onSpeakTap = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun VoiceInputSheetContentNoSpeechPreview() {
+    Surface {
+        VoiceInputSheetContent(
+            state = VoiceExperimentState.NoSpeech,
+            onSpeakTap = {},
+        )
+    }
+}

--- a/MobileGarage/androidApp/src/main/res/values/strings.xml
+++ b/MobileGarage/androidApp/src/main/res/values/strings.xml
@@ -69,6 +69,20 @@
     <string name="settings_developer_nav_rail_top_padding_increase">Increase padding</string>
     <string name="settings_developer_nav_rail_reset_button">Set default</string>
 
+    <!-- Settings → Developer → Voice input (experimental playground).
+         Speech becomes text on screen only: never persisted, never
+         wired to any door action. -->
+    <string name="settings_developer_voice_input_title">Voice input</string>
+    <string name="settings_developer_voice_input_subtitle">Experimental. Speech to text, display only.</string>
+    <string name="voice_experiment_sheet_title">Voice input</string>
+    <string name="voice_experiment_disclaimer">Experimental. Speech becomes text on this screen only. Nothing is saved and no door action is taken.</string>
+    <string name="voice_experiment_speak_button">Speak</string>
+    <!-- Prompt line shown inside the system speech dialog. -->
+    <string name="voice_experiment_prompt">Say something</string>
+    <string name="voice_experiment_hint">Tap Speak, then talk. The transcript appears here.</string>
+    <string name="voice_experiment_no_speech">No speech captured. Try again.</string>
+    <string name="voice_experiment_unavailable">Speech recognition is not available on this device.</string>
+
     <!-- Home screen — section labels. -->
     <string name="home_section_status">Status</string>
     <string name="home_section_remote_control">Remote control</string>

--- a/MobileGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/ProfileViewModel.kt
+++ b/MobileGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/ProfileViewModel.kt
@@ -58,6 +58,29 @@ private const val SNOOZE_ACTION_RESET_DELAY_MS = 10_000L
 private const val WATCH_INSTALL_ACTION_RESET_DELAY_MS = 10_000L
 
 /**
+ * State of the experimental voice-input playground (Settings →
+ * Developer → Voice input). Deliberately in-memory only: it lives in
+ * the screen ViewModel, so it survives rotation but evaporates when the
+ * user leaves the screen or the process dies. Nothing is written to
+ * DataStore/Room and no door action is ever taken from it.
+ */
+sealed interface VoiceExperimentState {
+    /** Nothing captured yet, or cleared by starting a new capture. */
+    data object Idle : VoiceExperimentState
+
+    /** The recognizer returned a transcript. */
+    data class Transcript(
+        val text: String,
+    ) : VoiceExperimentState
+
+    /** The capture ended without usable speech (silence, cancel, no match). */
+    data object NoSpeech : VoiceExperimentState
+
+    /** No speech recognizer exists on this device. */
+    data object Unavailable : VoiceExperimentState
+}
+
+/**
  * Drives the Settings screen — one VM per screen (ADR-026). Aggregates the
  * UseCases that the legacy `AuthViewModel` + `RemoteButtonViewModel` +
  * `AppSettingsViewModel` trio exposed to `ProfileContent.kt`. Phase 43 —
@@ -128,6 +151,28 @@ interface ProfileViewModel {
      * (snackbar; Failed also falls back to the phone Play Store).
      */
     val watchInstallAction: StateFlow<WatchInstallAction>
+
+    /**
+     * Experimental voice-input playground state. See
+     * [VoiceExperimentState] — in-memory only, never persisted, never
+     * wired to any action.
+     */
+    val voiceExperimentState: StateFlow<VoiceExperimentState>
+
+    /**
+     * Call when a new capture starts: clears the previous transcript so
+     * each prompt replaces the last one.
+     */
+    fun clearVoiceExperiment()
+
+    /**
+     * Report the recognizer outcome. Null or blank text means no usable
+     * speech was captured.
+     */
+    fun reportVoiceExperimentTranscript(text: String?)
+
+    /** Report that this device has no speech recognizer at all. */
+    fun reportVoiceExperimentUnavailable()
 
     fun signInWithGoogle(idToken: GoogleIdToken)
 
@@ -211,6 +256,10 @@ class DefaultProfileViewModel(
     private val _watchInstallAction = MutableStateFlow<WatchInstallAction>(WatchInstallAction.Idle)
     override val watchInstallAction: StateFlow<WatchInstallAction> = _watchInstallAction
 
+    private val _voiceExperimentState =
+        MutableStateFlow<VoiceExperimentState>(VoiceExperimentState.Idle)
+    override val voiceExperimentState: StateFlow<VoiceExperimentState> = _voiceExperimentState
+
     // Cached so the snooze action can attach the latest door change time
     // without the UI having to thread it through.
     private val currentDoorEvent = MutableStateFlow<DoorEvent?>(null)
@@ -256,6 +305,22 @@ class DefaultProfileViewModel(
             }
             scheduleWatchInstallActionReset()
         }
+    }
+
+    override fun clearVoiceExperiment() {
+        _voiceExperimentState.value = VoiceExperimentState.Idle
+    }
+
+    override fun reportVoiceExperimentTranscript(text: String?) {
+        _voiceExperimentState.value = if (text.isNullOrBlank()) {
+            VoiceExperimentState.NoSpeech
+        } else {
+            VoiceExperimentState.Transcript(text)
+        }
+    }
+
+    override fun reportVoiceExperimentUnavailable() {
+        _voiceExperimentState.value = VoiceExperimentState.Unavailable
     }
 
     override fun signInWithGoogle(idToken: GoogleIdToken) {

--- a/MobileGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/ProfileViewModelTest.kt
+++ b/MobileGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/ProfileViewModelTest.kt
@@ -368,4 +368,42 @@ class ProfileViewModelTest {
                 "NoWatchReachable surfaces as Failed so the UI falls back to the phone store",
             )
         }
+
+    @Test
+    fun voiceExperimentTranscriptIsHeldAndReplacedByClear() =
+        runTest {
+            val viewModel = createViewModel()
+            assertEquals(VoiceExperimentState.Idle, viewModel.voiceExperimentState.value)
+
+            viewModel.reportVoiceExperimentTranscript("open the garage door")
+            assertEquals(
+                VoiceExperimentState.Transcript("open the garage door"),
+                viewModel.voiceExperimentState.value,
+            )
+
+            // Starting a new capture deletes the previous text.
+            viewModel.clearVoiceExperiment()
+            assertEquals(VoiceExperimentState.Idle, viewModel.voiceExperimentState.value)
+        }
+
+    @Test
+    fun voiceExperimentNullOrBlankTranscriptIsNoSpeech() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.reportVoiceExperimentTranscript(null)
+            assertEquals(VoiceExperimentState.NoSpeech, viewModel.voiceExperimentState.value)
+
+            viewModel.reportVoiceExperimentTranscript("   ")
+            assertEquals(VoiceExperimentState.NoSpeech, viewModel.voiceExperimentState.value)
+        }
+
+    @Test
+    fun voiceExperimentUnavailableIsReported() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.reportVoiceExperimentUnavailable()
+            assertEquals(VoiceExperimentState.Unavailable, viewModel.voiceExperimentState.value)
+        }
 }


### PR DESCRIPTION
## Summary
- **Settings → Developer → "Voice input"** (subtitle: "Experimental. Speech to text, display only.") opens a bottom sheet with a **Speak** button. One tap launches the system speech prompt (`RecognizerIntent.ACTION_RECOGNIZE_SPEECH`); the OS records + recognizes and hands back the top transcript, which renders in the sheet. Single tap → speak → text; no confirmation, no edit step.
- **Not wired to anything**: no command parsing, no gate, no door action — this is the audio-to-text leg of the voice exploration (`MobileGarage/docs/VOICE_COMMANDS.md`), isolated so transcript quality and the system-dialog UX can be evaluated on a real device.
- **Each Speak clears the previous transcript** before launching (per spec).
- **Nothing persisted**: state is a `MutableStateFlow` in `ProfileViewModel` only — survives rotation, gone when leaving the screen. No DataStore/Room writes.
- No `RECORD_AUDIO` permission needed (the system speech activity records, not the app). `ActivityNotFoundException` → an "Unavailable" state instead of a crash on devices with no recognizer.

## Architecture notes
- VM constructor unchanged → **no DI changes on either platform** (`AppComponent`/`NativeComponent` untouched); `VoiceExperimentState` + three interface members added to the shared `ProfileViewModel`.
- Sheet follows the `NavRailBottomSheet` pattern (stateless `*SheetContent` split, `verticalScroll` owned by content, `private` previews with the same coverage-exemption rationale).

## Verification
- Full `./scripts/validate.sh` — **All checks passed** (0 FAIL markers).
- `:iosFramework:iosSimulatorArm64Test` — BUILD SUCCESSFUL (shared interface addition compiles for iOS targets).
- New `ProfileViewModelTest` cases: transcript held then cleared by a new capture, null/blank → NoSpeech, Unavailable reported.
- The recognizer round-trip itself is device-only by nature (it's the OS dialog) — that's the point of shipping the playground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)