### PR TITLE
feat(voice): finer cancel-window steps in the voice playground (2.22.7)

### DIFF
--- a/MobileGarage/CHANGELOG.md
+++ b/MobileGarage/CHANGELOG.md
@@ -15,6 +15,11 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
 
+## 2.22.7
+
+- **Finer cancel-window control in the voice playground.** The Voice control sheet's cancel window now adjusts in 0.5-second steps from 0.5 to 3 seconds (was 1-second steps, 2 to 5), so shorter windows can be felt out on-device. The label shows fractional values ("Cancel window: 1.5 seconds"); default stays 3 seconds.
+- **Internal:** #1126 — `MIN_ARMED_WINDOW_MS` 2000→500, `MAX` 5000→3000, stepper 500ms; clamp test covers both bounds. Developer-gated experiment; patch.
+
 ## 2.22.6
 
 - **Voice command loop with a cancel window (experimental playground, simulated door).** Settings → Developer gains a "Voice control" sheet that runs the full voice-to-action loop against a pretend door: tap the mic, speak, and a High-confidence command arms a 3-second cancel window (filling ring + "Opening in 3 · Tap to cancel"). Tapping during the window cancels and immediately re-listens; letting it complete presses a simulated button and the fake door moves. Anything non-actionable (loose phrasing, questions, wrong door state) shows a brief explanation instead, tappable to copy the verdict. A segmented control places the simulated door in any state to exercise the gate (already open, moving), and the cancel window is adjustable 2–5 seconds. The real door is never touched from this screen.

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/VoiceControlBottomSheet.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/VoiceControlBottomSheet.kt
@@ -84,7 +84,7 @@ import com.chriscartland.garage.usecase.VoiceCommandState
 import com.chriscartland.garage.usecase.VoiceDoorState
 import kotlin.math.ceil
 
-private const val ARMED_WINDOW_STEP_MS = 1_000L
+private const val ARMED_WINDOW_STEP_MS = 500L
 
 /**
  * Experimental voice-command UX playground (Settings → Developer →
@@ -258,6 +258,13 @@ private object VoiceControlHelpers {
         windowMs: Long,
         progress: Float,
     ): Int = ceil((1f - progress) * windowMs / 1000f).toInt().coerceAtLeast(1)
+
+    // "0.5", "1", "1.5" — trims the trailing .0 on whole seconds.
+    fun windowSecondsLabel(windowMs: Long): String {
+        val seconds = windowMs / 1000f
+        val whole = seconds.toInt()
+        return if (seconds == whole.toFloat()) whole.toString() else seconds.toString()
+    }
 
     // Door-motion metaphor: up = opening, down = closing.
     fun directionIcon(intent: VoiceIntent): ImageVector =
@@ -474,7 +481,7 @@ private fun CancelWindowStepper(
         Text(
             text = stringResource(
                 R.string.voice_control_window_label,
-                (armedWindowMs / 1000L).toInt(),
+                VoiceControlHelpers.windowSecondsLabel(armedWindowMs),
             ),
             style = MaterialTheme.typography.bodyMedium,
         )

--- a/MobileGarage/androidApp/src/main/res/values/strings.xml
+++ b/MobileGarage/androidApp/src/main/res/values/strings.xml
@@ -130,8 +130,8 @@
     <string name="voice_control_ignored_state_unknown">Door state is unknown</string>
     <string name="voice_control_ignored_state_changed">Door state changed before sending</string>
     <string name="voice_control_copy_hint">Tap the message to copy details</string>
-    <!-- Cancel-window stepper. %1$d is seconds. -->
-    <string name="voice_control_window_label">Cancel window: %1$d seconds</string>
+    <!-- Cancel-window stepper. %1$s is seconds, possibly fractional ("1.5"). -->
+    <string name="voice_control_window_label">Cancel window: %1$s seconds</string>
     <string name="voice_control_window_decrease">Shorten cancel window</string>
     <string name="voice_control_window_increase">Lengthen cancel window</string>
     <!-- Mic button content descriptions per state. -->

--- a/MobileGarage/docs/VOICE_COMMANDS.md
+++ b/MobileGarage/docs/VOICE_COMMANDS.md
@@ -165,7 +165,8 @@ confirmation step, and v1 capture is `RecognizerIntent`, not a
 - **The door-state gate runs twice**: at arm time (open only when
   closed, close only when open; moving/unknown refuse) and again when
   the cancel window elapses — a door that moved mid-countdown aborts.
-- **The cancel window** (default 3s, adjustable 2–5s) renders as a
+- **The cancel window** (default 3s, adjustable 0.5–3s in 0.5s steps
+  for playground experimentation) renders as a
   filling ring around the button with a countdown line ("Opening in 3 ·
   Tap to cancel"). Ring completion commits; the ~1s Sending state is
   not cancellable (a press cannot be unsent) and the button disables.

--- a/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/VoiceCommandController.kt
+++ b/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/VoiceCommandController.kt
@@ -326,8 +326,8 @@ class VoiceCommandController(
 
     companion object {
         const val DEFAULT_ARMED_WINDOW_MS = 3_000L
-        const val MIN_ARMED_WINDOW_MS = 2_000L
-        const val MAX_ARMED_WINDOW_MS = 5_000L
+        const val MIN_ARMED_WINDOW_MS = 500L
+        const val MAX_ARMED_WINDOW_MS = 3_000L
 
         /** How long an [VoiceCommandState.Ignored] explanation stays up. */
         const val IGNORED_DISMISS_MS = 4_000L

--- a/MobileGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/VoiceCommandControllerTest.kt
+++ b/MobileGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/VoiceCommandControllerTest.kt
@@ -311,16 +311,17 @@ class VoiceCommandControllerTest {
         runTest {
             val env = FakeVoiceCommandEnvironment()
             val controller = createController(env)
-            controller.setArmedWindowMs(VoiceCommandController.MAX_ARMED_WINDOW_MS)
+            controller.setArmedWindowMs(VoiceCommandController.MIN_ARMED_WINDOW_MS)
             controller.onMicTap()
             controller.onTranscript("open the garage door")
 
-            // The old default window elapsing must not commit.
-            advanceTimeBy(WINDOW)
+            // A shortened window still gives a real cancel opportunity...
+            advanceTimeBy(VoiceCommandController.MIN_ARMED_WINDOW_MS / 2)
             runCurrent()
             assertTrue(env.presses.isEmpty())
 
-            advanceTimeBy(VoiceCommandController.MAX_ARMED_WINDOW_MS - WINDOW)
+            // ...and commits at the shortened deadline, not the default.
+            advanceTimeBy(VoiceCommandController.MIN_ARMED_WINDOW_MS / 2)
             runCurrent()
             assertEquals(listOf(VoiceIntent.OPEN), env.presses)
 
@@ -329,6 +330,12 @@ class VoiceCommandControllerTest {
                 VoiceCommandController.MIN_ARMED_WINDOW_MS,
                 controller.armedWindowMs.value,
                 "Window must clamp to the safe minimum",
+            )
+            controller.setArmedWindowMs(10_000L)
+            assertEquals(
+                VoiceCommandController.MAX_ARMED_WINDOW_MS,
+                controller.armedWindowMs.value,
+                "Window must clamp to the maximum",
             )
         }
 

--- a/MobileGarage/version.properties
+++ b/MobileGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.22.6
+versionName=2.22.7


### PR DESCRIPTION
## Summary

The Voice control playground's cancel window now adjusts in **0.5s steps from 0.5s to 3s** (was 1s steps, 2–5s), per on-device experimentation feedback. Default stays 3s.

- `VoiceCommandController`: `MIN_ARMED_WINDOW_MS` 2000→500, `MAX_ARMED_WINDOW_MS` 5000→3000.
- Stepper step 1000ms→500ms; label formats fractional seconds ("Cancel window: 1.5 seconds").
- Clamp test rewritten to cover both bounds and to verify a shortened window commits at its own deadline (the old test relied on MAX > DEFAULT, no longer true).
- `validate.sh` green (printed PASS markers confirmed).

Version 2.22.7 (patch, developer-gated experiment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)