### PR TITLE
chore: bump versionName to 2.22.3

### DIFF
--- a/MobileGarage/CHANGELOG.md
+++ b/MobileGarage/CHANGELOG.md
@@ -15,6 +15,11 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
 
+## 2.22.3
+
+- **Voice playground results are copyable.** Tap the transcript to copy the raw text, or tap the verdict to copy a structured summary (input, intent, confidence, engine) ready to paste into a discussion about improving the classifier. A hint line marks both as tappable.
+- **Internal:** #1114 — `VoiceExperimentState.Transcript.clipboardSummary()` (shared, format pinned by test); house tap-to-copy pattern with the Android 13+ Toast gate. Developer-gated experiment; patch.
+
 ## 2.22.2
 
 - **Voice playground classifies intent (experimental).** The Developer voice-input sheet now labels each transcript with a door intent (Open / Close / Unknown) and a confidence tier (High / Medium / None), plus the engine that produced it. Display only, no action taken. High requires an exact imperative ("please open the door"); loose phrasing ("can you open the door") is Medium; negation, questions about state, and anything ambiguous stay Unknown.

--- a/MobileGarage/version.properties
+++ b/MobileGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.22.2
+versionName=2.22.3


### PR DESCRIPTION
Patch bump + changelog for tap-to-copy voice-playground results (#1114). Precedes the `android/264` release. No Wear change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)