### PR TITLE
fix(android): name what the remote button does, and what went wrong (2.23.4)

### DIFF
--- a/MobileGarage/CHANGELOG.md
+++ b/MobileGarage/CHANGELOG.md
@@ -15,6 +15,33 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
 
+## 2.23.4
+
+- **The remote button says what it does, and names the two ways it can fail.**
+  The idle label was "Garage Door Button", which told you where you were rather
+  than what would happen; it now reads "Tap to open or close", and the confirm
+  step says "Tap again to confirm". A failed press used to say "Failed" whether
+  the server refused the request or the door never moved — two problems with
+  different responses. They are now "Server error" and "Door did not move". The
+  two states that are genuinely waiting on the network also show a spinner.
+- **The Settings tab no longer has a person for an icon.** It was a leftover
+  from when the tab was called Profile, and History used a calendar. They are
+  now a gear and a history clock, matching what the labels say and pairing with
+  the iOS icons.
+- **Launching in dark mode no longer flashes a white screen.** The launch theme
+  had no dark variant, so the system splash was drawn light before the app
+  could render.
+- **Screen readers get the send progress.** The phone/server/door diagram
+  announced nothing, so a blind user got the button label and no sense of where
+  a press had got to. It now announces the phase. The door's arrow and warning
+  badges stopped announcing themselves, since the status text already says it.
+- Signing in from Settings says what it unlocks. The stale-connection alert uses
+  the same no-signal icon as the device pill instead of a second metaphor. The
+  Functions locked state reads as a deliberate state rather than a page that
+  failed to load. Each tab titles its own screen. "Privacy Policy" is sentence
+  case. Exporting diagnostics no longer writes from an unmanaged coroutine
+  scope that outlives the screen.
+
 ## 2.23.3
 
 - **The two voice experiments in Settings are now one, and it rehearses the

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/AnimatableGarageDoor.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/AnimatableGarageDoor.kt
@@ -64,7 +64,10 @@ val DEFAULT_GARAGE_DOOR_ANIMATION_DURATION: Duration =
 @Composable
 internal fun DirectionOverlay(
     rotationDegrees: Float,
-    contentDescription: String,
+    // Nullable and normally null: the arrow restates the door status the
+    // headline already announces, so describing it makes a screen reader say
+    // the same thing twice.
+    contentDescription: String?,
 ) {
     Box(
         modifier = Modifier
@@ -96,7 +99,9 @@ internal fun WarningOverlay() {
         Icon(
             imageVector = Icons.Filled.Warning,
             tint = MaterialTheme.colorScheme.onBackground,
-            contentDescription = "Warning Symbol",
+            // Decorative: the status headline and the warning chip already
+            // announce this state, so naming the glyph just repeats them.
+            contentDescription = null,
             modifier = Modifier.fillMaxSize(0.6f),
         )
     }

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/FunctionListContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/FunctionListContent.kt
@@ -20,10 +20,15 @@ package com.chriscartland.garage.ui
 import android.os.Build
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -190,17 +195,39 @@ private fun FunctionListWarning() {
     )
 }
 
+/**
+ * Shown when the account is not on the allowlist. A lone sentence on a blank
+ * page reads like a failure to load; an icon + title + explanation reads like a
+ * deliberate state, which is what this is. Mirrors iOS's locked state.
+ */
 @Composable
 private fun FunctionListAccessDeniedContent(modifier: Modifier = Modifier) {
     Box(
         modifier = modifier.padding(32.dp),
         contentAlignment = Alignment.Center,
     ) {
-        Text(
-            text = stringResource(R.string.function_list_access_denied),
-            style = MaterialTheme.typography.bodyLarge,
-            textAlign = TextAlign.Center,
-        )
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Lock,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(48.dp),
+            )
+            Text(
+                text = stringResource(R.string.function_list_access_denied_title),
+                style = MaterialTheme.typography.titleMedium,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = stringResource(R.string.function_list_access_denied),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
     }
 }
 

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/GarageDoorButton.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/GarageDoorButton.kt
@@ -17,20 +17,26 @@
 
 package com.chriscartland.garage.ui
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.chriscartland.garage.R
 import com.chriscartland.garage.domain.model.RemoteButtonState
 import com.chriscartland.garage.ui.theme.PreviewComponentSurface
 import com.chriscartland.garage.ui.theme.cautionContainer
@@ -39,9 +45,19 @@ import com.chriscartland.garage.ui.theme.onCautionContainer
 /**
  * Material3 button for the garage door remote.
  *
- * - Ready: "Garage Door Button" (tonal, tappable)
- * - AwaitingConfirmation: "Door will move." + "Confirm?" (amber, tappable)
- * - All other states: disabled with status text
+ * - Ready: "Tap to open or close" (tonal, tappable)
+ * - AwaitingConfirmation: "Door will move." + "Tap again to confirm" (amber, tappable)
+ * - All other states: disabled with status text; the two in-flight states also
+ *   show a spinner, per the in-flight button pattern (icon swapped for a 20 dp
+ *   indicator while the action is disabled).
+ *
+ * The labels are instructions, not nouns: "Tap to open or close" says what the
+ * button does, where "Garage Door Button" only repeated where the user already
+ * knew they were. The two failure states are named separately — the shared
+ * [RemoteButtonState] distinguishes "the server refused" from "the door never
+ * moved", and those call for different reactions, so collapsing both to
+ * "Failed" throws away the only information the user has. Copy is shared with
+ * iOS, which arrived at these first.
  *
  * The parent controls width via [modifier]. The button fills that width
  * in all states for visual stability.
@@ -61,7 +77,7 @@ fun GarageDoorButton(
                     .heightIn(min = 64.dp),
             ) {
                 Text(
-                    text = "Garage Door Button",
+                    text = stringResource(R.string.remote_button_ready),
                     style = MaterialTheme.typography.titleMedium,
                     textAlign = TextAlign.Center,
                 )
@@ -80,12 +96,12 @@ fun GarageDoorButton(
             ) {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Text(
-                        text = "Door will move.",
+                        text = stringResource(R.string.remote_button_confirm_title),
                         style = MaterialTheme.typography.titleMedium,
                         textAlign = TextAlign.Center,
                     )
                     Text(
-                        text = "Confirm?",
+                        text = stringResource(R.string.remote_button_confirm_subtitle),
                         style = MaterialTheme.typography.titleMedium,
                         textAlign = TextAlign.Center,
                     )
@@ -104,25 +120,43 @@ fun GarageDoorButton(
                     disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
                 ),
             ) {
-                Text(
-                    text = state.disabledLabel(),
-                    style = MaterialTheme.typography.titleMedium,
-                    textAlign = TextAlign.Center,
-                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    // Only the two states that are genuinely waiting on the
+                    // network spin. Cancelled / Succeeded / Failed are outcomes,
+                    // and a spinner on an outcome reads as "still working".
+                    if (state == RemoteButtonState.SendingToServer ||
+                        state == RemoteButtonState.SendingToDoor
+                    ) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                        )
+                    }
+                    Text(
+                        text = state.disabledLabel(),
+                        style = MaterialTheme.typography.titleMedium,
+                        textAlign = TextAlign.Center,
+                    )
+                }
             }
         }
     }
 }
 
+@Composable
 private fun RemoteButtonState.disabledLabel(): String =
     when (this) {
-        RemoteButtonState.Preparing -> "Garage Door Button"
-        RemoteButtonState.Cancelled -> "Cancelled"
-        RemoteButtonState.SendingToServer -> "Sending..."
-        RemoteButtonState.SendingToDoor -> "Waiting..."
-        RemoteButtonState.Succeeded -> "Done!"
-        RemoteButtonState.ServerFailed -> "Failed"
-        RemoteButtonState.DoorFailed -> "Failed"
+        RemoteButtonState.Preparing -> stringResource(R.string.remote_button_preparing)
+        RemoteButtonState.Cancelled -> stringResource(R.string.remote_button_cancelled)
+        RemoteButtonState.SendingToServer -> stringResource(R.string.remote_button_sending)
+        RemoteButtonState.SendingToDoor -> stringResource(R.string.remote_button_waiting)
+        RemoteButtonState.Succeeded -> stringResource(R.string.remote_button_succeeded)
+        RemoteButtonState.ServerFailed -> stringResource(R.string.remote_button_server_failed)
+        RemoteButtonState.DoorFailed -> stringResource(R.string.remote_button_door_failed)
         // Ready and AwaitingConfirmation are handled above, not here.
         RemoteButtonState.Ready,
         RemoteButtonState.AwaitingConfirmation,

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/GarageIcon.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/GarageIcon.kt
@@ -199,8 +199,8 @@ private fun DoorIconBox(
         )
         when (DoorAnimation.overlayFor(doorPosition)) {
             DoorOverlayKind.NONE -> Unit
-            DoorOverlayKind.ARROW_UP -> DirectionOverlay(-90f, "Up Arrow")
-            DoorOverlayKind.ARROW_DOWN -> DirectionOverlay(90f, "Down Arrow")
+            DoorOverlayKind.ARROW_UP -> DirectionOverlay(-90f, contentDescription = null)
+            DoorOverlayKind.ARROW_DOWN -> DirectionOverlay(90f, contentDescription = null)
             DoorOverlayKind.WARNING -> if (!suppressWarningOverlay) WarningOverlay()
         }
     }

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -37,9 +37,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -135,6 +135,19 @@ sealed interface Screen : NavKey {
 
 /**
  * Navigation tab definition linking a screen to its UI metadata.
+ *
+ * Icon pairing with iOS (`MainTab.swift`) — the two icon systems can't share a
+ * literal glyph, so the intended match is recorded here and there:
+ *
+ * | Tab      | Android Material    | iOS SF Symbol           |
+ * |----------|---------------------|-------------------------|
+ * | Home     | `Home`              | `house`                 |
+ * | History  | `History`           | `clock.arrow.circlepath`|
+ * | Settings | `Settings`          | `gearshape`             |
+ *
+ * History was `DateRange` (a calendar) and Settings was `Person` — the latter a
+ * leftover from when this tab was called Profile, which left a person glyph
+ * sitting under the word "Settings".
  */
 enum class Tab(
     val screen: Screen,
@@ -142,8 +155,8 @@ enum class Tab(
     val icon: ImageVector,
 ) {
     Home(Screen.Home, "Home", Icons.Filled.Home),
-    History(Screen.History, "History", Icons.Filled.DateRange),
-    Profile(Screen.Profile, "Settings", Icons.Filled.Person),
+    History(Screen.History, "History", Icons.Filled.History),
+    Profile(Screen.Profile, "Settings", Icons.Filled.Settings),
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -203,10 +216,17 @@ private fun AppScaffold(
                 currentScreen is Screen.Diagnostics
             TopAppBar(
                 title = {
+                    // Named per screen rather than a constant "Garage": the bar
+                    // is the only thing that says where you are once the tab bar
+                    // is off-screen (rail and 3-pane modes have no tab labels),
+                    // and "Garage" on the History tab tells the user nothing they
+                    // did not already know. Home keeps the app name.
                     Text(
                         text = when (currentScreen) {
                             is Screen.FunctionList -> "Function list"
                             is Screen.Diagnostics -> "Diagnostics"
+                            is Screen.History -> "History"
+                            is Screen.Profile -> "Settings"
                             else -> "Garage"
                         },
                     )

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/RemoteButtonContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/RemoteButtonContent.kt
@@ -27,8 +27,12 @@ import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.chriscartland.garage.R
 import com.chriscartland.garage.domain.model.RemoteButtonState
 import com.chriscartland.garage.ui.theme.PreviewComponentSurface
 
@@ -61,15 +65,50 @@ fun RemoteButtonContent(
             onTap = onTap,
             modifier = Modifier.fillMaxWidth(),
         )
+        // The diagram is the only thing that says *where* a send is: at the
+        // server, at the door, or stalled. Its icons are individually
+        // decorative, so without a description on the group a screen-reader
+        // user gets the button label and nothing else. Collapsed into one node
+        // announcing the phase, mirroring iOS's `RemoteProgressDiagram`.
+        val phaseDescription = state.phaseDescription()
         NetworkProgressDiagram(
             state = state.toNetworkDiagramState(),
             icons = GARAGE_DIAGRAM_ICONS,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 8.dp),
+                .padding(horizontal = 8.dp)
+                .then(
+                    if (phaseDescription == null) {
+                        Modifier
+                    } else {
+                        Modifier.semantics(mergeDescendants = true) {
+                            contentDescription = phaseDescription
+                        }
+                    },
+                ),
         )
     }
 }
+
+/**
+ * Spoken description of what the diagram is currently showing, or null while
+ * the button is idle (nothing has been sent, so there is no progress to
+ * report). Wording mirrors iOS's phase labels.
+ */
+@Composable
+private fun RemoteButtonState.phaseDescription(): String? =
+    when (this) {
+        RemoteButtonState.SendingToServer -> stringResource(R.string.remote_diagram_sending_to_server)
+        RemoteButtonState.SendingToDoor -> stringResource(R.string.remote_diagram_sending_to_door)
+        RemoteButtonState.Succeeded -> stringResource(R.string.remote_diagram_succeeded)
+        RemoteButtonState.ServerFailed -> stringResource(R.string.remote_diagram_server_failed)
+        RemoteButtonState.DoorFailed -> stringResource(R.string.remote_diagram_door_failed)
+        RemoteButtonState.AwaitingConfirmation -> stringResource(R.string.remote_diagram_armed)
+        RemoteButtonState.Ready,
+        RemoteButtonState.Preparing,
+        RemoteButtonState.Cancelled,
+        -> null
+    }
 
 // region Previews
 

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryFormatter.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryFormatter.kt
@@ -39,9 +39,13 @@ import java.util.Locale
  */
 object HistoryFormatter {
     /**
-     * Format an epoch-seconds time as a locale-aware "h:mm a" string
-     * (e.g. "9:47 AM"). Tests use [Locale.US] for reproducibility —
-     * production renders in the device locale.
+     * Format an epoch-seconds time as "h:mm a" (e.g. "9:47 AM").
+     *
+     * The pattern and [Locale.US] are fixed, in production as well as in tests
+     * — this is NOT locale-aware, despite what this comment used to claim. A
+     * device set to 24-hour time still sees AM/PM here. iOS renders History the
+     * same way, so the two platforms agree; if this is ever localized, both
+     * sides should change together.
      */
     fun formatTime(
         timeSeconds: Long,

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
@@ -34,7 +34,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Login
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.outlined.NotificationsActive
-import androidx.compose.material.icons.outlined.SignalWifiOff
+import androidx.compose.material.icons.outlined.SensorsOff
 import androidx.compose.material.icons.outlined.WarningAmber
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -600,7 +600,10 @@ private fun HomeAlertCard(
     onAction: () -> Unit,
 ) {
     val icon = when (alert) {
-        HomeAlert.Stale -> Icons.Outlined.SignalWifiOff
+        // Same Sensors family as DeviceCheckInPill: both mean "the device
+        // stopped checking in", so they should not use two different
+        // no-signal metaphors on one screen.
+        HomeAlert.Stale -> Icons.Outlined.SensorsOff
         is HomeAlert.PermissionMissing -> Icons.Outlined.NotificationsActive
         is HomeAlert.FetchError -> Icons.Outlined.WarningAmber
     }

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/DiagnosticsContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/DiagnosticsContent.kt
@@ -47,6 +47,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -67,8 +68,6 @@ import com.chriscartland.garage.ui.theme.PreviewScreenSurface
 import com.chriscartland.garage.ui.theme.Spacing
 import com.chriscartland.garage.ui.theme.safeListContentPadding
 import com.chriscartland.garage.viewmodel.DiagnosticsViewModel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -121,12 +120,16 @@ fun DiagnosticsScreen(
     )
 
     val clearInFlight by diagnosticsViewModel.clearInFlight.collectAsState()
+    val exportScope = rememberCoroutineScope()
 
     val csvLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.StartActivityForResult(),
     ) { result ->
         val uri = result.data?.data ?: return@rememberLauncherForActivityResult
-        CoroutineScope(Dispatchers.IO).launch {
+        // A composition-scoped scope, not a bare `CoroutineScope(Dispatchers.IO)`:
+        // an unmanaged scope is never cancelled, so leaving the screen mid-export
+        // leaves the write running against a screen that is gone.
+        exportScope.launch {
             // ADR-033: the CSV is built by the VM; the UI does only the write.
             writeCsvToUri(diagnosticsViewModel.buildExportCsv(), context, uri)
         }

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SettingsContent.kt
@@ -163,7 +163,9 @@ fun SettingsContent(
                     AccountRowState.SignedOut -> SettingsRow(
                         icon = Icons.AutoMirrored.Outlined.Login,
                         title = stringResource(R.string.settings_account_sign_in),
-                        subtitle = null,
+                        // Says why it is worth doing, rather than leaving the
+                        // user to guess what signing in buys them.
+                        subtitle = stringResource(R.string.settings_account_sign_in_subtitle),
                         showChevron = false,
                         onClick = onSignInTap,
                     )

--- a/MobileGarage/androidApp/src/main/res/values-night/themes.xml
+++ b/MobileGarage/androidApp/src/main/res/values-night/themes.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2024 Chris Cartland. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<!--
+  Dark-mode counterpart of values/themes.xml.
+
+  The manifest theme is what the system splash and the pre-Compose window
+  background are drawn from — before any Compose code runs and can consult
+  `isSystemInDarkTheme()`. With only a Light parent, launching in dark mode
+  flashed a full white screen and then snapped to the dark UI. iOS never had
+  this because its generated launch screen follows `systemBackground`.
+-->
+<resources>
+    <style name="Theme.Garage" parent="android:Theme.Material.NoActionBar" />
+</resources>

--- a/MobileGarage/androidApp/src/main/res/values/strings.xml
+++ b/MobileGarage/androidApp/src/main/res/values/strings.xml
@@ -25,9 +25,33 @@
     <string name="settings_section_about">About</string>
     <string name="settings_section_developer">Developer</string>
 
+    <!-- Home — remote button states. The two failure states are named
+         separately: the shared RemoteButtonState distinguishes a server refusal
+         from a door that never moved, and those call for different reactions. -->
+    <string name="remote_button_ready">Tap to open or close</string>
+    <string name="remote_button_confirm_title">Door will move.</string>
+    <string name="remote_button_confirm_subtitle">Tap again to confirm</string>
+    <string name="remote_button_preparing">Preparing…</string>
+    <string name="remote_button_cancelled">Cancelled</string>
+    <string name="remote_button_sending">Sending…</string>
+    <string name="remote_button_waiting">Waiting for door…</string>
+    <string name="remote_button_succeeded">Done</string>
+    <string name="remote_button_server_failed">Server error</string>
+    <string name="remote_button_door_failed">Door did not move</string>
+
+    <!-- Home — spoken description of the phone/server/door progress diagram.
+         The icons are decorative individually; the group announces the phase. -->
+    <string name="remote_diagram_armed">Armed, waiting for confirmation</string>
+    <string name="remote_diagram_sending_to_server">Sending to server</string>
+    <string name="remote_diagram_sending_to_door">Waiting for the door to respond</string>
+    <string name="remote_diagram_succeeded">Door responded</string>
+    <string name="remote_diagram_server_failed">Server did not accept the request</string>
+    <string name="remote_diagram_door_failed">Door did not respond</string>
+
     <!-- Settings — Account section rows. -->
     <string name="settings_account_sign_in">Sign in with Google</string>
     <string name="settings_account_checking">Checking sign-in…</string>
+    <string name="settings_account_sign_in_subtitle">Unlocks the remote button and snooze</string>
 
     <!-- Settings — Notifications section row + subtitle states. -->
     <string name="settings_notifications_row_title">Door open notifications</string>
@@ -50,7 +74,7 @@
     <!-- Version row subtitle. %1$s is the versionName, %2$s is the versionCode. -->
     <string name="settings_about_version_subtitle">%1$s (build %2$s)</string>
     <string name="settings_about_play_store_title">Play Store</string>
-    <string name="settings_about_privacy_policy_title">Privacy Policy</string>
+    <string name="settings_about_privacy_policy_title">Privacy policy</string>
 
     <!-- Settings — Developer section rows. -->
     <string name="settings_developer_diagnostics_title">Diagnostics</string>
@@ -249,6 +273,7 @@
 
     <!-- Function List screen — warning paragraph + per-action button labels. -->
     <string name="function_list_warning">Each button below performs a real action immediately. No confirmation prompts. Tapping triggers calls to the server, modifies app state, or wipes local data. Double-check the label before tapping.</string>
+    <string name="function_list_access_denied_title">Functions unavailable</string>
     <string name="function_list_access_denied">Access not enabled for your account.</string>
     <string name="function_list_door_action">Open or close garage door</string>
     <string name="function_list_refresh_door_status">Refresh door status</string>

--- a/MobileGarage/version.properties
+++ b/MobileGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.23.3
+versionName=2.23.4


### PR DESCRIPTION
## What

The Android half of a cross-platform UX audit (iOS half: #1152). Where the two apps disagreed and neither was obviously better, Android stayed the source of truth — so this is the places **iOS was right**, plus Android-only gaps the audit turned up.

## The remote button

Three problems, one surface:

| | Was | Now |
|---|---|---|
| Idle | "Garage Door Button" | "Tap to open or close" |
| Confirm | "Door will move." / "Confirm?" | "Door will move." / "Tap again to confirm" |
| Server refused | "Failed" | "Server error" |
| Door never moved | "Failed" | "Door did not move" |
| Sending / waiting | no indicator | 20 dp spinner |

The failure collapse is the one that matters. The shared `ButtonStateMachine` already distinguishes "the server refused the request" from "the door never moved" — those call for different reactions (retry vs. go look at the door), so rendering both as "Failed" threw away the only diagnostic the user had. iOS named them separately first; this adopts that copy.

All of these strings also moved into `strings.xml`, where the rest of the app's copy lives. The spinner is the in-flight button pattern this repo established in #675 and then didn't apply here.

## Tab icons said the wrong thing

**Settings had a person glyph** — a leftover from when the tab was called Profile — sitting under the word "Settings". History used a calendar for what is a time-ordered log. Now a gear and a history clock, pairing with iOS's `gearshape` / `clock.arrow.circlepath`. The pairing is recorded in the `Tab` KDoc, since the two icon systems can't share a literal glyph and this is exactly how it drifted.

## Launching in dark mode flashed white

`Theme.Garage` had only a `Light` parent and no `values-night`. The manifest theme is what the system splash and the pre-Compose window background are drawn from — before any Compose code runs and can consult `isSystemInDarkTheme()`. iOS never had this because its generated launch screen follows `systemBackground`.

## Accessibility, both directions

- **The progress diagram was silent.** `contentDescription = null` on every icon, no group semantics — a TalkBack user got the button label and no sense of where a press had reached. It now announces the phase ("Sending to server", "Door did not respond"), mirroring iOS's `RemoteProgressDiagram`.
- **The door canvas was too loud.** It announced "Up Arrow" / "Warning Symbol", repeating what the status headline and warning chip already say. iOS hides its canvas outright for this reason; these are now decorative.

## Smaller, all from the audit

- Signed-out row says what signing in unlocks, instead of leaving the user to guess.
- The stale-connection alert used `SignalWifiOff` while the device pill beside it used `SensorsOff` — two no-signal metaphors on one screen. Now one family.
- The Functions locked state was a lone sentence on a blank page, which reads as a failure to load. It gets an icon + title, like iOS's.
- Each tab titles its own screen. A constant "Garage" said nothing on History or Settings, and in rail / 3-pane modes the bar is the only label there is.
- "Privacy Policy" → "Privacy policy", per this repo's own sentence-case rule.
- Diagnostics CSV export ran on a bare `CoroutineScope(Dispatchers.IO)` — never cancelled, so leaving the screen mid-export left the write running against a screen that was gone. Now composition-scoped.
- `HistoryFormatter`'s KDoc claimed production renders in the device locale; the code pins `Locale.US`. Comment corrected rather than behavior changed — iOS renders History the same way, so the platforms agree.

## Verification

`./scripts/validate.sh` — **54 PASS, 0 FAIL, "All checks passed."**

Version **2.23.4** — patch: fixes and polish, no new capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
