### PR TITLE
fix(android): repair the instrumented tests my title change broke

### DIFF
--- a/MobileGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/BackStackTest.kt
+++ b/MobileGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/BackStackTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.espresso.Espresso
 import com.chriscartland.garage.MainActivity
+import com.chriscartland.garage.ui.NavigationTestMatchers.onSelectableNodeWithText
 import org.junit.Rule
 import org.junit.Test
 
@@ -70,8 +71,9 @@ class BackStackTest {
         composeTestRule.onNodeWithText("History").performClick()
         composeTestRule.waitForIdle()
 
-        // Tap History again
-        composeTestRule.onNodeWithText("History").performClick()
+        // Tap History again. Target the nav item explicitly: the bar now also
+        // reads "History" on this tab, so a bare text match is ambiguous.
+        composeTestRule.onSelectableNodeWithText("History").performClick()
         composeTestRule.waitForIdle()
 
         // Still on History, Back still goes to Home

--- a/MobileGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/ConfigurationChangeTest.kt
+++ b/MobileGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/ConfigurationChangeTest.kt
@@ -6,6 +6,8 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ActivityScenario
 import com.chriscartland.garage.MainActivity
+import com.chriscartland.garage.ui.NavigationTestMatchers.assertTopBarTitle
+import com.chriscartland.garage.ui.NavigationTestMatchers.onSelectableNodeWithText
 import org.junit.Rule
 import org.junit.Test
 
@@ -35,11 +37,11 @@ class ConfigurationChangeTest {
      */
     @Test
     fun appSurvivesActivityRecreation() {
-        composeTestRule.onNodeWithText("Garage").assertIsDisplayed()
+        composeTestRule.assertTopBarTitle("Garage")
 
         composeTestRule.activityRule.scenario.recreate()
 
-        composeTestRule.onNodeWithText("Garage").assertIsDisplayed()
+        composeTestRule.assertTopBarTitle("Garage")
     }
 
     /**
@@ -47,13 +49,13 @@ class ConfigurationChangeTest {
      *
      * Depth-1 to a non-Home destination is the load-bearing assertion:
      * pre-PR-A this would always reset to Home regardless of where the
-     * user was. Asserting that "Privacy Policy" (a Settings-only row)
+     * user was. Asserting that "Privacy policy" (a Settings-only row)
      * is still displayed post-recreate proves the back stack survived.
      *
      * Why not navigate to a sub-screen? Diagnostics and FunctionList
      * are gated by the developer allowlist (`functionListAccess`), so
      * they're not reachable from a fresh install in test conditions.
-     * "Privacy Policy" is in the always-visible "About" section of
+     * "Privacy policy" is in the always-visible "About" section of
      * Settings — independent of auth state, allowlist, or feature flags.
      */
     @Test
@@ -61,13 +63,13 @@ class ConfigurationChangeTest {
         // Navigate to Settings tab.
         composeTestRule.onNodeWithText("Settings").performClick()
         composeTestRule.waitForIdle()
-        // "Privacy Policy" row is unique to Settings and always visible.
-        composeTestRule.onNodeWithText("Privacy Policy").assertIsDisplayed()
+        // "Privacy policy" row is unique to Settings and always visible.
+        composeTestRule.onNodeWithText("Privacy policy").assertIsDisplayed()
 
         composeTestRule.activityRule.scenario.recreate()
 
         // Back stack survived: still on Settings.
-        composeTestRule.onNodeWithText("Privacy Policy").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Privacy policy").assertIsDisplayed()
     }
 
     /**
@@ -80,13 +82,15 @@ class ConfigurationChangeTest {
      */
     @Test
     fun allTabsSurviveRecreation() {
+        // Home's bar keeps the app name; the other tabs title themselves.
+        val expectedTitle = mapOf("Home" to "Garage", "History" to "History", "Settings" to "Settings")
         for (tab in listOf("Home", "History", "Settings")) {
-            composeTestRule.onNodeWithText(tab).performClick()
+            composeTestRule.onSelectableNodeWithText(tab).performClick()
             composeTestRule.waitForIdle()
 
             composeTestRule.activityRule.scenario.recreate()
 
-            composeTestRule.onNodeWithText("Garage").assertIsDisplayed()
+            composeTestRule.assertTopBarTitle(expectedTitle.getValue(tab))
         }
     }
 }

--- a/MobileGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/NavigationSmokeTest.kt
+++ b/MobileGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/NavigationSmokeTest.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.chriscartland.garage.MainActivity
+import com.chriscartland.garage.ui.NavigationTestMatchers.assertTopBarTitle
 import org.junit.Rule
 import org.junit.Test
 
@@ -39,7 +40,7 @@ class NavigationSmokeTest {
     @Test
     fun homeScreenDisplays() {
         // Home is the start destination — should show the top bar
-        composeTestRule.onNodeWithText("Garage").assertIsDisplayed()
+        composeTestRule.assertTopBarTitle("Garage")
     }
 
     @Test
@@ -53,16 +54,17 @@ class NavigationSmokeTest {
     fun navigateToHistory() {
         composeTestRule.onNodeWithText("History").performClick()
         composeTestRule.waitForIdle()
-        // If we get here without crashing, the History screen rendered
-        composeTestRule.onNodeWithText("Garage").assertIsDisplayed()
+        // If we get here without crashing, the History screen rendered. Titles
+        // are per screen, so this also pins which screen we landed on.
+        composeTestRule.assertTopBarTitle("History")
     }
 
     @Test
     fun navigateToProfile() {
         composeTestRule.onNodeWithText("Settings").performClick()
         composeTestRule.waitForIdle()
-        // If we get here without crashing, the Profile screen rendered
-        composeTestRule.onNodeWithText("Garage").assertIsDisplayed()
+        // If we get here without crashing, the Settings screen rendered
+        composeTestRule.assertTopBarTitle("Settings")
     }
 
     @Test
@@ -72,7 +74,7 @@ class NavigationSmokeTest {
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithText("Home").performClick()
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Garage").assertIsDisplayed()
+        composeTestRule.assertTopBarTitle("Garage")
     }
 
     @Test
@@ -87,6 +89,6 @@ class NavigationSmokeTest {
         composeTestRule.onNodeWithText("Home").performClick()
         composeTestRule.waitForIdle()
 
-        composeTestRule.onNodeWithText("Garage").assertIsDisplayed()
+        composeTestRule.assertTopBarTitle("Garage")
     }
 }

--- a/MobileGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/NavigationTestMatchers.kt
+++ b/MobileGarage/androidApp/src/androidTest/java/com/chriscartland/garage/ui/NavigationTestMatchers.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.ui
+
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isSelectable
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onNodeWithTag
+
+/**
+ * Matchers for navigation chrome, where a label can legitimately appear twice.
+ *
+ * The top app bar titles each screen ("History", "Settings"), and the nav rail /
+ * bottom bar labels its tabs with the same words. On the History tab, "History"
+ * therefore matches two nodes, and a bare `onNodeWithText` either fails
+ * outright or silently picks the wrong one. These helpers say which is meant.
+ */
+object NavigationTestMatchers {
+    /** Asserts the top app bar's title reads exactly [title]. */
+    fun ComposeTestRule.assertTopBarTitle(title: String) {
+        onNodeWithTag(TOP_BAR_TITLE_TEST_TAG)
+            .assertIsDisplayed()
+            .assertTextEquals(title)
+    }
+
+    /**
+     * The selectable nav item labelled [label] — a tab, never the bar title.
+     * Tabs carry the Selected semantics property (which is what `assertIsSelected`
+     * reads); a title is plain text.
+     */
+    fun ComposeTestRule.onSelectableNodeWithText(label: String): SemanticsNodeInteraction = onNode(hasText(label) and isSelectable())
+}

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/Main.kt
@@ -60,6 +60,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavBackStack
@@ -132,6 +133,15 @@ sealed interface Screen : NavKey {
     @Serializable
     data object Diagnostics : Screen
 }
+
+/**
+ * Test tag on the top app bar's title.
+ *
+ * Titles are now per screen, so "History" and "Settings" each appear twice on
+ * their own tab: once in the bar, once as the nav label. Instrumented tests must
+ * be able to say which one they mean.
+ */
+const val TOP_BAR_TITLE_TEST_TAG: String = "topBarTitle"
 
 /**
  * Navigation tab definition linking a screen to its UI metadata.
@@ -229,6 +239,7 @@ private fun AppScaffold(
                             is Screen.Profile -> "Settings"
                             else -> "Garage"
                         },
+                        modifier = Modifier.testTag(TOP_BAR_TITLE_TEST_TAG),
                     )
                 },
                 navigationIcon = {


### PR DESCRIPTION
Fixes #1156 — post-merge CI red on `1aeebb0d`.

## Five failures, five mine

| Test | Asserted |
|---|---|
| `ConfigurationChangeTest.nonHomeTabSurvivesRecreation` | "Privacy Policy" |
| `ConfigurationChangeTest.allTabsSurviveRecreation` | "Garage" on every tab |
| `NavigationSmokeTest.navigateToHistory` | "Garage" |
| `NavigationSmokeTest.navigateToProfile` | "Garage" |
| `BackStackTest.tappingCurrentTabIsNoOp` | *"Failed to inject touch input"* |

The first four are direct consequences of 2.23.4: per-screen titles mean the bar no longer says "Garage" on History or Settings, and the privacy row is sentence case now.

**The fifth is the one worth reading.** `Failed to inject touch input` reads like an emulator flake, and the honest first instinct was to re-run it. It isn't a flake. That test taps "History" *while already on History* — and now that the bar titles itself, the text "History" matches **two** nodes: the bar title and the nav label. The tap had nothing unambiguous to hit.

## So the fix isn't find-and-replace

Swapping the expected strings would leave the ambiguity in place for the next screen title anyone adds.

- The top bar title carries a **test tag**, and assertions go through `assertTopBarTitle(…)` — which says *"the bar reads X"*, not *"this text exists somewhere on screen"*.
- Tab taps that could now be ambiguous go through `onSelectableNodeWithText(…)`, matching the nav item rather than the title. Tabs carry the `Selected` semantics property (it's what `assertIsSelected` already reads); a title is plain text.
- Both live in `NavigationTestMatchers`, so this collision doesn't quietly come back.

`allTabsSurviveRecreation` now asserts the title each tab *actually* shows (Home keeps the app name; the others title themselves) instead of one constant, which makes it a stronger check than before.

## How this reached main

Instrumented tests need a device, so they're not in `validate.sh` — which was green on all 54 checks. The guardrail hook warns on navigation changes for exactly this reason, and I didn't act on it.

Verified properly this time: booted a phone emulator and ran the real suite.

```
:androidApp:connectedDebugAndroidTest → 75 tests, 0 failures, 0 errors
```

(All five above included.) Plus `./scripts/validate.sh` — 54 PASS, 0 FAIL.

## No version bump

2.23.4 already shipped as `android/275`. This is test code plus one test tag, which is inert in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)