### PR TITLE
feat(voice): 10s simulated door transit in the voice playground (2.22.8)

### DIFF
--- a/MobileGarage/CHANGELOG.md
+++ b/MobileGarage/CHANGELOG.md
@@ -15,6 +15,11 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
 
+## 2.22.8
+
+- **Slower simulated door in the voice playground.** The fake door now takes 10 seconds to travel (was 2.5), roughly matching a real garage door. The old transit finished before the speech recognizer round-trip did, so it was impossible to speak a command at a moving door and watch the gate refuse it ("The door is moving") — now there's a real window to try exactly that.
+- **Internal:** #1127 — `SimulatedVoiceCommandEnvironment.TRANSIT_MS` 2500→10000; tests reference the constant and are unchanged. Developer-gated experiment; patch.
+
 ## 2.22.7
 
 - **Finer cancel-window control in the voice playground.** The Voice control sheet's cancel window now adjusts in 0.5-second steps from 0.5 to 3 seconds (was 1-second steps, 2 to 5), so shorter windows can be felt out on-device. The label shows fractional values ("Cancel window: 1.5 seconds"); default stays 3 seconds.

--- a/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SimulatedVoiceCommandEnvironment.kt
+++ b/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/SimulatedVoiceCommandEnvironment.kt
@@ -73,7 +73,13 @@ class SimulatedVoiceCommandEnvironment(
         /** Fake button-press round-trip. */
         const val PRESS_DELAY_MS = 600L
 
-        /** Fake door travel time from press to settled state. */
-        const val TRANSIT_MS = 2_500L
+        /**
+         * Fake door travel time from press to settled state. Roughly a
+         * real garage door's travel, and deliberately long enough to
+         * speak a command AT the moving door mid-transit and watch the
+         * gate refuse it (2.5s was over before the recognizer round-trip
+         * finished).
+         */
+        const val TRANSIT_MS = 10_000L
     }
 }

--- a/MobileGarage/version.properties
+++ b/MobileGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.22.7
+versionName=2.22.8


### PR DESCRIPTION
## Summary

The simulated door now takes **10 seconds** to travel (was 2.5s), roughly matching a real garage door. The old transit was over before the speech-recognizer round-trip finished, so speaking a command at a moving door — the `DOOR_MOVING` gate path — was impossible to exercise by voice. Now there's a real window to try it and watch the refusal ("The door is moving").

- `SimulatedVoiceCommandEnvironment.TRANSIT_MS` 2500→10000, with a comment recording the rationale.
- Tests reference the constant and are unchanged; `validate.sh` green (printed PASS markers confirmed).

Version 2.22.8 (patch, developer-gated experiment). Releasing as `android/269` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)