### PR TITLE
feat(ios): make the History tab's text translatable

### DIFF
--- a/MobileGarage/iosApp/Core/DisplayText.swift
+++ b/MobileGarage/iosApp/Core/DisplayText.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Text bound for the screen: either translatable copy, or data shown as-is.
+///
+/// The distinction matters because a plain `String` erases it, and the two need
+/// opposite handling. Copy must reach the String Catalog or it can never be
+/// translated; data must never be looked up in the catalog, because translating
+/// a person's name, a formatted date, or a version number is meaningless at best
+/// — and a value that happened to collide with a catalog key would be silently
+/// rewritten into something else.
+///
+/// Deliberately NOT `ExpressibleByStringLiteral`. That would let call sites keep
+/// writing bare literals, but the literal would arrive as a plain `String`
+/// through `init(stringLiteral:)` and never be extracted — reintroducing exactly
+/// the silent failure this type exists to prevent, while looking tidier.
+///
+/// See MobileGarage/docs/IOS_LOCALIZATION.md.
+enum DisplayText {
+    /// Translatable copy. Write the literal inline, so the compiler sees a
+    /// `LocalizedStringResource` and extracts it.
+    case copy(LocalizedStringResource)
+
+    /// A value rendered exactly as given — a name, an email address, an
+    /// already-locale-formatted date, a version string.
+    case data(String)
+
+    /// Renders as a `Text`.
+    ///
+    /// Not `@ViewBuilder`: that would produce `_ConditionalContent`, and callers
+    /// apply `Text`-only modifiers such as `.font`.
+    var view: Text {
+        switch self {
+        case .copy(let resource): return Text(resource)
+        case .data(let string): return Text(verbatim: string)
+        }
+    }
+}

--- a/MobileGarage/iosApp/Features/History/HistoryScreen.swift
+++ b/MobileGarage/iosApp/Features/History/HistoryScreen.swift
@@ -110,7 +110,7 @@ struct HistoryContentView: View {
                             HistoryRow(entry: entry)
                         }
                     } header: {
-                        Text(day.title)
+                        day.title.view
                     }
                 }
                 // Bottom-of-list pagination footer: spinner while an older page
@@ -138,10 +138,13 @@ private struct HistoryRow: View {
                 .frame(width: 40, height: 40)
             VStack(alignment: .leading, spacing: GarageSpacing.tight) {
                 Text(entry.headline)
-                Text(entry.supporting)
+                entry.supporting.view
                     .font(.footnote)
                     .foregroundStyle(.secondary)
-                ForEach(entry.warnings, id: \.self) { warning in
+                // Keyed by position: LocalizedStringResource is not a
+                // dependable identity, and two warnings on one row are
+                // positional anyway.
+                ForEach(Array(entry.warnings.enumerated()), id: \.offset) { _, warning in
                     // Caution, not error: these annotate a past event ("took
                     // longer than usual"), so red would overstate them. Android
                     // uses its muted tertiary tone here.
@@ -234,28 +237,28 @@ private struct HistoryEmptyState: View {
     NavigationStack {
         HistoryContentView(
             days: [
-                .init(id: "today", title: "Today", entries: [
+                .init(id: "today", title: .copy("Today"), entries: [
                     .init(id: "t0", position: .open, headline: "Open",
-                          supporting: "Since 10:15 AM · 12 min and counting", warnings: []),
+                          supporting: .copy("Since 10:15 AM · 12 min and counting"), warnings: []),
                     .init(id: "t1", position: .closed, headline: "Closed at 9:53 AM",
-                          supporting: "Closed for 22 min", warnings: []),
+                          supporting: .copy("Closed for 22 min"), warnings: []),
                     .init(id: "t2", position: .open, headline: "Opened at 9:47 AM",
-                          supporting: "Open for 6 min",
+                          supporting: .copy("Open for 6 min"),
                           warnings: ["Took 4 min to open, longer than expected"]),
                 ]),
-                .init(id: "yesterday", title: "Yesterday", entries: [
+                .init(id: "yesterday", title: .copy("Yesterday"), entries: [
                     .init(id: "y0", position: .errorSensorConflict, headline: "Sensor conflict",
-                          supporting: "11:42 PM", warnings: []),
+                          supporting: .data("11:42 PM"), warnings: []),
                     .init(id: "y1", position: .closed, headline: "Closed at 8:30 PM",
-                          supporting: "Closed for 10 hr 12 min", warnings: []),
+                          supporting: .copy("Closed for 10 hr 12 min"), warnings: []),
                     .init(id: "y2", position: .open, headline: "Opened at 6:30 PM",
-                          supporting: "Open for 2 hr", warnings: []),
+                          supporting: .copy("Open for 2 hr"), warnings: []),
                 ]),
-                .init(id: "2026-4-27", title: "Mon, Apr 27", entries: [
+                .init(id: "2026-4-27", title: .data("Mon, Apr 27"), entries: [
                     .init(id: "d0", position: .openingTooLong, headline: "Stuck opening",
-                          supporting: "5:30 PM", warnings: []),
+                          supporting: .data("5:30 PM"), warnings: []),
                     .init(id: "d1", position: .closed, headline: "Closed at 7:18 AM",
-                          supporting: "Closed for 10 hr 12 min", warnings: []),
+                          supporting: .copy("Closed for 10 hr 12 min"), warnings: []),
                 ]),
             ],
             isLoading: false,
@@ -268,18 +271,18 @@ private struct HistoryEmptyState: View {
     NavigationStack {
         HistoryContentView(
             days: [
-                .init(id: "today", title: "Today", entries: [
+                .init(id: "today", title: .copy("Today"), entries: [
                     .init(id: "t0", position: .closed, headline: "Closed",
-                          supporting: "Since 11:30 AM · 47 min and counting",
+                          supporting: .copy("Since 11:30 AM · 47 min and counting"),
                           warnings: ["Took 3 min to close, longer than expected"]),
                     .init(id: "t1", position: .openMisaligned, headline: "Opened at 11:20 AM",
-                          supporting: "Open for 10 min", warnings: ["Door was misaligned"]),
+                          supporting: .copy("Open for 10 min"), warnings: ["Door was misaligned"]),
                 ]),
-                .init(id: "2026-4-27", title: "Mon, Apr 27", entries: [
+                .init(id: "2026-4-27", title: .data("Mon, Apr 27"), entries: [
                     .init(id: "d0", position: .closingTooLong, headline: "Stuck closing",
-                          supporting: "4:00 PM", warnings: []),
+                          supporting: .data("4:00 PM"), warnings: []),
                     .init(id: "d1", position: .unknown, headline: "Unknown state",
-                          supporting: "11:00 AM", warnings: []),
+                          supporting: .data("11:00 AM"), warnings: []),
                 ]),
             ],
             isLoading: false,
@@ -298,9 +301,9 @@ private struct HistoryEmptyState: View {
     NavigationStack {
         HistoryContentView(
             days: [
-                .init(id: "today", title: "Today", entries: [
+                .init(id: "today", title: .copy("Today"), entries: [
                     .init(id: "t0", position: .closed, headline: "Closed at 9:53 AM",
-                          supporting: "Closed for 22 min", warnings: []),
+                          supporting: .copy("Closed for 22 min"), warnings: []),
                 ]),
             ],
             isLoading: false,
@@ -318,11 +321,11 @@ private struct HistoryEmptyState: View {
     NavigationStack {
         HistoryContentView(
             days: [
-                .init(id: "today", title: "Today", entries: [
+                .init(id: "today", title: .copy("Today"), entries: [
                     .init(id: "t0", position: .closed, headline: "Closed at 9:53 AM",
-                          supporting: "Closed for 22 min", warnings: []),
+                          supporting: .copy("Closed for 22 min"), warnings: []),
                     .init(id: "t1", position: .open, headline: "Opened at 9:47 AM",
-                          supporting: "Open for 6 min", warnings: []),
+                          supporting: .copy("Open for 6 min"), warnings: []),
                 ]),
             ],
             isLoading: false,
@@ -338,9 +341,9 @@ private struct HistoryEmptyState: View {
     NavigationStack {
         HistoryContentView(
             days: [
-                .init(id: "today", title: "Today", entries: [
+                .init(id: "today", title: .copy("Today"), entries: [
                     .init(id: "t0", position: .closed, headline: "Closed at 9:53 AM",
-                          supporting: "Closed for 22 min", warnings: []),
+                          supporting: .copy("Closed for 22 min"), warnings: []),
                 ]),
             ],
             isLoading: false,

--- a/MobileGarage/iosApp/Features/History/HistoryViewModelWrapper.swift
+++ b/MobileGarage/iosApp/Features/History/HistoryViewModelWrapper.swift
@@ -31,7 +31,9 @@ final class HistoryViewModelWrapper: ObservableObject {
     /// One day section: a localized header + its rows (newest-first).
     struct DaySection: Identifiable {
         let id: String
-        let title: String
+        /// "Today"/"Yesterday" are copy; an explicit date is already
+        /// locale-formatted, so it is data. See `DisplayText`.
+        let title: DisplayText
         let entries: [Entry]
     }
 
@@ -40,9 +42,13 @@ final class HistoryViewModelWrapper: ObservableObject {
     struct Entry: Identifiable {
         let id: String
         let position: DoorPosition
-        let headline: String
-        let supporting: String
-        let warnings: [String]
+        /// `LocalizedStringResource`, not `String`: as a `String` these were
+        /// invisible to the compiler's extractor and could never be translated.
+        let headline: LocalizedStringResource
+        /// Copy for the state-duration lines; data for the anomaly rows, whose
+        /// supporting text is just an already-formatted clock time.
+        let supporting: DisplayText
+        let warnings: [LocalizedStringResource]
     }
 
     @Published private(set) var days: [DaySection] = []
@@ -151,19 +157,21 @@ final class HistoryViewModelWrapper: ObservableObject {
         }
     }
 
-    private static func dayTitle(_ label: DayLabel) -> String {
+    private static func dayTitle(_ label: DayLabel) -> DisplayText {
         switch onEnum(of: label) {
-        case .today: return "Today"
-        case .yesterday: return "Yesterday"
+        case .today: return .copy("Today")
+        case .yesterday: return .copy("Yesterday")
         case .date(let d):
             var components = DateComponents()
             components.year = Int(d.year)
             components.month = Int(d.monthNumber)
             components.day = Int(d.dayOfMonth)
             guard let date = Calendar.current.date(from: components) else {
-                return "\(d.monthNumber)/\(d.dayOfMonth)"
+                return .data("\(d.monthNumber)/\(d.dayOfMonth)")
             }
-            return dateLabelFormatter.string(from: date)
+            // Already formatted for the user's locale by the formatter — data,
+            // not copy, so it must not be looked up in the catalog.
+            return .data(dateLabelFormatter.string(from: date))
         }
     }
 
@@ -174,7 +182,7 @@ final class HistoryViewModelWrapper: ObservableObject {
         case .opened(let opened):
             let time = clockText(opened.timeSeconds)
             let duration = stateDuration(opened.durationSeconds, isCurrent: opened.isCurrent, isOpen: true)
-            let headline: String
+            let headline: LocalizedStringResource
             if opened.isCurrent && opened.misaligned {
                 headline = "Open (misaligned)"
             } else if opened.isCurrent {
@@ -182,26 +190,32 @@ final class HistoryViewModelWrapper: ObservableObject {
             } else {
                 headline = "Opened at \(time)"
             }
-            var warnings: [String] = []
+            var warnings: [LocalizedStringResource] = []
             if let warning = opened.transitWarning { warnings.append(transitText(warning)) }
+            // Suppressed when the headline already says "(misaligned)" — the tag
+            // would just repeat it.
             if opened.misaligned && !opened.isCurrent { warnings.append("Door was misaligned") }
             return Entry(
                 id: "\(opened.timeSeconds)-\(index)",
                 position: opened.misaligned ? .openMisaligned : .open,
                 headline: headline,
-                supporting: opened.isCurrent ? "Since \(time) · \(duration)" : duration,
+                supporting: opened.isCurrent
+                    ? .copy("Since \(time) · \(String(localized: duration))")
+                    : .copy(duration),
                 warnings: warnings
             )
         case .closed(let closed):
             let time = clockText(closed.timeSeconds)
             let duration = stateDuration(closed.durationSeconds, isCurrent: closed.isCurrent, isOpen: false)
-            var warnings: [String] = []
+            var warnings: [LocalizedStringResource] = []
             if let warning = closed.transitWarning { warnings.append(transitText(warning)) }
             return Entry(
                 id: "\(closed.timeSeconds)-\(index)",
                 position: .closed,
                 headline: closed.isCurrent ? "Closed" : "Closed at \(time)",
-                supporting: closed.isCurrent ? "Since \(time) · \(duration)" : duration,
+                supporting: closed.isCurrent
+                    ? .copy("Since \(time) · \(String(localized: duration))")
+                    : .copy(duration),
                 warnings: warnings
             )
         case .anomaly(let anomaly):
@@ -209,13 +223,13 @@ final class HistoryViewModelWrapper: ObservableObject {
                 id: "\(anomaly.timeSeconds)-\(index)",
                 position: anomaly.doorPosition,
                 headline: anomalyTitle(anomaly.kind),
-                supporting: clockText(anomaly.timeSeconds),
+                supporting: .data(clockText(anomaly.timeSeconds)),
                 warnings: []
             )
         }
     }
 
-    private static func anomalyTitle(_ kind: AnomalyKind) -> String {
+    private static func anomalyTitle(_ kind: AnomalyKind) -> LocalizedStringResource {
         switch onEnum(of: kind) {
         case .sensorConflict: return "Sensor conflict"
         case .unknownState: return "Unknown state"
@@ -233,7 +247,7 @@ final class HistoryViewModelWrapper: ObservableObject {
     /// this supplies the words. Both were previously reimplemented here against
     /// Android's `stateDurationDisplay`, on the highest-traffic surface in the
     /// app — every row of the history list.
-    private static func stateDuration(_ seconds: Int64, isCurrent: Bool, isOpen: Bool) -> String {
+    private static func stateDuration(_ seconds: Int64, isCurrent: Bool, isOpen: Bool) -> LocalizedStringResource {
         let display = HistoryDurationMapper.shared.stateSpan(
             seconds: seconds,
             isCurrent: isCurrent,
@@ -241,9 +255,9 @@ final class HistoryViewModelWrapper: ObservableObject {
         )
         let text = stateDurationText(display.duration)
         switch display.framing {
-        case .andCounting: return String(localized: "\(text) and counting")
-        case .openFor: return String(localized: "Open for \(text)")
-        case .closedFor: return String(localized: "Closed for \(text)")
+        case .andCounting: return "\(text) and counting"
+        case .openFor: return "Open for \(text)"
+        case .closedFor: return "Closed for \(text)"
         }
     }
 
@@ -272,7 +286,7 @@ final class HistoryViewModelWrapper: ObservableObject {
     /// Uses the transit ladder, which deliberately keeps seconds at minute
     /// scale — for a slow door the seconds are the interesting part. See
     /// `TransitSpanDuration`.
-    private static func transitText(_ warning: TransitWarning) -> String {
+    private static func transitText(_ warning: TransitWarning) -> LocalizedStringResource {
         let seconds: Int64
         let opening: Bool
         switch onEnum(of: warning) {
@@ -281,8 +295,8 @@ final class HistoryViewModelWrapper: ObservableObject {
         }
         let text = transitDurationText(HistoryDurationMapper.shared.transitSpan(seconds: seconds))
         return opening
-            ? String(localized: "Took \(text) to open, longer than expected")
-            : String(localized: "Took \(text) to close, longer than expected")
+            ? "Took \(text) to open, longer than expected"
+            : "Took \(text) to close, longer than expected"
     }
 
     /// iOS wording for one shared `TransitSpanDuration` arm.


### PR DESCRIPTION
Second feature area of the localization sweep. **25 more keys** reach the String Catalog (141 total), including the interpolated forms — `"Opened at %@"`, `"Since %@ · %@"`, `"Took %@ to open, longer than expected"` — that were previously assembled as plain `String`s in the wrapper and so were invisible to the extractor.

## Copy vs data, promoted to `Core/` — and unified

```swift
enum DisplayText {
    case copy(LocalizedStringResource)   // translatable
    case data(String)                    // rendered verbatim
}
```

This also **collapses #1165's `SettingsRowText` into it**. The two were the same idea written twice, which is the exact thing this session has been removing everywhere else — it would have been odd to introduce a fresh instance of it. (#1165 was in flight when History was written, hence the temporary duplication.)

Two places in History are genuinely **data**, and putting them through the catalog would be wrong:

- **A day header that is an explicit date.** `"Today"` / `"Yesterday"` are our words, but `"Mon, Apr 27"` has already been formatted for the user's locale by `DateFormatter`. Translating it again is at best a no-op, at worst a catalog collision that rewrites it.
- **An anomaly row's supporting line**, which is only a clock time. As a `LocalizedStringResource` it would have produced the degenerate catalog key `"%@"` — which every other bare interpolation in the app would then collide with.

## Also

Records, as a comment where the rule actually lives, that the misaligned tag is suppressed when the headline already says `"(misaligned)"` — otherwise the tag just repeats it. That rule is still implemented separately on both platforms; this PR doesn't fix it, it stops it being silent. (It's the one remaining survey item.)

The warnings `ForEach` now keys on position rather than `\.self`: `LocalizedStringResource` is not a dependable identity, and two warnings on one row are positional anyway.

## Verification

- `validate-ios.sh` — 6/6 green, including the localization fence from #1164 and cold + warm launch smoke
- Catalog membership checked **key by key**, not assumed — the failure mode here is "looks right, extracts nothing"
- **iOS snapshot regen produced zero changed PNGs.** Notable here: History is the most snapshot-covered screen and every row's text changed type, so this is a real signal rather than an absence of coverage.

Remaining for the sweep: Home (11 sites), Function list, Diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)