### PR TITLE
fix(ios): launch crash on iOS 16 — self! force-unwrap in HomeViewModelWrapper observation Tasks

### DIFF
--- a/MobileGarage/iosApp/CHANGELOG.md
+++ b/MobileGarage/iosApp/CHANGELOG.md
@@ -19,6 +19,17 @@ Versioning mirrors Android (see `MobileGarage/CHANGELOG.md` § versioning):
 major = rewrite or core-experience shift; minor = a user-facing feature added or
 removed; patch = fixes, polish, refactors. iOS uses independent `ios/N` tags.
 
+## 0.1.1
+
+- Fix a launch crash on iOS 16 (crashed every launch on iPhone X / iOS 16.3.1,
+  build 7): `HomeViewModelWrapper.init` registered observation Tasks with
+  `[weak self]` + `self!`, and a wrapper instance discarded by
+  `StateObject(wrappedValue:)` re-evaluation deallocated before its Tasks ran,
+  trapping on the force-unwrap. All 8 sites now use the safe
+  `guard let stream = self?...` pattern (same as `SettingsViewModelWrapper`).
+  Root-caused from the TestFlight crash-feedback log (Incident
+  3AE511E1-9499-4E51-A1CB-0A3D99F26919).
+
 ## 0.1.0
 
 First TestFlight (Internal) release — a native SwiftUI iOS app that shares all

--- a/MobileGarage/iosApp/Features/Home/HomeViewModelWrapper.swift
+++ b/MobileGarage/iosApp/Features/Home/HomeViewModelWrapper.swift
@@ -96,32 +96,50 @@ final class HomeViewModelWrapper: ObservableObject {
         // Async — rebuilds the alert stack again once the OS settings resolve.
         refreshNotificationPermission()
 
+        // `guard let stream = self?...` + `self?.` per iteration — NEVER
+        // `self!`. `StateObject(wrappedValue:)` evaluates its autoclosure on
+        // every HomeScreen init but keeps only the first object; a discarded
+        // wrapper's Tasks run after it deallocates, and `self!` then traps.
+        // Empirical: ios/7 crashed on EVERY launch on iOS 16.3.1 (iPhone X)
+        // with "Unexpectedly found nil while unwrapping an Optional value"
+        // right here — newer OS versions dodge the timing, which is why the
+        // simulator smoke (iOS 18/26) stayed green. Weak-per-iteration also
+        // lets `deinit` cancel these never-ending loops (mirrors
+        // SettingsViewModelWrapper's pattern from #1069).
         tasks.append(Task { @MainActor [weak self] in
-            for await v in self!.vm.authState { self?.applyAuth(v) }
+            guard let stream = self?.vm.authState else { return }
+            for await v in stream { self?.applyAuth(v) }
         })
         tasks.append(Task { @MainActor [weak self] in
-            for await v in self!.vm.currentDoorEvent { self?.applyDoor(v) }
+            guard let stream = self?.vm.currentDoorEvent else { return }
+            for await v in stream { self?.applyDoor(v) }
         })
         tasks.append(Task { @MainActor [weak self] in
-            for await v in self!.vm.warning { self?.applyWarning(v) }
+            guard let stream = self?.vm.warning else { return }
+            for await v in stream { self?.applyWarning(v) }
         })
         tasks.append(Task { @MainActor [weak self] in
-            for await v in self!.vm.sinceStatus { self?.applySince(v) }
+            guard let stream = self?.vm.sinceStatus else { return }
+            for await v in stream { self?.applySince(v) }
         })
         tasks.append(Task { @MainActor [weak self] in
-            for await v in self!.vm.buttonState { self?.applyButton(v) }
+            guard let stream = self?.vm.buttonState else { return }
+            for await v in stream { self?.applyButton(v) }
         })
         tasks.append(Task { @MainActor [weak self] in
-            for await v in self!.vm.buttonHealthDisplay { self?.applyHealth(v) }
+            guard let stream = self?.vm.buttonHealthDisplay else { return }
+            for await v in stream { self?.applyHealth(v) }
         })
         tasks.append(Task { @MainActor [weak self] in
-            for await v in self!.vm.isCheckInStale {
+            guard let stream = self?.vm.isCheckInStale else { return }
+            for await v in stream {
                 self?.isCheckInStale = v.boolValue
                 self?.rebuildAlerts()
             }
         })
         tasks.append(Task { @MainActor [weak self] in
-            for await v in self!.vm.nowEpochSeconds {
+            guard let stream = self?.vm.nowEpochSeconds else { return }
+            for await v in stream {
                 self?.latestNowEpochSeconds = v.int64Value
                 self?.rebuildCheckIn()
             }

--- a/MobileGarage/iosApp/project.yml
+++ b/MobileGarage/iosApp/project.yml
@@ -34,7 +34,7 @@ settings:
     SWIFT_STRICT_CONCURRENCY: minimal
     # KMP gradle Run Script writes outside the Xcode sandbox.
     ENABLE_USER_SCRIPT_SANDBOXING: NO
-    MARKETING_VERSION: "0.1.0"
+    MARKETING_VERSION: "0.1.1"
     CURRENT_PROJECT_VERSION: "1"
 
 packages:


### PR DESCRIPTION
## The crash

TestFlight build 7 (`ios/7`, 0.1.0) **crashes on every launch on iPhone X / iOS 16.3.1**:

```
Swift runtime failure: Unexpectedly found nil while unwrapping an Optional value
closure #1 in HomeViewModelWrapper.init(component:) (HomeViewModelWrapper.swift:98)
```

Retrieved autonomously from App Store Connect via the new `ios-crash-feedback` workflow (#1122) — both shared submissions point at the same site.

## Mechanism

`HomeScreen.init` does `StateObject(wrappedValue: HomeViewModelWrapper(component:))`. The autoclosure runs on **every** view init, but SwiftUI keeps only the first object — discarded wrapper instances deallocate immediately. Each wrapper registers 8 observation Tasks as `[weak self]` + `self!.vm.<flow>`; when a discarded instance's Task runs after dealloc, `self!` traps. iOS 16's SwiftUI re-inits the screen before the first Task tick → deterministic crash-on-launch; iOS 18/26 dodge the timing, which is why every simulator repro (Debug/Release, iOS 18.5/26.2/26.5, fresh/upgrade installs) stayed green.

#1069 fixed this exact pattern in `SettingsViewModelWrapper` but `HomeViewModelWrapper` kept `self!`.

## Fix

All 8 sites → the safe pattern: `guard let stream = self?.vm.<flow> else { return }`, then `self?.` per iteration (also lets `deinit` cancel the never-ending loops). `git grep 'self!'` on iosApp is clean after this. Plus `MARKETING_VERSION` 0.1.0 → 0.1.1 and the changelog entry that gates the `ios/8` release.

## Verification

- `validate-ios.sh` all green (framework tests + CI-exact build).
- Launch smoke (cold + warm) passes on the fixed build.
- The crash site is eliminated by construction (no force-unwrap remains). Empirical iOS 16.x simulator verification pending the 16.4 runtime download; will run before cutting `ios/8` if the runtime installs.

Follow-up (separate PR, after #1121 merges to avoid file overlap): a `self!` ban check in `validate-ios.sh` + iOS CI so the pattern can't come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)