### PR TITLE
feat(voice): Home-tab voice control card, shadow mode (2.22.9)

### DIFF
--- a/MobileGarage/CHANGELOG.md
+++ b/MobileGarage/CHANGELOG.md
@@ -15,6 +15,11 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
 
+## 2.22.9
+
+- **Voice control card on the Home tab (experimental shadow mode).** Home gains a "Voice control" section — mic button, countdown ring, and a clear two-line status — visible only to Developer-flag users while signed in. The full loop runs against the real door state: commands are refused when the door is already there, moving, anomalous, or the device check-in is stale, so refusals always agree with the status card above. The button press itself is simulated (a "Simulated" pill in the header says so) — nothing is ever sent to the door. Fixed 3-second cancel window; tap during the ring to cancel and speak again.
+- **Internal:** #1128 — `VoiceDoorStateMapper` (DoorPosition → gate projection; anomalies + stale check-in → UNKNOWN → refuse; closes the wrong-direction hazard for future real wiring) + `ShadowVoiceCommandEnvironment` (real state in, no action out) with tests; `HomeViewModel` hosts the controller (both DI components updated); shared `VoiceCommandUi` vocabulary deduped from the playground sheet; voice section injected as a slot so Home fixtures are untouched. Developer-gated experiment; patch.
+
 ## 2.22.8
 
 - **Slower simulated door in the voice playground.** The fake door now takes 10 seconds to travel (was 2.5), roughly matching a real garage door. The old transit finished before the speech recognizer round-trip did, so it was impossible to speak a command at a moving door and watch the gate refuse it ("The door is moving") — now there's a real window to try exactly that.

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/di/AppComponent.kt
@@ -337,6 +337,8 @@ abstract class AppComponent(
     fun provideHomeViewModel(
         observeDoorEvents: ObserveDoorEventsUseCase,
         observeAuthState: ObserveAuthStateUseCase,
+        observeFeatureAccess: ObserveFeatureAccessUseCase,
+        classifyVoiceIntent: ClassifyVoiceIntentUseCase,
         logAppEvent: LogAppEventUseCase,
         dispatchers: DispatcherProvider,
         fetchCurrentDoorEvent: FetchCurrentDoorEventUseCase,
@@ -352,6 +354,8 @@ abstract class AppComponent(
         DefaultHomeViewModel(
             observeDoorEvents = observeDoorEvents,
             observeAuthState = observeAuthState,
+            observeFeatureAccessUseCase = observeFeatureAccess,
+            classifyVoiceIntentUseCase = classifyVoiceIntent,
             logAppEvent = logAppEvent,
             dispatchers = dispatchers,
             fetchCurrentDoorEventUseCase = fetchCurrentDoorEvent,

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/HomeContent.kt
@@ -38,7 +38,9 @@ import com.chriscartland.garage.permissions.rememberNotificationPermissionState
 import com.chriscartland.garage.presentation.HomeAlert
 import com.chriscartland.garage.presentation.HomeAlertMapper
 import com.chriscartland.garage.ui.home.DeviceCheckIn
+import com.chriscartland.garage.ui.home.HomeAuthState
 import com.chriscartland.garage.ui.home.HomeMapper
+import com.chriscartland.garage.ui.home.HomeVoiceControlSection
 import com.chriscartland.garage.ui.home.rememberSinceLine
 import com.chriscartland.garage.usecase.ButtonHealthDisplay
 import com.chriscartland.garage.viewmodel.HomeViewModel
@@ -81,6 +83,12 @@ fun HomeContent(
     // brief "Checking…" flash on every fresh screen entry.
     val buttonHealthDisplay: ButtonHealthDisplay by resolved.buttonHealthDisplay
         .collectAsStateWithLifecycle()
+    // Voice control (shadow mode): gated by the same per-user flag as
+    // Settings → Developer. Shown only when signed in — it mirrors the
+    // remote button's availability even though the shadow press acts on
+    // nothing.
+    val developerAccess by resolved.developerAccess.collectAsState()
+    val voiceCommandState by resolved.voiceCommandState.collectAsState()
 
     val notificationPermissionState = rememberNotificationPermissionState()
     // Survives rotation + process death so the alert flicker on rotation
@@ -163,6 +171,22 @@ fun HomeContent(
             }
         },
         onSignIn = { googleSignIn.launchSignIn() },
+        voiceControlSection = if (
+            developerAccess == true &&
+            homeAuthState == HomeAuthState.SignedIn
+        ) {
+            {
+                HomeVoiceControlSection(
+                    state = voiceCommandState,
+                    onMicTap = resolved::voiceCommandMicTap,
+                    onTranscript = resolved::voiceCommandTranscript,
+                    onCaptureUnavailable = resolved::voiceCommandCaptureUnavailable,
+                    onBackgrounded = resolved::voiceCommandBackgrounded,
+                )
+            }
+        } else {
+            null
+        },
     )
     ReportDrawnWhen { currentDoorEvent is LoadingResult.Complete }
 }

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/VoiceCommandUi.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/VoiceCommandUi.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDownward
+import androidx.compose.material.icons.outlined.ArrowUpward
+import androidx.compose.material.icons.outlined.Check
+import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material.icons.outlined.Mic
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import com.chriscartland.garage.R
+import com.chriscartland.garage.domain.model.VoiceIntent
+import com.chriscartland.garage.usecase.VoiceCommandIgnoreReason
+import com.chriscartland.garage.usecase.VoiceCommandState
+import kotlin.math.ceil
+
+/**
+ * Shared visual vocabulary for the voice-command surfaces (the Home
+ * voice card and the Settings playground sheet) so the two render the
+ * state machine identically: same icons, same countdown math, same
+ * refusal wording.
+ */
+object VoiceCommandUi {
+    /** Whole seconds remaining in the cancel window, floored at 1. */
+    fun secondsLeft(
+        windowMs: Long,
+        progress: Float,
+    ): Int = ceil((1f - progress) * windowMs / 1000f).toInt().coerceAtLeast(1)
+
+    // "0.5", "1", "1.5" — trims the trailing .0 on whole seconds.
+    fun windowSecondsLabel(windowMs: Long): String {
+        val seconds = windowMs / 1000f
+        val whole = seconds.toInt()
+        return if (seconds == whole.toFloat()) whole.toString() else seconds.toString()
+    }
+
+    // Door-motion metaphor: up = opening, down = closing.
+    fun directionIcon(intent: VoiceIntent): ImageVector =
+        if (intent == VoiceIntent.CLOSE) Icons.Outlined.ArrowDownward else Icons.Outlined.ArrowUpward
+}
+
+/** Icon shown inside the mic button for each state. */
+fun VoiceCommandState.micIcon(): ImageVector =
+    when (this) {
+        VoiceCommandState.Ready, is VoiceCommandState.Listening, is VoiceCommandState.Ignored ->
+            Icons.Outlined.Mic
+        is VoiceCommandState.Armed -> VoiceCommandUi.directionIcon(intent)
+        is VoiceCommandState.Sending -> VoiceCommandUi.directionIcon(intent)
+        is VoiceCommandState.Sent -> Icons.Outlined.Check
+        is VoiceCommandState.Failed -> Icons.Outlined.ErrorOutline
+    }
+
+@Composable
+fun VoiceCommandState.micContentDescription(): String =
+    when (this) {
+        VoiceCommandState.Ready, is VoiceCommandState.Ignored ->
+            stringResource(R.string.voice_control_mic_cd_ready)
+        is VoiceCommandState.Listening -> stringResource(R.string.voice_control_mic_cd_listening)
+        is VoiceCommandState.Armed -> stringResource(R.string.voice_control_mic_cd_armed)
+        is VoiceCommandState.Sending -> stringResource(R.string.voice_control_mic_cd_sending)
+        is VoiceCommandState.Sent, is VoiceCommandState.Failed ->
+            stringResource(R.string.voice_control_mic_cd_ready)
+    }
+
+@Composable
+fun VoiceCommandIgnoreReason.displayText(): String =
+    when (this) {
+        VoiceCommandIgnoreReason.NO_SPEECH ->
+            stringResource(R.string.voice_control_ignored_no_speech)
+        VoiceCommandIgnoreReason.RECOGNIZER_UNAVAILABLE ->
+            stringResource(R.string.voice_control_ignored_unavailable)
+        VoiceCommandIgnoreReason.NOT_A_COMMAND ->
+            stringResource(R.string.voice_control_ignored_not_a_command)
+        VoiceCommandIgnoreReason.NOT_CONFIDENT ->
+            stringResource(R.string.voice_control_ignored_not_confident)
+        VoiceCommandIgnoreReason.DOOR_ALREADY_OPEN ->
+            stringResource(R.string.voice_control_ignored_already_open)
+        VoiceCommandIgnoreReason.DOOR_ALREADY_CLOSED ->
+            stringResource(R.string.voice_control_ignored_already_closed)
+        VoiceCommandIgnoreReason.DOOR_MOVING ->
+            stringResource(R.string.voice_control_ignored_moving)
+        VoiceCommandIgnoreReason.DOOR_STATE_UNKNOWN ->
+            stringResource(R.string.voice_control_ignored_state_unknown)
+        VoiceCommandIgnoreReason.DOOR_STATE_CHANGED ->
+            stringResource(R.string.voice_control_ignored_state_changed)
+    }

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
@@ -167,6 +167,10 @@ fun HomeContent(
     onAlertAction: (HomeAlert) -> Unit = {},
     onRemoteButtonTap: () -> Unit = {},
     onSignIn: () -> Unit = {},
+    // Developer-flag-gated voice-control section (shadow mode). Null =
+    // hidden. A slot (not data + lambdas) so the recognizer plumbing
+    // stays in HomeVoiceControlSection and fixtures stay untouched.
+    voiceControlSection: (@Composable () -> Unit)? = null,
 ) {
     // Local UI state for the per-pill info bottom sheets. Tap a pill to
     // open the matching sheet; tap outside or drag down to dismiss. Pure
@@ -242,6 +246,12 @@ fun HomeContent(
                     }
                 }
             }
+
+            if (voiceControlSection != null) {
+                item(key = "voice") {
+                    voiceControlSection()
+                }
+            }
         }
     }
     when (openInfoSheet) {
@@ -263,15 +273,21 @@ fun HomeContent(
 private enum class HomeInfoSheet { DoorStatus, RemoteControl }
 
 @Composable
-private fun HomeSection(
+internal fun HomeSection(
     label: String,
+    modifier: Modifier = Modifier,
     trailing: @Composable () -> Unit = {},
     content: @Composable () -> Unit,
 ) {
     // Outer Column owns the gap between header row and body card via
     // spacedBy (parent-owns-gaps rule). Header row has no vertical
     // padding — the parent LazyColumn owns the gap above the section.
-    Column(verticalArrangement = Arrangement.spacedBy(Spacing.SectionHeaderBottom)) {
+    // `internal` (not private) so sibling Home sections in this package
+    // (HomeVoiceControlSection) share the exact section language.
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(Spacing.SectionHeaderBottom),
+    ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeVoiceControlSection.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeVoiceControlSection.kt
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui.home
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.speech.RecognizerIntent
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.chriscartland.garage.R
+import com.chriscartland.garage.domain.model.VoiceIntent
+import com.chriscartland.garage.ui.VoiceCommandUi
+import com.chriscartland.garage.ui.displayText
+import com.chriscartland.garage.ui.micContentDescription
+import com.chriscartland.garage.ui.micIcon
+import com.chriscartland.garage.ui.theme.CardPadding
+import com.chriscartland.garage.ui.theme.PreviewComponentSurface
+import com.chriscartland.garage.usecase.VoiceCommandIgnoreReason
+import com.chriscartland.garage.usecase.VoiceCommandState
+
+/**
+ * Home-tab voice control section (developer-flag-gated, SHADOW MODE —
+ * the gate reads the real door state, the press is a no-op; a
+ * "Simulated" pill in the header keeps that honest). The mic button is
+ * the whole interface: tap to speak, tap during the countdown ring to
+ * cancel and immediately re-listen. Layout is a compact card row —
+ * mic + ring on the left, a stable two-line status column on the right
+ * — matching the Home section language (see [HomeSection]).
+ *
+ * Owns the recognizer plumbing: launch is driven by the
+ * [VoiceCommandState.Listening] state (not the tap), so "tap in Ready"
+ * and "tap cancels Armed" share one path; lifecycle ON_STOP cancels a
+ * pending command (nothing commits off-screen).
+ */
+@Composable
+fun HomeVoiceControlSection(
+    state: VoiceCommandState,
+    onMicTap: () -> Unit,
+    onTranscript: (String?) -> Unit,
+    onCaptureUnavailable: () -> Unit,
+    onBackgrounded: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val voiceLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        val transcript = if (result.resultCode == Activity.RESULT_OK) {
+            result.data
+                ?.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
+                ?.firstOrNull()
+        } else {
+            null
+        }
+        onTranscript(transcript)
+    }
+    val voicePrompt = stringResource(R.string.voice_experiment_prompt)
+    val listeningAttempt = (state as? VoiceCommandState.Listening)?.attempt
+    LaunchedEffect(listeningAttempt) {
+        if (listeningAttempt != null) {
+            val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH)
+                .putExtra(
+                    RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+                    RecognizerIntent.LANGUAGE_MODEL_FREE_FORM,
+                ).putExtra(RecognizerIntent.EXTRA_PROMPT, voicePrompt)
+                .putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1)
+            try {
+                voiceLauncher.launch(intent)
+            } catch (_: ActivityNotFoundException) {
+                onCaptureUnavailable()
+            }
+        }
+    }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_STOP) onBackgrounded()
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    HomeVoiceControlSectionBody(
+        state = state,
+        onMicTap = onMicTap,
+        modifier = modifier,
+    )
+}
+
+/**
+ * Pure layout (no activity-result plumbing) so previews can render
+ * every state directly.
+ */
+@Composable
+fun HomeVoiceControlSectionBody(
+    state: VoiceCommandState,
+    onMicTap: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    HomeSection(
+        label = stringResource(R.string.home_section_voice),
+        trailing = { SimulatedPill() },
+        modifier = modifier,
+    ) {
+        HomeVoiceCardBody(state = state, onMicTap = onMicTap)
+    }
+}
+
+/** Small header pill making shadow mode unmistakable. */
+@Composable
+private fun SimulatedPill(modifier: Modifier = Modifier) {
+    Surface(
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        shape = MaterialTheme.shapes.small,
+        modifier = modifier,
+    ) {
+        Text(
+            text = stringResource(R.string.home_voice_simulated_pill),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+        )
+    }
+}
+
+@Composable
+private fun HomeVoiceCardBody(
+    state: VoiceCommandState,
+    onMicTap: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // One shared progress drives the ring AND the countdown text so the
+    // two can never disagree; a fresh Animatable per Armed instance.
+    val armed = state as? VoiceCommandState.Armed
+    val armedProgress = remember(armed) { Animatable(0f) }
+    LaunchedEffect(armed) {
+        if (armed != null) {
+            armedProgress.animateTo(
+                targetValue = 1f,
+                animationSpec = tween(
+                    durationMillis = armed.windowMs.toInt(),
+                    easing = LinearEasing,
+                ),
+            )
+        }
+    }
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(CardPadding.Standard),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier.size(64.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            when (state) {
+                is VoiceCommandState.Armed -> CircularProgressIndicator(
+                    progress = { armedProgress.value },
+                    modifier = Modifier.fillMaxSize(),
+                    strokeWidth = 3.dp,
+                )
+                is VoiceCommandState.Sending -> CircularProgressIndicator(
+                    modifier = Modifier.fillMaxSize(),
+                    strokeWidth = 3.dp,
+                )
+                else -> Unit
+            }
+            FilledTonalIconButton(
+                onClick = onMicTap,
+                enabled = state !is VoiceCommandState.Sending,
+                modifier = Modifier.size(56.dp),
+            ) {
+                Icon(
+                    imageVector = state.micIcon(),
+                    contentDescription = state.micContentDescription(),
+                    modifier = Modifier.size(28.dp),
+                )
+            }
+        }
+        HomeVoiceStatusColumn(
+            state = state,
+            armedSecondsLeft = armed?.let {
+                VoiceCommandUi.secondsLeft(it.windowMs, armedProgress.value)
+            },
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+/**
+ * Stable two-line status: primary line (what is happening) + secondary
+ * line (transcript or guidance). Every state fills both lines so the
+ * card height never jumps mid-flow.
+ */
+@Composable
+private fun HomeVoiceStatusColumn(
+    state: VoiceCommandState,
+    armedSecondsLeft: Int?,
+    modifier: Modifier = Modifier,
+) {
+    val hint = stringResource(R.string.home_voice_hint)
+    val (primary, secondary) = when (state) {
+        VoiceCommandState.Ready ->
+            stringResource(R.string.home_voice_ready_title) to hint
+        is VoiceCommandState.Listening ->
+            stringResource(R.string.voice_control_listening) to hint
+        is VoiceCommandState.Armed ->
+            stringResource(
+                if (state.intent == VoiceIntent.CLOSE) {
+                    R.string.voice_control_armed_closing
+                } else {
+                    R.string.voice_control_armed_opening
+                },
+                armedSecondsLeft ?: VoiceCommandUi.secondsLeft(state.windowMs, 0f),
+            ) to stringResource(R.string.voice_control_transcript_quote, state.transcript)
+        is VoiceCommandState.Sending ->
+            stringResource(R.string.voice_control_sending) to
+                stringResource(R.string.home_voice_shadow_subtitle)
+        is VoiceCommandState.Sent ->
+            stringResource(R.string.voice_control_sent) to
+                stringResource(R.string.home_voice_shadow_subtitle)
+        is VoiceCommandState.Failed ->
+            stringResource(R.string.voice_control_failed) to
+                stringResource(R.string.home_voice_failed_subtitle)
+        is VoiceCommandState.Ignored ->
+            state.reason.displayText() to (
+                state.transcript?.let {
+                    stringResource(R.string.voice_control_transcript_quote, it)
+                } ?: hint
+            )
+    }
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Text(
+            text = primary,
+            style = MaterialTheme.typography.titleMedium,
+            color = if (state is VoiceCommandState.Failed) {
+                MaterialTheme.colorScheme.error
+            } else {
+                MaterialTheme.colorScheme.onSurface
+            },
+        )
+        Text(
+            text = secondary,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+// `private` so `checkPreviewCoverage` exempts them (developer-flag-gated
+// surface verified on a real device; Android Studio references only —
+// same rationale as the voice playground sheet).
+@Preview
+@Composable
+private fun HomeVoiceControlReadyPreview() {
+    PreviewComponentSurface {
+        HomeVoiceControlSectionBody(
+            state = VoiceCommandState.Ready,
+            onMicTap = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun HomeVoiceControlArmedPreview() {
+    PreviewComponentSurface {
+        HomeVoiceControlSectionBody(
+            state = VoiceCommandState.Armed(
+                intent = VoiceIntent.OPEN,
+                transcript = "open the garage door",
+                windowMs = 3_000L,
+            ),
+            onMicTap = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun HomeVoiceControlIgnoredPreview() {
+    PreviewComponentSurface {
+        HomeVoiceControlSectionBody(
+            state = VoiceCommandState.Ignored(
+                reason = VoiceCommandIgnoreReason.DOOR_ALREADY_OPEN,
+                transcript = "open the garage door",
+                classification = null,
+                engineName = "Rules v3",
+            ),
+            onMicTap = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun HomeVoiceControlSentPreview() {
+    PreviewComponentSurface {
+        HomeVoiceControlSectionBody(
+            state = VoiceCommandState.Sent(intent = VoiceIntent.OPEN),
+            onMicTap = {},
+        )
+    }
+}

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/VoiceControlBottomSheet.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/VoiceControlBottomSheet.kt
@@ -40,11 +40,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
-import androidx.compose.material.icons.outlined.ArrowDownward
-import androidx.compose.material.icons.outlined.ArrowUpward
-import androidx.compose.material.icons.outlined.Check
-import androidx.compose.material.icons.outlined.ErrorOutline
-import androidx.compose.material.icons.outlined.Mic
 import androidx.compose.material.icons.outlined.Remove
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -66,7 +61,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -78,11 +72,14 @@ import com.chriscartland.garage.R
 import com.chriscartland.garage.domain.model.VoiceIntent
 import com.chriscartland.garage.domain.model.VoiceIntentClassification
 import com.chriscartland.garage.domain.model.VoiceIntentConfidence
+import com.chriscartland.garage.ui.VoiceCommandUi
+import com.chriscartland.garage.ui.displayText
+import com.chriscartland.garage.ui.micContentDescription
+import com.chriscartland.garage.ui.micIcon
 import com.chriscartland.garage.usecase.VoiceCommandController
 import com.chriscartland.garage.usecase.VoiceCommandIgnoreReason
 import com.chriscartland.garage.usecase.VoiceCommandState
 import com.chriscartland.garage.usecase.VoiceDoorState
-import kotlin.math.ceil
 
 private const val ARMED_WINDOW_STEP_MS = 500L
 
@@ -241,7 +238,7 @@ fun VoiceControlSheetContent(
         VoiceCommandStatus(
             state = state,
             armedSecondsLeft = armed?.let {
-                VoiceControlHelpers.secondsLeft(it.windowMs, armedProgress.value)
+                VoiceCommandUi.secondsLeft(it.windowMs, armedProgress.value)
             },
             onCopy = onCopy,
         )
@@ -250,25 +247,6 @@ fun VoiceControlSheetContent(
             onSetArmedWindowMs = onSetArmedWindowMs,
         )
     }
-}
-
-// ADR-009: non-Composable helpers live in a named object.
-private object VoiceControlHelpers {
-    fun secondsLeft(
-        windowMs: Long,
-        progress: Float,
-    ): Int = ceil((1f - progress) * windowMs / 1000f).toInt().coerceAtLeast(1)
-
-    // "0.5", "1", "1.5" — trims the trailing .0 on whole seconds.
-    fun windowSecondsLabel(windowMs: Long): String {
-        val seconds = windowMs / 1000f
-        val whole = seconds.toInt()
-        return if (seconds == whole.toFloat()) whole.toString() else seconds.toString()
-    }
-
-    // Door-motion metaphor: up = opening, down = closing.
-    fun directionIcon(intent: VoiceIntent): ImageVector =
-        if (intent == VoiceIntent.CLOSE) Icons.Outlined.ArrowDownward else Icons.Outlined.ArrowUpward
 }
 
 @Composable
@@ -376,7 +354,7 @@ private fun VoiceCommandStatus(
                         } else {
                             R.string.voice_control_armed_opening
                         },
-                        armedSecondsLeft ?: VoiceControlHelpers.secondsLeft(state.windowMs, 0f),
+                        armedSecondsLeft ?: VoiceCommandUi.secondsLeft(state.windowMs, 0f),
                     ),
                     style = MaterialTheme.typography.titleMedium,
                     textAlign = TextAlign.Center,
@@ -481,7 +459,7 @@ private fun CancelWindowStepper(
         Text(
             text = stringResource(
                 R.string.voice_control_window_label,
-                VoiceControlHelpers.windowSecondsLabel(armedWindowMs),
+                VoiceCommandUi.windowSecondsLabel(armedWindowMs),
             ),
             style = MaterialTheme.typography.bodyMedium,
         )
@@ -506,51 +484,6 @@ private fun CancelWindowStepper(
         }
     }
 }
-
-private fun VoiceCommandState.micIcon(): ImageVector =
-    when (this) {
-        VoiceCommandState.Ready, is VoiceCommandState.Listening, is VoiceCommandState.Ignored ->
-            Icons.Outlined.Mic
-        is VoiceCommandState.Armed -> VoiceControlHelpers.directionIcon(intent)
-        is VoiceCommandState.Sending -> VoiceControlHelpers.directionIcon(intent)
-        is VoiceCommandState.Sent -> Icons.Outlined.Check
-        is VoiceCommandState.Failed -> Icons.Outlined.ErrorOutline
-    }
-
-@Composable
-private fun VoiceCommandState.micContentDescription(): String =
-    when (this) {
-        VoiceCommandState.Ready, is VoiceCommandState.Ignored ->
-            stringResource(R.string.voice_control_mic_cd_ready)
-        is VoiceCommandState.Listening -> stringResource(R.string.voice_control_mic_cd_listening)
-        is VoiceCommandState.Armed -> stringResource(R.string.voice_control_mic_cd_armed)
-        is VoiceCommandState.Sending -> stringResource(R.string.voice_control_mic_cd_sending)
-        is VoiceCommandState.Sent, is VoiceCommandState.Failed ->
-            stringResource(R.string.voice_control_mic_cd_ready)
-    }
-
-@Composable
-private fun VoiceCommandIgnoreReason.displayText(): String =
-    when (this) {
-        VoiceCommandIgnoreReason.NO_SPEECH ->
-            stringResource(R.string.voice_control_ignored_no_speech)
-        VoiceCommandIgnoreReason.RECOGNIZER_UNAVAILABLE ->
-            stringResource(R.string.voice_control_ignored_unavailable)
-        VoiceCommandIgnoreReason.NOT_A_COMMAND ->
-            stringResource(R.string.voice_control_ignored_not_a_command)
-        VoiceCommandIgnoreReason.NOT_CONFIDENT ->
-            stringResource(R.string.voice_control_ignored_not_confident)
-        VoiceCommandIgnoreReason.DOOR_ALREADY_OPEN ->
-            stringResource(R.string.voice_control_ignored_already_open)
-        VoiceCommandIgnoreReason.DOOR_ALREADY_CLOSED ->
-            stringResource(R.string.voice_control_ignored_already_closed)
-        VoiceCommandIgnoreReason.DOOR_MOVING ->
-            stringResource(R.string.voice_control_ignored_moving)
-        VoiceCommandIgnoreReason.DOOR_STATE_UNKNOWN ->
-            stringResource(R.string.voice_control_ignored_state_unknown)
-        VoiceCommandIgnoreReason.DOOR_STATE_CHANGED ->
-            stringResource(R.string.voice_control_ignored_state_changed)
-    }
 
 // `private` so `checkPreviewCoverage` exempts them (same rationale as
 // NavRailBottomSheet and VoiceInputBottomSheet: developer-gated sheet

--- a/MobileGarage/androidApp/src/main/res/values/strings.xml
+++ b/MobileGarage/androidApp/src/main/res/values/strings.xml
@@ -145,6 +145,15 @@
     <string name="home_section_remote_control">Remote control</string>
     <string name="home_section_sign_in">Sign in</string>
 
+    <!-- Home — voice-control section (developer-flag-gated shadow mode:
+         the gate reads real door state; the press is simulated). -->
+    <string name="home_section_voice">Voice control</string>
+    <string name="home_voice_simulated_pill">Simulated</string>
+    <string name="home_voice_ready_title">Voice command</string>
+    <string name="home_voice_hint">Try “open the garage door”</string>
+    <string name="home_voice_shadow_subtitle">Simulated. Nothing was sent to the door.</string>
+    <string name="home_voice_failed_subtitle">Try again</string>
+
     <!-- Home — signed-out remote-button placeholder. -->
     <string name="home_sign_in_title">Sign in with Google</string>
     <string name="home_sign_in_subtitle">Required to use the remote button</string>

--- a/MobileGarage/androidApp/src/test/java/com/chriscartland/garage/konsist/ComposableNullableDefaultKonsistTest.kt
+++ b/MobileGarage/androidApp/src/test/java/com/chriscartland/garage/konsist/ComposableNullableDefaultKonsistTest.kt
@@ -45,7 +45,11 @@ import org.junit.Test
  *   Null distinct from `false` is intentional semantics.
  * - Function types (`(...) -> Unit?` or `((...) -> ...)? = null`) —
  *   optional callbacks. The Composable should still render when no
- *   handler is provided; this is independent of UI shape.
+ *   handler is provided; this is independent of UI shape. Includes
+ *   ANNOTATED function types (`(@Composable () -> Unit)? = null` —
+ *   optional composable slots for flag-gated sections; canonical:
+ *   `HomeContent.voiceControlSection`), whose AST type name collapses
+ *   to just the annotation.
  *
  * Konsist param type names are taken from the source AST. `String?` is
  * the type's nullable form; `String` is non-nullable. Default values
@@ -121,7 +125,15 @@ class ComposableNullableDefaultKonsistTest {
                             if (baseTypeName == "Boolean") return@filter false
                             // Skip function-type parameters — `(...) -> T`
                             // serializes with a `->` in the AST type string.
+                            // An ANNOTATED function type — e.g. the composable
+                            // slot `(@Composable () -> Unit)?` (canonical:
+                            // `HomeContent.voiceControlSection`, a flag-gated
+                            // optional section) — serializes as just
+                            // `@Composable`: the annotation swallows the
+                            // arrow. Treat any annotation-prefixed type name
+                            // as a function-type slot too.
                             if ("->" in baseTypeName) return@filter false
+                            if (baseTypeName.startsWith("@")) return@filter false
                             true
                         }.map { param -> Triple(file.path, fn.name, param) }
                 }

--- a/MobileGarage/docs/VOICE_COMMANDS.md
+++ b/MobileGarage/docs/VOICE_COMMANDS.md
@@ -185,6 +185,22 @@ Promoting to the real thing is an environment swap (door repository
 projection + `PushRemoteButtonUseCase`) plus a Home-screen surface —
 the controller, gate, and tests carry over unchanged.
 
+**Home shadow surface (shipped 2.22.9, developer-flag-gated):** the
+Home tab renders the production-intent voice card (mic + countdown
+ring + stable two-line status, "Simulated" pill in the header) behind
+the same per-user flag as Settings → Developer, signed-in only, fixed
+3s window. It runs in **shadow mode** via
+`ShadowVoiceCommandEnvironment`: the gate reads the REAL observed door
+state — projected by `VoiceDoorStateMapper` (clean terminals →
+actionable, clean transits → MOVING, every anomaly [stuck too long,
+misaligned, sensor conflict] and a **stale check-in** → UNKNOWN →
+refuse) — so refusals always match the status card above, but the
+press is a no-op success. The projection is the promotion-critical
+safety mapping (it closes the wrong-direction hazard: stale cache says
+closed, door actually open, "open" would really close); promoting to
+the real door now means swapping only the environment's `pressButton`
+for `PushRemoteButtonUseCase`.
+
 ## Testing plan
 
 - Parser: table-driven accept/reject test mirroring the table above.

--- a/MobileGarage/iosFramework/src/commonMain/kotlin/com/chriscartland/garage/iosframework/NativeComponent.kt
+++ b/MobileGarage/iosFramework/src/commonMain/kotlin/com/chriscartland/garage/iosframework/NativeComponent.kt
@@ -299,6 +299,8 @@ abstract class NativeComponent(
     fun provideHomeViewModel(
         observeDoorEvents: ObserveDoorEventsUseCase,
         observeAuthState: ObserveAuthStateUseCase,
+        observeFeatureAccess: ObserveFeatureAccessUseCase,
+        classifyVoiceIntent: ClassifyVoiceIntentUseCase,
         logAppEvent: LogAppEventUseCase,
         dispatchers: DispatcherProvider,
         fetchCurrentDoorEvent: FetchCurrentDoorEventUseCase,
@@ -314,6 +316,8 @@ abstract class NativeComponent(
         DefaultHomeViewModel(
             observeDoorEvents = observeDoorEvents,
             observeAuthState = observeAuthState,
+            observeFeatureAccessUseCase = observeFeatureAccess,
+            classifyVoiceIntentUseCase = classifyVoiceIntent,
             logAppEvent = logAppEvent,
             dispatchers = dispatchers,
             fetchCurrentDoorEventUseCase = fetchCurrentDoorEvent,

--- a/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ShadowVoiceCommandEnvironment.kt
+++ b/MobileGarage/usecase/src/commonMain/kotlin/com/chriscartland/garage/usecase/ShadowVoiceCommandEnvironment.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.DoorPosition
+import com.chriscartland.garage.domain.model.VoiceIntent
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Projects the rich door model into the voice-command gate's view.
+ *
+ * Deny-by-default (the standing principle: okay to incorrectly ignore,
+ * never okay to incorrectly execute): only the two clean terminal
+ * positions map to actionable states, clean transits map to MOVING, and
+ * every anomaly (stuck too long, misaligned, sensor conflict) maps to
+ * UNKNOWN so the gate refuses rather than guesses. A stale device
+ * check-in also forces UNKNOWN — cached state that may no longer match
+ * reality must never pass the direction gate (the wrong-direction
+ * hazard: cache says closed, door is actually open, an "open" command
+ * would really close it).
+ */
+object VoiceDoorStateMapper {
+    fun project(
+        position: DoorPosition?,
+        isCheckInStale: Boolean,
+    ): VoiceDoorState {
+        if (isCheckInStale) return VoiceDoorState.UNKNOWN
+        return when (position) {
+            DoorPosition.CLOSED -> VoiceDoorState.CLOSED
+            DoorPosition.OPEN -> VoiceDoorState.OPEN
+            DoorPosition.OPENING, DoorPosition.CLOSING -> VoiceDoorState.MOVING
+            DoorPosition.OPENING_TOO_LONG,
+            DoorPosition.CLOSING_TOO_LONG,
+            DoorPosition.OPEN_MISALIGNED,
+            DoorPosition.ERROR_SENSOR_CONFLICT,
+            DoorPosition.UNKNOWN,
+            null,
+            -> VoiceDoorState.UNKNOWN
+        }
+    }
+}
+
+/**
+ * Shadow-mode world for the Home voice surface: the gate reads the REAL
+ * observed door state (so refusals always match the status card the
+ * user is looking at), but [pressButton] is a no-op success — nothing
+ * is ever sent to the door. Promoting to the real thing later swaps
+ * only this class for one whose press calls `PushRemoteButtonUseCase`.
+ */
+class ShadowVoiceCommandEnvironment(
+    override val doorState: StateFlow<VoiceDoorState>,
+    private val pressDelayMs: Long = PRESS_DELAY_MS,
+) : VoiceCommandEnvironment {
+    override suspend fun pressButton(intent: VoiceIntent): Boolean {
+        // Fake round-trip so Sending renders like the real thing.
+        delay(pressDelayMs)
+        return true
+    }
+
+    companion object {
+        const val PRESS_DELAY_MS = 600L
+    }
+}

--- a/MobileGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ShadowVoiceCommandEnvironmentTest.kt
+++ b/MobileGarage/usecase/src/commonTest/kotlin/com/chriscartland/garage/usecase/ShadowVoiceCommandEnvironmentTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.usecase
+
+import com.chriscartland.garage.domain.model.DoorPosition
+import com.chriscartland.garage.domain.model.VoiceIntent
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ShadowVoiceCommandEnvironmentTest {
+    @Test
+    fun pressSucceedsWithoutTouchingDoorState() =
+        runTest {
+            val door = MutableStateFlow(VoiceDoorState.CLOSED)
+            val env = ShadowVoiceCommandEnvironment(doorState = door, pressDelayMs = 0L)
+            assertTrue(env.pressButton(VoiceIntent.OPEN))
+            assertEquals(
+                VoiceDoorState.CLOSED,
+                door.value,
+                "Shadow press must never mutate door state",
+            )
+        }
+
+    // The projection is the promotion-critical safety mapping: only the
+    // two clean terminal positions are actionable; transits are MOVING;
+    // every anomaly and a stale check-in force UNKNOWN (gate refuses).
+    @Test
+    fun projectionMapsCleanStatesAndDeniesAnomalies() {
+        assertEquals(
+            VoiceDoorState.CLOSED,
+            VoiceDoorStateMapper.project(DoorPosition.CLOSED, isCheckInStale = false),
+        )
+        assertEquals(
+            VoiceDoorState.OPEN,
+            VoiceDoorStateMapper.project(DoorPosition.OPEN, isCheckInStale = false),
+        )
+        assertEquals(
+            VoiceDoorState.MOVING,
+            VoiceDoorStateMapper.project(DoorPosition.OPENING, isCheckInStale = false),
+        )
+        assertEquals(
+            VoiceDoorState.MOVING,
+            VoiceDoorStateMapper.project(DoorPosition.CLOSING, isCheckInStale = false),
+        )
+        val anomalies = listOf(
+            DoorPosition.OPENING_TOO_LONG,
+            DoorPosition.CLOSING_TOO_LONG,
+            DoorPosition.OPEN_MISALIGNED,
+            DoorPosition.ERROR_SENSOR_CONFLICT,
+            DoorPosition.UNKNOWN,
+            null,
+        )
+        anomalies.forEach { position ->
+            assertEquals(
+                VoiceDoorState.UNKNOWN,
+                VoiceDoorStateMapper.project(position, isCheckInStale = false),
+                "Anomalous position $position must project to UNKNOWN",
+            )
+        }
+    }
+
+    @Test
+    fun staleCheckInForcesUnknownEvenWhenPositionIsClean() {
+        DoorPosition.entries.forEach { position ->
+            assertEquals(
+                VoiceDoorState.UNKNOWN,
+                VoiceDoorStateMapper.project(position, isCheckInStale = true),
+                "Stale check-in must project $position to UNKNOWN",
+            )
+        }
+    }
+}

--- a/MobileGarage/version.properties
+++ b/MobileGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.22.8
+versionName=2.22.9

--- a/MobileGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/HomeViewModel.kt
+++ b/MobileGarage/viewmodel/src/commonMain/kotlin/com/chriscartland/garage/viewmodel/HomeViewModel.kt
@@ -38,6 +38,7 @@ import com.chriscartland.garage.usecase.ButtonAckToken
 import com.chriscartland.garage.usecase.ButtonHealthDisplay
 import com.chriscartland.garage.usecase.ButtonStateMachine
 import com.chriscartland.garage.usecase.CheckInStalenessManager
+import com.chriscartland.garage.usecase.ClassifyVoiceIntentUseCase
 import com.chriscartland.garage.usecase.DeregisterFcmUseCase
 import com.chriscartland.garage.usecase.FetchButtonHealthUseCase
 import com.chriscartland.garage.usecase.FetchCurrentDoorEventUseCase
@@ -45,8 +46,14 @@ import com.chriscartland.garage.usecase.LiveClock
 import com.chriscartland.garage.usecase.LogAppEventUseCase
 import com.chriscartland.garage.usecase.ObserveAuthStateUseCase
 import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
+import com.chriscartland.garage.usecase.ObserveFeatureAccessUseCase
 import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
+import com.chriscartland.garage.usecase.ShadowVoiceCommandEnvironment
 import com.chriscartland.garage.usecase.SignInWithGoogleUseCase
+import com.chriscartland.garage.usecase.VoiceCommandController
+import com.chriscartland.garage.usecase.VoiceCommandState
+import com.chriscartland.garage.usecase.VoiceDoorState
+import com.chriscartland.garage.usecase.VoiceDoorStateMapper
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -112,6 +119,38 @@ interface HomeViewModel {
      */
     val buttonHealthDisplay: StateFlow<ButtonHealthDisplay>
 
+    /**
+     * Per-user access for the Developer features (same server-maintained
+     * flag that gates Settings → Developer). Gates the Home voice-control
+     * section. Tri-state: `null` (loading or denied), `false`, `true`.
+     */
+    val developerAccess: StateFlow<Boolean?>
+
+    /**
+     * Experimental Home voice-control surface, SHADOW MODE: the gate
+     * reads the real observed door state (projected via
+     * [VoiceDoorStateMapper] — anomalies and stale check-ins refuse),
+     * but the button press is a no-op success. The door is never
+     * touched. Fixed 3s cancel window. State machine:
+     * [VoiceCommandController] in `:usecase`.
+     */
+    val voiceCommandState: StateFlow<VoiceCommandState>
+
+    /** Mic tap: always starts over; cancels a pending command first. */
+    fun voiceCommandMicTap()
+
+    /** Recognizer outcome for the command loop (null = no speech). */
+    fun voiceCommandTranscript(text: String?)
+
+    /** The recognizer launch failed: no recognizer on this device. */
+    fun voiceCommandCaptureUnavailable()
+
+    /**
+     * The Home screen left the foreground: cancels a pending (Armed)
+     * command so nothing commits off-screen.
+     */
+    fun voiceCommandBackgrounded()
+
     fun signInWithGoogle(idToken: GoogleIdToken)
 
     fun fetchCurrentDoorEvent()
@@ -134,6 +173,8 @@ interface HomeViewModel {
 class DefaultHomeViewModel(
     observeDoorEvents: ObserveDoorEventsUseCase,
     observeAuthState: ObserveAuthStateUseCase,
+    private val observeFeatureAccessUseCase: ObserveFeatureAccessUseCase,
+    private val classifyVoiceIntentUseCase: ClassifyVoiceIntentUseCase,
     private val logAppEvent: LogAppEventUseCase,
     private val dispatchers: DispatcherProvider,
     private val fetchCurrentDoorEventUseCase: FetchCurrentDoorEventUseCase,
@@ -205,6 +246,38 @@ class DefaultHomeViewModel(
     private val _isCheckInStale = MutableStateFlow(false)
     override val isCheckInStale: StateFlow<Boolean> = _isCheckInStale
 
+    private val _developerAccess = MutableStateFlow<Boolean?>(null)
+    override val developerAccess: StateFlow<Boolean?> = _developerAccess
+
+    // Shadow-mode voice control: the gate's door view projects the REAL
+    // observed state (stale check-in → UNKNOWN → refuse), so refusals
+    // always match the status card above — it combines the same two
+    // mirrors the card renders from. Seeded synchronously (Eagerly) so
+    // a fresh screen entry gates correctly on the first utterance,
+    // before the combine's first async emission.
+    private val voiceDoorState: StateFlow<VoiceDoorState> =
+        combine(
+            _currentDoorEvent,
+            _isCheckInStale,
+        ) { event, stale ->
+            VoiceDoorStateMapper.project(event.data?.doorPosition, stale)
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = VoiceDoorStateMapper.project(
+                _currentDoorEvent.value.data?.doorPosition,
+                _isCheckInStale.value,
+            ),
+        )
+
+    private val voiceCommandController = VoiceCommandController(
+        classify = classifyVoiceIntentUseCase,
+        environment = ShadowVoiceCommandEnvironment(doorState = voiceDoorState),
+        scope = viewModelScope,
+        // Fixed 3s window on Home (the playground keeps the stepper).
+    )
+    override val voiceCommandState: StateFlow<VoiceCommandState> = voiceCommandController.state
+
     private val stateMachine = ButtonStateMachine(
         doorPosition = observeDoorEvents.position(),
         onSubmit = ::submitButtonPress,
@@ -225,6 +298,9 @@ class DefaultHomeViewModel(
                 Logger.d { "currentDoorEvent collect: $it" }
                 _currentDoorEvent.value = LoadingResult.Complete(it)
             }
+        }
+        viewModelScope.launch(dispatchers.io) {
+            observeFeatureAccessUseCase.developer().collect { _developerAccess.value = it }
         }
         if (fetchOnInit) {
             viewModelScope.launch(dispatchers.io) {
@@ -282,6 +358,14 @@ class DefaultHomeViewModel(
     override fun onButtonTap() {
         stateMachine.onTap()
     }
+
+    override fun voiceCommandMicTap() = voiceCommandController.onMicTap()
+
+    override fun voiceCommandTranscript(text: String?) = voiceCommandController.onTranscript(text)
+
+    override fun voiceCommandCaptureUnavailable() = voiceCommandController.onCaptureUnavailable()
+
+    override fun voiceCommandBackgrounded() = voiceCommandController.onBackgrounded()
 
     override fun log(key: String) {
         viewModelScope.launch(dispatchers.io) {

--- a/MobileGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/HomeViewModelTest.kt
+++ b/MobileGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/HomeViewModelTest.kt
@@ -38,9 +38,11 @@ import com.chriscartland.garage.testcommon.FakeAuthRepository
 import com.chriscartland.garage.testcommon.FakeDiagnosticsCountersRepository
 import com.chriscartland.garage.testcommon.FakeDoorFcmRepository
 import com.chriscartland.garage.testcommon.FakeDoorRepository
+import com.chriscartland.garage.testcommon.FakeFeatureAllowlistRepository
 import com.chriscartland.garage.testcommon.FakeRemoteButtonRepository
 import com.chriscartland.garage.testcommon.TestDispatcherProvider
 import com.chriscartland.garage.usecase.CheckInStalenessManager
+import com.chriscartland.garage.usecase.ClassifyVoiceIntentUseCase
 import com.chriscartland.garage.usecase.ComputeButtonHealthDisplayUseCase
 import com.chriscartland.garage.usecase.DefaultLiveClock
 import com.chriscartland.garage.usecase.DeregisterFcmUseCase
@@ -49,7 +51,9 @@ import com.chriscartland.garage.usecase.FetchCurrentDoorEventUseCase
 import com.chriscartland.garage.usecase.LogAppEventUseCase
 import com.chriscartland.garage.usecase.ObserveAuthStateUseCase
 import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
+import com.chriscartland.garage.usecase.ObserveFeatureAccessUseCase
 import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
+import com.chriscartland.garage.usecase.RuleBasedVoiceIntentClassifier
 import com.chriscartland.garage.usecase.SignInWithGoogleUseCase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -144,6 +148,8 @@ class HomeViewModelTest {
         val vm = DefaultHomeViewModel(
             observeDoorEvents = ObserveDoorEventsUseCase(doorRepository),
             observeAuthState = ObserveAuthStateUseCase(authRepository),
+            observeFeatureAccessUseCase = ObserveFeatureAccessUseCase(FakeFeatureAllowlistRepository()),
+            classifyVoiceIntentUseCase = ClassifyVoiceIntentUseCase(RuleBasedVoiceIntentClassifier()),
             logAppEvent = LogAppEventUseCase(
                 appLoggerRepository,
                 FakeDiagnosticsCountersRepository(),

--- a/MobileGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/RealNetworkButtonHealthRepositoryPropagationTest.kt
+++ b/MobileGarage/viewmodel/src/commonTest/kotlin/com/chriscartland/garage/viewmodel/RealNetworkButtonHealthRepositoryPropagationTest.kt
@@ -34,6 +34,7 @@ import com.chriscartland.garage.testcommon.FakeAuthRepository
 import com.chriscartland.garage.testcommon.FakeDiagnosticsCountersRepository
 import com.chriscartland.garage.testcommon.FakeDoorFcmRepository
 import com.chriscartland.garage.testcommon.FakeDoorRepository
+import com.chriscartland.garage.testcommon.FakeFeatureAllowlistRepository
 import com.chriscartland.garage.testcommon.FakeNetworkButtonHealthDataSource
 import com.chriscartland.garage.testcommon.FakeNetworkConfigDataSource
 import com.chriscartland.garage.testcommon.FakeRemoteButtonRepository
@@ -41,6 +42,7 @@ import com.chriscartland.garage.testcommon.FakeStatusSnapshotStore
 import com.chriscartland.garage.testcommon.TestDispatcherProvider
 import com.chriscartland.garage.usecase.ButtonHealthDisplay
 import com.chriscartland.garage.usecase.CheckInStalenessManager
+import com.chriscartland.garage.usecase.ClassifyVoiceIntentUseCase
 import com.chriscartland.garage.usecase.ComputeButtonHealthDisplayUseCase
 import com.chriscartland.garage.usecase.DefaultLiveClock
 import com.chriscartland.garage.usecase.DeregisterFcmUseCase
@@ -49,7 +51,9 @@ import com.chriscartland.garage.usecase.FetchCurrentDoorEventUseCase
 import com.chriscartland.garage.usecase.LogAppEventUseCase
 import com.chriscartland.garage.usecase.ObserveAuthStateUseCase
 import com.chriscartland.garage.usecase.ObserveDoorEventsUseCase
+import com.chriscartland.garage.usecase.ObserveFeatureAccessUseCase
 import com.chriscartland.garage.usecase.PushRemoteButtonUseCase
+import com.chriscartland.garage.usecase.RuleBasedVoiceIntentClassifier
 import com.chriscartland.garage.usecase.SignInWithGoogleUseCase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -158,6 +162,8 @@ class RealNetworkButtonHealthRepositoryPropagationTest {
         val vm = DefaultHomeViewModel(
             observeDoorEvents = ObserveDoorEventsUseCase(doorRepo),
             observeAuthState = ObserveAuthStateUseCase(authRepo),
+            observeFeatureAccessUseCase = ObserveFeatureAccessUseCase(FakeFeatureAllowlistRepository()),
+            classifyVoiceIntentUseCase = ClassifyVoiceIntentUseCase(RuleBasedVoiceIntentClassifier()),
             logAppEvent = LogAppEventUseCase(appLogger, counters),
             dispatchers = TestDispatcherProvider(testDispatcher),
             fetchCurrentDoorEventUseCase = FetchCurrentDoorEventUseCase(doorRepo),


### PR DESCRIPTION
## Summary

The Home tab gains the **production-intent voice control card** behind the same per-user flag as Settings → Developer (`developerAccess`), signed-in only — fully real except the press (**shadow mode**).

## Design

- **Card**: a "VOICE CONTROL" Home section in the exact section language of the tab — 56dp tonal mic button with the countdown ring wrapping it, stable two-line status column (primary: what's happening; secondary: transcript or hint), and a "Simulated" pill in the header so shadow mode is unmistakable. Fixed 3s cancel window (the stepper stays playground-only).
- **Real state, fake press**: the gate reads the REAL observed door state via the new `VoiceDoorStateMapper` — clean Closed/Open actionable, Opening/Closing → Moving, and **every anomaly (stuck-too-long, misaligned, sensor conflict) plus a stale device check-in → UNKNOWN → refuse**. Refusals always agree with the status card above. This projection is the promotion-critical safety mapping (closes the wrong-direction hazard: stale cache says closed, door actually open, "open" would really close). `ShadowVoiceCommandEnvironment.pressButton` is a no-op success — nothing is ever sent to the door; the Sent state says so.
- **Promotion path**: real wiring later = swap the environment's press for `PushRemoteButtonUseCase`. Controller, gate, mapper, and tests carry over unchanged.

## Mechanics

- `HomeViewModel` hosts the controller (ctor +2 deps — **both `AppComponent` and `NativeComponent` updated**; `:iosFramework:iosSimulatorArm64Test` green locally).
- Voice section injected into the stateless `HomeContent` as a nullable composable **slot** — Home fixtures and all 14 previews untouched; the recognizer plumbing lives in `HomeVoiceControlSection`.
- Shared `VoiceCommandUi` vocabulary (icons, countdown math, refusal wording) deduped out of the playground sheet so both surfaces render identically.
- `ComposableNullableDefaultKonsistTest` taught to recognize annotated function-type slots (`(@Composable () -> Unit)?` serializes as just `@Composable` in Konsist's AST — the `->` exclusion missed it), per the file's drift policy.
- New tests: `VoiceDoorStateMapper` exhaustive projection + stale-forces-UNKNOWN across all positions; shadow press never mutates door state.
- Full `validate.sh` green (printed PASS markers confirmed).

Version 2.22.9 (patch, developer-gated experiment). Releasing as `android/270` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)