### PR TITLE
refactor: name the door and nag about permissions once, not twice

### DIFF
--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/home/HomeContent.kt
@@ -62,9 +62,13 @@ import com.chriscartland.garage.R
 import com.chriscartland.garage.domain.model.DoorEvent
 import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.domain.model.RemoteButtonState
+import com.chriscartland.garage.presentation.DoorHeadline
+import com.chriscartland.garage.presentation.DoorHeadlineMapper
 import com.chriscartland.garage.presentation.DoorWarning
 import com.chriscartland.garage.presentation.ElapsedDuration
 import com.chriscartland.garage.presentation.HomeAlert
+import com.chriscartland.garage.presentation.PermissionNagLine
+import com.chriscartland.garage.presentation.PermissionNagMapper
 import com.chriscartland.garage.presentation.SinceStatus
 import com.chriscartland.garage.ui.DeviceCheckInPill
 import com.chriscartland.garage.ui.DoorStatusInfoBottomSheet
@@ -446,57 +450,51 @@ private fun doorWarningText(warning: DoorWarning): String =
  */
 @Composable
 private fun notificationJustificationText(attemptCount: Int): String {
-    val base = stringResource(R.string.notification_justification_base)
-    val attempt = attemptCount
-    val attempt3 = if (attempt > 2) {
-        stringResource(R.string.notification_justification_attempt_3)
-    } else {
-        null
-    }
-    val attempt4 = if (attempt > 3) {
-        stringResource(R.string.notification_justification_attempt_4)
-    } else {
-        null
-    }
-    val attempt5 = if (attempt > 4) {
-        stringResource(R.string.notification_justification_attempt_5, attempt)
-    } else {
-        null
-    }
+    // A plain loop, not joinToString: `stringResource` is @Composable and
+    // cannot be called from a lambda passed to a non-inline function.
+    val lines = PermissionNagMapper.linesFor(attemptCount)
     return buildString {
-        append(base)
-        attempt3?.let { append("\n").append(it) }
-        attempt4?.let { append("\n").append(it) }
-        attempt5?.let { append("\n").append(it) }
+        lines.forEachIndexed { index, line ->
+            if (index > 0) append("\n")
+            append(notificationJustificationLine(line, attemptCount))
+        }
     }
 }
 
+/** Android wording for one shared [PermissionNagLine]. */
+@Composable
+private fun notificationJustificationLine(
+    line: PermissionNagLine,
+    attemptCount: Int,
+): String =
+    when (line) {
+        PermissionNagLine.BASE ->
+            stringResource(R.string.notification_justification_base)
+        PermissionNagLine.MENTION_SETTINGS ->
+            stringResource(R.string.notification_justification_attempt_3)
+        PermissionNagLine.MENTION_REPEATED_DENIAL ->
+            stringResource(R.string.notification_justification_attempt_4)
+        PermissionNagLine.ATTEMPT_COUNT ->
+            stringResource(R.string.notification_justification_attempt_5, attemptCount)
+    }
+
 /**
- * Resolves a [DoorPosition] to the headline label string for the Status card.
+ * Android wording for the shared [DoorHeadline].
  *
- * Multiple positions share a label by design: `OPENING` and `OPENING_TOO_LONG`
- * both render "Opening"; `OPEN` and `OPEN_MISALIGNED` both render "Open";
- * `CLOSING` and `CLOSING_TOO_LONG` both render "Closing". The anomalous
- * variants surface their distinguishing detail in the [DoorWarning] chip
- * below, not in the headline.
- *
- * Phase 2B of the string-resource migration plan — replaces the previous
- * `HomeMapper.stateLabel(DoorPosition): String` function. The mapper no
- * longer emits user-visible text for the door state; the Composable
- * resolves position to a localized resource at render time.
+ * Which of the nine [DoorPosition]s collapse onto the same headline is decided
+ * in [DoorHeadlineMapper] so both platforms name the door identically; this
+ * only picks the words. The anomalous variants surface what makes them
+ * anomalous in the [DoorWarning] chip below, not here.
  */
 @Composable
 private fun doorStateLabel(doorPosition: DoorPosition): String =
-    when (doorPosition) {
-        DoorPosition.OPEN -> stringResource(R.string.home_door_state_open)
-        DoorPosition.OPEN_MISALIGNED -> stringResource(R.string.home_door_state_open)
-        DoorPosition.CLOSED -> stringResource(R.string.home_door_state_closed)
-        DoorPosition.UNKNOWN -> stringResource(R.string.home_door_state_unknown)
-        DoorPosition.OPENING -> stringResource(R.string.home_door_state_opening)
-        DoorPosition.OPENING_TOO_LONG -> stringResource(R.string.home_door_state_opening)
-        DoorPosition.CLOSING -> stringResource(R.string.home_door_state_closing)
-        DoorPosition.CLOSING_TOO_LONG -> stringResource(R.string.home_door_state_closing)
-        DoorPosition.ERROR_SENSOR_CONFLICT -> stringResource(R.string.home_door_state_sensor_conflict)
+    when (DoorHeadlineMapper.forPosition(doorPosition)) {
+        DoorHeadline.OPEN -> stringResource(R.string.home_door_state_open)
+        DoorHeadline.CLOSED -> stringResource(R.string.home_door_state_closed)
+        DoorHeadline.OPENING -> stringResource(R.string.home_door_state_opening)
+        DoorHeadline.CLOSING -> stringResource(R.string.home_door_state_closing)
+        DoorHeadline.UNKNOWN -> stringResource(R.string.home_door_state_unknown)
+        DoorHeadline.SENSOR_CONFLICT -> stringResource(R.string.home_door_state_sensor_conflict)
     }
 
 /**

--- a/MobileGarage/iosApp/Features/Home/GarageDoorCanvas.swift
+++ b/MobileGarage/iosApp/Features/Home/GarageDoorCanvas.swift
@@ -420,16 +420,20 @@ private extension Color {
 // MARK: - Door state label (mirror HomeContent.doorStateLabel)
 
 extension DoorPosition {
-    /// User-visible label for the door state. Mirrors Android's
-    /// `doorStateLabel(DoorPosition)` + `home_door_state_*` strings.
+    /// iOS wording for the shared `DoorHeadline`.
+    ///
+    /// Which positions collapse onto the same headline is decided by
+    /// `DoorHeadlineMapper`, so the two apps cannot end up naming the same door
+    /// differently; this picks only the words. Anomalous variants say what makes
+    /// them anomalous in the warning chip, not here.
     var statusLabel: String {
-        switch self {
-        case .open, .openMisaligned: return "Open"
-        case .closed: return "Closed"
-        case .unknown: return "Unknown"
-        case .opening, .openingTooLong: return "Opening"
-        case .closing, .closingTooLong: return "Closing"
-        case .errorSensorConflict: return "Sensor conflict"
+        switch DoorHeadlineMapper.shared.forPosition(position: self) {
+        case .open: return String(localized: "Open")
+        case .closed: return String(localized: "Closed")
+        case .opening: return String(localized: "Opening")
+        case .closing: return String(localized: "Closing")
+        case .unknown: return String(localized: "Unknown")
+        case .sensorConflict: return String(localized: "Sensor conflict")
         }
     }
 }

--- a/MobileGarage/iosApp/Features/Home/HomeViewModelWrapper.swift
+++ b/MobileGarage/iosApp/Features/Home/HomeViewModelWrapper.swift
@@ -254,20 +254,32 @@ final class HomeViewModelWrapper: ObservableObject {
     }
 
     /// Assembles the multi-line permission justification from the attempt count.
-    /// Mirrors Android's `notificationJustificationText` escalation (3+, 4+, 5+)
-    /// but with iOS-appropriate wording.
+    ///
+    /// How far the banner escalates is decided by `PermissionNagMapper` — the
+    /// thresholds used to be written out here *and* in Android's
+    /// `notificationJustificationText`, so how insistent the app is about
+    /// notifications was two independent decisions that happened to agree. The
+    /// wording stays here, and stays iOS-specific (it names the iOS Settings
+    /// app).
     private static func justificationText(attemptCount: Int32) -> String {
-        var lines = ["Turn on notifications to get alerted when the door is left open."]
-        if attemptCount > 2 {
-            lines.append("You can manage permissions in the iOS Settings app.")
+        PermissionNagMapper.shared
+            .linesFor(attemptCount: Int32(attemptCount))
+            .map { line(for: $0, attemptCount: attemptCount) }
+            .joined(separator: "\n")
+    }
+
+    /// iOS wording for one shared `PermissionNagLine`.
+    private static func line(for line: PermissionNagLine, attemptCount: Int32) -> String {
+        switch line {
+        case .base:
+            return String(localized: "Turn on notifications to get alerted when the door is left open.")
+        case .mentionSettings:
+            return String(localized: "You can manage permissions in the iOS Settings app.")
+        case .mentionRepeatedDenial:
+            return String(localized: "iOS may be blocking requests because the permission was denied multiple times.")
+        case .attemptCount:
+            return String(localized: "You have tapped the button \(attemptCount) times.")
         }
-        if attemptCount > 3 {
-            lines.append("iOS may be blocking requests because the permission was denied multiple times.")
-        }
-        if attemptCount > 4 {
-            lines.append("You have tapped the button \(attemptCount) times.")
-        }
-        return lines.joined(separator: "\n")
     }
 
     /// Builds the "Since {time} · {duration}" line from the shared typed

--- a/MobileGarage/iosApp/GarageControl/Localizable.xcstrings
+++ b/MobileGarage/iosApp/GarageControl/Localizable.xcstrings
@@ -49,6 +49,12 @@
     "Clearing…": {
       "extractionState": "manual"
     },
+    "Closed": {
+      "extractionState": "manual"
+    },
+    "Closing": {
+      "extractionState": "manual"
+    },
     "Confirm": {
       "extractionState": "manual"
     },
@@ -136,10 +142,16 @@
     "Notifications enabled": {
       "extractionState": "manual"
     },
+    "Open": {
+      "extractionState": "manual"
+    },
     "Open / close door": {
       "extractionState": "manual"
     },
     "Open or close the garage and check back here.": {
+      "extractionState": "manual"
+    },
+    "Opening": {
       "extractionState": "manual"
     },
     "Privacy policy": {
@@ -173,6 +185,9 @@
       "extractionState": "manual"
     },
     "Sending": {
+      "extractionState": "manual"
+    },
+    "Sensor conflict": {
       "extractionState": "manual"
     },
     "Settings": {
@@ -226,6 +241,12 @@
     "Topic": {
       "extractionState": "manual"
     },
+    "Turn on notifications to get alerted when the door is left open.": {
+      "extractionState": "manual"
+    },
+    "Unknown": {
+      "extractionState": "manual"
+    },
     "Unsubscribe test notifications": {
       "extractionState": "manual"
     },
@@ -235,7 +256,16 @@
     "Waiting for the latest door status": {
       "extractionState": "manual"
     },
+    "You can manage permissions in the iOS Settings app.": {
+      "extractionState": "manual"
+    },
+    "You have tapped the button %d times.": {
+      "extractionState": "manual"
+    },
     "You've reached the beginning of your history": {
+      "extractionState": "manual"
+    },
+    "iOS may be blocking requests because the permission was denied multiple times.": {
       "extractionState": "manual"
     }
   },

--- a/MobileGarage/presentation-model/src/commonMain/kotlin/com/chriscartland/garage/presentation/DoorHeadline.kt
+++ b/MobileGarage/presentation-model/src/commonMain/kotlin/com/chriscartland/garage/presentation/DoorHeadline.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.presentation
+
+import com.chriscartland.garage.domain.model.DoorPosition
+
+/**
+ * What the Status card's headline says, as one of six answers.
+ *
+ * Nine [DoorPosition]s collapse to six headlines: the anomalous variants read
+ * the same as their normal counterparts, and surface what makes them anomalous
+ * in the [DoorWarning] chip below instead. A door that has been opening too
+ * long is still, to the person reading the card, *opening*.
+ *
+ * Which positions collapse together is a product decision, and it was being
+ * made twice — a nine-arm `when` on Android, a six-case `switch` on iOS. They
+ * agreed, but nothing held them to it: adding a tenth position would have
+ * compiled on both sides only after two independent edits, and a disagreement
+ * between them would show up as the two apps naming the same door differently.
+ */
+enum class DoorHeadline {
+    OPEN,
+    CLOSED,
+    OPENING,
+    CLOSING,
+    UNKNOWN,
+    SENSOR_CONFLICT,
+}
+
+/** Collapses a [DoorPosition] to the headline the Status card shows for it. */
+object DoorHeadlineMapper {
+    fun forPosition(position: DoorPosition): DoorHeadline =
+        when (position) {
+            // The misaligned/too-long variants deliberately share a headline
+            // with their normal counterpart; the difference is the warning chip.
+            DoorPosition.OPEN, DoorPosition.OPEN_MISALIGNED -> DoorHeadline.OPEN
+            DoorPosition.CLOSED -> DoorHeadline.CLOSED
+            DoorPosition.OPENING, DoorPosition.OPENING_TOO_LONG -> DoorHeadline.OPENING
+            DoorPosition.CLOSING, DoorPosition.CLOSING_TOO_LONG -> DoorHeadline.CLOSING
+            DoorPosition.UNKNOWN -> DoorHeadline.UNKNOWN
+            DoorPosition.ERROR_SENSOR_CONFLICT -> DoorHeadline.SENSOR_CONFLICT
+        }
+}

--- a/MobileGarage/presentation-model/src/commonMain/kotlin/com/chriscartland/garage/presentation/PermissionNag.kt
+++ b/MobileGarage/presentation-model/src/commonMain/kotlin/com/chriscartland/garage/presentation/PermissionNag.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.presentation
+
+/**
+ * One line of the notification-permission justification banner.
+ *
+ * The banner escalates: it opens with the reason, and as the user keeps
+ * declining it adds progressively more pointed explanations. Each arm is one
+ * line; the platform supplies the sentence.
+ */
+enum class PermissionNagLine {
+    /** Why the app wants notifications at all. Always present. */
+    BASE,
+
+    /** Points at the OS settings app, where the decision can be reversed. */
+    MENTION_SETTINGS,
+
+    /** Explains that the OS itself may now be suppressing the prompt. */
+    MENTION_REPEATED_DENIAL,
+
+    /**
+     * States how many times the button has been tapped. The platform
+     * interpolates the count it already holds on the alert.
+     */
+    ATTEMPT_COUNT,
+}
+
+/**
+ * Decides how far the permission banner escalates for a given attempt count.
+ *
+ * The thresholds are a product decision about how hard to push, and they were
+ * written out twice — `attempt > 2 / > 3 / > 4` on Android, `attemptCount > 2 /
+ * > 3 / > 4` on iOS. The two happened to agree, but each was free to drift, and
+ * "how insistent is this app about notifications" is exactly the kind of thing
+ * that should not differ by platform.
+ *
+ * Cumulative by construction: every level includes the lines below it, so the
+ * banner only ever grows as the user keeps declining. Returning the lines
+ * themselves rather than a level ordinal keeps the platform's job purely
+ * mechanical — map each arm to a sentence and join.
+ */
+object PermissionNagMapper {
+    /** Lines to show, in display order, for [attemptCount] taps so far. */
+    fun linesFor(attemptCount: Int): List<PermissionNagLine> =
+        buildList {
+            add(PermissionNagLine.BASE)
+            if (attemptCount > MENTION_SETTINGS_AFTER) add(PermissionNagLine.MENTION_SETTINGS)
+            if (attemptCount > MENTION_REPEATED_DENIAL_AFTER) add(PermissionNagLine.MENTION_REPEATED_DENIAL)
+            if (attemptCount > ATTEMPT_COUNT_AFTER) add(PermissionNagLine.ATTEMPT_COUNT)
+        }
+
+    private const val MENTION_SETTINGS_AFTER = 2
+    private const val MENTION_REPEATED_DENIAL_AFTER = 3
+    private const val ATTEMPT_COUNT_AFTER = 4
+}

--- a/MobileGarage/presentation-model/src/commonTest/kotlin/com/chriscartland/garage/presentation/DoorHeadlineMapperTest.kt
+++ b/MobileGarage/presentation-model/src/commonTest/kotlin/com/chriscartland/garage/presentation/DoorHeadlineMapperTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.presentation
+
+import com.chriscartland.garage.domain.model.DoorPosition
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DoorHeadlineMapperTest {
+    @Test
+    fun everyPositionHasAHeadline() {
+        // Guards the mapper against a DoorPosition added later: the `when` is
+        // exhaustive so this cannot actually throw, but the assertion documents
+        // that total coverage is the contract, not an accident.
+        DoorPosition.entries.forEach { position ->
+            DoorHeadlineMapper.forPosition(position)
+        }
+    }
+
+    @Test
+    fun anomalousVariantsShareTheirNormalHeadline() {
+        // The core product rule: an anomaly changes the warning chip, not the
+        // headline. A door that has been opening too long is still "opening".
+        assertEquals(
+            DoorHeadlineMapper.forPosition(DoorPosition.OPEN),
+            DoorHeadlineMapper.forPosition(DoorPosition.OPEN_MISALIGNED),
+        )
+        assertEquals(
+            DoorHeadlineMapper.forPosition(DoorPosition.OPENING),
+            DoorHeadlineMapper.forPosition(DoorPosition.OPENING_TOO_LONG),
+        )
+        assertEquals(
+            DoorHeadlineMapper.forPosition(DoorPosition.CLOSING),
+            DoorHeadlineMapper.forPosition(DoorPosition.CLOSING_TOO_LONG),
+        )
+    }
+
+    @Test
+    fun ninePositionsCollapseToSixHeadlines() {
+        val distinct = DoorPosition.entries.map { DoorHeadlineMapper.forPosition(it) }.toSet()
+        assertEquals(6, distinct.size)
+        // ...and every headline is reachable, so none is dead.
+        assertEquals(DoorHeadline.entries.toSet(), distinct)
+    }
+
+    @Test
+    fun openAndClosedNeverShareAHeadline() {
+        // The one collapse that would be a real bug. Stated explicitly because
+        // the "n positions to m headlines" count above would still pass if two
+        // opposite states were merged and two others split.
+        assertTrue(
+            DoorHeadlineMapper.forPosition(DoorPosition.OPEN) !=
+                DoorHeadlineMapper.forPosition(DoorPosition.CLOSED),
+        )
+        assertTrue(
+            DoorHeadlineMapper.forPosition(DoorPosition.OPENING) !=
+                DoorHeadlineMapper.forPosition(DoorPosition.CLOSING),
+        )
+    }
+}

--- a/MobileGarage/presentation-model/src/commonTest/kotlin/com/chriscartland/garage/presentation/PermissionNagMapperTest.kt
+++ b/MobileGarage/presentation-model/src/commonTest/kotlin/com/chriscartland/garage/presentation/PermissionNagMapperTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.presentation
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PermissionNagMapperTest {
+    @Test
+    fun baseLineIsAlwaysPresent() {
+        // Including at zero and at absurd counts — the banner must never be empty.
+        listOf(0, 1, 2, 3, 4, 5, 50, Int.MAX_VALUE).forEach { count ->
+            assertTrue(
+                PermissionNagMapper.linesFor(count).contains(PermissionNagLine.BASE),
+                "attemptCount $count dropped the base line",
+            )
+        }
+    }
+
+    @Test
+    fun escalationIsCumulative() {
+        // Each step is a superset of the one before, so the banner only grows.
+        // This is the property the two hand-written ladders were relied on to
+        // have; nothing checked it before.
+        (0..8).forEach { count ->
+            val smaller = PermissionNagMapper.linesFor(count).toSet()
+            val larger = PermissionNagMapper.linesFor(count + 1).toSet()
+            assertTrue(
+                larger.containsAll(smaller),
+                "going from $count to ${count + 1} attempts dropped a line",
+            )
+        }
+    }
+
+    @Test
+    fun thresholdsMatchTheShippedLadder() {
+        // Pins the exact boundaries both platforms shipped: settings at 3+,
+        // repeated-denial at 4+, the tap count at 5+.
+        assertEquals(listOf(PermissionNagLine.BASE), PermissionNagMapper.linesFor(2))
+        assertEquals(
+            listOf(PermissionNagLine.BASE, PermissionNagLine.MENTION_SETTINGS),
+            PermissionNagMapper.linesFor(3),
+        )
+        assertEquals(
+            listOf(
+                PermissionNagLine.BASE,
+                PermissionNagLine.MENTION_SETTINGS,
+                PermissionNagLine.MENTION_REPEATED_DENIAL,
+            ),
+            PermissionNagMapper.linesFor(4),
+        )
+        assertEquals(
+            listOf(
+                PermissionNagLine.BASE,
+                PermissionNagLine.MENTION_SETTINGS,
+                PermissionNagLine.MENTION_REPEATED_DENIAL,
+                PermissionNagLine.ATTEMPT_COUNT,
+            ),
+            PermissionNagMapper.linesFor(5),
+        )
+    }
+
+    @Test
+    fun linesAreOrderedAndUnique() {
+        // Display order is part of the contract — the platform just joins them.
+        val lines = PermissionNagMapper.linesFor(10)
+        assertEquals(lines.distinct(), lines, "a line was emitted twice")
+        assertEquals(
+            lines.sortedBy { PermissionNagLine.entries.indexOf(it) },
+            lines,
+            "lines must come out in declaration order",
+        )
+    }
+}


### PR DESCRIPTION
Two more decisions that were being made independently on each platform.

## Which door states share a headline

Nine `DoorPosition`s collapse onto six headlines. A door that has been opening too long is still, to the person reading the card, *opening* — the anomaly surfaces in the warning chip below, not in the headline.

That grouping is a product decision, and it was written twice: a nine-arm `when` on Android, a six-case `switch` on iOS. They agreed, but nothing held them to it. Adding a tenth position would have needed two independent edits, and a disagreement between them would show up as the two apps naming the same door differently.

`DoorHeadlineMapper` now decides; each platform supplies the words.

## How hard to push about notifications

The permission justification banner escalates at 3, 4 and 5 declines. Both platforms hardcoded `> 2 / > 3 / > 4` separately — "how insistent is this app about notifications" was two decisions that happened to agree.

`PermissionNagMapper` returns the lines to show, in display order; each platform maps an arm to a sentence and joins them. The wording stays per-platform and stays deliberately different — iOS names the iOS Settings app, Android does not.

## Tests

Nine, written as properties rather than examples:

- escalation is cumulative at **every** step, so the banner can only ever grow
- the base line survives every count, including `0` and `Int.MAX_VALUE`
- all nine positions map; exactly six headlines are reachable and none is dead
- **open/closed and opening/closing never collapse** — the one merge that would be a real bug, and one that a bare "nine into six" count would happily pass if two opposite states merged while two others split

## Side effect

Ten more iOS strings move from wrapper-resolved `String` — invisible to the compiler's extractor — into the String Catalog.

## Verification

- `validate.sh` — all checks passed
- `validate-ios.sh` — green, including cold + warm launch smoke
- **iOS snapshot regen produced zero changed PNGs**

One thing worth noting for future Compose work: `stringResource` is `@Composable` and so cannot be called from a lambda passed to a non-inline function, which means `joinToString { ... }` does not compile here. It needs a plain loop. Same trap as the offline-pill mapping in #1158.

Follows ADR-035 (#1158), #1160, #1161. Remaining from the survey: the two history refactors (duration ladders, row-variant/tag composition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)