### PR TITLE
feat(voice): tap-to-copy transcript and structured verdict

### DIFF
--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
@@ -329,6 +329,20 @@ fun ProfileContent(
         VoiceInputBottomSheet(
             state = voiceExperimentState,
             onSpeakTap = onVoiceSpeakTap,
+            onCopy = { label, value ->
+                clipboardManager.setText(AnnotatedString(value))
+                // Android 13+ shows the OS clipboard chip after setText;
+                // an app Toast on top is duplicate noise (same gate as
+                // the Version sheet).
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                    Toast
+                        .makeText(
+                            context,
+                            resources.getString(R.string.profile_version_toast_copied, label),
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                }
+            },
             onDismiss = { voiceSheetOpen = false },
         )
     }

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/VoiceInputBottomSheet.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/VoiceInputBottomSheet.kt
@@ -17,6 +17,7 @@
 
 package com.chriscartland.garage.ui.settings
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -37,6 +38,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -59,6 +61,7 @@ import com.chriscartland.garage.viewmodel.VoiceExperimentState
 fun VoiceInputBottomSheet(
     state: VoiceExperimentState,
     onSpeakTap: () -> Unit,
+    onCopy: (label: String, value: String) -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -71,6 +74,7 @@ fun VoiceInputBottomSheet(
         VoiceInputSheetContent(
             state = state,
             onSpeakTap = onSpeakTap,
+            onCopy = onCopy,
         )
     }
 }
@@ -83,6 +87,7 @@ fun VoiceInputBottomSheet(
 fun VoiceInputSheetContent(
     state: VoiceExperimentState,
     onSpeakTap: () -> Unit,
+    onCopy: (label: String, value: String) -> Unit = { _, _ -> },
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -124,10 +129,16 @@ fun VoiceInputSheetContent(
             is VoiceExperimentState.Transcript -> Column(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
+                val transcriptLabel = stringResource(R.string.voice_copy_label_transcript)
+                val verdictLabel = stringResource(R.string.voice_copy_label_verdict)
+                // Tap the transcript to copy the raw text.
                 Surface(
                     color = MaterialTheme.colorScheme.surfaceContainerHighest,
                     shape = MaterialTheme.shapes.medium,
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(MaterialTheme.shapes.medium)
+                        .clickable { onCopy(transcriptLabel, state.text) },
                 ) {
                     Text(
                         text = state.text,
@@ -135,19 +146,35 @@ fun VoiceInputSheetContent(
                         modifier = Modifier.padding(16.dp),
                     )
                 }
+                // Tap the verdict to copy the structured summary
+                // (input + intent + confidence + engine) for pasting
+                // into a discussion.
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(MaterialTheme.shapes.medium)
+                        .clickable { onCopy(verdictLabel, state.clipboardSummary()) },
+                ) {
+                    Text(
+                        text = stringResource(
+                            R.string.voice_experiment_classification,
+                            state.classification.intent.displayName(),
+                            state.classification.confidence.displayName(),
+                        ),
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    Text(
+                        text = stringResource(
+                            R.string.voice_experiment_engine,
+                            state.engineName,
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
                 Text(
-                    text = stringResource(
-                        R.string.voice_experiment_classification,
-                        state.classification.intent.displayName(),
-                        state.classification.confidence.displayName(),
-                    ),
-                    style = MaterialTheme.typography.titleMedium,
-                )
-                Text(
-                    text = stringResource(
-                        R.string.voice_experiment_engine,
-                        state.engineName,
-                    ),
+                    text = stringResource(R.string.voice_experiment_copy_hint),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/MobileGarage/androidApp/src/main/res/values/strings.xml
+++ b/MobileGarage/androidApp/src/main/res/values/strings.xml
@@ -92,6 +92,10 @@
     <string name="voice_confidence_high">High</string>
     <string name="voice_confidence_medium">Medium</string>
     <string name="voice_confidence_none">None</string>
+    <string name="voice_experiment_copy_hint">Tap the text or the verdict to copy</string>
+    <!-- Labels for the "Copied X" toast (Android 12 and older). -->
+    <string name="voice_copy_label_transcript">transcript</string>
+    <string name="voice_copy_label_verdict">verdict</string>
 
     <!-- Home screen — section labels. -->
     <string name="home_section_status">Status</string>

--- a/MobileGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/ProfileViewModel.kt
+++ b/MobileGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/ProfileViewModel.kt
@@ -79,7 +79,21 @@ sealed interface VoiceExperimentState {
         val text: String,
         val classification: VoiceIntentClassification,
         val engineName: String,
-    ) : VoiceExperimentState
+    ) : VoiceExperimentState {
+        /**
+         * Paste-friendly structured summary for sharing/discussing
+         * classifier results. Uses raw enum names (locale-independent,
+         * stable across app versions) and quotes the input so leading/
+         * trailing whitespace is visible.
+         */
+        fun clipboardSummary(): String =
+            """
+            input: "$text"
+            intent: ${classification.intent.name}
+            confidence: ${classification.confidence.name}
+            engine: $engineName
+            """.trimIndent()
+    }
 
     /** The capture ended without usable speech (silence, cancel, no match). */
     data object NoSpeech : VoiceExperimentState

--- a/MobileGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/ProfileViewModelTest.kt
+++ b/MobileGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/ProfileViewModelTest.kt
@@ -418,6 +418,25 @@ class ProfileViewModelTest {
         }
 
     @Test
+    fun voiceExperimentClipboardSummaryIsStructured() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.reportVoiceExperimentTranscript("can you open the door")
+            val state = viewModel.voiceExperimentState.value
+            assertTrue(state is VoiceExperimentState.Transcript)
+            assertEquals(
+                """
+                input: "can you open the door"
+                intent: OPEN
+                confidence: MEDIUM
+                engine: Rules v1
+                """.trimIndent(),
+                state.clipboardSummary(),
+            )
+        }
+
+    @Test
     fun voiceExperimentUnavailableIsReported() =
         runTest {
             val viewModel = createViewModel()


### PR DESCRIPTION
## Summary
- **Tap the transcript card** → copies the raw recognized text.
- **Tap the verdict block** → copies a structured, paste-friendly summary for discussing classifier results:
  ```
  input: "can you open the door"
  intent: OPEN
  confidence: MEDIUM
  engine: Rules v1
  ```
  Raw enum names (locale-independent, stable across versions); input quoted so whitespace is visible.
- A small hint line marks both surfaces as tappable.

## Notes
- Summary built by `VoiceExperimentState.Transcript.clipboardSummary()` in the shared ViewModel layer (unit-tested exact-format), UI does only the clipboard write — house tap-to-copy pattern (`LocalClipboardManager.setText` + Toast gated to Android < 13; 13+ shows the OS clipboard chip).
- `onCopy(label, value)` callback mirrors `VersionBottomSheet`'s signature.
- No VM ctor change, no DI changes.

## Verification
- Full `./scripts/validate.sh` — **All checks passed** (0 FAIL markers).
- `:iosFramework:iosSimulatorArm64Test` — BUILD SUCCESSFUL.
- New test pins the exact clipboard summary format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)