### PR TITLE
feat(voice): on-device intent classification in the voice playground

### DIFF
--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -65,6 +65,7 @@ import com.chriscartland.garage.datalocal.RoomAppLoggerRepository
 import com.chriscartland.garage.domain.coroutines.AppClock
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.AppConfig
+import com.chriscartland.garage.domain.model.VoiceIntentClassifier
 import com.chriscartland.garage.domain.repository.AppLoggerRepository
 import com.chriscartland.garage.domain.repository.AppSettingsRepository
 import com.chriscartland.garage.domain.repository.AuthRepository
@@ -90,6 +91,7 @@ import com.chriscartland.garage.usecase.BuildAppLogCsvUseCase
 import com.chriscartland.garage.usecase.ButtonHealthFcmSubscriptionManager
 import com.chriscartland.garage.usecase.ChangeTestNotificationTopicUseCase
 import com.chriscartland.garage.usecase.CheckInStalenessManager
+import com.chriscartland.garage.usecase.ClassifyVoiceIntentUseCase
 import com.chriscartland.garage.usecase.ClearDiagnosticsUseCase
 import com.chriscartland.garage.usecase.ComputeButtonHealthDisplayUseCase
 import com.chriscartland.garage.usecase.ComputeEffectiveSnoozeStateUseCase
@@ -122,6 +124,7 @@ import com.chriscartland.garage.usecase.ReceiveFcmDoorEventUseCase
 import com.chriscartland.garage.usecase.RegisterFcmUseCase
 import com.chriscartland.garage.usecase.RequestWatchAppInstallUseCase
 import com.chriscartland.garage.usecase.RevalidateSnoozeStatusUseCase
+import com.chriscartland.garage.usecase.RuleBasedVoiceIntentClassifier
 import com.chriscartland.garage.usecase.RunStartupDiagnosticsMaintenanceUseCase
 import com.chriscartland.garage.usecase.SeedDiagnosticsCountersFromRoomUseCase
 import com.chriscartland.garage.usecase.SignInWithGoogleUseCase
@@ -370,6 +373,7 @@ abstract class AppComponent(
         observeFeatureAccess: ObserveFeatureAccessUseCase,
         observeWatchAppStatus: ObserveWatchAppStatusUseCase,
         requestWatchAppInstall: RequestWatchAppInstallUseCase,
+        classifyVoiceIntent: ClassifyVoiceIntentUseCase,
         signInWithGoogle: SignInWithGoogleUseCase,
         signOut: SignOutUseCase,
         fetchSnoozeStatus: FetchSnoozeStatusUseCase,
@@ -386,6 +390,7 @@ abstract class AppComponent(
             observeFeatureAccessUseCase = observeFeatureAccess,
             observeWatchAppStatusUseCase = observeWatchAppStatus,
             requestWatchAppInstallUseCase = requestWatchAppInstall,
+            classifyVoiceIntentUseCase = classifyVoiceIntent,
             signInWithGoogleUseCase = signInWithGoogle,
             signOutUseCase = signOut,
             fetchSnoozeStatusUseCase = fetchSnoozeStatus,
@@ -549,6 +554,13 @@ abstract class AppComponent(
             // release id, not BuildConfig.APPLICATION_ID.
             playStorePackageName = "com.chriscartland.garage",
         )
+
+    @Provides
+    fun provideVoiceIntentClassifier(): VoiceIntentClassifier = RuleBasedVoiceIntentClassifier()
+
+    @Provides
+    fun provideClassifyVoiceIntentUseCase(classifier: VoiceIntentClassifier): ClassifyVoiceIntentUseCase =
+        ClassifyVoiceIntentUseCase(classifier)
 
     @Provides
     fun provideObserveWatchAppStatusUseCase(wearCompanionRepository: WearCompanionRepository): ObserveWatchAppStatusUseCase =

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/VoiceInputBottomSheet.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/VoiceInputBottomSheet.kt
@@ -41,6 +41,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.chriscartland.garage.R
+import com.chriscartland.garage.domain.model.VoiceIntent
+import com.chriscartland.garage.domain.model.VoiceIntentClassification
+import com.chriscartland.garage.domain.model.VoiceIntentConfidence
 import com.chriscartland.garage.viewmodel.VoiceExperimentState
 
 /**
@@ -118,15 +121,35 @@ fun VoiceInputSheetContent(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            is VoiceExperimentState.Transcript -> Surface(
-                color = MaterialTheme.colorScheme.surfaceContainerHighest,
-                shape = MaterialTheme.shapes.medium,
-                modifier = Modifier.fillMaxWidth(),
+            is VoiceExperimentState.Transcript -> Column(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
+                Surface(
+                    color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    shape = MaterialTheme.shapes.medium,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        text = state.text,
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.padding(16.dp),
+                    )
+                }
                 Text(
-                    text = state.text,
-                    style = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier.padding(16.dp),
+                    text = stringResource(
+                        R.string.voice_experiment_classification,
+                        state.classification.intent.displayName(),
+                        state.classification.confidence.displayName(),
+                    ),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Text(
+                    text = stringResource(
+                        R.string.voice_experiment_engine,
+                        state.engineName,
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
             VoiceExperimentState.NoSpeech -> Text(
@@ -142,6 +165,24 @@ fun VoiceInputSheetContent(
         }
     }
 }
+
+// User-visible names for the classification result. UI-local mapping —
+// the domain enums stay display-free.
+@Composable
+private fun VoiceIntent.displayName(): String =
+    when (this) {
+        VoiceIntent.OPEN -> stringResource(R.string.voice_intent_open)
+        VoiceIntent.CLOSE -> stringResource(R.string.voice_intent_close)
+        VoiceIntent.UNKNOWN -> stringResource(R.string.voice_intent_unknown)
+    }
+
+@Composable
+private fun VoiceIntentConfidence.displayName(): String =
+    when (this) {
+        VoiceIntentConfidence.HIGH -> stringResource(R.string.voice_confidence_high)
+        VoiceIntentConfidence.MEDIUM -> stringResource(R.string.voice_confidence_medium)
+        VoiceIntentConfidence.NONE -> stringResource(R.string.voice_confidence_none)
+    }
 
 // `private` so `checkPreviewCoverage` exempts them (same rationale as
 // NavRailBottomSheet: developer-gated sheet verified on a real device;
@@ -162,7 +203,32 @@ private fun VoiceInputSheetContentIdlePreview() {
 private fun VoiceInputSheetContentTranscriptPreview() {
     Surface {
         VoiceInputSheetContent(
-            state = VoiceExperimentState.Transcript("open the garage door"),
+            state = VoiceExperimentState.Transcript(
+                text = "open the garage door",
+                classification = VoiceIntentClassification(
+                    intent = VoiceIntent.OPEN,
+                    confidence = VoiceIntentConfidence.HIGH,
+                ),
+                engineName = "Rules v1",
+            ),
+            onSpeakTap = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun VoiceInputSheetContentUnknownIntentPreview() {
+    Surface {
+        VoiceInputSheetContent(
+            state = VoiceExperimentState.Transcript(
+                text = "what a nice day",
+                classification = VoiceIntentClassification(
+                    intent = VoiceIntent.UNKNOWN,
+                    confidence = VoiceIntentConfidence.NONE,
+                ),
+                engineName = "Rules v1",
+            ),
             onSpeakTap = {},
         )
     }

--- a/MobileGarage/androidApp/src/main/res/values/strings.xml
+++ b/MobileGarage/androidApp/src/main/res/values/strings.xml
@@ -82,6 +82,16 @@
     <string name="voice_experiment_hint">Tap Speak, then talk. The transcript appears here.</string>
     <string name="voice_experiment_no_speech">No speech captured. Try again.</string>
     <string name="voice_experiment_unavailable">Speech recognition is not available on this device.</string>
+    <!-- Classification line under the transcript. %1$s intent, %2$s confidence. -->
+    <string name="voice_experiment_classification">Intent: %1$s · Confidence: %2$s</string>
+    <!-- Engine caption. %1$s is the classifier engine name. -->
+    <string name="voice_experiment_engine">Engine: %1$s</string>
+    <string name="voice_intent_open">Open</string>
+    <string name="voice_intent_close">Close</string>
+    <string name="voice_intent_unknown">Unknown</string>
+    <string name="voice_confidence_high">High</string>
+    <string name="voice_confidence_medium">Medium</string>
+    <string name="voice_confidence_none">None</string>
 
     <!-- Home screen — section labels. -->
     <string name="home_section_status">Status</string>

--- a/MobileGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/VoiceIntent.kt
+++ b/MobileGarage/domain/src/commonMain/kotlin/com/chriscartland/garage/domain/model/VoiceIntent.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.domain.model
+
+/**
+ * What a spoken utterance asks the door to do. [UNKNOWN] is the safe
+ * default for anything a classifier cannot confidently place — per the
+ * voice design principle (docs/VOICE_COMMANDS.md): it is okay to
+ * incorrectly ignore a command; it is never okay to incorrectly execute
+ * one.
+ */
+enum class VoiceIntent {
+    OPEN,
+    CLOSE,
+    UNKNOWN,
+}
+
+/**
+ * How sure the classifier is. A future action layer decides what tier
+ * is actionable (expected: only [HIGH]); the experiment surfaces every
+ * tier so engines can be compared.
+ */
+enum class VoiceIntentConfidence {
+    /** Unambiguous imperative — e.g. an exact grammar match. */
+    HIGH,
+
+    /**
+     * The intent is recognizable but the phrasing is loose — extra
+     * words, a question form, a bare verb+object. Informative, not
+     * actionable.
+     */
+    MEDIUM,
+
+    /** No intent found. Always and only paired with [VoiceIntent.UNKNOWN]. */
+    NONE,
+}
+
+/**
+ * A classifier verdict. Invariant (pinned by tests): `intent == UNKNOWN`
+ * if and only if `confidence == NONE`.
+ */
+data class VoiceIntentClassification(
+    val intent: VoiceIntent,
+    val confidence: VoiceIntentConfidence,
+)
+
+/**
+ * Pluggable text-to-intent engine. Implementations must be pure and
+ * fast (callable synchronously from a ViewModel): rules/regex today
+ * (`RuleBasedVoiceIntentClassifier` in `:usecase`), potentially
+ * on-device ML models later — all behind this same contract so the
+ * playground and any future action layer are engine-agnostic.
+ */
+interface VoiceIntentClassifier {
+    /** Short human-readable engine identifier, shown in the playground. */
+    val name: String
+
+    fun classify(text: String): VoiceIntentClassification
+}

--- a/MobileGarage/iosFramework/src/commonMain/kotlin/com/chriscartland/garage/iosframework/NativeComponent.kt
+++ b/MobileGarage/iosFramework/src/commonMain/kotlin/com/chriscartland/garage/iosframework/NativeComponent.kt
@@ -62,6 +62,7 @@ import com.chriscartland.garage.datalocal.RoomAppLoggerRepository
 import com.chriscartland.garage.domain.coroutines.AppClock
 import com.chriscartland.garage.domain.coroutines.DispatcherProvider
 import com.chriscartland.garage.domain.model.AppConfig
+import com.chriscartland.garage.domain.model.VoiceIntentClassifier
 import com.chriscartland.garage.domain.repository.AppLoggerRepository
 import com.chriscartland.garage.domain.repository.AppSettingsRepository
 import com.chriscartland.garage.domain.repository.AuthRepository
@@ -86,6 +87,7 @@ import com.chriscartland.garage.usecase.BuildAppLogCsvUseCase
 import com.chriscartland.garage.usecase.ButtonHealthFcmSubscriptionManager
 import com.chriscartland.garage.usecase.ChangeTestNotificationTopicUseCase
 import com.chriscartland.garage.usecase.CheckInStalenessManager
+import com.chriscartland.garage.usecase.ClassifyVoiceIntentUseCase
 import com.chriscartland.garage.usecase.ClearDiagnosticsUseCase
 import com.chriscartland.garage.usecase.ComputeButtonHealthDisplayUseCase
 import com.chriscartland.garage.usecase.ComputeEffectiveSnoozeStateUseCase
@@ -118,6 +120,7 @@ import com.chriscartland.garage.usecase.ReceiveFcmDoorEventUseCase
 import com.chriscartland.garage.usecase.RegisterFcmUseCase
 import com.chriscartland.garage.usecase.RequestWatchAppInstallUseCase
 import com.chriscartland.garage.usecase.RevalidateSnoozeStatusUseCase
+import com.chriscartland.garage.usecase.RuleBasedVoiceIntentClassifier
 import com.chriscartland.garage.usecase.RunStartupDiagnosticsMaintenanceUseCase
 import com.chriscartland.garage.usecase.SeedDiagnosticsCountersFromRoomUseCase
 import com.chriscartland.garage.usecase.SignInWithGoogleUseCase
@@ -332,6 +335,7 @@ abstract class NativeComponent(
         observeFeatureAccess: ObserveFeatureAccessUseCase,
         observeWatchAppStatus: ObserveWatchAppStatusUseCase,
         requestWatchAppInstall: RequestWatchAppInstallUseCase,
+        classifyVoiceIntent: ClassifyVoiceIntentUseCase,
         signInWithGoogle: SignInWithGoogleUseCase,
         signOut: SignOutUseCase,
         fetchSnoozeStatus: FetchSnoozeStatusUseCase,
@@ -348,6 +352,7 @@ abstract class NativeComponent(
             observeFeatureAccessUseCase = observeFeatureAccess,
             observeWatchAppStatusUseCase = observeWatchAppStatus,
             requestWatchAppInstallUseCase = requestWatchAppInstall,
+            classifyVoiceIntentUseCase = classifyVoiceIntent,
             signInWithGoogleUseCase = signInWithGoogle,
             signOutUseCase = signOut,
             fetchSnoozeStatusUseCase = fetchSnoozeStatus,
@@ -530,6 +535,13 @@ abstract class NativeComponent(
 
     @Provides
     fun provideWearCompanionRepository(): WearCompanionRepository = UnavailableWearCompanionRepository()
+
+    @Provides
+    fun provideVoiceIntentClassifier(): VoiceIntentClassifier = RuleBasedVoiceIntentClassifier()
+
+    @Provides
+    fun provideClassifyVoiceIntentUseCase(classifier: VoiceIntentClassifier): ClassifyVoiceIntentUseCase =
+        ClassifyVoiceIntentUseCase(classifier)
 
     @Provides
     fun provideObserveWatchAppStatusUseCase(wearCompanionRepository: WearCompanionRepository): ObserveWatchAppStatusUseCase =

--- a/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ClassifyVoiceIntentUseCase.kt
+++ b/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ClassifyVoiceIntentUseCase.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.VoiceIntentClassification
+import com.chriscartland.garage.domain.model.VoiceIntentClassifier
+
+/**
+ * Classifies transcript text into a door intent + confidence via the
+ * DI-selected [VoiceIntentClassifier] engine. Pure and synchronous.
+ */
+class ClassifyVoiceIntentUseCase(
+    private val classifier: VoiceIntentClassifier,
+) {
+    /** Engine identifier for display in the experiment UI. */
+    val engineName: String get() = classifier.name
+
+    operator fun invoke(text: String): VoiceIntentClassification = classifier.classify(text)
+}

--- a/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RuleBasedVoiceIntentClassifier.kt
+++ b/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/RuleBasedVoiceIntentClassifier.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.VoiceIntent
+import com.chriscartland.garage.domain.model.VoiceIntentClassification
+import com.chriscartland.garage.domain.model.VoiceIntentClassifier
+import com.chriscartland.garage.domain.model.VoiceIntentConfidence
+
+/**
+ * Deterministic rules engine — the first [VoiceIntentClassifier]
+ * (docs/VOICE_COMMANDS.md decision 2: an allowlist grammar is the most
+ * conservative confidence gate). Offline, pure, exhaustively
+ * table-tested.
+ *
+ * Tiers, applied to the normalized utterance (lowercased, punctuation
+ * stripped, whitespace collapsed):
+ *
+ * 1. **Deny-first**: empty text, a negation word ("don't", "never",
+ *    "stop"), or both an open verb and a close verb present — UNKNOWN.
+ *    Negation checks run before anything else so "don't open the door"
+ *    can never classify as OPEN.
+ * 2. **HIGH** — the whole utterance is an exact imperative:
+ *    `(please) open|close|shut (the|my|our) garage door|garage|door (please)`.
+ *    Question forms ("can you open the door") never match because the
+ *    leading words fail the whole-utterance grammar.
+ * 3. **MEDIUM** — a single direction verb appears somewhere before a
+ *    door object ("open up the garage for me", "can you close the
+ *    door"). Recognizable but loose; a future action layer is expected
+ *    to require HIGH.
+ * 4. **UNKNOWN/NONE** — everything else, including verb-after-object
+ *    ("the door is open" describes state, not a command) and
+ *    verb-without-object ("open the window").
+ */
+class RuleBasedVoiceIntentClassifier : VoiceIntentClassifier {
+    override val name: String = "Rules v1"
+
+    override fun classify(text: String): VoiceIntentClassification {
+        val normalized = normalize(text)
+        if (normalized.isEmpty()) return UNKNOWN_RESULT
+
+        val tokens = normalized.split(' ')
+        if (tokens.any { it in NEGATION_TOKENS }) return UNKNOWN_RESULT
+
+        val openIndex = tokens.indexOfFirst { it in OPEN_VERBS }
+        val closeIndex = tokens.indexOfFirst { it in CLOSE_VERBS }
+        val intent = when {
+            openIndex >= 0 && closeIndex >= 0 -> return UNKNOWN_RESULT
+            openIndex >= 0 -> VoiceIntent.OPEN
+            closeIndex >= 0 -> VoiceIntent.CLOSE
+            else -> return UNKNOWN_RESULT
+        }
+
+        if (HIGH_GRAMMAR.matches(normalized)) {
+            return VoiceIntentClassification(intent, VoiceIntentConfidence.HIGH)
+        }
+
+        val verbIndex = if (intent == VoiceIntent.OPEN) openIndex else closeIndex
+        val objectIndex = tokens.indexOfFirst { it in DOOR_OBJECTS }
+        if (objectIndex > verbIndex) {
+            return VoiceIntentClassification(intent, VoiceIntentConfidence.MEDIUM)
+        }
+
+        return UNKNOWN_RESULT
+    }
+
+    private fun normalize(text: String): String =
+        text
+            .lowercase()
+            .map { if (it.isLetterOrDigit()) it else ' ' }
+            .joinToString("")
+            .split(' ')
+            .filter { it.isNotEmpty() }
+            .joinToString(" ")
+
+    private companion object {
+        val UNKNOWN_RESULT =
+            VoiceIntentClassification(VoiceIntent.UNKNOWN, VoiceIntentConfidence.NONE)
+
+        val OPEN_VERBS = setOf("open")
+        val CLOSE_VERBS = setOf("close", "shut")
+        val DOOR_OBJECTS = setOf("door", "doors", "garage")
+
+        // Post-normalization tokens ("don't" normalizes to "don" + "t";
+        // both "don" and "not" are covered).
+        val NEGATION_TOKENS = setOf("don", "dont", "not", "never", "stop")
+
+        val HIGH_GRAMMAR =
+            Regex("^(please )?(open|close|shut) ((the|my|our) )?(garage door|garage|door)( please)?$")
+    }
+}

--- a/MobileGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RuleBasedVoiceIntentClassifierTest.kt
+++ b/MobileGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/RuleBasedVoiceIntentClassifierTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.VoiceIntent
+import com.chriscartland.garage.domain.model.VoiceIntentConfidence
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Table-driven accept/reject/confidence matrix for the rules engine —
+ * the executable version of the table in docs/VOICE_COMMANDS.md. The
+ * safety-critical rows are the UNKNOWN ones: negation, questions about
+ * state, wrong objects, and conflicting verbs must never classify as a
+ * direction.
+ */
+class RuleBasedVoiceIntentClassifierTest {
+    private val classifier = RuleBasedVoiceIntentClassifier()
+
+    private data class Case(
+        val utterance: String,
+        val intent: VoiceIntent,
+        val confidence: VoiceIntentConfidence,
+    )
+
+    private val table = listOf(
+        // HIGH — exact imperatives (punctuation and case are normalized away).
+        Case("open the door", VoiceIntent.OPEN, VoiceIntentConfidence.HIGH),
+        Case("Open the garage door!", VoiceIntent.OPEN, VoiceIntentConfidence.HIGH),
+        Case("please open the door", VoiceIntent.OPEN, VoiceIntentConfidence.HIGH),
+        Case("open my garage door", VoiceIntent.OPEN, VoiceIntentConfidence.HIGH),
+        Case("close the garage", VoiceIntent.CLOSE, VoiceIntentConfidence.HIGH),
+        Case("close the door please", VoiceIntent.CLOSE, VoiceIntentConfidence.HIGH),
+        Case("shut the door", VoiceIntent.CLOSE, VoiceIntentConfidence.HIGH),
+        Case("PLEASE CLOSE THE GARAGE DOOR", VoiceIntent.CLOSE, VoiceIntentConfidence.HIGH),
+        // MEDIUM — recognizable but loose: extra words or question forms.
+        Case("can you open the door", VoiceIntent.OPEN, VoiceIntentConfidence.MEDIUM),
+        Case("open up the garage door for me", VoiceIntent.OPEN, VoiceIntentConfidence.MEDIUM),
+        Case("would you please close the garage door", VoiceIntent.CLOSE, VoiceIntentConfidence.MEDIUM),
+        Case("close the garage door now", VoiceIntent.CLOSE, VoiceIntentConfidence.MEDIUM),
+        Case("i want to open the door", VoiceIntent.OPEN, VoiceIntentConfidence.MEDIUM),
+        // UNKNOWN — negation must never classify as a direction.
+        Case("don't open the door", VoiceIntent.UNKNOWN, VoiceIntentConfidence.NONE),
+        Case("do not close the garage", VoiceIntent.UNKNOWN, VoiceIntentConfidence.NONE),
+        Case("never open the door", VoiceIntent.UNKNOWN, VoiceIntentConfidence.NONE),
+        // UNKNOWN — conflicting directions.
+        Case("open and close the door", VoiceIntent.UNKNOWN, VoiceIntentConfidence.NONE),
+        // UNKNOWN — state descriptions (verb after object) are not commands.
+        Case("the door is open", VoiceIntent.UNKNOWN, VoiceIntentConfidence.NONE),
+        Case("is the garage closed", VoiceIntent.UNKNOWN, VoiceIntentConfidence.NONE),
+        // UNKNOWN — wrong or missing object.
+        Case("open the window", VoiceIntent.UNKNOWN, VoiceIntentConfidence.NONE),
+        Case("close the deal", VoiceIntent.UNKNOWN, VoiceIntentConfidence.NONE),
+        Case("open", VoiceIntent.UNKNOWN, VoiceIntentConfidence.NONE),
+        Case("shut up", VoiceIntent.UNKNOWN, VoiceIntentConfidence.NONE),
+        // UNKNOWN — no intent at all.
+        Case("hello world", VoiceIntent.UNKNOWN, VoiceIntentConfidence.NONE),
+        Case("", VoiceIntent.UNKNOWN, VoiceIntentConfidence.NONE),
+        Case("   ", VoiceIntent.UNKNOWN, VoiceIntentConfidence.NONE),
+    )
+
+    @Test
+    fun classificationTable() {
+        table.forEach { case ->
+            val result = classifier.classify(case.utterance)
+            assertEquals(
+                case.intent,
+                result.intent,
+                "intent for \"${case.utterance}\"",
+            )
+            assertEquals(
+                case.confidence,
+                result.confidence,
+                "confidence for \"${case.utterance}\"",
+            )
+        }
+    }
+
+    @Test
+    fun unknownIfAndOnlyIfNoneConfidence() {
+        table.forEach { case ->
+            val result = classifier.classify(case.utterance)
+            assertEquals(
+                result.intent == VoiceIntent.UNKNOWN,
+                result.confidence == VoiceIntentConfidence.NONE,
+                "invariant UNKNOWN <=> NONE for \"${case.utterance}\"",
+            )
+        }
+    }
+
+    @Test
+    fun engineNameIsStable() {
+        assertTrue(classifier.name.isNotBlank())
+        assertEquals("Rules v1", classifier.name)
+    }
+}

--- a/MobileGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/ProfileViewModel.kt
+++ b/MobileGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/ProfileViewModel.kt
@@ -32,11 +32,13 @@ import com.chriscartland.garage.domain.model.NavigationRailLayout
 import com.chriscartland.garage.domain.model.SnoozeAction
 import com.chriscartland.garage.domain.model.SnoozeDurationUIOption
 import com.chriscartland.garage.domain.model.SnoozeState
+import com.chriscartland.garage.domain.model.VoiceIntentClassification
 import com.chriscartland.garage.domain.model.WatchAppStatus
 import com.chriscartland.garage.domain.model.WatchInstallAction
 import com.chriscartland.garage.domain.model.WatchInstallResult
 import com.chriscartland.garage.domain.model.toServer
 import com.chriscartland.garage.usecase.AppSettingsUseCase
+import com.chriscartland.garage.usecase.ClassifyVoiceIntentUseCase
 import com.chriscartland.garage.usecase.ComputeEffectiveSnoozeStateUseCase
 import com.chriscartland.garage.usecase.FetchSnoozeStatusUseCase
 import com.chriscartland.garage.usecase.LogAppEventUseCase
@@ -68,9 +70,15 @@ sealed interface VoiceExperimentState {
     /** Nothing captured yet, or cleared by starting a new capture. */
     data object Idle : VoiceExperimentState
 
-    /** The recognizer returned a transcript. */
+    /**
+     * The recognizer returned a transcript, classified into a door
+     * intent + confidence by the DI-selected engine. Classification is
+     * display-only in this experiment — nothing acts on it.
+     */
     data class Transcript(
         val text: String,
+        val classification: VoiceIntentClassification,
+        val engineName: String,
     ) : VoiceExperimentState
 
     /** The capture ended without usable speech (silence, cancel, no match). */
@@ -211,6 +219,7 @@ class DefaultProfileViewModel(
     private val observeFeatureAccessUseCase: ObserveFeatureAccessUseCase,
     private val observeWatchAppStatusUseCase: ObserveWatchAppStatusUseCase,
     private val requestWatchAppInstallUseCase: RequestWatchAppInstallUseCase,
+    private val classifyVoiceIntentUseCase: ClassifyVoiceIntentUseCase,
     private val signInWithGoogleUseCase: SignInWithGoogleUseCase,
     private val signOutUseCase: SignOutUseCase,
     private val fetchSnoozeStatusUseCase: FetchSnoozeStatusUseCase,
@@ -315,7 +324,11 @@ class DefaultProfileViewModel(
         _voiceExperimentState.value = if (text.isNullOrBlank()) {
             VoiceExperimentState.NoSpeech
         } else {
-            VoiceExperimentState.Transcript(text)
+            VoiceExperimentState.Transcript(
+                text = text,
+                classification = classifyVoiceIntentUseCase(text),
+                engineName = classifyVoiceIntentUseCase.engineName,
+            )
         }
     }
 

--- a/MobileGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/ProfileViewModelTest.kt
+++ b/MobileGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/ProfileViewModelTest.kt
@@ -32,6 +32,8 @@ import com.chriscartland.garage.domain.model.SnoozeAction
 import com.chriscartland.garage.domain.model.SnoozeDurationUIOption
 import com.chriscartland.garage.domain.model.SnoozeState
 import com.chriscartland.garage.domain.model.User
+import com.chriscartland.garage.domain.model.VoiceIntent
+import com.chriscartland.garage.domain.model.VoiceIntentConfidence
 import com.chriscartland.garage.domain.model.WatchAppStatus
 import com.chriscartland.garage.domain.model.WatchInstallAction
 import com.chriscartland.garage.domain.model.WatchInstallResult
@@ -45,6 +47,7 @@ import com.chriscartland.garage.testcommon.FakeSnoozeRepository
 import com.chriscartland.garage.testcommon.FakeWearCompanionRepository
 import com.chriscartland.garage.testcommon.TestDispatcherProvider
 import com.chriscartland.garage.usecase.AppSettingsUseCase
+import com.chriscartland.garage.usecase.ClassifyVoiceIntentUseCase
 import com.chriscartland.garage.usecase.ComputeEffectiveSnoozeStateUseCase
 import com.chriscartland.garage.usecase.DefaultLiveClock
 import com.chriscartland.garage.usecase.FetchSnoozeStatusUseCase
@@ -55,6 +58,7 @@ import com.chriscartland.garage.usecase.ObserveFeatureAccessUseCase
 import com.chriscartland.garage.usecase.ObserveWatchAppStatusUseCase
 import com.chriscartland.garage.usecase.RequestWatchAppInstallUseCase
 import com.chriscartland.garage.usecase.RevalidateSnoozeStatusUseCase
+import com.chriscartland.garage.usecase.RuleBasedVoiceIntentClassifier
 import com.chriscartland.garage.usecase.SignInWithGoogleUseCase
 import com.chriscartland.garage.usecase.SignOutUseCase
 import com.chriscartland.garage.usecase.SnoozeNotificationsUseCase
@@ -123,6 +127,7 @@ class ProfileViewModelTest {
             observeFeatureAccessUseCase = ObserveFeatureAccessUseCase(featureAllowlistRepository),
             observeWatchAppStatusUseCase = ObserveWatchAppStatusUseCase(wearCompanionRepository),
             requestWatchAppInstallUseCase = RequestWatchAppInstallUseCase(wearCompanionRepository),
+            classifyVoiceIntentUseCase = ClassifyVoiceIntentUseCase(RuleBasedVoiceIntentClassifier()),
             signInWithGoogleUseCase = SignInWithGoogleUseCase(authRepository),
             signOutUseCase = SignOutUseCase(authRepository),
             fetchSnoozeStatusUseCase = FetchSnoozeStatusUseCase(snoozeRepository),
@@ -370,20 +375,34 @@ class ProfileViewModelTest {
         }
 
     @Test
-    fun voiceExperimentTranscriptIsHeldAndReplacedByClear() =
+    fun voiceExperimentTranscriptIsHeldClassifiedAndReplacedByClear() =
         runTest {
             val viewModel = createViewModel()
             assertEquals(VoiceExperimentState.Idle, viewModel.voiceExperimentState.value)
 
             viewModel.reportVoiceExperimentTranscript("open the garage door")
-            assertEquals(
-                VoiceExperimentState.Transcript("open the garage door"),
-                viewModel.voiceExperimentState.value,
-            )
+            val state = viewModel.voiceExperimentState.value
+            assertTrue(state is VoiceExperimentState.Transcript)
+            assertEquals("open the garage door", state.text)
+            assertEquals(VoiceIntent.OPEN, state.classification.intent)
+            assertEquals(VoiceIntentConfidence.HIGH, state.classification.confidence)
+            assertEquals("Rules v1", state.engineName)
 
             // Starting a new capture deletes the previous text.
             viewModel.clearVoiceExperiment()
             assertEquals(VoiceExperimentState.Idle, viewModel.voiceExperimentState.value)
+        }
+
+    @Test
+    fun voiceExperimentUnrecognizedTextClassifiesUnknown() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.reportVoiceExperimentTranscript("hello world")
+            val state = viewModel.voiceExperimentState.value
+            assertTrue(state is VoiceExperimentState.Transcript)
+            assertEquals(VoiceIntent.UNKNOWN, state.classification.intent)
+            assertEquals(VoiceIntentConfidence.NONE, state.classification.confidence)
         }
 
     @Test

--- a/MobileGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/RealNetworkSnoozeRepositoryPropagationTest.kt
+++ b/MobileGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/RealNetworkSnoozeRepositoryPropagationTest.kt
@@ -45,6 +45,7 @@ import com.chriscartland.garage.testcommon.FakeStatusSnapshotStore
 import com.chriscartland.garage.testcommon.FakeWearCompanionRepository
 import com.chriscartland.garage.testcommon.TestDispatcherProvider
 import com.chriscartland.garage.usecase.AppSettingsUseCase
+import com.chriscartland.garage.usecase.ClassifyVoiceIntentUseCase
 import com.chriscartland.garage.usecase.ComputeEffectiveSnoozeStateUseCase
 import com.chriscartland.garage.usecase.DefaultLiveClock
 import com.chriscartland.garage.usecase.FetchSnoozeStatusUseCase
@@ -55,6 +56,7 @@ import com.chriscartland.garage.usecase.ObserveFeatureAccessUseCase
 import com.chriscartland.garage.usecase.ObserveWatchAppStatusUseCase
 import com.chriscartland.garage.usecase.RequestWatchAppInstallUseCase
 import com.chriscartland.garage.usecase.RevalidateSnoozeStatusUseCase
+import com.chriscartland.garage.usecase.RuleBasedVoiceIntentClassifier
 import com.chriscartland.garage.usecase.SignInWithGoogleUseCase
 import com.chriscartland.garage.usecase.SignOutUseCase
 import com.chriscartland.garage.usecase.SnoozeNotificationsUseCase
@@ -213,6 +215,7 @@ class RealNetworkSnoozeRepositoryPropagationTest {
                 observeFeatureAccessUseCase = ObserveFeatureAccessUseCase(featureAllowlistRepository),
                 observeWatchAppStatusUseCase = ObserveWatchAppStatusUseCase(FakeWearCompanionRepository()),
                 requestWatchAppInstallUseCase = RequestWatchAppInstallUseCase(FakeWearCompanionRepository()),
+                classifyVoiceIntentUseCase = ClassifyVoiceIntentUseCase(RuleBasedVoiceIntentClassifier()),
                 signInWithGoogleUseCase = SignInWithGoogleUseCase(authRepository),
                 signOutUseCase = SignOutUseCase(authRepository),
                 fetchSnoozeStatusUseCase = FetchSnoozeStatusUseCase(snoozeRepository),
@@ -321,6 +324,7 @@ class RealNetworkSnoozeRepositoryPropagationTest {
                 observeFeatureAccessUseCase = ObserveFeatureAccessUseCase(featureAllowlistRepository),
                 observeWatchAppStatusUseCase = ObserveWatchAppStatusUseCase(FakeWearCompanionRepository()),
                 requestWatchAppInstallUseCase = RequestWatchAppInstallUseCase(FakeWearCompanionRepository()),
+                classifyVoiceIntentUseCase = ClassifyVoiceIntentUseCase(RuleBasedVoiceIntentClassifier()),
                 signInWithGoogleUseCase = SignInWithGoogleUseCase(authRepository),
                 signOutUseCase = SignOutUseCase(authRepository),
                 fetchSnoozeStatusUseCase = FetchSnoozeStatusUseCase(snoozeRepository),


### PR DESCRIPTION
## Summary
The Settings → Developer → Voice input experiment now **classifies each transcript** into `VoiceIntent` (OPEN / CLOSE / UNKNOWN) with a `VoiceIntentConfidence` enum (HIGH / MEDIUM / NONE), shown under the transcript as `Intent: Open · Confidence: High` plus the engine name. Still display-only — nothing acts on it.

## Engine foundation
- **`VoiceIntentClassifier`** (`:domain`): pluggable engine contract (`name` + `classify(text)`), so future engines — on-device ML, server-side — slot in behind the same interface with no UI/VM changes.
- **`RuleBasedVoiceIntentClassifier`** ("Rules v1", `:usecase`): pure offline computed rules, deny-by-default:
  - deny-first: negation ("don't open the door"), conflicting verbs ("open and close the door"), empty → UNKNOWN/NONE
  - **HIGH** — exact whole-utterance imperative grammar (`please open the door`, `shut the door`); question forms can never reach HIGH
  - **MEDIUM** — direction verb before a door object with loose phrasing (`can you open the door`, `open up the garage door for me`)
  - **UNKNOWN** — state descriptions (`the door is open`), wrong objects (`open the window`), bare verbs
- Invariant pinned by tests: `intent == UNKNOWN ⟺ confidence == NONE`. The table-driven test is the executable version of the accept/reject table in `docs/VOICE_COMMANDS.md`.

## Verification
- Full `./scripts/validate.sh` — **All checks passed** (0 FAIL markers).
- `:iosFramework:iosSimulatorArm64Test` — BUILD SUCCESSFUL (VM ctor changed → AppComponent **and** NativeComponent updated together).
- New `RuleBasedVoiceIntentClassifierTest` (26-row table + invariant) and updated `ProfileViewModelTest` (transcript now carries classification; unknown text → UNKNOWN/NONE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)