### PR TITLE
feat(voice): Voice command UX playground with simulated door (2.22.6)

### DIFF
--- a/MobileGarage/CHANGELOG.md
+++ b/MobileGarage/CHANGELOG.md
@@ -15,6 +15,11 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
 
+## 2.22.6
+
+- **Voice command loop with a cancel window (experimental playground, simulated door).** Settings → Developer gains a "Voice control" sheet that runs the full voice-to-action loop against a pretend door: tap the mic, speak, and a High-confidence command arms a 3-second cancel window (filling ring + "Opening in 3 · Tap to cancel"). Tapping during the window cancels and immediately re-listens; letting it complete presses a simulated button and the fake door moves. Anything non-actionable (loose phrasing, questions, wrong door state) shows a brief explanation instead, tappable to copy the verdict. A segmented control places the simulated door in any state to exercise the gate (already open, moving), and the cancel window is adjustable 2–5 seconds. The real door is never touched from this screen.
+- **Internal:** #1120 — `VoiceCommandController` state machine + `VoiceCommandEnvironment` in `:usecase` (19 virtual-time tests: only HIGH arms, gate checked at arm AND commit, cancel-relisten, nothing commits off-screen, Sending not cancellable) + `SimulatedVoiceCommandEnvironment`. Confirmed UX design recorded in `docs/VOICE_COMMANDS.md` § Command UX. Real wiring later = environment swap + Home surface. Developer-gated experiment; patch.
+
 ## 2.22.5
 
 - **Rules v3 voice classification (experimental playground).** A second adversarial eval round, armed with the engine internals, found one real hole ("open my door" reached the actionable tier via the possessive, though it is not unambiguously the garage door) and 64 loose direction claims: other doors ("close the car door"), reported speech ("she said close the garage door"), self-plans ("ill close the garage later"), and negations without classic tokens ("no need to open the garage door"). All fixed: possessives now count only with garage objects, and new reported-speech, self-plan, and phrase-shape checks force Unknown. "i want you to close the door" and "can you open the door" still classify at Medium. The playground shows "Rules v3".

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
@@ -62,6 +62,7 @@ import com.chriscartland.garage.ui.settings.SettingsContent
 import com.chriscartland.garage.ui.settings.SnoozeBottomSheet
 import com.chriscartland.garage.ui.settings.SnoozeRowState
 import com.chriscartland.garage.ui.settings.VersionBottomSheet
+import com.chriscartland.garage.ui.settings.VoiceControlBottomSheet
 import com.chriscartland.garage.ui.settings.VoiceInputBottomSheet
 import com.chriscartland.garage.version.AppVersion
 import com.chriscartland.garage.viewmodel.ProfileViewModel
@@ -124,6 +125,7 @@ fun ProfileContent(
     var versionSheetOpen by rememberSaveable { mutableStateOf(false) }
     var navRailSheetOpen by rememberSaveable { mutableStateOf(false) }
     var voiceSheetOpen by rememberSaveable { mutableStateOf(false) }
+    var voiceControlSheetOpen by rememberSaveable { mutableStateOf(false) }
 
     // Experimental voice-input playground (Settings → Developer → Voice
     // input). The system speech dialog (RecognizerIntent) records and
@@ -158,6 +160,13 @@ fun ProfileContent(
             resolved.reportVoiceExperimentUnavailable()
         }
     }
+
+    // Experimental voice-command playground (Settings → Developer →
+    // Voice control): the full command loop against a simulated door.
+    // Recognizer plumbing lives inside VoiceControlBottomSheet.
+    val voiceCommandState by resolved.voiceCommandState.collectAsState()
+    val voiceCommandDoorState by resolved.voiceCommandDoorState.collectAsState()
+    val voiceCommandArmedWindowMs by resolved.voiceCommandArmedWindowMs.collectAsState()
 
     // TTL-gated revalidate, once per screen entry (STATUS_CACHE_PLAN.md
     // D3). The cached snooze state renders instantly (hydrated across
@@ -273,6 +282,7 @@ fun ProfileContent(
             onLayoutDebugChange = resolved::setLayoutDebugEnabled,
             onNavRailTap = { navRailSheetOpen = true },
             onVoiceInputTap = { voiceSheetOpen = true },
+            onVoiceControlTap = { voiceControlSheetOpen = true },
         )
         SnackbarHost(
             hostState = snackbarHostState,
@@ -344,6 +354,34 @@ fun ProfileContent(
                 }
             },
             onDismiss = { voiceSheetOpen = false },
+        )
+    }
+
+    if (voiceControlSheetOpen) {
+        VoiceControlBottomSheet(
+            state = voiceCommandState,
+            doorState = voiceCommandDoorState,
+            armedWindowMs = voiceCommandArmedWindowMs,
+            onMicTap = resolved::voiceCommandMicTap,
+            onTranscript = resolved::voiceCommandTranscript,
+            onCaptureUnavailable = resolved::voiceCommandCaptureUnavailable,
+            onBackgrounded = resolved::voiceCommandBackgrounded,
+            onSetDoorState = resolved::setVoiceCommandDoorState,
+            onSetArmedWindowMs = resolved::setVoiceCommandArmedWindowMs,
+            onCopy = { label, value ->
+                clipboardManager.setText(AnnotatedString(value))
+                // Same Android 13+ gate as the Version sheet: the OS
+                // clipboard chip already confirms the copy there.
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                    Toast
+                        .makeText(
+                            context,
+                            resources.getString(R.string.profile_version_toast_copied, label),
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                }
+            },
+            onDismiss = { voiceControlSheetOpen = false },
         )
     }
 

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
@@ -41,6 +41,7 @@ import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.NotificationsOff
 import androidx.compose.material.icons.outlined.NotificationsPaused
 import androidx.compose.material.icons.outlined.Palette
+import androidx.compose.material.icons.outlined.SettingsVoice
 import androidx.compose.material.icons.outlined.Storefront
 import androidx.compose.material.icons.outlined.VerticalAlignCenter
 import androidx.compose.material.icons.outlined.Watch
@@ -144,6 +145,7 @@ fun SettingsContent(
     onLayoutDebugChange: (Boolean) -> Unit = {},
     onNavRailTap: () -> Unit = {},
     onVoiceInputTap: () -> Unit = {},
+    onVoiceControlTap: () -> Unit = {},
 ) {
     LazyColumn(
         modifier = modifier.fillMaxSize(),
@@ -336,6 +338,14 @@ fun SettingsContent(
                         subtitle = stringResource(R.string.settings_developer_voice_input_subtitle),
                         showChevron = true,
                         onClick = onVoiceInputTap,
+                    )
+                    HorizontalDivider(modifier = Modifier.padding(start = DividerInset.ListItem))
+                    SettingsRow(
+                        icon = Icons.Outlined.SettingsVoice,
+                        title = stringResource(R.string.settings_developer_voice_control_title),
+                        subtitle = stringResource(R.string.settings_developer_voice_control_subtitle),
+                        showChevron = true,
+                        onClick = onVoiceControlTap,
                     )
                 }
             }

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/VoiceControlBottomSheet.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/VoiceControlBottomSheet.kt
@@ -1,0 +1,613 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui.settings
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.speech.RecognizerIntent
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.ArrowDownward
+import androidx.compose.material.icons.outlined.ArrowUpward
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material.icons.outlined.Mic
+import androidx.compose.material.icons.outlined.Remove
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.chriscartland.garage.R
+import com.chriscartland.garage.domain.model.VoiceIntent
+import com.chriscartland.garage.domain.model.VoiceIntentClassification
+import com.chriscartland.garage.domain.model.VoiceIntentConfidence
+import com.chriscartland.garage.usecase.VoiceCommandController
+import com.chriscartland.garage.usecase.VoiceCommandIgnoreReason
+import com.chriscartland.garage.usecase.VoiceCommandState
+import com.chriscartland.garage.usecase.VoiceDoorState
+import kotlin.math.ceil
+
+private const val ARMED_WINDOW_STEP_MS = 1_000L
+
+/**
+ * Experimental voice-command UX playground (Settings → Developer →
+ * Voice control). The full loop — mic tap → system speech dialog →
+ * classify → door-state gate → cancel window → commit — running against
+ * a SIMULATED door and pretend button ([com.chriscartland.garage.usecase.SimulatedVoiceCommandEnvironment]).
+ * The real door is never touched from this sheet.
+ *
+ * The mic button is the whole interface: a tap always means "listen to
+ * me now" — it starts over from any pre-commit state, cancelling a
+ * pending command if there is one. The recognizer launch is driven by
+ * the [VoiceCommandState.Listening] state (not the tap), so "tap in
+ * Ready" and "tap cancels Armed" share one launch path.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun VoiceControlBottomSheet(
+    state: VoiceCommandState,
+    doorState: VoiceDoorState,
+    armedWindowMs: Long,
+    onMicTap: () -> Unit,
+    onTranscript: (String?) -> Unit,
+    onCaptureUnavailable: () -> Unit,
+    onBackgrounded: () -> Unit,
+    onSetDoorState: (VoiceDoorState) -> Unit,
+    onSetArmedWindowMs: (Long) -> Unit,
+    onCopy: (label: String, value: String) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val voiceLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        val transcript = if (result.resultCode == Activity.RESULT_OK) {
+            result.data
+                ?.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
+                ?.firstOrNull()
+        } else {
+            null
+        }
+        onTranscript(transcript)
+    }
+    val voicePrompt = stringResource(R.string.voice_experiment_prompt)
+    val listeningAttempt = (state as? VoiceCommandState.Listening)?.attempt
+    LaunchedEffect(listeningAttempt) {
+        if (listeningAttempt != null) {
+            val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH)
+                .putExtra(
+                    RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+                    RecognizerIntent.LANGUAGE_MODEL_FREE_FORM,
+                ).putExtra(RecognizerIntent.EXTRA_PROMPT, voicePrompt)
+                .putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
+            try {
+                voiceLauncher.launch(intent)
+            } catch (_: ActivityNotFoundException) {
+                onCaptureUnavailable()
+            }
+        }
+    }
+
+    // Safety: never commit off-screen. ON_STOP cancels a pending
+    // (Armed) command; Listening and Sending are unaffected (the system
+    // dialog owns Listening, and a sent press cannot be recalled).
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_STOP) onBackgrounded()
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = {
+            // Dismiss = leaving the playground: cancel any pending command.
+            onBackgrounded()
+            onDismiss()
+        },
+        sheetState = sheetState,
+        modifier = modifier,
+    ) {
+        VoiceControlSheetContent(
+            state = state,
+            doorState = doorState,
+            armedWindowMs = armedWindowMs,
+            onMicTap = onMicTap,
+            onSetDoorState = onSetDoorState,
+            onSetArmedWindowMs = onSetArmedWindowMs,
+            onCopy = onCopy,
+        )
+    }
+}
+
+/**
+ * Sheet content extracted so previews can render it directly (the
+ * ModalBottomSheet show animation doesn't run under previews) and so
+ * the activity-result plumbing stays in the wrapper.
+ */
+@Composable
+fun VoiceControlSheetContent(
+    state: VoiceCommandState,
+    doorState: VoiceDoorState,
+    armedWindowMs: Long,
+    onMicTap: () -> Unit,
+    onSetDoorState: (VoiceDoorState) -> Unit = {},
+    onSetArmedWindowMs: (Long) -> Unit = {},
+    onCopy: (label: String, value: String) -> Unit = { _, _ -> },
+    modifier: Modifier = Modifier,
+) {
+    // One shared progress drives the ring AND the countdown text so the
+    // two can never disagree. A fresh Animatable per Armed instance;
+    // cancel-and-relisten produces a new instance and restarts it.
+    val armed = state as? VoiceCommandState.Armed
+    val armedProgress = remember(armed) { Animatable(0f) }
+    LaunchedEffect(armed) {
+        if (armed != null) {
+            armedProgress.animateTo(
+                targetValue = 1f,
+                animationSpec = tween(
+                    durationMillis = armed.windowMs.toInt(),
+                    easing = LinearEasing,
+                ),
+            )
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 24.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.voice_control_sheet_title),
+            style = MaterialTheme.typography.titleLarge,
+        )
+        Text(
+            text = stringResource(R.string.voice_control_disclaimer),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        SimulatedDoorSelector(
+            doorState = doorState,
+            onSetDoorState = onSetDoorState,
+        )
+        VoiceCommandButton(
+            state = state,
+            armedProgress = { armedProgress.value },
+            onMicTap = onMicTap,
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        )
+        VoiceCommandStatus(
+            state = state,
+            armedSecondsLeft = armed?.let {
+                VoiceControlHelpers.secondsLeft(it.windowMs, armedProgress.value)
+            },
+            onCopy = onCopy,
+        )
+        CancelWindowStepper(
+            armedWindowMs = armedWindowMs,
+            onSetArmedWindowMs = onSetArmedWindowMs,
+        )
+    }
+}
+
+// ADR-009: non-Composable helpers live in a named object.
+private object VoiceControlHelpers {
+    fun secondsLeft(
+        windowMs: Long,
+        progress: Float,
+    ): Int = ceil((1f - progress) * windowMs / 1000f).toInt().coerceAtLeast(1)
+
+    // Door-motion metaphor: up = opening, down = closing.
+    fun directionIcon(intent: VoiceIntent): ImageVector =
+        if (intent == VoiceIntent.CLOSE) Icons.Outlined.ArrowDownward else Icons.Outlined.ArrowUpward
+}
+
+@Composable
+private fun SimulatedDoorSelector(
+    doorState: VoiceDoorState,
+    onSetDoorState: (VoiceDoorState) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.voice_control_simulated_door_label),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        val options = listOf(
+            VoiceDoorState.CLOSED to stringResource(R.string.voice_door_closed),
+            VoiceDoorState.OPEN to stringResource(R.string.voice_door_open),
+            VoiceDoorState.MOVING to stringResource(R.string.voice_door_moving),
+        )
+        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+            options.forEachIndexed { index, (option, label) ->
+                SegmentedButton(
+                    selected = doorState == option,
+                    onClick = { onSetDoorState(option) },
+                    shape = SegmentedButtonDefaults.itemShape(
+                        index = index,
+                        count = options.size,
+                    ),
+                ) {
+                    Text(text = label)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun VoiceCommandButton(
+    state: VoiceCommandState,
+    armedProgress: () -> Float,
+    onMicTap: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.size(104.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        when (state) {
+            // The "completing circle": fills over the cancel window.
+            is VoiceCommandState.Armed -> CircularProgressIndicator(
+                progress = armedProgress,
+                modifier = Modifier.fillMaxSize(),
+                strokeWidth = 4.dp,
+            )
+            is VoiceCommandState.Sending -> CircularProgressIndicator(
+                modifier = Modifier.fillMaxSize(),
+                strokeWidth = 4.dp,
+            )
+            else -> Unit
+        }
+        FilledTonalIconButton(
+            onClick = onMicTap,
+            enabled = state !is VoiceCommandState.Sending,
+            modifier = Modifier.size(80.dp),
+        ) {
+            Icon(
+                imageVector = state.micIcon(),
+                contentDescription = state.micContentDescription(),
+                modifier = Modifier.size(36.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun VoiceCommandStatus(
+    state: VoiceCommandState,
+    armedSecondsLeft: Int?,
+    onCopy: (label: String, value: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        when (state) {
+            VoiceCommandState.Ready -> StatusText(
+                text = stringResource(R.string.voice_control_ready_hint),
+            )
+            is VoiceCommandState.Listening -> StatusText(
+                text = stringResource(R.string.voice_control_listening),
+            )
+            is VoiceCommandState.Armed -> {
+                StatusText(
+                    text = stringResource(R.string.voice_control_transcript_quote, state.transcript),
+                )
+                Text(
+                    text = stringResource(
+                        if (state.intent == VoiceIntent.CLOSE) {
+                            R.string.voice_control_armed_closing
+                        } else {
+                            R.string.voice_control_armed_opening
+                        },
+                        armedSecondsLeft ?: VoiceControlHelpers.secondsLeft(state.windowMs, 0f),
+                    ),
+                    style = MaterialTheme.typography.titleMedium,
+                    textAlign = TextAlign.Center,
+                )
+            }
+            is VoiceCommandState.Sending -> StatusText(
+                text = stringResource(R.string.voice_control_sending),
+            )
+            is VoiceCommandState.Sent -> Text(
+                text = stringResource(R.string.voice_control_sent),
+                style = MaterialTheme.typography.titleMedium,
+                textAlign = TextAlign.Center,
+            )
+            is VoiceCommandState.Failed -> Text(
+                text = stringResource(R.string.voice_control_failed),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.error,
+                textAlign = TextAlign.Center,
+            )
+            is VoiceCommandState.Ignored -> IgnoredStatus(
+                state = state,
+                onCopy = onCopy,
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatusText(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center,
+        modifier = modifier,
+    )
+}
+
+/**
+ * Transient explanation for a capture that didn't commit. Tap to copy
+ * the structured verdict (same format as the transcription playground)
+ * so misses can be pasted into eval discussions.
+ */
+@Composable
+private fun IgnoredStatus(
+    state: VoiceCommandState.Ignored,
+    onCopy: (label: String, value: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val verdictLabel = stringResource(R.string.voice_copy_label_verdict)
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        shape = MaterialTheme.shapes.medium,
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.medium)
+            .clickable { onCopy(verdictLabel, state.clipboardSummary()) },
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        ) {
+            Text(
+                text = state.reason.displayText(),
+                style = MaterialTheme.typography.titleSmall,
+                textAlign = TextAlign.Center,
+            )
+            state.transcript?.let {
+                Text(
+                    text = stringResource(R.string.voice_control_transcript_quote, it),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
+            Text(
+                text = stringResource(R.string.voice_control_copy_hint),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Composable
+private fun CancelWindowStepper(
+    armedWindowMs: Long,
+    onSetArmedWindowMs: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stringResource(
+                R.string.voice_control_window_label,
+                (armedWindowMs / 1000L).toInt(),
+            ),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        IconButton(
+            onClick = { onSetArmedWindowMs(armedWindowMs - ARMED_WINDOW_STEP_MS) },
+            enabled = armedWindowMs > VoiceCommandController.MIN_ARMED_WINDOW_MS,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Remove,
+                contentDescription = stringResource(R.string.voice_control_window_decrease),
+            )
+        }
+        IconButton(
+            onClick = { onSetArmedWindowMs(armedWindowMs + ARMED_WINDOW_STEP_MS) },
+            enabled = armedWindowMs < VoiceCommandController.MAX_ARMED_WINDOW_MS,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Add,
+                contentDescription = stringResource(R.string.voice_control_window_increase),
+            )
+        }
+    }
+}
+
+private fun VoiceCommandState.micIcon(): ImageVector =
+    when (this) {
+        VoiceCommandState.Ready, is VoiceCommandState.Listening, is VoiceCommandState.Ignored ->
+            Icons.Outlined.Mic
+        is VoiceCommandState.Armed -> VoiceControlHelpers.directionIcon(intent)
+        is VoiceCommandState.Sending -> VoiceControlHelpers.directionIcon(intent)
+        is VoiceCommandState.Sent -> Icons.Outlined.Check
+        is VoiceCommandState.Failed -> Icons.Outlined.ErrorOutline
+    }
+
+@Composable
+private fun VoiceCommandState.micContentDescription(): String =
+    when (this) {
+        VoiceCommandState.Ready, is VoiceCommandState.Ignored ->
+            stringResource(R.string.voice_control_mic_cd_ready)
+        is VoiceCommandState.Listening -> stringResource(R.string.voice_control_mic_cd_listening)
+        is VoiceCommandState.Armed -> stringResource(R.string.voice_control_mic_cd_armed)
+        is VoiceCommandState.Sending -> stringResource(R.string.voice_control_mic_cd_sending)
+        is VoiceCommandState.Sent, is VoiceCommandState.Failed ->
+            stringResource(R.string.voice_control_mic_cd_ready)
+    }
+
+@Composable
+private fun VoiceCommandIgnoreReason.displayText(): String =
+    when (this) {
+        VoiceCommandIgnoreReason.NO_SPEECH ->
+            stringResource(R.string.voice_control_ignored_no_speech)
+        VoiceCommandIgnoreReason.RECOGNIZER_UNAVAILABLE ->
+            stringResource(R.string.voice_control_ignored_unavailable)
+        VoiceCommandIgnoreReason.NOT_A_COMMAND ->
+            stringResource(R.string.voice_control_ignored_not_a_command)
+        VoiceCommandIgnoreReason.NOT_CONFIDENT ->
+            stringResource(R.string.voice_control_ignored_not_confident)
+        VoiceCommandIgnoreReason.DOOR_ALREADY_OPEN ->
+            stringResource(R.string.voice_control_ignored_already_open)
+        VoiceCommandIgnoreReason.DOOR_ALREADY_CLOSED ->
+            stringResource(R.string.voice_control_ignored_already_closed)
+        VoiceCommandIgnoreReason.DOOR_MOVING ->
+            stringResource(R.string.voice_control_ignored_moving)
+        VoiceCommandIgnoreReason.DOOR_STATE_UNKNOWN ->
+            stringResource(R.string.voice_control_ignored_state_unknown)
+        VoiceCommandIgnoreReason.DOOR_STATE_CHANGED ->
+            stringResource(R.string.voice_control_ignored_state_changed)
+    }
+
+// `private` so `checkPreviewCoverage` exempts them (same rationale as
+// NavRailBottomSheet and VoiceInputBottomSheet: developer-gated sheet
+// verified on a real device; these are Android Studio references only).
+@Preview
+@Composable
+private fun VoiceControlSheetContentReadyPreview() {
+    Surface {
+        VoiceControlSheetContent(
+            state = VoiceCommandState.Ready,
+            doorState = VoiceDoorState.CLOSED,
+            armedWindowMs = VoiceCommandController.DEFAULT_ARMED_WINDOW_MS,
+            onMicTap = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun VoiceControlSheetContentArmedPreview() {
+    Surface {
+        VoiceControlSheetContent(
+            state = VoiceCommandState.Armed(
+                intent = VoiceIntent.OPEN,
+                transcript = "open the garage door",
+                windowMs = VoiceCommandController.DEFAULT_ARMED_WINDOW_MS,
+            ),
+            doorState = VoiceDoorState.CLOSED,
+            armedWindowMs = VoiceCommandController.DEFAULT_ARMED_WINDOW_MS,
+            onMicTap = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun VoiceControlSheetContentIgnoredPreview() {
+    Surface {
+        VoiceControlSheetContent(
+            state = VoiceCommandState.Ignored(
+                reason = VoiceCommandIgnoreReason.NOT_CONFIDENT,
+                transcript = "can you open the garage door",
+                classification = VoiceIntentClassification(
+                    intent = VoiceIntent.OPEN,
+                    confidence = VoiceIntentConfidence.MEDIUM,
+                ),
+                engineName = "Rules v3",
+            ),
+            doorState = VoiceDoorState.CLOSED,
+            armedWindowMs = VoiceCommandController.DEFAULT_ARMED_WINDOW_MS,
+            onMicTap = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun VoiceControlSheetContentSentPreview() {
+    Surface {
+        VoiceControlSheetContent(
+            state = VoiceCommandState.Sent(intent = VoiceIntent.OPEN),
+            doorState = VoiceDoorState.MOVING,
+            armedWindowMs = VoiceCommandController.DEFAULT_ARMED_WINDOW_MS,
+            onMicTap = {},
+        )
+    }
+}

--- a/MobileGarage/androidApp/src/main/res/values/strings.xml
+++ b/MobileGarage/androidApp/src/main/res/values/strings.xml
@@ -97,6 +97,49 @@
     <string name="voice_copy_label_transcript">transcript</string>
     <string name="voice_copy_label_verdict">verdict</string>
 
+    <!-- Settings → Developer → Voice control (experimental playground).
+         The full voice-command loop (mic → classify → gate → cancel
+         window → commit) against a SIMULATED door. No real door action
+         is ever taken from this screen. -->
+    <string name="settings_developer_voice_control_title">Voice control</string>
+    <string name="settings_developer_voice_control_subtitle">Experimental. Voice to action with a simulated door.</string>
+    <string name="voice_control_sheet_title">Voice control</string>
+    <string name="voice_control_disclaimer">Simulated playground. Commands press a pretend button and move a pretend door. The real door is never touched.</string>
+    <string name="voice_control_simulated_door_label">Simulated door</string>
+    <string name="voice_door_closed">Closed</string>
+    <string name="voice_door_open">Open</string>
+    <string name="voice_door_moving">Moving</string>
+    <string name="voice_door_unknown">Unknown</string>
+    <string name="voice_control_ready_hint">Tap the mic, then say a command like “open the garage door”</string>
+    <string name="voice_control_listening">Listening…</string>
+    <!-- Heard transcript, quoted. %1$s is the raw transcript. -->
+    <string name="voice_control_transcript_quote">“%1$s”</string>
+    <!-- Countdown line while a command is armed. %1$d is seconds left. -->
+    <string name="voice_control_armed_opening">Opening in %1$d · Tap to cancel</string>
+    <string name="voice_control_armed_closing">Closing in %1$d · Tap to cancel</string>
+    <string name="voice_control_sending">Pressing the button…</string>
+    <string name="voice_control_sent">Command sent</string>
+    <string name="voice_control_failed">Button press failed</string>
+    <string name="voice_control_ignored_no_speech">No speech captured</string>
+    <string name="voice_control_ignored_unavailable">Speech recognition is not available on this device</string>
+    <string name="voice_control_ignored_not_a_command">No command heard</string>
+    <string name="voice_control_ignored_not_confident">Heard a command, but not confident enough to act</string>
+    <string name="voice_control_ignored_already_open">The door is already open</string>
+    <string name="voice_control_ignored_already_closed">The door is already closed</string>
+    <string name="voice_control_ignored_moving">The door is moving</string>
+    <string name="voice_control_ignored_state_unknown">Door state is unknown</string>
+    <string name="voice_control_ignored_state_changed">Door state changed before sending</string>
+    <string name="voice_control_copy_hint">Tap the message to copy details</string>
+    <!-- Cancel-window stepper. %1$d is seconds. -->
+    <string name="voice_control_window_label">Cancel window: %1$d seconds</string>
+    <string name="voice_control_window_decrease">Shorten cancel window</string>
+    <string name="voice_control_window_increase">Lengthen cancel window</string>
+    <!-- Mic button content descriptions per state. -->
+    <string name="voice_control_mic_cd_ready">Start voice command</string>
+    <string name="voice_control_mic_cd_listening">Listening</string>
+    <string name="voice_control_mic_cd_armed">Cancel and speak again</string>
+    <string name="voice_control_mic_cd_sending">Sending command</string>
+
     <!-- Home screen — section labels. -->
     <string name="home_section_status">Status</string>
     <string name="home_section_remote_control">Remote control</string>

--- a/MobileGarage/docs/VOICE_COMMANDS.md
+++ b/MobileGarage/docs/VOICE_COMMANDS.md
@@ -144,6 +144,46 @@ recognition quality is device-only, and that is Google's code, not ours.
    proves too brittle in practice (revisit only with real missed-command
    data, and keep the imperative-only rule).
 
+## Command UX: cancel-window loop (confirmed design; simulated playground shipped)
+
+The interaction design for the action loop was settled 2026-07-24 and
+supersedes the sketches above where they differ (notably: the cancel
+window replaces the `ButtonStateMachine` confirmed-submit idea as the
+confirmation step, and v1 capture is `RecognizerIntent`, not a
+`SpeechRecognizer` bridge). Confirmed decisions:
+
+- **One button is the whole interface.** A tap always means "listen to
+  me now": it starts over from any pre-commit state, cancelling a
+  pending command and immediately re-listening (the correction flow —
+  "close… no wait, open" — is one tap + re-speak).
+- **Capture is `RecognizerIntent` for v1** (system dialog = the
+  recording state; no mic permission). An in-app `SpeechRecognizer`
+  icon-morph is a later polish option.
+- **Only HIGH arms.** MEDIUM/UNKNOWN/no-speech/gate-blocked render a
+  ~4s transient explanation chip (tap-to-copy the structured verdict,
+  feeding the eval corpus), then auto-return to Ready.
+- **The door-state gate runs twice**: at arm time (open only when
+  closed, close only when open; moving/unknown refuse) and again when
+  the cancel window elapses — a door that moved mid-countdown aborts.
+- **The cancel window** (default 3s, adjustable 2–5s) renders as a
+  filling ring around the button with a countdown line ("Opening in 3 ·
+  Tap to cancel"). Ring completion commits; the ~1s Sending state is
+  not cancellable (a press cannot be unsent) and the button disables.
+- **Nothing commits off-screen**: lifecycle stop or sheet dismissal
+  cancels a pending (Armed) command.
+
+Implementation (shipped 2.22.6, simulated only): the state machine is
+`VoiceCommandController` in `:usecase` (`Ready → Listening → Armed →
+Sending → Sent/Failed/Ignored`), acting on a `VoiceCommandEnvironment`
+(door state + `pressButton`). The Settings → Developer → **Voice
+control** sheet (`VoiceControlBottomSheet`) wires the real controller to
+`SimulatedVoiceCommandEnvironment` — an in-memory door with a pretend
+button and fake transit, plus a segmented control to place the door in
+any state to exercise every gate path. The real door is never touched.
+Promoting to the real thing is an environment swap (door repository
+projection + `PushRemoteButtonUseCase`) plus a Home-screen surface —
+the controller, gate, and tests carry over unchanged.
+
 ## Testing plan
 
 - Parser: table-driven accept/reject test mirroring the table above.

--- a/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SimulatedVoiceCommandEnvironment.kt
+++ b/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SimulatedVoiceCommandEnvironment.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.VoiceIntent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Fake world for the voice-command playground: an in-memory door and a
+ * pretend button. [pressButton] waits a moment (fake network), flips
+ * the door to [VoiceDoorState.MOVING], then settles it on the commanded
+ * side after a fake transit. The real door is never touched.
+ *
+ * [setDoorState] lets the playground UI place the door directly so the
+ * user can exercise every gate path (already-open, moving, etc.); a
+ * manual set cancels any in-flight transit.
+ */
+class SimulatedVoiceCommandEnvironment(
+    private val scope: CoroutineScope,
+    private val pressDelayMs: Long = PRESS_DELAY_MS,
+    private val transitMs: Long = TRANSIT_MS,
+) : VoiceCommandEnvironment {
+    private val _doorState = MutableStateFlow(VoiceDoorState.CLOSED)
+    override val doorState: StateFlow<VoiceDoorState> = _doorState
+
+    private var transitJob: Job? = null
+
+    fun setDoorState(state: VoiceDoorState) {
+        transitJob?.cancel()
+        transitJob = null
+        _doorState.value = state
+    }
+
+    override suspend fun pressButton(intent: VoiceIntent): Boolean {
+        delay(pressDelayMs)
+        transitJob?.cancel()
+        _doorState.value = VoiceDoorState.MOVING
+        transitJob = scope.launch {
+            delay(transitMs)
+            _doorState.value = when (intent) {
+                VoiceIntent.OPEN -> VoiceDoorState.OPEN
+                VoiceIntent.CLOSE -> VoiceDoorState.CLOSED
+                // The controller never sends UNKNOWN (only HIGH commands
+                // commit, and HIGH implies a direction) — settle to
+                // UNKNOWN so a misuse is visible instead of a guess.
+                VoiceIntent.UNKNOWN -> VoiceDoorState.UNKNOWN
+            }
+        }
+        return true
+    }
+
+    companion object {
+        /** Fake button-press round-trip. */
+        const val PRESS_DELAY_MS = 600L
+
+        /** Fake door travel time from press to settled state. */
+        const val TRANSIT_MS = 2_500L
+    }
+}

--- a/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/VoiceCommandController.kt
+++ b/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/VoiceCommandController.kt
@@ -1,0 +1,338 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.VoiceIntent
+import com.chriscartland.garage.domain.model.VoiceIntentClassification
+import com.chriscartland.garage.domain.model.VoiceIntentConfidence
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Door state as the voice-command gate sees it. A projection of the
+ * richer door-event model: the gate only needs "is the door settled,
+ * and which side" to decide whether a spoken direction is actionable.
+ */
+enum class VoiceDoorState { CLOSED, OPEN, MOVING, UNKNOWN }
+
+/** Why a capture ended without arming a command. */
+enum class VoiceCommandIgnoreReason {
+    /** The recognizer returned no usable speech (silence, cancel). */
+    NO_SPEECH,
+
+    /** No speech recognizer exists on this device. */
+    RECOGNIZER_UNAVAILABLE,
+
+    /** Classifier verdict UNKNOWN: not a door command at all. */
+    NOT_A_COMMAND,
+
+    /** Classifier verdict MEDIUM: heard a direction, not confident enough to act. */
+    NOT_CONFIDENT,
+
+    /** Open command while the door is already open. */
+    DOOR_ALREADY_OPEN,
+
+    /** Close command while the door is already closed. */
+    DOOR_ALREADY_CLOSED,
+
+    /** The door is mid-motion; commands only apply to settled states. */
+    DOOR_MOVING,
+
+    /** The door state is unknown; refuse rather than guess. */
+    DOOR_STATE_UNKNOWN,
+
+    /** The door state changed during the cancel window; commit aborted. */
+    DOOR_STATE_CHANGED,
+}
+
+/**
+ * States of the voice-command loop. The mic button renders these; taps
+ * feed back into [VoiceCommandController]. Design rule: a tap always
+ * means "listen to me now" — it starts over from any pre-commit state,
+ * cancelling a pending command if there is one.
+ */
+sealed interface VoiceCommandState {
+    /** Mic idle, waiting for a tap. */
+    data object Ready : VoiceCommandState
+
+    /**
+     * Speech capture in progress. [attempt] increments per capture so UI
+     * launch effects re-fire when a cancel immediately re-listens.
+     */
+    data class Listening(
+        val attempt: Int,
+    ) : VoiceCommandState
+
+    /**
+     * A HIGH-confidence command passed the door-state gate and is
+     * counting down. Tapping before [windowMs] elapses cancels and
+     * re-listens; letting it complete re-checks the gate and commits.
+     */
+    data class Armed(
+        val intent: VoiceIntent,
+        val transcript: String,
+        val windowMs: Long,
+    ) : VoiceCommandState
+
+    /** Button press in flight. Not cancellable — a press cannot be unsent. */
+    data class Sending(
+        val intent: VoiceIntent,
+    ) : VoiceCommandState
+
+    /** Press succeeded; brief confirmation before returning to [Ready]. */
+    data class Sent(
+        val intent: VoiceIntent,
+    ) : VoiceCommandState
+
+    /** Press failed; brief error before returning to [Ready]. */
+    data class Failed(
+        val intent: VoiceIntent,
+    ) : VoiceCommandState
+
+    /**
+     * The capture ended without a committed action. Renders as a
+     * transient explanation, then auto-returns to [Ready].
+     */
+    data class Ignored(
+        val reason: VoiceCommandIgnoreReason,
+        val transcript: String?,
+        val classification: VoiceIntentClassification?,
+        val engineName: String,
+    ) : VoiceCommandState {
+        /**
+         * Paste-friendly structured summary (same conventions as the
+         * transcription playground's verdict copy) so misses can be
+         * shared and turned into eval-corpus rows.
+         */
+        fun clipboardSummary(): String =
+            buildString {
+                appendLine("input: " + (transcript?.let { "\"$it\"" } ?: "none"))
+                classification?.let {
+                    appendLine("intent: ${it.intent.name}")
+                    appendLine("confidence: ${it.confidence.name}")
+                    appendLine("engine: $engineName")
+                }
+                append("outcome: ${reason.name}")
+            }
+    }
+}
+
+/**
+ * The world the voice-command loop acts on: the door's current state
+ * and the one action it can take. The playground injects
+ * [SimulatedVoiceCommandEnvironment]; a future Home-screen wiring
+ * injects the real door repository + remote button press.
+ *
+ * Contract: [pressButton] reports failure by returning `false`, never
+ * by throwing.
+ */
+interface VoiceCommandEnvironment {
+    val doorState: StateFlow<VoiceDoorState>
+
+    suspend fun pressButton(intent: VoiceIntent): Boolean
+}
+
+/**
+ * The voice-command state machine (shared KMP; UI-free). One capture
+ * flows: transcript → classify → gate → cancel window → commit.
+ *
+ * Safety properties, per the standing principle "okay to incorrectly
+ * ignore, never okay to incorrectly execute":
+ * - Only a HIGH-confidence classification can arm. MEDIUM and UNKNOWN
+ *   are ignored with an explanation.
+ * - The door-state gate runs twice: at arm time and again when the
+ *   cancel window elapses — a door that moved mid-countdown aborts the
+ *   commit ([VoiceCommandIgnoreReason.DOOR_STATE_CHANGED]).
+ * - [onBackgrounded] cancels a pending command: nothing commits while
+ *   the UI is off-screen.
+ * - [onMicTap] during [VoiceCommandState.Armed] cancels and immediately
+ *   re-listens; during [VoiceCommandState.Sending] it is a no-op (the
+ *   press is already on its way).
+ */
+class VoiceCommandController(
+    private val classify: ClassifyVoiceIntentUseCase,
+    private val environment: VoiceCommandEnvironment,
+    private val scope: CoroutineScope,
+    initialArmedWindowMs: Long = DEFAULT_ARMED_WINDOW_MS,
+) {
+    private val _state = MutableStateFlow<VoiceCommandState>(VoiceCommandState.Ready)
+    val state: StateFlow<VoiceCommandState> = _state
+
+    private val _armedWindowMs = MutableStateFlow(coerceWindow(initialArmedWindowMs))
+    val armedWindowMs: StateFlow<Long> = _armedWindowMs
+
+    // The one in-flight coroutine (countdown, or transient auto-return).
+    // Only user-input handlers cancel it; transitions from inside the
+    // running job overwrite the reference instead of self-cancelling.
+    private var job: Job? = null
+    private var listeningAttempt = 0
+
+    fun onMicTap() {
+        when (_state.value) {
+            // Dialog already up / press already sent: nothing to restart.
+            is VoiceCommandState.Listening, is VoiceCommandState.Sending -> Unit
+            else -> startListening()
+        }
+    }
+
+    /** Recognizer outcome. Null or blank means no usable speech. */
+    fun onTranscript(text: String?) {
+        if (_state.value !is VoiceCommandState.Listening) return
+        if (text.isNullOrBlank()) {
+            ignore(VoiceCommandIgnoreReason.NO_SPEECH, transcript = null, classification = null)
+            return
+        }
+        val classification = classify(text)
+        when (classification.confidence) {
+            VoiceIntentConfidence.NONE ->
+                ignore(VoiceCommandIgnoreReason.NOT_A_COMMAND, text, classification)
+            VoiceIntentConfidence.MEDIUM ->
+                ignore(VoiceCommandIgnoreReason.NOT_CONFIDENT, text, classification)
+            VoiceIntentConfidence.HIGH -> arm(classification, text)
+        }
+    }
+
+    /** The device has no speech recognizer (capture launch failed). */
+    fun onCaptureUnavailable() {
+        if (_state.value !is VoiceCommandState.Listening) return
+        ignore(VoiceCommandIgnoreReason.RECOGNIZER_UNAVAILABLE, transcript = null, classification = null)
+    }
+
+    /**
+     * The UI left the screen (lifecycle stop, sheet dismissed). Cancels
+     * a pending command so nothing commits off-screen. Other states are
+     * untouched: Listening is owned by the system dialog, and a Sending
+     * press cannot be recalled.
+     */
+    fun onBackgrounded() {
+        if (_state.value is VoiceCommandState.Armed) {
+            job?.cancel()
+            job = null
+            _state.value = VoiceCommandState.Ready
+        }
+    }
+
+    fun setArmedWindowMs(ms: Long) {
+        _armedWindowMs.value = coerceWindow(ms)
+    }
+
+    private fun startListening() {
+        job?.cancel()
+        job = null
+        listeningAttempt += 1
+        _state.value = VoiceCommandState.Listening(listeningAttempt)
+    }
+
+    private fun arm(
+        classification: VoiceIntentClassification,
+        transcript: String,
+    ) {
+        val gateReason = gateReason(classification.intent, environment.doorState.value)
+        if (gateReason != null) {
+            ignore(gateReason, transcript, classification)
+            return
+        }
+        val windowMs = _armedWindowMs.value
+        _state.value = VoiceCommandState.Armed(classification.intent, transcript, windowMs)
+        job = scope.launch {
+            delay(windowMs)
+            commit(classification, transcript)
+        }
+    }
+
+    private suspend fun commit(
+        classification: VoiceIntentClassification,
+        transcript: String,
+    ) {
+        // Second gate check: the world may have moved during the window.
+        if (gateReason(classification.intent, environment.doorState.value) != null) {
+            ignore(VoiceCommandIgnoreReason.DOOR_STATE_CHANGED, transcript, classification)
+            return
+        }
+        _state.value = VoiceCommandState.Sending(classification.intent)
+        val success = environment.pressButton(classification.intent)
+        val result = if (success) {
+            VoiceCommandState.Sent(classification.intent)
+        } else {
+            VoiceCommandState.Failed(classification.intent)
+        }
+        _state.value = result
+        scheduleReturnToReady(result, RESULT_FLASH_MS)
+    }
+
+    private fun ignore(
+        reason: VoiceCommandIgnoreReason,
+        transcript: String?,
+        classification: VoiceIntentClassification?,
+    ) {
+        val ignored = VoiceCommandState.Ignored(
+            reason = reason,
+            transcript = transcript,
+            classification = classification,
+            engineName = classify.engineName,
+        )
+        _state.value = ignored
+        scheduleReturnToReady(ignored, IGNORED_DISMISS_MS)
+    }
+
+    private fun scheduleReturnToReady(
+        from: VoiceCommandState,
+        delayMs: Long,
+    ) {
+        // Overwrites `job` — safe when called from inside the old job
+        // (the old coroutine is completing) and the identity guard keeps
+        // a stale timer from clobbering a newer state.
+        job = scope.launch {
+            delay(delayMs)
+            if (_state.value === from) {
+                _state.value = VoiceCommandState.Ready
+            }
+        }
+    }
+
+    private fun gateReason(
+        intent: VoiceIntent,
+        door: VoiceDoorState,
+    ): VoiceCommandIgnoreReason? =
+        when (door) {
+            VoiceDoorState.MOVING -> VoiceCommandIgnoreReason.DOOR_MOVING
+            VoiceDoorState.UNKNOWN -> VoiceCommandIgnoreReason.DOOR_STATE_UNKNOWN
+            VoiceDoorState.OPEN ->
+                if (intent == VoiceIntent.OPEN) VoiceCommandIgnoreReason.DOOR_ALREADY_OPEN else null
+            VoiceDoorState.CLOSED ->
+                if (intent == VoiceIntent.CLOSE) VoiceCommandIgnoreReason.DOOR_ALREADY_CLOSED else null
+        }
+
+    private fun coerceWindow(ms: Long): Long = ms.coerceIn(MIN_ARMED_WINDOW_MS, MAX_ARMED_WINDOW_MS)
+
+    companion object {
+        const val DEFAULT_ARMED_WINDOW_MS = 3_000L
+        const val MIN_ARMED_WINDOW_MS = 2_000L
+        const val MAX_ARMED_WINDOW_MS = 5_000L
+
+        /** How long an [VoiceCommandState.Ignored] explanation stays up. */
+        const val IGNORED_DISMISS_MS = 4_000L
+
+        /** How long the Sent/Failed confirmation stays up. */
+        const val RESULT_FLASH_MS = 1_500L
+    }
+}

--- a/MobileGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SimulatedVoiceCommandEnvironmentTest.kt
+++ b/MobileGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/SimulatedVoiceCommandEnvironmentTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.VoiceIntent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SimulatedVoiceCommandEnvironmentTest {
+    @Test
+    fun pressMovesThenSettlesOnCommandedSide() =
+        runTest {
+            val env = SimulatedVoiceCommandEnvironment(scope = backgroundScope)
+            assertEquals(VoiceDoorState.CLOSED, env.doorState.value)
+
+            var pressed = false
+            backgroundScope.launch { pressed = env.pressButton(VoiceIntent.OPEN) }
+
+            advanceTimeBy(SimulatedVoiceCommandEnvironment.PRESS_DELAY_MS)
+            runCurrent()
+            assertTrue(pressed)
+            assertEquals(VoiceDoorState.MOVING, env.doorState.value)
+
+            advanceTimeBy(SimulatedVoiceCommandEnvironment.TRANSIT_MS)
+            runCurrent()
+            assertEquals(VoiceDoorState.OPEN, env.doorState.value)
+        }
+
+    @Test
+    fun manualSetCancelsTransit() =
+        runTest {
+            val env = SimulatedVoiceCommandEnvironment(scope = backgroundScope)
+            backgroundScope.launch { env.pressButton(VoiceIntent.OPEN) }
+            advanceTimeBy(SimulatedVoiceCommandEnvironment.PRESS_DELAY_MS)
+            runCurrent()
+            assertEquals(VoiceDoorState.MOVING, env.doorState.value)
+
+            // The user places the door by hand mid-transit; the pending
+            // settle must not fire later and overwrite it.
+            env.setDoorState(VoiceDoorState.CLOSED)
+            advanceTimeBy(SimulatedVoiceCommandEnvironment.TRANSIT_MS * 2)
+            runCurrent()
+            assertEquals(VoiceDoorState.CLOSED, env.doorState.value)
+        }
+}

--- a/MobileGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/VoiceCommandControllerTest.kt
+++ b/MobileGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/VoiceCommandControllerTest.kt
@@ -1,0 +1,347 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.VoiceIntent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+private const val WINDOW = VoiceCommandController.DEFAULT_ARMED_WINDOW_MS
+private const val IGNORED = VoiceCommandController.IGNORED_DISMISS_MS
+private const val FLASH = VoiceCommandController.RESULT_FLASH_MS
+
+/**
+ * Exercises the voice-command state machine's safety properties under
+ * virtual time: only HIGH arms, the gate runs at arm AND commit, a tap
+ * during the window cancels-and-relistens, and nothing commits after
+ * backgrounding. The environment is a hand-rolled fake so door state
+ * and press outcomes are fully scriptable.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class VoiceCommandControllerTest {
+    /** Scriptable environment: settable door, recorded presses. */
+    private class FakeVoiceCommandEnvironment(
+        private val pressDelayMs: Long = 0L,
+    ) : VoiceCommandEnvironment {
+        val door = MutableStateFlow(VoiceDoorState.CLOSED)
+        override val doorState: StateFlow<VoiceDoorState> = door
+
+        val presses = mutableListOf<VoiceIntent>()
+        var failNextPress = false
+
+        override suspend fun pressButton(intent: VoiceIntent): Boolean {
+            if (pressDelayMs > 0) delay(pressDelayMs)
+            presses.add(intent)
+            val success = !failNextPress
+            failNextPress = false
+            return success
+        }
+    }
+
+    private fun TestScope.createController(environment: FakeVoiceCommandEnvironment): VoiceCommandController =
+        VoiceCommandController(
+            classify = ClassifyVoiceIntentUseCase(RuleBasedVoiceIntentClassifier()),
+            environment = environment,
+            scope = backgroundScope,
+        )
+
+    @Test
+    fun micTapFromReadyStartsListening() =
+        runTest {
+            val controller = createController(FakeVoiceCommandEnvironment())
+            controller.onMicTap()
+            assertEquals(VoiceCommandState.Listening(attempt = 1), controller.state.value)
+        }
+
+    @Test
+    fun highConfidenceCommandArmsThenCommits() =
+        runTest {
+            val env = FakeVoiceCommandEnvironment()
+            val controller = createController(env)
+            controller.onMicTap()
+            controller.onTranscript("open the garage door")
+
+            val armed = assertIs<VoiceCommandState.Armed>(controller.state.value)
+            assertEquals(VoiceIntent.OPEN, armed.intent)
+            assertEquals("open the garage door", armed.transcript)
+            assertTrue(env.presses.isEmpty(), "Nothing may send during the cancel window")
+
+            advanceTimeBy(WINDOW)
+            runCurrent()
+            assertEquals(listOf(VoiceIntent.OPEN), env.presses)
+            assertEquals(VoiceCommandState.Sent(VoiceIntent.OPEN), controller.state.value)
+
+            advanceTimeBy(FLASH)
+            runCurrent()
+            assertEquals(VoiceCommandState.Ready, controller.state.value)
+        }
+
+    @Test
+    fun closeCommandCommitsWhenDoorOpen() =
+        runTest {
+            val env = FakeVoiceCommandEnvironment()
+            env.door.value = VoiceDoorState.OPEN
+            val controller = createController(env)
+            controller.onMicTap()
+            controller.onTranscript("close the garage door")
+            advanceTimeBy(WINDOW)
+            runCurrent()
+            assertEquals(listOf(VoiceIntent.CLOSE), env.presses)
+            assertEquals(VoiceCommandState.Sent(VoiceIntent.CLOSE), controller.state.value)
+        }
+
+    @Test
+    fun tapDuringArmedCancelsAndRelistens() =
+        runTest {
+            val env = FakeVoiceCommandEnvironment()
+            val controller = createController(env)
+            controller.onMicTap()
+            controller.onTranscript("open the garage door")
+            assertIs<VoiceCommandState.Armed>(controller.state.value)
+
+            advanceTimeBy(WINDOW / 2)
+            controller.onMicTap()
+            assertEquals(VoiceCommandState.Listening(attempt = 2), controller.state.value)
+
+            // The cancelled countdown must never fire.
+            advanceTimeBy(WINDOW * 2)
+            runCurrent()
+            assertTrue(env.presses.isEmpty(), "Cancelled command must not send")
+            assertEquals(VoiceCommandState.Listening(attempt = 2), controller.state.value)
+        }
+
+    @Test
+    fun mediumConfidenceIsIgnoredNotConfident() =
+        runTest {
+            val env = FakeVoiceCommandEnvironment()
+            val controller = createController(env)
+            controller.onMicTap()
+            controller.onTranscript("can you open the garage door")
+            val ignored = assertIs<VoiceCommandState.Ignored>(controller.state.value)
+            assertEquals(VoiceCommandIgnoreReason.NOT_CONFIDENT, ignored.reason)
+            advanceTimeBy(WINDOW * 2)
+            runCurrent()
+            assertTrue(env.presses.isEmpty(), "MEDIUM must never act")
+        }
+
+    @Test
+    fun unknownIntentIsIgnoredNotACommand() =
+        runTest {
+            val controller = createController(FakeVoiceCommandEnvironment())
+            controller.onMicTap()
+            controller.onTranscript("is the door open")
+            val ignored = assertIs<VoiceCommandState.Ignored>(controller.state.value)
+            assertEquals(VoiceCommandIgnoreReason.NOT_A_COMMAND, ignored.reason)
+        }
+
+    @Test
+    fun blankTranscriptIsIgnoredNoSpeech() =
+        runTest {
+            val controller = createController(FakeVoiceCommandEnvironment())
+            controller.onMicTap()
+            controller.onTranscript(null)
+            val ignored = assertIs<VoiceCommandState.Ignored>(controller.state.value)
+            assertEquals(VoiceCommandIgnoreReason.NO_SPEECH, ignored.reason)
+        }
+
+    @Test
+    fun ignoredAutoDismissesToReady() =
+        runTest {
+            val controller = createController(FakeVoiceCommandEnvironment())
+            controller.onMicTap()
+            controller.onTranscript("is the door open")
+            advanceTimeBy(IGNORED)
+            runCurrent()
+            assertEquals(VoiceCommandState.Ready, controller.state.value)
+        }
+
+    @Test
+    fun gateBlocksOpenWhenAlreadyOpen() =
+        runTest {
+            val env = FakeVoiceCommandEnvironment()
+            env.door.value = VoiceDoorState.OPEN
+            val controller = createController(env)
+            controller.onMicTap()
+            controller.onTranscript("open the garage door")
+            val ignored = assertIs<VoiceCommandState.Ignored>(controller.state.value)
+            assertEquals(VoiceCommandIgnoreReason.DOOR_ALREADY_OPEN, ignored.reason)
+            assertTrue(env.presses.isEmpty())
+        }
+
+    @Test
+    fun gateBlocksCloseWhenAlreadyClosed() =
+        runTest {
+            val env = FakeVoiceCommandEnvironment()
+            val controller = createController(env)
+            controller.onMicTap()
+            controller.onTranscript("close the garage door")
+            val ignored = assertIs<VoiceCommandState.Ignored>(controller.state.value)
+            assertEquals(VoiceCommandIgnoreReason.DOOR_ALREADY_CLOSED, ignored.reason)
+        }
+
+    @Test
+    fun gateBlocksWhenDoorMoving() =
+        runTest {
+            val env = FakeVoiceCommandEnvironment()
+            env.door.value = VoiceDoorState.MOVING
+            val controller = createController(env)
+            controller.onMicTap()
+            controller.onTranscript("open the garage door")
+            val ignored = assertIs<VoiceCommandState.Ignored>(controller.state.value)
+            assertEquals(VoiceCommandIgnoreReason.DOOR_MOVING, ignored.reason)
+        }
+
+    @Test
+    fun gateBlocksWhenDoorUnknown() =
+        runTest {
+            val env = FakeVoiceCommandEnvironment()
+            env.door.value = VoiceDoorState.UNKNOWN
+            val controller = createController(env)
+            controller.onMicTap()
+            controller.onTranscript("open the garage door")
+            val ignored = assertIs<VoiceCommandState.Ignored>(controller.state.value)
+            assertEquals(VoiceCommandIgnoreReason.DOOR_STATE_UNKNOWN, ignored.reason)
+        }
+
+    @Test
+    fun doorMovedDuringWindowAbortsCommit() =
+        runTest {
+            val env = FakeVoiceCommandEnvironment()
+            val controller = createController(env)
+            controller.onMicTap()
+            controller.onTranscript("open the garage door")
+            assertIs<VoiceCommandState.Armed>(controller.state.value)
+
+            // Someone opens the door by hand mid-countdown.
+            env.door.value = VoiceDoorState.OPEN
+            advanceTimeBy(WINDOW)
+            runCurrent()
+
+            val ignored = assertIs<VoiceCommandState.Ignored>(controller.state.value)
+            assertEquals(VoiceCommandIgnoreReason.DOOR_STATE_CHANGED, ignored.reason)
+            assertTrue(env.presses.isEmpty(), "Commit must re-check the gate")
+        }
+
+    @Test
+    fun backgroundedDuringArmedCancelsWithoutSending() =
+        runTest {
+            val env = FakeVoiceCommandEnvironment()
+            val controller = createController(env)
+            controller.onMicTap()
+            controller.onTranscript("open the garage door")
+            controller.onBackgrounded()
+            assertEquals(VoiceCommandState.Ready, controller.state.value)
+            advanceTimeBy(WINDOW * 2)
+            runCurrent()
+            assertTrue(env.presses.isEmpty(), "Nothing may commit off-screen")
+        }
+
+    @Test
+    fun backgroundedDuringListeningIsUntouched() =
+        runTest {
+            val controller = createController(FakeVoiceCommandEnvironment())
+            controller.onMicTap()
+            controller.onBackgrounded()
+            assertEquals(VoiceCommandState.Listening(attempt = 1), controller.state.value)
+        }
+
+    @Test
+    fun micTapDuringSendingIsNoOp() =
+        runTest {
+            val env = FakeVoiceCommandEnvironment(pressDelayMs = 500L)
+            val controller = createController(env)
+            controller.onMicTap()
+            controller.onTranscript("open the garage door")
+            advanceTimeBy(WINDOW)
+            runCurrent()
+            assertIs<VoiceCommandState.Sending>(controller.state.value)
+
+            controller.onMicTap()
+            assertIs<VoiceCommandState.Sending>(controller.state.value)
+
+            advanceTimeBy(500L)
+            runCurrent()
+            assertEquals(listOf(VoiceIntent.OPEN), env.presses)
+            assertEquals(VoiceCommandState.Sent(VoiceIntent.OPEN), controller.state.value)
+        }
+
+    @Test
+    fun failedPressShowsFailedThenReady() =
+        runTest {
+            val env = FakeVoiceCommandEnvironment()
+            env.failNextPress = true
+            val controller = createController(env)
+            controller.onMicTap()
+            controller.onTranscript("open the garage door")
+            advanceTimeBy(WINDOW)
+            runCurrent()
+            assertEquals(VoiceCommandState.Failed(VoiceIntent.OPEN), controller.state.value)
+            advanceTimeBy(FLASH)
+            runCurrent()
+            assertEquals(VoiceCommandState.Ready, controller.state.value)
+        }
+
+    @Test
+    fun armedWindowIsAdjustableAndClamped() =
+        runTest {
+            val env = FakeVoiceCommandEnvironment()
+            val controller = createController(env)
+            controller.setArmedWindowMs(VoiceCommandController.MAX_ARMED_WINDOW_MS)
+            controller.onMicTap()
+            controller.onTranscript("open the garage door")
+
+            // The old default window elapsing must not commit.
+            advanceTimeBy(WINDOW)
+            runCurrent()
+            assertTrue(env.presses.isEmpty())
+
+            advanceTimeBy(VoiceCommandController.MAX_ARMED_WINDOW_MS - WINDOW)
+            runCurrent()
+            assertEquals(listOf(VoiceIntent.OPEN), env.presses)
+
+            controller.setArmedWindowMs(0L)
+            assertEquals(
+                VoiceCommandController.MIN_ARMED_WINDOW_MS,
+                controller.armedWindowMs.value,
+                "Window must clamp to the safe minimum",
+            )
+        }
+
+    @Test
+    fun transcriptOutsideListeningIsDropped() =
+        runTest {
+            val env = FakeVoiceCommandEnvironment()
+            val controller = createController(env)
+            // A stale recognizer result arriving in Ready must not act.
+            controller.onTranscript("open the garage door")
+            assertEquals(VoiceCommandState.Ready, controller.state.value)
+            advanceTimeBy(WINDOW * 2)
+            runCurrent()
+            assertTrue(env.presses.isEmpty())
+        }
+}

--- a/MobileGarage/version.properties
+++ b/MobileGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.22.5
+versionName=2.22.6

--- a/MobileGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/ProfileViewModel.kt
+++ b/MobileGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/ProfileViewModel.kt
@@ -50,7 +50,11 @@ import com.chriscartland.garage.usecase.RequestWatchAppInstallUseCase
 import com.chriscartland.garage.usecase.RevalidateSnoozeStatusUseCase
 import com.chriscartland.garage.usecase.SignInWithGoogleUseCase
 import com.chriscartland.garage.usecase.SignOutUseCase
+import com.chriscartland.garage.usecase.SimulatedVoiceCommandEnvironment
 import com.chriscartland.garage.usecase.SnoozeNotificationsUseCase
+import com.chriscartland.garage.usecase.VoiceCommandController
+import com.chriscartland.garage.usecase.VoiceCommandState
+import com.chriscartland.garage.usecase.VoiceDoorState
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -196,6 +200,41 @@ interface ProfileViewModel {
     /** Report that this device has no speech recognizer at all. */
     fun reportVoiceExperimentUnavailable()
 
+    /**
+     * Experimental voice-command UX playground (Settings → Developer →
+     * Voice control): the full mic → classify → gate → cancel-window →
+     * commit loop, running against a simulated door and a pretend
+     * button. The real door is never touched. State machine:
+     * [VoiceCommandController] in `:usecase`.
+     */
+    val voiceCommandState: StateFlow<VoiceCommandState>
+
+    /** The simulated door the playground's gate checks against. */
+    val voiceCommandDoorState: StateFlow<VoiceDoorState>
+
+    /** Cancel-window length, user-adjustable within the clamp range. */
+    val voiceCommandArmedWindowMs: StateFlow<Long>
+
+    /** Mic tap: always starts over; cancels a pending command first. */
+    fun voiceCommandMicTap()
+
+    /** Recognizer outcome for the command loop (null = no speech). */
+    fun voiceCommandTranscript(text: String?)
+
+    /** The recognizer launch failed: no recognizer on this device. */
+    fun voiceCommandCaptureUnavailable()
+
+    /**
+     * The playground left the screen: cancels a pending (Armed) command
+     * so nothing commits off-screen.
+     */
+    fun voiceCommandBackgrounded()
+
+    /** Place the simulated door directly to exercise gate paths. */
+    fun setVoiceCommandDoorState(state: VoiceDoorState)
+
+    fun setVoiceCommandArmedWindowMs(ms: Long)
+
     fun signInWithGoogle(idToken: GoogleIdToken)
 
     /** Open the app's Play Store listing on the connected watch. */
@@ -283,6 +322,19 @@ class DefaultProfileViewModel(
         MutableStateFlow<VoiceExperimentState>(VoiceExperimentState.Idle)
     override val voiceExperimentState: StateFlow<VoiceExperimentState> = _voiceExperimentState
 
+    // Voice-command playground: the real state machine wired to a fake
+    // world (simulated door + pretend button). viewModelScope-owned so
+    // the experiment's state evaporates with the screen VM.
+    private val voiceCommandEnvironment = SimulatedVoiceCommandEnvironment(scope = viewModelScope)
+    private val voiceCommandController = VoiceCommandController(
+        classify = classifyVoiceIntentUseCase,
+        environment = voiceCommandEnvironment,
+        scope = viewModelScope,
+    )
+    override val voiceCommandState: StateFlow<VoiceCommandState> = voiceCommandController.state
+    override val voiceCommandDoorState: StateFlow<VoiceDoorState> = voiceCommandEnvironment.doorState
+    override val voiceCommandArmedWindowMs: StateFlow<Long> = voiceCommandController.armedWindowMs
+
     // Cached so the snooze action can attach the latest door change time
     // without the UI having to thread it through.
     private val currentDoorEvent = MutableStateFlow<DoorEvent?>(null)
@@ -349,6 +401,18 @@ class DefaultProfileViewModel(
     override fun reportVoiceExperimentUnavailable() {
         _voiceExperimentState.value = VoiceExperimentState.Unavailable
     }
+
+    override fun voiceCommandMicTap() = voiceCommandController.onMicTap()
+
+    override fun voiceCommandTranscript(text: String?) = voiceCommandController.onTranscript(text)
+
+    override fun voiceCommandCaptureUnavailable() = voiceCommandController.onCaptureUnavailable()
+
+    override fun voiceCommandBackgrounded() = voiceCommandController.onBackgrounded()
+
+    override fun setVoiceCommandDoorState(state: VoiceDoorState) = voiceCommandEnvironment.setDoorState(state)
+
+    override fun setVoiceCommandArmedWindowMs(ms: Long) = voiceCommandController.setArmedWindowMs(ms)
 
     override fun signInWithGoogle(idToken: GoogleIdToken) {
         viewModelScope.launch(dispatchers.io) {


### PR DESCRIPTION
## Summary

Builds the confirmed voice-command UX design (2026-07-24) as a **simulated playground** in Settings → Developer → Voice control. The full loop runs for real — mic tap → system speech dialog → Rules v3 classify → door-state gate → cancel window → commit — but against a pretend door and pretend button. **The real door is never touched.**

## What's in the loop

- **`VoiceCommandController`** (`:usecase`, shared KMP): the state machine `Ready → Listening → Armed → Sending → Sent/Failed/Ignored`. A mic tap always means "listen to me now": it cancels a pending (Armed) command and immediately re-listens. Safety properties:
  - Only a **HIGH** classification arms; MEDIUM/UNKNOWN/no-speech render a ~4s explanation chip (tap-to-copy the structured verdict, feeding the eval corpus).
  - The **door-state gate runs twice**: at arm time and again when the cancel window elapses — a door that moved mid-countdown aborts (`DOOR_STATE_CHANGED`).
  - **Nothing commits off-screen**: lifecycle ON_STOP or sheet dismissal cancels a pending command.
  - **Sending is not cancellable** (a press cannot be unsent); the button disables for that ~1s.
- **`VoiceCommandEnvironment`** interface (door state + `pressButton`) + **`SimulatedVoiceCommandEnvironment`**: in-memory door, fake press delay, fake transit (MOVING → settled). Promoting to the real door later is an environment swap (door repo projection + `PushRemoteButtonUseCase`) + a Home surface — controller, gate, and tests carry over unchanged.
- **`VoiceControlBottomSheet`** (androidApp): big mic button with the filling-ring cancel window ("Opening in 3 · Tap to cancel"), direction arrows while armed/sending, segmented control to place the simulated door in any state (exercises already-open / moving / gate paths), and a 2–5s cancel-window stepper. Recognizer launch is driven by the `Listening` state so "tap in Ready" and "tap cancels Armed" share one path.

## Tests

- `VoiceCommandControllerTest` — 19 virtual-time tests pinning the safety properties (only HIGH arms; gate at arm AND commit; cancel-relisten never sends; backgrounding never commits; stale transcripts dropped; window clamped).
- `SimulatedVoiceCommandEnvironmentTest` — transit behavior + manual-set cancels transit.
- Full `./scripts/validate.sh` green (printed PASS markers verified); `:iosFramework:iosSimulatorArm64Test` run locally (commonMain API additions; no DI ctor changes, so `NativeComponent` untouched).

## Docs

`docs/VOICE_COMMANDS.md` gains a "Command UX: cancel-window loop" section recording the confirmed design decisions (RecognizerIntent v1, miss-explanation chips, double gate, no off-screen commit) and noting it supersedes the earlier `ButtonStateMachine` confirmed-submit sketch.

Version 2.22.6 (patch, developer-gated experiment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
