### PR TITLE
refactor: two duration ladders, decided once

### DIFF
--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryContent.kt
@@ -61,8 +61,12 @@ import com.chriscartland.garage.domain.model.DoorPosition
 import com.chriscartland.garage.presentation.AnomalyKind
 import com.chriscartland.garage.presentation.DayLabel
 import com.chriscartland.garage.presentation.HistoryDay
+import com.chriscartland.garage.presentation.HistoryDurationMapper
 import com.chriscartland.garage.presentation.HistoryEntry
 import com.chriscartland.garage.presentation.HistoryMapper
+import com.chriscartland.garage.presentation.StateSpanDuration
+import com.chriscartland.garage.presentation.StateSpanFraming
+import com.chriscartland.garage.presentation.TransitSpanDuration
 import com.chriscartland.garage.presentation.TransitWarning
 import com.chriscartland.garage.ui.GarageIcon
 import com.chriscartland.garage.ui.theme.DividerInset
@@ -353,9 +357,12 @@ private fun anomalyTitle(kind: AnomalyKind): String =
     }
 
 /**
- * Assemble the localized "Open for X" / "Closed for X" / "X and counting"
- * string for a state-span duration, picking plural / single-unit / multi-unit
- * granularity based on [HistoryFormatter.stateDurationParts].
+ * Android wording for a shared [StateSpanDisplay].
+ *
+ * The bucket and the framing are decided by [HistoryDurationMapper]; this maps
+ * each arm to a localized resource. Plurals go through `plurals.xml` rather
+ * than a hand-picked suffix, because how many plural forms a language has is
+ * not something this app should be deciding.
  */
 @Composable
 private fun stateDurationDisplay(
@@ -363,31 +370,30 @@ private fun stateDurationDisplay(
     isCurrent: Boolean,
     isOpenState: Boolean,
 ): String {
-    val parts = remember(durationSeconds) { HistoryFormatter.stateDurationParts(durationSeconds) }
-    val durationText = when {
-        parts.days >= 1 -> {
-            if (parts.hours == 0) {
-                pluralStringResource(R.plurals.home_duration_days, parts.days, parts.days)
-            } else {
-                stringResource(R.string.history_state_duration_days_with_hours, parts.days, parts.hours)
-            }
-        }
-        parts.hours >= 1 -> {
-            if (parts.minutes == 0) {
-                stringResource(R.string.history_state_duration_hours_only, parts.hours)
-            } else {
-                stringResource(R.string.home_duration_hours_minutes, parts.hours, parts.minutes)
-            }
-        }
-        parts.minutes >= 1 ->
-            pluralStringResource(R.plurals.home_duration_minutes, parts.minutes, parts.minutes)
-        else ->
-            pluralStringResource(R.plurals.home_duration_seconds, parts.seconds, parts.seconds)
+    val display = remember(durationSeconds, isCurrent, isOpenState) {
+        HistoryDurationMapper.stateSpan(durationSeconds, isCurrent = isCurrent, isOpen = isOpenState)
     }
-    return when {
-        isCurrent -> stringResource(R.string.history_state_duration_and_counting, durationText)
-        isOpenState -> stringResource(R.string.history_state_duration_open_for, durationText)
-        else -> stringResource(R.string.history_state_duration_closed_for, durationText)
+    val durationText = when (val d = display.duration) {
+        is StateSpanDuration.Days ->
+            pluralStringResource(R.plurals.home_duration_days, d.days, d.days)
+        is StateSpanDuration.DaysHours ->
+            stringResource(R.string.history_state_duration_days_with_hours, d.days, d.hours)
+        is StateSpanDuration.Hours ->
+            stringResource(R.string.history_state_duration_hours_only, d.hours)
+        is StateSpanDuration.HoursMinutes ->
+            stringResource(R.string.home_duration_hours_minutes, d.hours, d.minutes)
+        is StateSpanDuration.Minutes ->
+            pluralStringResource(R.plurals.home_duration_minutes, d.minutes, d.minutes)
+        is StateSpanDuration.Seconds ->
+            pluralStringResource(R.plurals.home_duration_seconds, d.seconds, d.seconds)
+    }
+    return when (display.framing) {
+        StateSpanFraming.AND_COUNTING ->
+            stringResource(R.string.history_state_duration_and_counting, durationText)
+        StateSpanFraming.OPEN_FOR ->
+            stringResource(R.string.history_state_duration_open_for, durationText)
+        StateSpanFraming.CLOSED_FOR ->
+            stringResource(R.string.history_state_duration_closed_for, durationText)
     }
 }
 
@@ -397,26 +403,20 @@ private fun stateDurationDisplay(
  */
 @Composable
 private fun transitWarningText(warning: TransitWarning): String {
-    val parts = remember(warning.transitSeconds) {
-        HistoryFormatter.transitDurationParts(warning.transitSeconds)
+    val duration = remember(warning.transitSeconds) {
+        HistoryDurationMapper.transitSpan(warning.transitSeconds)
     }
-    val durationText = when {
-        parts.hours >= 1 -> {
-            if (parts.minutes == 0) {
-                stringResource(R.string.history_state_duration_hours_only, parts.hours)
-            } else {
-                stringResource(R.string.home_duration_hours_minutes, parts.hours, parts.minutes)
-            }
-        }
-        parts.minutes >= 1 -> {
-            if (parts.seconds == 0) {
-                pluralStringResource(R.plurals.home_duration_minutes, parts.minutes, parts.minutes)
-            } else {
-                stringResource(R.string.history_transit_minutes_seconds, parts.minutes, parts.seconds)
-            }
-        }
-        else ->
-            pluralStringResource(R.plurals.home_duration_seconds, parts.seconds, parts.seconds)
+    val durationText = when (duration) {
+        is TransitSpanDuration.Hours ->
+            stringResource(R.string.history_state_duration_hours_only, duration.hours)
+        is TransitSpanDuration.HoursMinutes ->
+            stringResource(R.string.home_duration_hours_minutes, duration.hours, duration.minutes)
+        is TransitSpanDuration.Minutes ->
+            pluralStringResource(R.plurals.home_duration_minutes, duration.minutes, duration.minutes)
+        is TransitSpanDuration.MinutesSeconds ->
+            stringResource(R.string.history_transit_minutes_seconds, duration.minutes, duration.seconds)
+        is TransitSpanDuration.Seconds ->
+            pluralStringResource(R.plurals.home_duration_seconds, duration.seconds, duration.seconds)
     }
     return when (warning) {
         is TransitWarning.ToOpen ->

--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryFormatter.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryFormatter.kt
@@ -26,12 +26,11 @@ import java.util.Locale
 /**
  * Pure-function utilities for the History tab.
  *
- * Phase 2E of the string-resource migration plan
- * (`MobileGarage/docs/PENDING_FOLLOWUPS.md` item #1) — locale-aware
- * formatting of times and date labels lives here, alongside the
- * [StateDurationParts] / [TransitDurationParts] decomposition that
- * mirrors `HomeStatusFormatter` for the History context's
- * different display granularities.
+ * Clock-time and date-label formatting only. The duration-granularity
+ * decomposition that used to live here moved to the shared
+ * `HistoryDurationMapper` — both platforms were implementing the same two
+ * ladders, so the buckets are now decided once and each platform supplies
+ * the words.
  *
  * No user-visible label strings are produced here. The Composable
  * layer assembles localized strings via `stringResource` +
@@ -62,74 +61,8 @@ object HistoryFormatter {
      */
     fun formatDate(date: LocalDate): String = date.format(dateFormatter)
 
-    /**
-     * Decompose a state-span duration in seconds into the parts the
-     * Composable uses to pick a granularity:
-     *  - `days >= 1` → render `"$days day [$hours hr]"` (drop hours when 0)
-     *  - `hours >= 1` → render `"$hours hr [$mins min]"` (drop minutes when 0)
-     *  - `minutes >= 1` → render `"$minutes min"`
-     *  - else → render `"$seconds sec"`
-     *
-     * Mirrors `HomeStatusFormatter.durationParts` but drops sub-day
-     * granularity differently — History shows "1 day 5 hr" while Home
-     * shows just "1 day" (Home's "Since X" line stays compact; History's
-     * "Open for X" line wants more precision).
-     */
-    fun stateDurationParts(seconds: Long): StateDurationParts {
-        val safe = seconds.coerceAtLeast(0L)
-        val days = (safe / SECONDS_PER_DAY).toInt()
-        val hours = ((safe % SECONDS_PER_DAY) / SECONDS_PER_HOUR).toInt()
-        val minutes = ((safe % SECONDS_PER_HOUR) / SECONDS_PER_MIN).toInt()
-        val seconds = (safe % SECONDS_PER_MIN).toInt()
-        return StateDurationParts(days, hours, minutes, seconds)
-    }
-
-    /**
-     * Decompose a transit-span duration in seconds. Transits are
-     * typically seconds, occasionally minutes for `_TOO_LONG` cases —
-     * keep seconds suffix at minute scale (the precision helps), drop
-     * seconds at hour scale (rare; readable).
-     *
-     *  - `hours >= 1` → render `"$hours hr [$mins min]"`
-     *  - `minutes >= 1` → render `"$minutes min [$secs sec]"`
-     *  - else → render `"$seconds sec"`
-     */
-    fun transitDurationParts(seconds: Long): TransitDurationParts {
-        val safe = seconds.coerceAtLeast(0L)
-        val hours = (safe / SECONDS_PER_HOUR).toInt()
-        val minutes = ((safe % SECONDS_PER_HOUR) / SECONDS_PER_MIN).toInt()
-        val seconds = (safe % SECONDS_PER_MIN).toInt()
-        return TransitDurationParts(hours, minutes, seconds)
-    }
-
     private val timeFormatter: DateTimeFormatter =
         DateTimeFormatter.ofPattern("h:mm a", Locale.US)
     private val dateFormatter: DateTimeFormatter =
         DateTimeFormatter.ofPattern("EEE, MMM d", Locale.US)
-    private const val SECONDS_PER_MIN = 60L
-    private const val SECONDS_PER_HOUR = 3_600L
-    private const val SECONDS_PER_DAY = 86_400L
 }
-
-/**
- * Decomposed state-span duration. The Composable renders only the
- * top-most non-zero granularity (e.g. days dominates; minutes are
- * shown alongside hours but seconds aren't shown alongside minutes).
- */
-data class StateDurationParts(
-    val days: Int,
-    val hours: Int,
-    val minutes: Int,
-    val seconds: Int,
-)
-
-/**
- * Decomposed transit-span duration. Different shape from
- * [StateDurationParts] because transits never carry day-scale data
- * (they're typically <1 minute, occasionally minutes).
- */
-data class TransitDurationParts(
-    val hours: Int,
-    val minutes: Int,
-    val seconds: Int,
-)

--- a/MobileGarage/androidApp/src/test/java/com/chriscartland/garage/ui/history/HistoryFormatterTest.kt
+++ b/MobileGarage/androidApp/src/test/java/com/chriscartland/garage/ui/history/HistoryFormatterTest.kt
@@ -26,15 +26,10 @@ import java.time.ZoneOffset
 /**
  * Tests for [HistoryFormatter].
  *
- * Phase 2E of the string-resource migration plan
- * (`MobileGarage/docs/PENDING_FOLLOWUPS.md` item #1) — `formatTime`,
- * `stateDurationParts`, `transitDurationParts`, and `formatDate` were
- * moved here from `HistoryMapper`. The Composable layer assembles the
- * final localized strings via `stringResource` + `pluralStringResource`.
- *
- * Tests cover the pure-function decomposition; the localized
- * "Open for X" / "Took Y to open" assembly is screenshot-tested in the
- * `HistoryContent` previews.
+ * Covers clock-time and date-label formatting. The duration-bucket tests
+ * that used to live here moved to `HistoryDurationMapperTest` in
+ * `presentation-model` along with the logic — the ladders are shared now, so
+ * testing them once covers both platforms.
  */
 class HistoryFormatterTest {
     // ---------- formatTime ----------
@@ -80,75 +75,5 @@ class HistoryFormatterTest {
     @Test
     fun formatDate_wednesday() {
         assertEquals("Wed, Apr 22", HistoryFormatter.formatDate(LocalDate.parse("2026-04-22")))
-    }
-
-    // ---------- stateDurationParts ----------
-
-    @Test
-    fun stateDurationParts_zero() {
-        assertEquals(StateDurationParts(0, 0, 0, 0), HistoryFormatter.stateDurationParts(0))
-    }
-
-    @Test
-    fun stateDurationParts_negativeClampsToZero() {
-        assertEquals(StateDurationParts(0, 0, 0, 0), HistoryFormatter.stateDurationParts(-100))
-    }
-
-    @Test
-    fun stateDurationParts_secondsOnly() {
-        assertEquals(StateDurationParts(0, 0, 0, 30), HistoryFormatter.stateDurationParts(30))
-        assertEquals(StateDurationParts(0, 0, 0, 59), HistoryFormatter.stateDurationParts(59))
-    }
-
-    @Test
-    fun stateDurationParts_minutesOnly() {
-        assertEquals(StateDurationParts(0, 0, 1, 0), HistoryFormatter.stateDurationParts(60))
-        assertEquals(StateDurationParts(0, 0, 6, 0), HistoryFormatter.stateDurationParts(6 * 60))
-        assertEquals(StateDurationParts(0, 0, 59, 0), HistoryFormatter.stateDurationParts(59 * 60))
-    }
-
-    @Test
-    fun stateDurationParts_hours() {
-        assertEquals(StateDurationParts(0, 1, 0, 0), HistoryFormatter.stateDurationParts(60 * 60))
-        assertEquals(StateDurationParts(0, 1, 30, 0), HistoryFormatter.stateDurationParts(90 * 60))
-        assertEquals(StateDurationParts(0, 13, 17, 0), HistoryFormatter.stateDurationParts((13 * 60 + 17) * 60L))
-    }
-
-    @Test
-    fun stateDurationParts_days() {
-        assertEquals(StateDurationParts(1, 0, 0, 0), HistoryFormatter.stateDurationParts(24 * 60 * 60))
-        assertEquals(StateDurationParts(1, 1, 0, 0), HistoryFormatter.stateDurationParts(25 * 60 * 60))
-        assertEquals(StateDurationParts(3, 0, 0, 0), HistoryFormatter.stateDurationParts(3 * 24 * 60 * 60))
-    }
-
-    // ---------- transitDurationParts ----------
-
-    @Test
-    fun transitDurationParts_zero() {
-        assertEquals(TransitDurationParts(0, 0, 0), HistoryFormatter.transitDurationParts(0))
-    }
-
-    @Test
-    fun transitDurationParts_negativeClamps() {
-        assertEquals(TransitDurationParts(0, 0, 0), HistoryFormatter.transitDurationParts(-50))
-    }
-
-    @Test
-    fun transitDurationParts_secondsOnly() {
-        assertEquals(TransitDurationParts(0, 0, 30), HistoryFormatter.transitDurationParts(30))
-    }
-
-    @Test
-    fun transitDurationParts_minutes() {
-        assertEquals(TransitDurationParts(0, 1, 0), HistoryFormatter.transitDurationParts(60))
-        assertEquals(TransitDurationParts(0, 1, 30), HistoryFormatter.transitDurationParts(90))
-        assertEquals(TransitDurationParts(0, 4, 0), HistoryFormatter.transitDurationParts(240))
-    }
-
-    @Test
-    fun transitDurationParts_hours() {
-        assertEquals(TransitDurationParts(1, 0, 0), HistoryFormatter.transitDurationParts(60 * 60))
-        assertEquals(TransitDurationParts(1, 30, 0), HistoryFormatter.transitDurationParts(90 * 60))
-        assertEquals(TransitDurationParts(14, 30, 8), HistoryFormatter.transitDurationParts(14 * 3600 + 30 * 60 + 8L))
     }
 }

--- a/MobileGarage/docs/IOS_LOCALIZATION.md
+++ b/MobileGarage/docs/IOS_LOCALIZATION.md
@@ -86,6 +86,27 @@ needs either opening Xcode once per string-adding PR, or a
 `scripts/sync-ios-string-catalog.sh` that merges keys from `$STRINGSDATA_DIR/*.stringsdata`
 (plain plists, `plutil -p` readable).
 
+## `Localizable.xcstrings` conflicts on every parallel PR — regenerate, don't merge
+
+The catalog is a **generated** artifact keyed by string, so any two PRs that add strings
+conflict in it, even when they touch unrelated features. Hit three times in a row across
+#1161 → #1162 → #1163.
+
+Do not hand-merge the JSON. The deterministic resolution mirrors the
+`SCREENSHOT_GALLERY.md` recipe: take main's copy, then re-run the sync, which re-adds your
+keys on top.
+
+```bash
+git checkout --ours MobileGarage/iosApp/GarageControl/Localizable.xcstrings
+git add MobileGarage/iosApp/GarageControl/Localizable.xcstrings
+git rebase --continue
+./scripts/sync-ios-string-catalog.sh          # re-adds this branch's keys
+git add MobileGarage/iosApp/GarageControl/Localizable.xcstrings && git commit --amend --no-edit
+```
+
+The script only ever adds keys, so the result is the union of both branches. Sanity-check
+the printed total: it should equal main's count plus your PR's new keys.
+
 ## Recommended path
 
 Use a **String Catalog** (`.xcstrings`), not classic `.strings`. No downside at Xcode 26 /

--- a/MobileGarage/iosApp/Features/History/HistoryViewModelWrapper.swift
+++ b/MobileGarage/iosApp/Features/History/HistoryViewModelWrapper.swift
@@ -227,32 +227,51 @@ final class HistoryViewModelWrapper: ObservableObject {
 
     // MARK: - Duration formatting (mirrors HistoryContent + HistoryFormatter)
 
-    /// "Open for X" / "Closed for X" / "X and counting". Granularity mirrors
-    /// Android's `stateDurationDisplay`: days dominate (with hours), then hours
-    /// (with minutes), then minutes, then seconds.
+    /// "Open for X" / "Closed for X" / "X and counting".
+    ///
+    /// The bucket and the framing come from the shared `HistoryDurationMapper`;
+    /// this supplies the words. Both were previously reimplemented here against
+    /// Android's `stateDurationDisplay`, on the highest-traffic surface in the
+    /// app — every row of the history list.
     private static func stateDuration(_ seconds: Int64, isCurrent: Bool, isOpen: Bool) -> String {
-        let safe = max(seconds, 0)
-        let days = Int(safe / 86_400)
-        let hours = Int((safe % 86_400) / 3_600)
-        let minutes = Int((safe % 3_600) / 60)
-        let secs = Int(safe % 60)
-        let text: String
-        if days >= 1 {
-            text = hours == 0 ? plural(days, "day") : "\(days) day \(hours) hr"
-        } else if hours >= 1 {
-            text = minutes == 0 ? "\(hours) hr" : "\(hours) hr \(minutes) min"
-        } else if minutes >= 1 {
-            text = "\(minutes) min"
-        } else {
-            text = "\(secs) sec"
+        let display = HistoryDurationMapper.shared.stateSpan(
+            seconds: seconds,
+            isCurrent: isCurrent,
+            isOpen: isOpen
+        )
+        let text = stateDurationText(display.duration)
+        switch display.framing {
+        case .andCounting: return String(localized: "\(text) and counting")
+        case .openFor: return String(localized: "Open for \(text)")
+        case .closedFor: return String(localized: "Closed for \(text)")
         }
-        if isCurrent { return "\(text) and counting" }
-        return isOpen ? "Open for \(text)" : "Closed for \(text)"
     }
 
-    /// "Took X to open/close, longer than expected". Transit granularity mirrors
-    /// Android's `transitWarningText`: hours (with minutes), then minutes (with
-    /// seconds), then seconds.
+    /// iOS wording for one shared `StateSpanDuration` arm.
+    private static func stateDurationText(_ duration: StateSpanDuration) -> String {
+        switch onEnum(of: duration) {
+        case .days(let d):
+            return d.days == 1
+                ? String(localized: "1 day")
+                : String(localized: "\(Int(d.days)) days")
+        case .daysHours(let d):
+            return String(localized: "\(Int(d.days)) day \(Int(d.hours)) hr")
+        case .hours(let d):
+            return String(localized: "\(Int(d.hours)) hr")
+        case .hoursMinutes(let d):
+            return String(localized: "\(Int(d.hours)) hr \(Int(d.minutes)) min")
+        case .minutes(let d):
+            return String(localized: "\(Int(d.minutes)) min")
+        case .seconds(let d):
+            return String(localized: "\(Int(d.seconds)) sec")
+        }
+    }
+
+    /// "Took X to open/close, longer than expected".
+    ///
+    /// Uses the transit ladder, which deliberately keeps seconds at minute
+    /// scale — for a slow door the seconds are the interesting part. See
+    /// `TransitSpanDuration`.
     private static func transitText(_ warning: TransitWarning) -> String {
         let seconds: Int64
         let opening: Bool
@@ -260,25 +279,26 @@ final class HistoryViewModelWrapper: ObservableObject {
         case .toOpen(let w): seconds = w.transitSeconds; opening = true
         case .toClose(let w): seconds = w.transitSeconds; opening = false
         }
-        let safe = max(seconds, 0)
-        let hours = Int(safe / 3_600)
-        let minutes = Int((safe % 3_600) / 60)
-        let secs = Int(safe % 60)
-        let text: String
-        if hours >= 1 {
-            text = minutes == 0 ? "\(hours) hr" : "\(hours) hr \(minutes) min"
-        } else if minutes >= 1 {
-            text = secs == 0 ? "\(minutes) min" : "\(minutes) min \(secs) sec"
-        } else {
-            text = "\(secs) sec"
-        }
+        let text = transitDurationText(HistoryDurationMapper.shared.transitSpan(seconds: seconds))
         return opening
-            ? "Took \(text) to open, longer than expected"
-            : "Took \(text) to close, longer than expected"
+            ? String(localized: "Took \(text) to open, longer than expected")
+            : String(localized: "Took \(text) to close, longer than expected")
     }
 
-    private static func plural(_ value: Int, _ unit: String) -> String {
-        value == 1 ? "\(value) \(unit)" : "\(value) \(unit)s"
+    /// iOS wording for one shared `TransitSpanDuration` arm.
+    private static func transitDurationText(_ duration: TransitSpanDuration) -> String {
+        switch onEnum(of: duration) {
+        case .hours(let d):
+            return String(localized: "\(Int(d.hours)) hr")
+        case .hoursMinutes(let d):
+            return String(localized: "\(Int(d.hours)) hr \(Int(d.minutes)) min")
+        case .minutes(let d):
+            return String(localized: "\(Int(d.minutes)) min")
+        case .minutesSeconds(let d):
+            return String(localized: "\(Int(d.minutes)) min \(Int(d.seconds)) sec")
+        case .seconds(let d):
+            return String(localized: "\(Int(d.seconds)) sec")
+        }
     }
 
     // MARK: - Clock formatting (mirrors HistoryFormatter.formatTime)

--- a/MobileGarage/iosApp/GarageControl/Localizable.xcstrings
+++ b/MobileGarage/iosApp/GarageControl/Localizable.xcstrings
@@ -1,7 +1,34 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "%@ and counting": {
+      "extractionState": "manual"
+    },
     "%lld": {
+      "extractionState": "manual"
+    },
+    "%lld day %lld hr": {
+      "extractionState": "manual"
+    },
+    "%lld days": {
+      "extractionState": "manual"
+    },
+    "%lld hr": {
+      "extractionState": "manual"
+    },
+    "%lld hr %lld min": {
+      "extractionState": "manual"
+    },
+    "%lld min": {
+      "extractionState": "manual"
+    },
+    "%lld min %lld sec": {
+      "extractionState": "manual"
+    },
+    "%lld sec": {
+      "extractionState": "manual"
+    },
+    "1 day": {
       "extractionState": "manual"
     },
     "1 hour": {
@@ -50,6 +77,9 @@
       "extractionState": "manual"
     },
     "Closed": {
+      "extractionState": "manual"
+    },
+    "Closed for %@": {
       "extractionState": "manual"
     },
     "Closing": {
@@ -148,6 +178,9 @@
     "Open / close door": {
       "extractionState": "manual"
     },
+    "Open for %@": {
+      "extractionState": "manual"
+    },
     "Open or close the garage and check back here.": {
       "extractionState": "manual"
     },
@@ -236,6 +269,12 @@
       "extractionState": "manual"
     },
     "This developer panel is gated to allowlisted accounts.": {
+      "extractionState": "manual"
+    },
+    "Took %@ to close, longer than expected": {
+      "extractionState": "manual"
+    },
+    "Took %@ to open, longer than expected": {
       "extractionState": "manual"
     },
     "Topic": {

--- a/MobileGarage/presentation-model/src/commonMain/kotlin/com/chriscartland/garage/presentation/HistoryDuration.kt
+++ b/MobileGarage/presentation-model/src/commonMain/kotlin/com/chriscartland/garage/presentation/HistoryDuration.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.presentation
+
+/**
+ * How long the door sat in one state, bucketed for the History row's
+ * "Open for 2 hr 14 min" line.
+ *
+ * The sibling of [ElapsedDuration], which does the same job for Home's "Since"
+ * line. History needs its own ladder because it wants more precision: Home
+ * shows "1 day" where History shows "1 day 5 hr", because Home's line is a
+ * glance and History's is the record.
+ *
+ * Each arm carries only the units it renders — the leftovers are dropped
+ * deliberately, not lost. Arms map one-to-one onto the string resources both
+ * platforms already have, so wording stays entirely per-platform.
+ */
+sealed interface StateSpanDuration {
+    /** 1+ whole days, on the hour. Leftover minutes dropped. */
+    data class Days(
+        val days: Int,
+    ) : StateSpanDuration
+
+    /** 1+ whole days with leftover hours. Leftover minutes dropped. */
+    data class DaysHours(
+        val days: Int,
+        val hours: Int,
+    ) : StateSpanDuration
+
+    /** Under a day, 1+ hours, on the hour. Leftover seconds dropped. */
+    data class Hours(
+        val hours: Int,
+    ) : StateSpanDuration
+
+    /** Under a day, 1+ hours with leftover minutes. Leftover seconds dropped. */
+    data class HoursMinutes(
+        val hours: Int,
+        val minutes: Int,
+    ) : StateSpanDuration
+
+    /** Under an hour, 1+ minutes. Leftover seconds dropped. */
+    data class Minutes(
+        val minutes: Int,
+    ) : StateSpanDuration
+
+    /** Under a minute. */
+    data class Seconds(
+        val seconds: Int,
+    ) : StateSpanDuration
+}
+
+/**
+ * How long a transit (opening or closing) took, bucketed for the warning tag.
+ *
+ * A *different* ladder from [StateSpanDuration] on purpose. A transit is
+ * normally seconds and occasionally minutes, so seconds stay visible at minute
+ * scale — "2 min 30 sec" is the interesting fact about a slow door, and
+ * rounding it to "2 min" throws away the point. A state span, by contrast, is
+ * normally hours, so its seconds are noise and get dropped.
+ *
+ * The two ladders differing is exactly why they are worth sharing: two
+ * near-identical rules are far easier to accidentally converge or diverge than
+ * one, and both platforms previously carried both.
+ */
+sealed interface TransitSpanDuration {
+    /** 1+ hours, on the hour. */
+    data class Hours(
+        val hours: Int,
+    ) : TransitSpanDuration
+
+    /** 1+ hours with leftover minutes. Leftover seconds dropped — hours-scale
+     *  transits are pathological, and precision stops helping. */
+    data class HoursMinutes(
+        val hours: Int,
+        val minutes: Int,
+    ) : TransitSpanDuration
+
+    /** Under an hour, 1+ minutes, on the minute. */
+    data class Minutes(
+        val minutes: Int,
+    ) : TransitSpanDuration
+
+    /** Under an hour, 1+ minutes with leftover seconds — kept, unlike the
+     *  state-span ladder. */
+    data class MinutesSeconds(
+        val minutes: Int,
+        val seconds: Int,
+    ) : TransitSpanDuration
+
+    /** Under a minute. The common case. */
+    data class Seconds(
+        val seconds: Int,
+    ) : TransitSpanDuration
+}
+
+/**
+ * How a state-span duration is framed in the row.
+ *
+ * The precedence is the decision: **an ongoing span is "and counting"
+ * regardless of which state it is in**. Both platforms encoded that as a
+ * conditional chain that checked `isCurrent` first; stating it once means the
+ * two cannot disagree about whether a currently-open door reads "Open for 3 hr"
+ * or "3 hr and counting".
+ */
+enum class StateSpanFraming {
+    /** Span is still running. */
+    AND_COUNTING,
+
+    /** Completed span, door was open. */
+    OPEN_FOR,
+
+    /** Completed span, door was closed. */
+    CLOSED_FOR,
+}
+
+/** A state span: how long, and how to frame it. */
+data class StateSpanDisplay(
+    val duration: StateSpanDuration,
+    val framing: StateSpanFraming,
+)
+
+/**
+ * Buckets History's two duration ladders.
+ *
+ * Both were implemented twice — `HistoryFormatter.stateDurationParts` +
+ * `stateDurationDisplay` on Android, `stateDuration` / `transitText` on iOS —
+ * with the granularity rules restated in each. That is the highest-reach
+ * duplication in the app: it renders on every row of the history list.
+ *
+ * Negative inputs clamp to zero. A negative span means clock skew between the
+ * device and the server, and "0 sec" is a better answer than a negative
+ * duration or a crash.
+ */
+object HistoryDurationMapper {
+    fun stateSpan(
+        seconds: Long,
+        isCurrent: Boolean,
+        isOpen: Boolean,
+    ): StateSpanDisplay =
+        StateSpanDisplay(
+            duration = stateSpanDuration(seconds),
+            framing = when {
+                // Ongoing outranks which state it is: a door that is open right now
+                // reads "3 hr and counting", not "Open for 3 hr".
+                isCurrent -> StateSpanFraming.AND_COUNTING
+                isOpen -> StateSpanFraming.OPEN_FOR
+                else -> StateSpanFraming.CLOSED_FOR
+            },
+        )
+
+    fun stateSpanDuration(seconds: Long): StateSpanDuration {
+        val safe = seconds.coerceAtLeast(0L)
+        val days = (safe / SECONDS_PER_DAY).toInt()
+        val hours = ((safe % SECONDS_PER_DAY) / SECONDS_PER_HOUR).toInt()
+        val minutes = ((safe % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE).toInt()
+        return when {
+            days >= 1 && hours == 0 -> StateSpanDuration.Days(days)
+            days >= 1 -> StateSpanDuration.DaysHours(days, hours)
+            hours >= 1 && minutes == 0 -> StateSpanDuration.Hours(hours)
+            hours >= 1 -> StateSpanDuration.HoursMinutes(hours, minutes)
+            minutes >= 1 -> StateSpanDuration.Minutes(minutes)
+            else -> StateSpanDuration.Seconds((safe % SECONDS_PER_MINUTE).toInt())
+        }
+    }
+
+    fun transitSpan(seconds: Long): TransitSpanDuration {
+        val safe = seconds.coerceAtLeast(0L)
+        val hours = (safe / SECONDS_PER_HOUR).toInt()
+        val minutes = ((safe % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE).toInt()
+        val secs = (safe % SECONDS_PER_MINUTE).toInt()
+        return when {
+            hours >= 1 && minutes == 0 -> TransitSpanDuration.Hours(hours)
+            hours >= 1 -> TransitSpanDuration.HoursMinutes(hours, minutes)
+            minutes >= 1 && secs == 0 -> TransitSpanDuration.Minutes(minutes)
+            minutes >= 1 -> TransitSpanDuration.MinutesSeconds(minutes, secs)
+            else -> TransitSpanDuration.Seconds(secs)
+        }
+    }
+
+    private const val SECONDS_PER_MINUTE = 60L
+    private const val SECONDS_PER_HOUR = 3_600L
+    private const val SECONDS_PER_DAY = 86_400L
+}

--- a/MobileGarage/presentation-model/src/commonTest/kotlin/com/chriscartland/garage/presentation/HistoryDurationMapperTest.kt
+++ b/MobileGarage/presentation-model/src/commonTest/kotlin/com/chriscartland/garage/presentation/HistoryDurationMapperTest.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.presentation
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class HistoryDurationMapperTest {
+    private val minute = 60L
+    private val hour = 3_600L
+    private val day = 86_400L
+
+    // ---- state span ladder ----
+
+    @Test
+    fun stateSpanPicksTheExpectedBucket() {
+        assertEquals(StateSpanDuration.Seconds(0), HistoryDurationMapper.stateSpanDuration(0))
+        assertEquals(StateSpanDuration.Seconds(59), HistoryDurationMapper.stateSpanDuration(59))
+        assertEquals(StateSpanDuration.Minutes(1), HistoryDurationMapper.stateSpanDuration(minute))
+        assertEquals(StateSpanDuration.Minutes(59), HistoryDurationMapper.stateSpanDuration(59 * minute + 59))
+        assertEquals(StateSpanDuration.Hours(1), HistoryDurationMapper.stateSpanDuration(hour))
+        assertEquals(StateSpanDuration.HoursMinutes(2, 14), HistoryDurationMapper.stateSpanDuration(2 * hour + 14 * minute))
+        assertEquals(StateSpanDuration.Days(1), HistoryDurationMapper.stateSpanDuration(day))
+        assertEquals(StateSpanDuration.DaysHours(1, 5), HistoryDurationMapper.stateSpanDuration(day + 5 * hour))
+    }
+
+    @Test
+    fun stateSpanDropsSecondsAtMinuteScaleAndAbove() {
+        // The defining difference from the transit ladder. A state span of
+        // "2 hr 14 min 37 sec" reads as "2 hr 14 min" — the seconds are noise.
+        assertEquals(
+            HistoryDurationMapper.stateSpanDuration(2 * hour + 14 * minute),
+            HistoryDurationMapper.stateSpanDuration(2 * hour + 14 * minute + 37),
+        )
+        assertEquals(
+            HistoryDurationMapper.stateSpanDuration(5 * minute),
+            HistoryDurationMapper.stateSpanDuration(5 * minute + 59),
+        )
+    }
+
+    @Test
+    fun stateSpanDropsMinutesAtDayScale() {
+        assertEquals(
+            HistoryDurationMapper.stateSpanDuration(3 * day + 7 * hour),
+            HistoryDurationMapper.stateSpanDuration(3 * day + 7 * hour + 42 * minute),
+        )
+    }
+
+    @Test
+    fun stateSpanSeparatesOnTheHourFromWithLeftover() {
+        // Exactly-on-the-unit gets its own arm so the platform can render
+        // "2 hr" rather than "2 hr 0 min".
+        assertEquals(StateSpanDuration.Hours(2), HistoryDurationMapper.stateSpanDuration(2 * hour))
+        assertEquals(StateSpanDuration.HoursMinutes(2, 1), HistoryDurationMapper.stateSpanDuration(2 * hour + minute))
+        assertEquals(StateSpanDuration.Days(2), HistoryDurationMapper.stateSpanDuration(2 * day))
+        assertEquals(StateSpanDuration.DaysHours(2, 1), HistoryDurationMapper.stateSpanDuration(2 * day + hour))
+    }
+
+    // ---- transit span ladder ----
+
+    @Test
+    fun transitSpanPicksTheExpectedBucket() {
+        assertEquals(TransitSpanDuration.Seconds(0), HistoryDurationMapper.transitSpan(0))
+        assertEquals(TransitSpanDuration.Seconds(45), HistoryDurationMapper.transitSpan(45))
+        assertEquals(TransitSpanDuration.Minutes(2), HistoryDurationMapper.transitSpan(2 * minute))
+        assertEquals(TransitSpanDuration.MinutesSeconds(2, 30), HistoryDurationMapper.transitSpan(2 * minute + 30))
+        assertEquals(TransitSpanDuration.Hours(1), HistoryDurationMapper.transitSpan(hour))
+        assertEquals(TransitSpanDuration.HoursMinutes(1, 5), HistoryDurationMapper.transitSpan(hour + 5 * minute))
+    }
+
+    @Test
+    fun transitSpanKeepsSecondsAtMinuteScale() {
+        // The whole reason this is a separate ladder: for a slow door, the
+        // seconds ARE the interesting part. Contrast the state-span test above.
+        assertTrue(
+            HistoryDurationMapper.transitSpan(2 * minute + 30) !=
+                HistoryDurationMapper.transitSpan(2 * minute),
+        )
+        assertEquals(TransitSpanDuration.MinutesSeconds(2, 30), HistoryDurationMapper.transitSpan(2 * minute + 30))
+    }
+
+    @Test
+    fun theTwoLaddersDisagreeAtMinuteScaleAndThatIsTheContract() {
+        // Same input, deliberately different granularity. Pinned so a future
+        // "cleanup" that unifies them fails here with an explanation rather
+        // than silently changing every transit tag in the history list.
+        val seconds = 3 * minute + 20
+        assertEquals(StateSpanDuration.Minutes(3), HistoryDurationMapper.stateSpanDuration(seconds))
+        assertEquals(TransitSpanDuration.MinutesSeconds(3, 20), HistoryDurationMapper.transitSpan(seconds))
+    }
+
+    // ---- clamping ----
+
+    @Test
+    fun negativeSpansClampToZero() {
+        // Clock skew between device and server. Better than a negative duration.
+        assertEquals(StateSpanDuration.Seconds(0), HistoryDurationMapper.stateSpanDuration(-1))
+        assertEquals(StateSpanDuration.Seconds(0), HistoryDurationMapper.stateSpanDuration(-100_000))
+        assertEquals(TransitSpanDuration.Seconds(0), HistoryDurationMapper.transitSpan(-1))
+        assertEquals(TransitSpanDuration.Seconds(0), HistoryDurationMapper.transitSpan(-100_000))
+    }
+
+    // ---- framing ----
+
+    @Test
+    fun ongoingSpansOutrankWhichStateTheyAreIn() {
+        // The precedence both platforms encoded by hand: isCurrent is checked
+        // first, so an open door right now reads "and counting", not "Open for".
+        listOf(true, false).forEach { isOpen ->
+            assertEquals(
+                StateSpanFraming.AND_COUNTING,
+                HistoryDurationMapper.stateSpan(hour, isCurrent = true, isOpen = isOpen).framing,
+                "isCurrent should win regardless of isOpen=$isOpen",
+            )
+        }
+    }
+
+    @Test
+    fun completedSpansAreFramedByState() {
+        assertEquals(
+            StateSpanFraming.OPEN_FOR,
+            HistoryDurationMapper.stateSpan(hour, isCurrent = false, isOpen = true).framing,
+        )
+        assertEquals(
+            StateSpanFraming.CLOSED_FOR,
+            HistoryDurationMapper.stateSpan(hour, isCurrent = false, isOpen = false).framing,
+        )
+    }
+
+    @Test
+    fun framingDoesNotDisturbTheDuration() {
+        // The two halves are independent; bucketing must not depend on framing.
+        val seconds = 2 * hour + 14 * minute
+        val expected = HistoryDurationMapper.stateSpanDuration(seconds)
+        listOf(true to true, true to false, false to true, false to false).forEach { (current, open) ->
+            assertEquals(
+                expected,
+                HistoryDurationMapper.stateSpan(seconds, isCurrent = current, isOpen = open).duration,
+            )
+        }
+    }
+}


### PR DESCRIPTION
The highest-reach duplication in the app — this renders on **every row** of the history list.

## Two ladders, deliberately different

History formats two kinds of duration, and they round differently on purpose:

- A **state span** ("Open for 2 hr 14 min") drops seconds. A door that sat open for two hours does not need them.
- A **transit span** ("Took 2 min 30 sec to open") keeps them. For a slow door, the seconds are the whole point.

Both platforms implemented both ladders — Android in `HistoryFormatter`'s parts-decomposition plus a conditional chain in `HistoryContent`, iOS in two hand-written chains in `HistoryViewModelWrapper`. Four implementations of two rules that differ from each other by exactly one dropped unit, which is the easy kind to accidentally converge.

## What moved

`HistoryDurationMapper` emits typed buckets whose arms map **one-to-one onto the string resources each platform already had**, so no wording moved into shared. Home's "Since" line already got this treatment in ADR-031 (`ElapsedDuration`); History simply never received it. The KDoc records *why* the two ladders differ, so the next reader gets the reason and not just the fact.

Framing is shared too — "and counting" outranks open/closed — so a door that is open right now cannot read "Open for 3 hr" on one platform and "3 hr and counting" on the other.

## Tests

Twelve. The load-bearing one asserts the two ladders **disagree** at minute scale on the same input:

```kotlin
val seconds = 3 * minute + 20
assertEquals(StateSpanDuration.Minutes(3), ...stateSpanDuration(seconds))
assertEquals(TransitSpanDuration.MinutesSeconds(3, 20), ...transitSpan(seconds))
```

That pins the difference, so a future cleanup that "simplifies" them into one ladder fails here with an explanation rather than silently rewriting every transit tag in the list. Others cover the drop-vs-keep rules explicitly, on-the-unit versus with-leftover arms, and negative clamping (clock skew between device and server).

## Deletions

`HistoryFormatter.stateDurationParts` / `transitDurationParts`, both parts data classes, and their 12 now-superseded Android tests — the shared tests cover both platforms.

## Side effect

13 more iOS strings enter the String Catalog. The duration units were built by interpolation inside the wrapper and so were invisible to the compiler's extractor.

## Verification

- `validate.sh` — all checks passed
- `validate-ios.sh` — green, including cold + warm launch smoke
- **iOS snapshot regen produced zero changed PNGs**, on the surface where a rounding slip would have been most visible

Follows ADR-035 (#1158), #1160, #1161, #1162. One survey item remains: history row-variant + tag composition (the "suppress the tag when the headline already says it" rule, still written on both sides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)