### PR TITLE
ci: run wearApp unit tests in validate.sh

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -320,6 +320,16 @@ else
     fail "testBenchmarkUnitTest"
 fi
 
+# CI already runs these via the aggregate `./gradlew test` in the Unit Tests
+# job; validate.sh's other unit-test steps are :androidApp:-scoped, so without
+# this a wear-breaking change passes locally and only fails in CI.
+step "Unit Tests (wear)"
+if $GRADLE :wearApp:testDebugUnitTest; then
+    pass "wearApp testDebugUnitTest"
+else
+    fail "wearApp testDebugUnitTest"
+fi
+
 step "Build Debug APK"
 if $GRADLE :androidApp:assembleDebug; then
     pass "assembleDebug"


### PR DESCRIPTION
## What

Adds a `Unit Tests (wear)` step (`:wearApp:testDebugUnitTest`) to `scripts/validate.sh`.

## Why

CI **already** covers wear unit tests — the `Unit Tests` job runs the aggregate `./gradlew test`, which includes `:wearApp:testDebugUnitTest` and `:wearApp:testReleaseUnitTest` (verified with `test --dry-run`).

`validate.sh` did not. Its other unit-test steps are `:androidApp:`-scoped, and wearApp only got an `assembleDebug` — which does not compile the test source set at all. So a change breaking any of the 38 existing wear unit tests passed local validation and only surfaced later in CI.

This is a local-DX fix, not a correctness gap: the PR gate was always there.

## Verification

`MobileGarage/gradlew -p MobileGarage :wearApp:testDebugUnitTest` — 38 tests across 5 classes, green:

| Class | Tests |
| --- | --- |
| `WearHomeViewModelTest` | 26 |
| `WearComponentGraphTest` | 5 |
| `HeroScreenMappersTest` | 4 |
| `RelayFallbackAuthBridgeTest` | 2 |
| `WearCapabilityDeclarationTest` | 1 |

Groundwork for the Wear voice-demo work, whose tests should run locally before the first push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)