### PR TITLE
refactor: one type decides what the snooze row says

### DIFF
--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/ProfileContent.kt
@@ -47,9 +47,10 @@ import com.chriscartland.garage.di.rememberAppComponent
 import com.chriscartland.garage.domain.model.AppLinks
 import com.chriscartland.garage.domain.model.AuthState
 import com.chriscartland.garage.domain.model.SnoozeAction
-import com.chriscartland.garage.domain.model.SnoozeState
 import com.chriscartland.garage.domain.model.WatchInstallAction
 import com.chriscartland.garage.permissions.rememberNotificationPermissionState
+import com.chriscartland.garage.presentation.SnoozeRowStatus
+import com.chriscartland.garage.presentation.SnoozeRowStatusMapper
 import com.chriscartland.garage.ui.settings.AccountBottomSheet
 import com.chriscartland.garage.ui.settings.AccountRowState
 import com.chriscartland.garage.ui.settings.NavRailBottomSheet
@@ -65,6 +66,7 @@ import com.google.accompanist.permissions.isGranted
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 /**
  * Settings screen — bottom-nav destination. Sectioned-list redesign
@@ -192,12 +194,11 @@ fun ProfileContent(
         // Cold start: don't flash the sign-in CTA before Firebase resolves.
         AuthState.Unknown -> AccountRowState.Checking
     }
-    val notificationsGranted = notificationPermissionState.status.isGranted
-    val snoozeRowState = if (notificationsGranted) {
-        ProfileContentHelpers.snoozeRowStateOf(snoozeState)
-    } else {
-        SnoozeRowState.PermissionDenied
-    }
+    val snoozeRowStatus = SnoozeRowStatusMapper.forState(
+        snoozeState = snoozeState,
+        notificationsGranted = notificationPermissionState.status.isGranted,
+    )
+    val snoozeRowState = ProfileContentHelpers.displayFor(snoozeRowStatus)
 
     Box(modifier = modifier) {
         SettingsContent(
@@ -218,7 +219,9 @@ fun ProfileContent(
             onAccountTap = { accountSheetOpen = true },
             onSignInTap = { googleSignIn.launchSignIn() },
             onSnoozeTap = {
-                if (notificationsGranted) {
+                // Branch on the same status the row rendered from, so the tap
+                // target can never disagree with the label above it.
+                if (snoozeRowStatus !is SnoozeRowStatus.PermissionDenied) {
                     // Force-refresh (not TTL-gated): the sheet pre-selects
                     // from the current state, and opening it is the one
                     // user gesture that deserves an immediate uncached
@@ -337,13 +340,31 @@ fun ProfileContent(
 }
 
 private object ProfileContentHelpers {
-    private val snoozeTimeFormatter = DateTimeFormatter.ofPattern("h:mm a")
+    /**
+     * Localized short time — "5:30 PM" in the US, "17:30" where that is the
+     * convention. Was a hardcoded `ofPattern("h:mm a")`, which forced 12-hour
+     * AM/PM on every locale; whether a clock is 12- or 24-hour is a property of
+     * the locale, not of this app.
+     */
+    private val snoozeTimeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
 
-    fun snoozeRowStateOf(state: SnoozeState): SnoozeRowState =
-        when (state) {
-            SnoozeState.Loading -> SnoozeRowState.Loading
-            SnoozeState.NotSnoozing -> SnoozeRowState.Off
-            is SnoozeState.Snoozing -> SnoozeRowState.SnoozingUntil(formatSnoozeTime(state.untilEpochSeconds))
+    /**
+     * Renders the shared [SnoozeRowStatus] into the display-ready shape the
+     * stateless [SettingsContent] takes.
+     *
+     * The shared type carries an instant; this is where it becomes text. The
+     * two types look near-identical on purpose — the difference is that one is
+     * the decision (shared, testable, platform-neutral) and the other is a
+     * preview-friendly render input, which is why previews can pass a fixed
+     * `"5:30 PM"` and stay independent of the machine's time zone.
+     */
+    fun displayFor(status: SnoozeRowStatus): SnoozeRowState =
+        when (status) {
+            SnoozeRowStatus.Loading -> SnoozeRowState.Loading
+            SnoozeRowStatus.PermissionDenied -> SnoozeRowState.PermissionDenied
+            SnoozeRowStatus.Off -> SnoozeRowState.Off
+            is SnoozeRowStatus.SnoozingUntil ->
+                SnoozeRowState.SnoozingUntil(formatSnoozeTime(status.untilEpochSeconds))
         }
 
     fun formatSnoozeTime(epochSeconds: Long): String =

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SnoozeBottomSheet.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/settings/SnoozeBottomSheet.kt
@@ -52,6 +52,25 @@ import com.chriscartland.garage.R
 import com.chriscartland.garage.domain.model.SnoozeDurationUIOption
 
 /**
+ * Android wording for the shared [SnoozeDurationUIOption] set.
+ *
+ * The option list and its order are a shared product decision; the words are
+ * not. Keeping the mapping exhaustive means adding a duration to the shared
+ * enum is a compile error here until it has a label, rather than an option that
+ * quietly never renders.
+ */
+private object SnoozeDurationLabels {
+    fun resourceFor(option: SnoozeDurationUIOption): Int =
+        when (option) {
+            SnoozeDurationUIOption.None -> R.string.settings_snooze_option_none
+            SnoozeDurationUIOption.OneHour -> R.string.settings_snooze_option_one_hour
+            SnoozeDurationUIOption.FourHours -> R.string.settings_snooze_option_four_hours
+            SnoozeDurationUIOption.EightHours -> R.string.settings_snooze_option_eight_hours
+            SnoozeDurationUIOption.TwelveHours -> R.string.settings_snooze_option_twelve_hours
+        }
+}
+
+/**
  * Production wrapper. Shows the sheet content inside a [ModalBottomSheet].
  * Tracks the user's pending selection locally; only commits via [onSave].
  *
@@ -122,35 +141,18 @@ fun SnoozeSheetContent(
             style = MaterialTheme.typography.titleLarge,
         )
 
-        SnoozeOptionRow(
-            label = stringResource(R.string.settings_snooze_option_none),
-            selected = selectedOption == SnoozeDurationUIOption.None,
-            onClick = { onOptionSelected(SnoozeDurationUIOption.None) },
-        )
-        HorizontalDivider()
-        SnoozeOptionRow(
-            label = stringResource(R.string.settings_snooze_option_one_hour),
-            selected = selectedOption == SnoozeDurationUIOption.OneHour,
-            onClick = { onOptionSelected(SnoozeDurationUIOption.OneHour) },
-        )
-        HorizontalDivider()
-        SnoozeOptionRow(
-            label = stringResource(R.string.settings_snooze_option_four_hours),
-            selected = selectedOption == SnoozeDurationUIOption.FourHours,
-            onClick = { onOptionSelected(SnoozeDurationUIOption.FourHours) },
-        )
-        HorizontalDivider()
-        SnoozeOptionRow(
-            label = stringResource(R.string.settings_snooze_option_eight_hours),
-            selected = selectedOption == SnoozeDurationUIOption.EightHours,
-            onClick = { onOptionSelected(SnoozeDurationUIOption.EightHours) },
-        )
-        HorizontalDivider()
-        SnoozeOptionRow(
-            label = stringResource(R.string.settings_snooze_option_twelve_hours),
-            selected = selectedOption == SnoozeDurationUIOption.TwelveHours,
-            onClick = { onOptionSelected(SnoozeDurationUIOption.TwelveHours) },
-        )
+        // Driven off the shared enum rather than five hand-written rows, so a
+        // duration added there appears here (and on iOS) instead of silently
+        // existing in the model with no way to pick it. The label `when` is
+        // exhaustive, so a new option fails the build until it has wording.
+        SnoozeDurationUIOption.entries.forEachIndexed { index, option ->
+            if (index > 0) HorizontalDivider()
+            SnoozeOptionRow(
+                label = stringResource(SnoozeDurationLabels.resourceFor(option)),
+                selected = selectedOption == option,
+                onClick = { onOptionSelected(option) },
+            )
+        }
 
         Spacer(Modifier.height(8.dp))
         Row(

--- a/MobileGarage/iosApp/Features/Settings/SettingsScreen.swift
+++ b/MobileGarage/iosApp/Features/Settings/SettingsScreen.swift
@@ -69,8 +69,7 @@ struct SettingsScreen: View {
             authState: wrapper.authState,
             displayName: wrapper.displayName,
             email: wrapper.email,
-            snoozeLabel: wrapper.snoozeLabel,
-            snoozeSnoozing: wrapper.snoozeSnoozing,
+            snoozeRow: wrapper.snoozeRow,
             snoozeSending: wrapper.snoozeSending,
             snoozeError: wrapper.snoozeError,
             durations: wrapper.durations,
@@ -80,7 +79,6 @@ struct SettingsScreen: View {
             appBuild: Self.appBuild,
             appPackage: Self.appPackage,
             appBuilt: Self.appBuilt,
-            notificationsGranted: wrapper.notificationsGranted,
             snoozeOptionEnabled: wrapper.snoozeOptionEnabled,
             onSignIn: { wrapper.signInWithGoogle() },
             onSignOut: { wrapper.signOut() },
@@ -123,10 +121,10 @@ struct SettingsContentView: View {
     let authState: AuthDisplayState
     let displayName: String?
     let email: String?
-    let snoozeLabel: String
-    /// Whether a snooze is currently active — drives the row icon
-    /// (mirrors Android's `SnoozeRowState.SnoozingUntil` icon swap).
-    var snoozeSnoozing: Bool = false
+    /// The whole snooze row as one value: which state, and (when snoozing) the
+    /// already-formatted time. Replaced a label/flag/permission trio that made
+    /// the view responsible for their precedence.
+    let snoozeRow: SnoozeRowDisplay
     let snoozeSending: Bool
     let snoozeError: String?
     let durations: [(label: String, option: SnoozeDurationUIOption)]
@@ -136,7 +134,6 @@ struct SettingsContentView: View {
     let appBuild: String
     let appPackage: String
     let appBuilt: String
-    var notificationsGranted: Bool = true
     /// Server-config gate (`AppConfig.snoozeNotificationsOption`). Android hides
     /// the whole Notifications section when the server turns snooze off; this
     /// mirrors it so the two platforms honor the same switch. Defaults to the
@@ -161,8 +158,7 @@ struct SettingsContentView: View {
         authState: AuthDisplayState,
         displayName: String?,
         email: String?,
-        snoozeLabel: String,
-        snoozeSnoozing: Bool = false,
+        snoozeRow: SnoozeRowDisplay,
         snoozeSending: Bool,
         snoozeError: String?,
         durations: [(label: String, option: SnoozeDurationUIOption)],
@@ -172,7 +168,6 @@ struct SettingsContentView: View {
         appBuild: String,
         appPackage: String,
         appBuilt: String,
-        notificationsGranted: Bool = true,
         snoozeOptionEnabled: Bool = true,
         onSignIn: @escaping () -> Void,
         onSignOut: @escaping () -> Void,
@@ -183,8 +178,7 @@ struct SettingsContentView: View {
         self.authState = authState
         self.displayName = displayName
         self.email = email
-        self.snoozeLabel = snoozeLabel
-        self.snoozeSnoozing = snoozeSnoozing
+        self.snoozeRow = snoozeRow
         self.snoozeSending = snoozeSending
         self.snoozeError = snoozeError
         self.durations = durations
@@ -194,7 +188,6 @@ struct SettingsContentView: View {
         self.appBuild = appBuild
         self.appPackage = appPackage
         self.appBuilt = appBuilt
-        self.notificationsGranted = notificationsGranted
         self.snoozeOptionEnabled = snoozeOptionEnabled
         self.onSignIn = onSignIn
         self.onSignOut = onSignOut
@@ -249,44 +242,32 @@ struct SettingsContentView: View {
             // mirroring Android's `showSnoozeRow` gate.
             if snoozeOptionEnabled {
                 Section("Notifications") {
-                    if notificationsGranted {
-                        // The duration picker lives in a sheet this row opens —
-                        // current state reads as the subtitle (Android's snooze
-                        // row + SnoozeBottomSheet pattern).
-                        Button { snoozeSheetOpen = true } label: {
-                            SettingsRowLabel(
-                                // bell.badge.slash = snoozed by you; bell.slash =
-                                // blocked by the OS (below). Distinct on purpose:
-                                // sharing one glyph made a snooze you set look
-                                // identical to notifications you cannot receive.
-                                icon: snoozeSnoozing ? "bell.badge.slash" : "bell",
-                                title: "Door open notifications",
-                                subtitle: snoozeLabel,
-                                showChevron: !snoozeSending,
-                                inFlight: snoozeSending
-                            )
+                    // One row for all four states. Icon, subtitle and tap target
+                    // all read from `snoozeRow`, so they cannot disagree with each
+                    // other — the previous two-branch form derived them from
+                    // separate booleans, which is how a snooze you set came to look
+                    // identical to notifications you could not receive.
+                    Button {
+                        if snoozeRow.opensDurationSheet {
+                            snoozeSheetOpen = true
+                        } else {
+                            onEnableNotifications()
                         }
-                        .buttonStyle(.plain)
-                        .disabled(snoozeSending)
-                        if let error = snoozeError {
-                            Label(error, systemImage: "exclamationmark.triangle")
-                                .font(.footnote)
-                                .foregroundStyle(GarageColors.statusWarning)
-                        }
-                    } else {
-                        // Notifications denied — snoozing is meaningless without them,
-                        // so replace the controls with a tap-to-enable row (mirrors
-                        // Android's SnoozeRowState.PermissionDenied, whose tap calls
-                        // launchPermissionRequest()).
-                        Button(action: onEnableNotifications) {
-                            SettingsRowLabel(
-                                icon: "bell.slash",
-                                title: "Door open notifications",
-                                subtitle: "Notifications disabled. Tap to enable.",
-                                showChevron: false
-                            )
-                        }
-                        .buttonStyle(.plain)
+                    } label: {
+                        SettingsRowLabel(
+                            icon: snoozeRow.icon,
+                            title: "Door open notifications",
+                            subtitle: snoozeRow.subtitle,
+                            showChevron: snoozeRow.opensDurationSheet && !snoozeSending,
+                            inFlight: snoozeSending
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(snoozeSending)
+                    if let error = snoozeError {
+                        Label(error, systemImage: "exclamationmark.triangle")
+                            .font(.footnote)
+                            .foregroundStyle(GarageColors.statusWarning)
                     }
                 }
             }
@@ -334,7 +315,7 @@ struct SettingsContentView: View {
         .refreshable { await onRefresh() }
         .sheet(isPresented: $snoozeSheetOpen) {
             SnoozeSheetView(
-                currentLabel: snoozeLabel,
+                currentLabel: snoozeRow.subtitle,
                 durations: durations,
                 onSave: { option in
                     onSnooze(option)
@@ -593,16 +574,14 @@ private struct CopyableValueRow: View {
 // — never a `private` file-scope helper. Hence the durations are inlined here.
 
 #Preview("Settings signed out") {
-    let durations: [(label: String, option: SnoozeDurationUIOption)] = [
-        ("Don't snooze", .none), ("1 hour", .oneHour), ("4 hours", .fourHours),
-        ("8 hours", .eightHours), ("12 hours", .twelveHours),
-    ]
+    let durations: [(label: String, option: SnoozeDurationUIOption)] =
+        SnoozeDurationUIOption.allCases.map { (SnoozeDurationLabels.text(for: $0), $0) }
     return NavigationStack {
         SettingsContentView(
             authState: .signedOut,
             displayName: nil,
             email: nil,
-            snoozeLabel: "Notifications enabled",
+            snoozeRow: .off,
             snoozeSending: false,
             snoozeError: nil,
             durations: durations,
@@ -618,17 +597,14 @@ private struct CopyableValueRow: View {
 }
 
 #Preview("Settings signed in developer") {
-    let durations: [(label: String, option: SnoozeDurationUIOption)] = [
-        ("Don't snooze", .none), ("1 hour", .oneHour), ("4 hours", .fourHours),
-        ("8 hours", .eightHours), ("12 hours", .twelveHours),
-    ]
+    let durations: [(label: String, option: SnoozeDurationUIOption)] =
+        SnoozeDurationUIOption.allCases.map { (SnoozeDurationLabels.text(for: $0), $0) }
     return NavigationStack {
         SettingsContentView(
             authState: .signedIn,
             displayName: "Chris Cartland",
             email: "chris@example.com",
-            snoozeLabel: "Snoozing until 9:00 PM",
-            snoozeSnoozing: true,
+            snoozeRow: .snoozingUntil("9:00 PM"),
             snoozeSending: false,
             snoozeError: nil,
             durations: durations,
@@ -644,16 +620,14 @@ private struct CopyableValueRow: View {
 }
 
 #Preview("Settings snooze sending") {
-    let durations: [(label: String, option: SnoozeDurationUIOption)] = [
-        ("Don't snooze", .none), ("1 hour", .oneHour), ("4 hours", .fourHours),
-        ("8 hours", .eightHours), ("12 hours", .twelveHours),
-    ]
+    let durations: [(label: String, option: SnoozeDurationUIOption)] =
+        SnoozeDurationUIOption.allCases.map { (SnoozeDurationLabels.text(for: $0), $0) }
     return NavigationStack {
         SettingsContentView(
             authState: .signedIn,
             displayName: "Chris Cartland",
             email: "chris@example.com",
-            snoozeLabel: "Notifications enabled",
+            snoozeRow: .off,
             snoozeSending: true,
             snoozeError: nil,
             durations: durations,
@@ -669,16 +643,14 @@ private struct CopyableValueRow: View {
 }
 
 #Preview("Settings notifications disabled") {
-    let durations: [(label: String, option: SnoozeDurationUIOption)] = [
-        ("Don't snooze", .none), ("1 hour", .oneHour), ("4 hours", .fourHours),
-        ("8 hours", .eightHours), ("12 hours", .twelveHours),
-    ]
+    let durations: [(label: String, option: SnoozeDurationUIOption)] =
+        SnoozeDurationUIOption.allCases.map { (SnoozeDurationLabels.text(for: $0), $0) }
     return NavigationStack {
         SettingsContentView(
             authState: .signedIn,
             displayName: "Chris Cartland",
             email: "chris@example.com",
-            snoozeLabel: "Notifications enabled",
+            snoozeRow: .permissionDenied,
             snoozeSending: false,
             snoozeError: nil,
             durations: durations,
@@ -688,17 +660,14 @@ private struct CopyableValueRow: View {
             appBuild: "1",
             appPackage: "com.chriscartland.garage",
             appBuilt: "2026-01-15 12:00:00 UTC",
-            notificationsGranted: false,
             onSignIn: {}, onSignOut: {}, onSnooze: { _ in }, onRefresh: {}
         )
     }
 }
 
 #Preview("Snooze sheet nothing selected") {
-    let durations: [(label: String, option: SnoozeDurationUIOption)] = [
-        ("Don't snooze", .none), ("1 hour", .oneHour), ("4 hours", .fourHours),
-        ("8 hours", .eightHours), ("12 hours", .twelveHours),
-    ]
+    let durations: [(label: String, option: SnoozeDurationUIOption)] =
+        SnoozeDurationUIOption.allCases.map { (SnoozeDurationLabels.text(for: $0), $0) }
     return SnoozeSheetContentView(
         currentLabel: "Not snoozing",
         durations: durations,
@@ -710,10 +679,8 @@ private struct CopyableValueRow: View {
 }
 
 #Preview("Snooze sheet option selected") {
-    let durations: [(label: String, option: SnoozeDurationUIOption)] = [
-        ("Don't snooze", .none), ("1 hour", .oneHour), ("4 hours", .fourHours),
-        ("8 hours", .eightHours), ("12 hours", .twelveHours),
-    ]
+    let durations: [(label: String, option: SnoozeDurationUIOption)] =
+        SnoozeDurationUIOption.allCases.map { (SnoozeDurationLabels.text(for: $0), $0) }
     return SnoozeSheetContentView(
         currentLabel: "Snoozing until 9:00 PM",
         durations: durations,

--- a/MobileGarage/iosApp/Features/Settings/SettingsViewModelWrapper.swift
+++ b/MobileGarage/iosApp/Features/Settings/SettingsViewModelWrapper.swift
@@ -27,19 +27,27 @@ final class SettingsViewModelWrapper: ObservableObject {
     @Published private(set) var authState: AuthDisplayState = .checking
     @Published private(set) var displayName: String?
     @Published private(set) var email: String?
-    @Published private(set) var snoozeLabel: String = "Notifications enabled"
-    /// Whether a snooze is currently active — drives the Settings row icon
-    /// (bell vs bell.slash), mirroring Android's `SnoozeRowState` icon swap.
-    @Published private(set) var snoozeSnoozing: Bool = false
+    /// What the snooze row says, as one exhaustive value.
+    ///
+    /// This used to be `snoozeLabel: String` + `snoozeSnoozing: Bool` alongside
+    /// `notificationsGranted`, leaving the view to re-derive which of them wins.
+    /// The shared `SnoozeRowStatusMapper` decides that now; this is its rendered
+    /// projection (see `SnoozeRowDisplay`).
+    @Published private(set) var snoozeRow: SnoozeRowDisplay = .off
     @Published private(set) var snoozeSending: Bool = false
     @Published private(set) var snoozeError: String?
-    /// Whether notification authorization is granted. Drives the snooze section:
-    /// when `false`, the snooze controls are replaced by a "tap to enable" row
-    /// (mirrors Android's `SnoozeRowState.PermissionDenied`). Defaults `true` so
-    /// the prompt doesn't flash before the async read resolves. The notification
-    /// read/request mirror `HomeViewModelWrapper` (per-UI `UNUserNotificationCenter`,
-    /// the analog of Android's runtime permission).
-    @Published private(set) var notificationsGranted: Bool = true
+    /// Whether notification authorization is granted. Feeds the shared mapper,
+    /// which gives a denied permission precedence over any snooze state.
+    /// Defaults `true` so the prompt doesn't flash before the async read
+    /// resolves. The notification read/request mirror `HomeViewModelWrapper`
+    /// (per-UI `UNUserNotificationCenter`, the analog of Android's runtime
+    /// permission).
+    @Published private(set) var notificationsGranted: Bool = true {
+        didSet { recomputeSnoozeRow() }
+    }
+    /// Last snooze state seen from shared, kept so the row can be recomputed
+    /// when the permission changes without a new snooze emission.
+    private var lastSnoozeState: SnoozeState = SnoozeStateNotSnoozing.shared
     /// Tri-state allowlist flags (`nil` = not yet known). The Developer section
     /// is shown only when `developerAccess == true`; the Functions row inside it
     /// only when `functionListAccess == true` — mirrors Android. See FEATURE_FLAGS.md.
@@ -47,13 +55,14 @@ final class SettingsViewModelWrapper: ObservableObject {
     @Published private(set) var functionListAccess: Bool?
 
     /// Duration options exposed to the UI, in display order.
-    let durations: [(label: String, option: SnoozeDurationUIOption)] = [
-        ("Don't snooze", .none),
-        ("1 hour", .oneHour),
-        ("4 hours", .fourHours),
-        ("8 hours", .eightHours),
-        ("12 hours", .twelveHours),
-    ]
+    ///
+    /// Iterated from the shared enum rather than hand-listed, so the set and its
+    /// order stay a single shared decision. `SnoozeDurationUIOption` bridges to a
+    /// Swift enum conforming to `CaseIterable`, and the label switch below is
+    /// exhaustive — adding a duration in shared is a compile error here until it
+    /// has wording, instead of an option that never appears in the sheet.
+    let durations: [(label: String, option: SnoozeDurationUIOption)] =
+        SnoozeDurationUIOption.allCases.map { (SnoozeDurationLabels.text(for: $0), $0) }
 
     /// Server-config gate for the whole snooze surface, read once from the
     /// component's `AppConfig` (it is fixed for the process). Android hides its
@@ -121,17 +130,31 @@ final class SettingsViewModelWrapper: ObservableObject {
         // Counts emissions so `refreshSnooze()` can tell "the fetch came back"
         // from "nothing has happened yet".
         snoozeRevision &+= 1
-        switch onEnum(of: state) {
-        case .snoozing(let snoozing):
-            let date = Date(timeIntervalSince1970: TimeInterval(snoozing.untilEpochSeconds))
-            snoozeLabel = "Snoozing until \(date.formatted(date: .omitted, time: .shortened))"
-            snoozeSnoozing = true
+        lastSnoozeState = state
+        recomputeSnoozeRow()
+    }
+
+    /// Runs the shared precedence, then renders the one arm that carries a time.
+    ///
+    /// Formatting stays here rather than in the view so the stateless
+    /// `SettingsContentView` keeps taking display-ready text — which is what
+    /// lets its snapshots pass a fixed `"9:00 PM"` and stay independent of the
+    /// machine's time zone.
+    private func recomputeSnoozeRow() {
+        let status = SnoozeRowStatusMapper.shared.forState(
+            snoozeState: lastSnoozeState,
+            notificationsGranted: notificationsGranted
+        )
+        switch onEnum(of: status) {
         case .loading:
-            snoozeLabel = "Loading…"
-            snoozeSnoozing = false
-        case .notSnoozing:
-            snoozeLabel = "Notifications enabled"
-            snoozeSnoozing = false
+            snoozeRow = .loading
+        case .permissionDenied:
+            snoozeRow = .permissionDenied
+        case .off:
+            snoozeRow = .off
+        case .snoozingUntil(let snoozing):
+            let date = Date(timeIntervalSince1970: TimeInterval(snoozing.untilEpochSeconds))
+            snoozeRow = .snoozingUntil(date.formatted(date: .omitted, time: .shortened))
         }
     }
 

--- a/MobileGarage/iosApp/Features/Settings/SnoozeRowDisplay.swift
+++ b/MobileGarage/iosApp/Features/Settings/SnoozeRowDisplay.swift
@@ -1,0 +1,76 @@
+import Foundation
+import shared
+
+/// The snooze row's state, with its one time value already rendered.
+///
+/// The mirror of Android's `SnoozeRowState`: a rendered projection of the shared
+/// `SnoozeRowStatus`. The shared type carries an instant because 12- versus
+/// 24-hour is a locale property; this type carries the formatted string because
+/// the stateless view — and therefore the snapshot suite — must not depend on
+/// the host's time zone.
+///
+/// Being one exhaustive enum is the point. The view previously received
+/// `snoozeLabel: String`, `snoozeSnoozing: Bool` and `notificationsGranted: Bool`
+/// and worked out the precedence itself, which is how "you snoozed this" and
+/// "the OS is blocking notifications" ended up sharing a glyph.
+enum SnoozeRowDisplay: Equatable {
+    case loading
+    case permissionDenied
+    case off
+    /// Snoozing until the given already-localized time of day.
+    case snoozingUntil(String)
+
+    /// SF Symbol for each state.
+    ///
+    /// `bell.badge.slash` (snoozed by you) and `bell.slash` (blocked by the OS)
+    /// are deliberately different: one is a choice you can undo here, the other
+    /// sends you to Settings. Android's equivalent pairing is
+    /// `NotificationsPaused` / `NotificationsOff`.
+    var icon: String {
+        switch self {
+        case .loading, .off: return "bell"
+        case .snoozingUntil: return "bell.badge.slash"
+        case .permissionDenied: return "bell.slash"
+        }
+    }
+
+    /// Whether tapping the row opens the duration sheet (versus asking the OS
+    /// for permission). Derived from the same value the row rendered from, so
+    /// the tap target cannot disagree with the label.
+    var opensDurationSheet: Bool { self != .permissionDenied }
+
+    /// Row subtitle.
+    ///
+    /// `String(localized:)` rather than a bare literal so these are extracted
+    /// into the String Catalog — a plain `String` reaching a `Text` is invisible
+    /// to the compiler's extractor (see `docs/IOS_LOCALIZATION.md`).
+    var subtitle: String {
+        switch self {
+        case .loading:
+            return String(localized: "Loading…")
+        case .permissionDenied:
+            return String(localized: "Notifications disabled. Tap to enable.")
+        case .off:
+            return String(localized: "Notifications enabled")
+        case .snoozingUntil(let time):
+            return String(localized: "Snoozing until \(time)")
+        }
+    }
+}
+
+/// iOS wording for the shared `SnoozeDurationUIOption` set.
+///
+/// The options and their order are shared; the words are not. The switch is
+/// exhaustive so a duration added to shared fails the build here until it has a
+/// label.
+enum SnoozeDurationLabels {
+    static func text(for option: SnoozeDurationUIOption) -> String {
+        switch option {
+        case .none: return String(localized: "Don't snooze")
+        case .oneHour: return String(localized: "1 hour")
+        case .fourHours: return String(localized: "4 hours")
+        case .eightHours: return String(localized: "8 hours")
+        case .twelveHours: return String(localized: "12 hours")
+        }
+    }
+}

--- a/MobileGarage/iosApp/GarageControl/Localizable.xcstrings
+++ b/MobileGarage/iosApp/GarageControl/Localizable.xcstrings
@@ -4,6 +4,18 @@
     "%lld": {
       "extractionState": "manual"
     },
+    "1 hour": {
+      "extractionState": "manual"
+    },
+    "12 hours": {
+      "extractionState": "manual"
+    },
+    "4 hours": {
+      "extractionState": "manual"
+    },
+    "8 hours": {
+      "extractionState": "manual"
+    },
     "About": {
       "extractionState": "manual"
     },
@@ -64,6 +76,9 @@
     "Diagnostics": {
       "extractionState": "manual"
     },
+    "Don't snooze": {
+      "extractionState": "manual"
+    },
     "Done": {
       "extractionState": "manual"
     },
@@ -113,6 +128,12 @@
       "extractionState": "manual"
     },
     "Notifications": {
+      "extractionState": "manual"
+    },
+    "Notifications disabled. Tap to enable.": {
+      "extractionState": "manual"
+    },
+    "Notifications enabled": {
       "extractionState": "manual"
     },
     "Open / close door": {
@@ -182,6 +203,9 @@
       "extractionState": "manual"
     },
     "Snooze status": {
+      "extractionState": "manual"
+    },
+    "Snoozing until %@": {
       "extractionState": "manual"
     },
     "Status": {

--- a/MobileGarage/presentation-model/src/commonMain/kotlin/com/chriscartland/garage/presentation/SnoozeRowStatus.kt
+++ b/MobileGarage/presentation-model/src/commonMain/kotlin/com/chriscartland/garage/presentation/SnoozeRowStatus.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.presentation
+
+import com.chriscartland.garage.domain.model.SnoozeState
+
+/**
+ * What the snooze row is currently saying — as four mutually exclusive states.
+ *
+ * The row answers one question ("will I be told when the door is open?"), but
+ * the answer comes from two independent sources: the OS notification permission
+ * and the server-side snooze. Representing that as two booleans, which is what
+ * iOS did, forces every reader to re-derive the precedence between them, and a
+ * reader that gets it wrong is not obviously wrong — it just renders a state
+ * that looks plausible.
+ *
+ * That already cost us one bug: the iOS row used the same bell-with-slash glyph
+ * for "you snoozed this" and "the OS is blocking notifications", so a snooze the
+ * user set looked identical to notifications they could not receive at all. One
+ * exhaustive type makes that collapse visible instead of silent.
+ */
+sealed interface SnoozeRowStatus {
+    /** Snooze state not yet known. Nothing actionable to say. */
+    data object Loading : SnoozeRowStatus
+
+    /**
+     * The OS is withholding notifications, so snoozing is moot. The row
+     * becomes a prompt to grant permission rather than a snooze control.
+     */
+    data object PermissionDenied : SnoozeRowStatus
+
+    /** Notifications will arrive. */
+    data object Off : SnoozeRowStatus
+
+    /**
+     * Snoozing until [untilEpochSeconds].
+     *
+     * Deliberately an instant, not a rendered time. Formatting a clock time is
+     * exactly the kind of thing that has to be locale-aware — 12- versus 24-hour
+     * is a locale property, not a product decision — so each platform formats it
+     * with its own localized formatter.
+     */
+    data class SnoozingUntil(
+        val untilEpochSeconds: Long,
+    ) : SnoozeRowStatus
+}
+
+/**
+ * Resolves the snooze row's state from the two inputs that feed it.
+ *
+ * The one real decision here is the precedence: **a missing notification
+ * permission outranks everything, including [SnoozeState.Loading]**. Permission
+ * is known locally and synchronously; the snooze state is a network fact. If
+ * both are unresolved-looking, the permission is the one the user can act on,
+ * and showing "Loading…" over a denied permission would hide the actual problem
+ * behind a spinner that never resolves into anything useful.
+ *
+ * Whether a save is in flight is deliberately *not* modeled here. Both platforms
+ * already treat it as an orthogonal overlay on the row (a spinner replacing the
+ * chevron) rather than a fifth state, and folding it in would multiply every arm
+ * by two for no gain.
+ */
+object SnoozeRowStatusMapper {
+    fun forState(
+        snoozeState: SnoozeState,
+        notificationsGranted: Boolean,
+    ): SnoozeRowStatus {
+        if (!notificationsGranted) return SnoozeRowStatus.PermissionDenied
+        return when (snoozeState) {
+            SnoozeState.Loading -> SnoozeRowStatus.Loading
+            SnoozeState.NotSnoozing -> SnoozeRowStatus.Off
+            is SnoozeState.Snoozing -> SnoozeRowStatus.SnoozingUntil(snoozeState.untilEpochSeconds)
+        }
+    }
+}

--- a/MobileGarage/presentation-model/src/commonTest/kotlin/com/chriscartland/garage/presentation/SnoozeRowStatusMapperTest.kt
+++ b/MobileGarage/presentation-model/src/commonTest/kotlin/com/chriscartland/garage/presentation/SnoozeRowStatusMapperTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.presentation
+
+import com.chriscartland.garage.domain.model.SnoozeState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SnoozeRowStatusMapperTest {
+    private val allSnoozeStates = listOf(
+        SnoozeState.Loading,
+        SnoozeState.NotSnoozing,
+        SnoozeState.Snoozing(untilEpochSeconds = 1_700_000_000L),
+    )
+
+    @Test
+    fun deniedPermissionOutranksEverySnoozeState() {
+        // The precedence rule, stated as a property rather than three examples:
+        // no snooze state can produce anything but PermissionDenied when the OS
+        // is withholding notifications. Loading is the interesting case — the
+        // one a naive `when (snoozeState)` written first would get wrong.
+        allSnoozeStates.forEach { state ->
+            assertEquals(
+                SnoozeRowStatus.PermissionDenied,
+                SnoozeRowStatusMapper.forState(state, notificationsGranted = false),
+                "snooze state $state should not survive a denied permission",
+            )
+        }
+    }
+
+    @Test
+    fun grantedPermissionNeverReportsPermissionDenied() {
+        allSnoozeStates.forEach { state ->
+            assertTrue(
+                SnoozeRowStatusMapper.forState(state, notificationsGranted = true)
+                    !is SnoozeRowStatus.PermissionDenied,
+                "granted permission should never render as denied (state $state)",
+            )
+        }
+    }
+
+    @Test
+    fun snoozeStateMapsThroughWhenPermissionIsGranted() {
+        assertEquals(
+            SnoozeRowStatus.Loading,
+            SnoozeRowStatusMapper.forState(SnoozeState.Loading, notificationsGranted = true),
+        )
+        assertEquals(
+            SnoozeRowStatus.Off,
+            SnoozeRowStatusMapper.forState(SnoozeState.NotSnoozing, notificationsGranted = true),
+        )
+    }
+
+    @Test
+    fun snoozingCarriesTheInstantUnchanged() {
+        // The row must be able to render the real time, so the instant has to
+        // survive the mapping exactly — no rounding, no re-basing on "now".
+        val until = 1_700_003_600L
+        assertEquals(
+            SnoozeRowStatus.SnoozingUntil(until),
+            SnoozeRowStatusMapper.forState(
+                SnoozeState.Snoozing(untilEpochSeconds = until),
+                notificationsGranted = true,
+            ),
+        )
+    }
+
+    @Test
+    fun snoozingAndOffAreDistinguishable() {
+        // The bug this type exists to prevent: "snoozed by you" collapsing into
+        // the same rendering as "notifications unavailable". Assert the three
+        // notification-relevant answers are three distinct values.
+        val snoozing = SnoozeRowStatusMapper.forState(
+            SnoozeState.Snoozing(untilEpochSeconds = 1L),
+            notificationsGranted = true,
+        )
+        val off = SnoozeRowStatusMapper.forState(SnoozeState.NotSnoozing, notificationsGranted = true)
+        val denied = SnoozeRowStatusMapper.forState(SnoozeState.NotSnoozing, notificationsGranted = false)
+        assertEquals(3, setOf(snoozing, off, denied).size, "these three must not collapse")
+    }
+}


### PR DESCRIPTION
The snooze row answers one question — "will I be told when the door is open?" — from two independent inputs: the OS notification permission and the server-side snooze. Both platforms modeled that as separate values and re-derived the precedence between them at the point of rendering.

That already cost a bug. iOS held `snoozeLabel`, `snoozeSnoozing` and `notificationsGranted` and branched on them in the view, and the two bell-with-slash states collapsed: a snooze the user set looked identical to notifications the OS was withholding. The icon was patched in #1158; the structure that lost the distinction was not.

## Shared owns the decision

```
SnoozeRowStatus = Loading | PermissionDenied | Off | SnoozingUntil(instant)
```

The precedence is stated once: **a missing permission outranks every snooze state, including `Loading`** — permission is known locally and synchronously, and it is the thing the user can actually act on, so hiding it behind a spinner would hide the real problem. Five tests pin the behavior, including that the three notification-relevant answers cannot collapse to fewer than three distinct values.

Each platform now renders one exhaustive switch. On iOS the icon, subtitle and tap target all read from the same value, so they cannot disagree with each other; on Android the tap handler branches on the same status the row rendered from rather than re-reading the permission independently.

## An instant, not text

`SnoozingUntil` carries epoch seconds. Whether a clock reads 12- or 24-hour is a property of the locale, not a product decision. That surfaced a latent bug: Android formatted with a hardcoded `ofPattern("h:mm a")`, forcing AM/PM everywhere. Now `ofLocalizedTime(SHORT)`.

Both platforms keep a small rendered projection (Android's existing `SnoozeRowState`, iOS's new `SnoozeRowDisplay`) holding the already-formatted time. That is deliberate: it keeps the stateless views — and therefore their snapshots — independent of the machine's time zone, which is why the previews can pass a fixed `"9:00 PM"`.

## Five options, written once

Both sides hand-wrote the five snooze durations that the shared enum already defines. They now iterate `SnoozeDurationUIOption` with an exhaustive label mapping, so an option added to shared is a compile error until it has wording, instead of one that silently never appears in the sheet. Removes eight hand-written copies (two production, six previews).

## Side effect

Eight strings lived in the iOS wrapper as plain `String` and were therefore invisible to the compiler's extractor. Moving the wording to the platform edge puts them in the String Catalog — visible in the `Localizable.xcstrings` diff.

## Verification

- `validate.sh` — 54 PASS / 0 FAIL
- `validate-ios.sh` — green, including cold + warm launch smoke
- `presentation-model` tests pass
- **iOS snapshot regen produced zero changed PNGs.** Both platforms already rendered this identically; only the representation moved. One preview needed care: `"Settings notifications disabled"` set its state via the `notificationsGranted: false` parameter I was deleting, so it would have silently become an enabled row.

Follows ADR-035 (#1158) and the diagram refactor (#1160). Still queued from the survey: history duration ladders and row-variant/tag composition, door-headline grouping, and permission-escalation thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)