### PR TITLE
chore(ios): 0.1.2 — release the parity fixes

### DIFF
--- a/MobileGarage/iosApp/CHANGELOG.md
+++ b/MobileGarage/iosApp/CHANGELOG.md
@@ -19,6 +19,36 @@ Versioning mirrors Android (see `MobileGarage/CHANGELOG.md` § versioning):
 major = rewrite or core-experience shift; minor = a user-facing feature added or
 removed; patch = fixes, polish, refactors. iOS uses independent `ios/N` tags.
 
+## 0.1.2
+
+- **The app stops forgetting what it knew.** On every launch while signed in, it
+  briefly believed you were signed out — long enough for the cleanup that runs
+  on sign-out to delete the cached remote-button status, snooze state, and
+  feature access it had just restored. The visible cost was a few seconds of
+  missing pills and late-appearing rows on each cold start. It now knows about
+  your session from the first moment.
+- **It no longer asks signed-in people to sign in.** Home and Settings treated
+  "we have not heard from Firebase yet" as "signed out", so the sign-in row
+  flashed at the start of every launch. Both now say "Checking sign-in…" until
+  the answer is actually known.
+- **A first launch no longer looks like a fault.** With nothing cached yet, the
+  door read "Unknown" with a warning badge — blaming the door for the app having
+  no data. It now says "Connecting…" with no badge.
+- **Pull to refresh waits for the refresh.** The spinner used to disappear the
+  instant you let go, while the request was still in flight, so the gesture
+  looked like it did nothing. On Home, History, and Settings it now stays until
+  the data actually arrives.
+- **The "not receiving updates" warning stays put.** In History it used to
+  scroll away with the list, taking its Retry button with it.
+- Leaving History, Functions, or Diagnostics now releases their work instead of
+  leaving it running for the rest of the session. History's "took longer than
+  usual" tags are amber rather than alarm red. Times follow your device's
+  12- or 24-hour setting. VoiceOver announces the status pills as buttons and
+  reads the check-in age. Exported diagnostics files are timestamped instead of
+  overwriting each other. On iPad, content no longer stretches the full width of
+  the screen. The account sheet scrolls, so "Sign out" is reachable at large
+  text sizes.
+
 ## 0.1.1
 
 - Fix a launch crash on iOS 16 (crashed every launch on iPhone X / iOS 16.3.1,

--- a/MobileGarage/iosApp/project.yml
+++ b/MobileGarage/iosApp/project.yml
@@ -34,7 +34,7 @@ settings:
     SWIFT_STRICT_CONCURRENCY: minimal
     # KMP gradle Run Script writes outside the Xcode sandbox.
     ENABLE_USER_SCRIPT_SANDBOXING: NO
-    MARKETING_VERSION: "0.1.1"
+    MARKETING_VERSION: "0.1.2"
     CURRENT_PROJECT_VERSION: "1"
 
 packages:


### PR DESCRIPTION
## What

`MARKETING_VERSION` + changelog entry for the fixes that merged in #1152, so `release-ios.sh`'s changelog gate has a matching `## 0.1.2` heading to find.

The entry is written for a TestFlight tester, not a reviewer — what changed on screen and why it mattered, rather than which class held `self` too strongly. The cache bug in particular is described by its visible cost (missing pills, late rows on every cold start) rather than by the null-seeded StateFlow that caused it.

**0.1.2** — patch: fixes and polish, no new capability.

## Next

Once this and #1153 are in, both apps get released: `ios/N` to TestFlight internal and `android/N` to the Play internal track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)