### PR TITLE
ci: run the 33 architecture checks on every PR

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -49,6 +49,44 @@ jobs:
         working-directory: MobileGarage
         run: ./release/clean-secrets.sh
 
+  # The 33 custom architecture checks (ADR conformance, layer boundaries,
+  # DI scoping, spacing/theme rules). Until this job existed they ran ONLY
+  # from scripts/validate.sh — i.e. only when a human remembered to — so a
+  # violation reached main unless a reviewer caught it by eye.
+  #
+  # No branch-protection change was needed to make this blocking: the
+  # required context is "Android CI Complete", which gates on the result
+  # of this whole reusable workflow, so a new job here is covered
+  # automatically (see CLAUDE.md § "Renaming a branch-protection-required
+  # gate job" for why adding a NEW required context would not be).
+  #
+  # Task membership is discovered by the `architectureChecks` aggregate in
+  # MobileGarage/build.gradle.kts, not listed here — a list in YAML would
+  # silently omit the next check someone registers.
+  architecture_checks:
+    name: Architecture Checks
+    if: inputs.android == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-android
+        with:
+          encrypt-key: ${{ secrets.ENCRYPT_KEY }}
+      # Secrets are needed because checkSingletonCaching inspects KSP
+      # output and so dependsOn(":androidApp:kspDebugKotlin").
+      # --continue reports every violation in one run rather than making
+      # the author push a fix per failing check.
+      - name: Run architecture checks
+        working-directory: MobileGarage
+        env:
+          SERVER_CONFIG_KEY: ${{ secrets.SERVER_CONFIG_KEY }}
+          GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
+        run: ./gradlew architectureChecks --continue -PSERVER_CONFIG_KEY="$SERVER_CONFIG_KEY" -PGOOGLE_WEB_CLIENT_ID="$GOOGLE_WEB_CLIENT_ID"
+      - name: Clean secrets
+        if: always()
+        working-directory: MobileGarage
+        run: ./release/clean-secrets.sh
+
   unit_tests:
     name: Unit Tests
     if: inputs.android == 'true'

--- a/MobileGarage/build.gradle.kts
+++ b/MobileGarage/build.gradle.kts
@@ -388,6 +388,42 @@ tasks.register<architecture.AuthStateProjectionTask>("checkAuthStateProjection")
     )
 }
 
+/**
+ * Aggregate of every architecture check, so CI can enforce them all in
+ * one job (`.github/workflows/ci-checks.yml` → "Architecture Checks").
+ *
+ * Before this existed, all 33 `check*` tasks ran ONLY from
+ * `scripts/validate.sh` — i.e. only when a human remembered to. None of
+ * them ran on a pull request, so a violation reached `main` unless a
+ * reviewer caught it by eye.
+ *
+ * The membership is **discovered, not listed**: any task registered on
+ * the root project whose name matches `check[A-Z]…` joins automatically.
+ * A hand-maintained list in YAML would silently omit the next check
+ * someone adds, which is the exact failure mode this task exists to end.
+ * Deliberate consequence: registering a `check*` task opts it into CI on
+ * day one. That is the intent — an unenforced check is a comment.
+ *
+ * This task's own name must NOT match the pattern, or it would depend on
+ * itself.
+ *
+ * Per-module `checkImportBoundary` tasks live on the subprojects rather
+ * than the root, so they are named explicitly.
+ */
+tasks.register("architectureChecks") {
+    group = "verification"
+    description = "Runs every architecture check* task (root) plus per-module import-boundary checks."
+
+    // Live filtered collection: tasks registered after this block still match.
+    dependsOn(tasks.matching { it.name.matches(Regex("""check[A-Z].*""")) })
+
+    // Keep in sync with the module list in scripts/validate.sh.
+    dependsOn(
+        listOf("domain", "data", "data-local", "usecase", "presentation-model")
+            .map { ":$it:checkImportBoundary" },
+    )
+}
+
 allprojects {
     apply(plugin = "com.diffplug.spotless")
     apply(plugin = "io.gitlab.arturbosch.detekt")

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -6,6 +6,18 @@ set -euo pipefail
 #
 # Automatically discovers all modules with test sources so new
 # modules are covered without editing this script.
+#
+# Architecture check* tasks: this script runs them one per step so each
+# gets its own PASS/FAIL marker and explanation. CI runs the same rules
+# via the `architectureChecks` aggregate task (MobileGarage/build.gradle.kts),
+# which DISCOVERS every root `check[A-Z]…` task rather than listing them.
+#
+# The two lists can therefore drift in one direction only: a newly
+# registered check is enforced by CI immediately, even if nobody adds a
+# step here. That is the safe direction (CI is the gate). The reverse —
+# a check that runs locally but not in CI — is what the aggregate makes
+# impossible, and is why all 33 of these went unenforced on PRs until
+# the "Architecture Checks" job was added.
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 GRADLE="$REPO_ROOT/MobileGarage/gradlew -p $REPO_ROOT/MobileGarage"


### PR DESCRIPTION
Phase 0 of the [remediation plan](https://github.com/cartland/SmartGarageDoor/pull/1133).

## The problem

This repo has 33 custom `check*` Gradle tasks encoding its architecture
rules — ADR conformance, layer boundaries, DI scoping, spacing and theme
invariants. Rules that took real incidents to learn.

**None of them ran in CI.**

```
$ git grep -n "check[A-Z]" -- .github/workflows/
(no output)
```

They fired only from `scripts/validate.sh` — only when a human
remembered. A violation reached `main` unless a reviewer caught it by
eye.

This also inverts how CLAUDE.md describes Konsist. It's documented as
"explicitly additive, not migration" — a redundant second enforcement
point layered over the Gradle tasks. In practice Konsist (inside
`./gradlew test`) was the **only** architecture enforcement that could
block a PR: sole gate for the rules it mirrors, and no gate at all for
the ~28 it doesn't.

## The fix

An `architectureChecks` aggregate task plus an "Architecture Checks" CI
job that runs it.

**Membership is discovered, not listed.** Any root task matching
`check[A-Z]…` joins automatically. A hand-maintained list in YAML would
silently omit the next check someone registers — the exact failure mode
this is meant to end. Deliberate consequence: registering a `check*`
task opts it into CI on day one.

## Why no branch-protection dance

The required context is `Android CI Complete`, which gates on the result
of the **whole reusable workflow** (`needs: [checks]`). A job added
inside `ci-checks.yml` is covered automatically.

Adding a *new required context* would have needed the multi-PR rename
ordering documented in CLAUDE.md, where deleting a gate job before
removing it from required contexts blocks every PR in the repo. This
avoids that entirely.

## Verification

- `--dry-run` resolves to **all 33** root checks + **all 5** module
  `checkImportBoundary` tasks
- Full run: `BUILD SUCCESSFUL`, 127 tasks executed
- `./scripts/validate.sh` end to end: **53 PASS, 0 FAIL**, "All checks
  passed" (checked the printed markers, not the exit code, per the
  documented trap)
- `shellcheck` clean; workflow YAML parses; `spotlessApply` no-op

## One thing this surfaces

The aggregate wires in `checkTestCoverage`, which `validate.sh` never
ran. Running it directly:

```
=== Test Coverage Check ===
Covered: 0
All classes have test coverage.
```

It finds zero classes and declares success — **vacuous, not passing**.
Including it is harmless today, and means Phase 2's fix becomes enforced
the moment it lands rather than needing a separate wiring step.

## Risk

Low. The task list is known-green locally on `main`. The job mirrors the
existing `unit_tests` secret handling because `checkSingletonCaching`
inspects KSP output (`dependsOn(":androidApp:kspDebugKotlin")`).

The honest cost: one more ~5-8 min job per PR, running in parallel with
the existing ones.