### PR TITLE
refactor: a history row's four decisions, made once

### DIFF
--- a/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryContent.kt
+++ b/MobileGarage/androidApp/src/main/java/com/chriscartland/garage/ui/history/HistoryContent.kt
@@ -63,7 +63,12 @@ import com.chriscartland.garage.presentation.DayLabel
 import com.chriscartland.garage.presentation.HistoryDay
 import com.chriscartland.garage.presentation.HistoryDurationMapper
 import com.chriscartland.garage.presentation.HistoryEntry
+import com.chriscartland.garage.presentation.HistoryHeadline
 import com.chriscartland.garage.presentation.HistoryMapper
+import com.chriscartland.garage.presentation.HistoryRowMapper
+import com.chriscartland.garage.presentation.HistorySupporting
+import com.chriscartland.garage.presentation.HistoryTag
+import com.chriscartland.garage.presentation.StateSpanDisplay
 import com.chriscartland.garage.presentation.StateSpanDuration
 import com.chriscartland.garage.presentation.StateSpanFraming
 import com.chriscartland.garage.presentation.TransitSpanDuration
@@ -251,84 +256,68 @@ private fun HistoryEntryRow(
     entry: HistoryEntry,
     zone: ZoneId,
 ) {
-    when (entry) {
-        is HistoryEntry.Opened -> {
-            val timeDisplay = remember(entry.timeSeconds, zone) {
-                HistoryFormatter.formatTime(entry.timeSeconds, zone)
-            }
-            val durationDisplay = stateDurationDisplay(
-                durationSeconds = entry.durationSeconds,
-                isCurrent = entry.isCurrent,
-                isOpenState = true,
-            )
-            HistoryStateRow(
-                // When misaligned, render the OPEN_MISALIGNED door art so the
-                // misalignment is visible even on a row that's just an "Opened"
-                // event with the misalignment property set.
-                doorPosition = if (entry.misaligned) DoorPosition.OPEN_MISALIGNED else DoorPosition.OPEN,
-                headline = when {
-                    entry.isCurrent && entry.misaligned ->
-                        stringResource(R.string.history_headline_open_misaligned)
-                    entry.isCurrent ->
-                        stringResource(R.string.history_headline_open)
-                    else ->
-                        stringResource(R.string.history_headline_opened_at, timeDisplay)
-                },
-                supporting = if (entry.isCurrent) {
-                    stringResource(R.string.history_supporting_since_format, timeDisplay, durationDisplay)
-                } else {
-                    durationDisplay
-                },
-                warnings = listOfNotNull(
-                    entry.transitWarning?.let { transitWarningText(it) },
-                    // For past Opened rows, surface misalignment as a tag below
-                    // the duration. When isCurrent, the headline already says
-                    // "Open (misaligned)" — no need for a duplicate tag.
-                    if (entry.misaligned && !entry.isCurrent) {
-                        stringResource(R.string.history_warning_misaligned)
-                    } else {
-                        null
-                    },
-                ),
-            )
-        }
-        is HistoryEntry.Closed -> {
-            val timeDisplay = remember(entry.timeSeconds, zone) {
-                HistoryFormatter.formatTime(entry.timeSeconds, zone)
-            }
-            val durationDisplay = stateDurationDisplay(
-                durationSeconds = entry.durationSeconds,
-                isCurrent = entry.isCurrent,
-                isOpenState = false,
-            )
-            HistoryStateRow(
-                doorPosition = DoorPosition.CLOSED,
-                headline = if (entry.isCurrent) {
-                    stringResource(R.string.history_headline_closed)
-                } else {
-                    stringResource(R.string.history_headline_closed_at, timeDisplay)
-                },
-                supporting = if (entry.isCurrent) {
-                    stringResource(R.string.history_supporting_since_format, timeDisplay, durationDisplay)
-                } else {
-                    durationDisplay
-                },
-                warnings = listOfNotNull(entry.transitWarning?.let { transitWarningText(it) }),
-            )
-        }
-        is HistoryEntry.Anomaly -> {
-            val timeDisplay = remember(entry.timeSeconds, zone) {
-                HistoryFormatter.formatTime(entry.timeSeconds, zone)
-            }
-            HistoryStateRow(
-                doorPosition = entry.doorPosition,
-                headline = anomalyTitle(entry.kind),
-                supporting = timeDisplay,
-                warnings = emptyList(),
-            )
-        }
-    }
+    // Every decision this row makes — door art, which headline, which supporting
+    // line, which tags and whether to suppress one — comes from the shared
+    // mapper. This Composable only supplies words.
+    val row = remember(entry) { HistoryRowMapper.forEntry(entry) }
+    HistoryStateRow(
+        doorPosition = row.doorPosition,
+        headline = historyHeadlineText(row.headline, zone),
+        supporting = historySupportingText(row.supporting, zone),
+        warnings = row.tags.map { historyTagText(it) },
+    )
 }
+
+/** Android wording for a shared [HistoryHeadline]. */
+@Composable
+private fun historyHeadlineText(
+    headline: HistoryHeadline,
+    zone: ZoneId,
+): String =
+    when (headline) {
+        HistoryHeadline.OpenNow ->
+            stringResource(R.string.history_headline_open)
+        HistoryHeadline.OpenNowMisaligned ->
+            stringResource(R.string.history_headline_open_misaligned)
+        is HistoryHeadline.OpenedAt ->
+            stringResource(R.string.history_headline_opened_at, clockText(headline.timeSeconds, zone))
+        HistoryHeadline.ClosedNow ->
+            stringResource(R.string.history_headline_closed)
+        is HistoryHeadline.ClosedAt ->
+            stringResource(R.string.history_headline_closed_at, clockText(headline.timeSeconds, zone))
+        is HistoryHeadline.Anomaly ->
+            anomalyTitle(headline.kind)
+    }
+
+/** Android wording for a shared [HistorySupporting]. */
+@Composable
+private fun historySupportingText(
+    supporting: HistorySupporting,
+    zone: ZoneId,
+): String =
+    when (supporting) {
+        is HistorySupporting.SinceWithSpan -> stringResource(
+            R.string.history_supporting_since_format,
+            clockText(supporting.timeSeconds, zone),
+            stateSpanText(supporting.span),
+        )
+        is HistorySupporting.Span -> stateSpanText(supporting.span)
+        is HistorySupporting.ClockTime -> clockText(supporting.timeSeconds, zone)
+    }
+
+/** Android wording for a shared [HistoryTag]. */
+@Composable
+private fun historyTagText(tag: HistoryTag): String =
+    when (tag) {
+        is HistoryTag.Transit -> transitWarningText(tag.warning)
+        HistoryTag.Misaligned -> stringResource(R.string.history_warning_misaligned)
+    }
+
+@Composable
+private fun clockText(
+    timeSeconds: Long,
+    zone: ZoneId,
+): String = remember(timeSeconds, zone) { HistoryFormatter.formatTime(timeSeconds, zone) }
 
 /**
  * Resolve a [DayLabel] to a localized day-section header string.
@@ -365,14 +354,7 @@ private fun anomalyTitle(kind: AnomalyKind): String =
  * not something this app should be deciding.
  */
 @Composable
-private fun stateDurationDisplay(
-    durationSeconds: Long,
-    isCurrent: Boolean,
-    isOpenState: Boolean,
-): String {
-    val display = remember(durationSeconds, isCurrent, isOpenState) {
-        HistoryDurationMapper.stateSpan(durationSeconds, isCurrent = isCurrent, isOpen = isOpenState)
-    }
+private fun stateSpanText(display: StateSpanDisplay): String {
     val durationText = when (val d = display.duration) {
         is StateSpanDuration.Days ->
             pluralStringResource(R.plurals.home_duration_days, d.days, d.days)

--- a/MobileGarage/iosApp/Features/History/HistoryViewModelWrapper.swift
+++ b/MobileGarage/iosApp/Features/History/HistoryViewModelWrapper.swift
@@ -175,57 +175,68 @@ final class HistoryViewModelWrapper: ObservableObject {
         }
     }
 
-    // MARK: - Entry resolution (mirrors HistoryContent.HistoryEntryRow)
+    // MARK: - Entry resolution (words for the shared HistoryRowMapper)
 
+    /// Every decision this row makes — door art, which of six headlines, which
+    /// supporting line, which tags and whether one is suppressed — comes from
+    /// `HistoryRowMapper`. This only supplies the words, and the `id`.
     private static func resolve(_ entry: HistoryEntry, index: Int) -> Entry {
+        let row = HistoryRowMapper.shared.forEntry(entry: entry)
+        return Entry(
+            id: "\(entryTimeSeconds(entry))-\(index)",
+            position: row.doorPosition,
+            headline: headlineText(row.headline),
+            supporting: supportingText(row.supporting),
+            warnings: row.tags.map { tagText($0) }
+        )
+    }
+
+    /// iOS wording for one shared `HistoryHeadline`.
+    private static func headlineText(_ headline: HistoryHeadline) -> LocalizedStringResource {
+        switch onEnum(of: headline) {
+        case .openNow:
+            return "Open"
+        case .openNowMisaligned:
+            return "Open (misaligned)"
+        case .openedAt(let h):
+            return "Opened at \(clockText(h.timeSeconds))"
+        case .closedNow:
+            return "Closed"
+        case .closedAt(let h):
+            return "Closed at \(clockText(h.timeSeconds))"
+        case .anomaly(let h):
+            return anomalyTitle(h.kind)
+        }
+    }
+
+    /// iOS wording for one shared `HistorySupporting`.
+    private static func supportingText(_ supporting: HistorySupporting) -> DisplayText {
+        switch onEnum(of: supporting) {
+        case .sinceWithSpan(let s):
+            let span = String(localized: stateSpanText(s.span))
+            return .copy("Since \(clockText(s.timeSeconds)) · \(span)")
+        case .span(let s):
+            return .copy(stateSpanText(s.span))
+        case .clockTime(let s):
+            // An already-locale-formatted clock time: data, not copy.
+            return .data(clockText(s.timeSeconds))
+        }
+    }
+
+    /// iOS wording for one shared `HistoryTag`.
+    private static func tagText(_ tag: HistoryTag) -> LocalizedStringResource {
+        switch onEnum(of: tag) {
+        case .transit(let t): return transitText(t.warning)
+        case .misaligned: return "Door was misaligned"
+        }
+    }
+
+    /// The row's own timestamp, used only to build a stable list identity.
+    private static func entryTimeSeconds(_ entry: HistoryEntry) -> Int64 {
         switch onEnum(of: entry) {
-        case .opened(let opened):
-            let time = clockText(opened.timeSeconds)
-            let duration = stateDuration(opened.durationSeconds, isCurrent: opened.isCurrent, isOpen: true)
-            let headline: LocalizedStringResource
-            if opened.isCurrent && opened.misaligned {
-                headline = "Open (misaligned)"
-            } else if opened.isCurrent {
-                headline = "Open"
-            } else {
-                headline = "Opened at \(time)"
-            }
-            var warnings: [LocalizedStringResource] = []
-            if let warning = opened.transitWarning { warnings.append(transitText(warning)) }
-            // Suppressed when the headline already says "(misaligned)" — the tag
-            // would just repeat it.
-            if opened.misaligned && !opened.isCurrent { warnings.append("Door was misaligned") }
-            return Entry(
-                id: "\(opened.timeSeconds)-\(index)",
-                position: opened.misaligned ? .openMisaligned : .open,
-                headline: headline,
-                supporting: opened.isCurrent
-                    ? .copy("Since \(time) · \(String(localized: duration))")
-                    : .copy(duration),
-                warnings: warnings
-            )
-        case .closed(let closed):
-            let time = clockText(closed.timeSeconds)
-            let duration = stateDuration(closed.durationSeconds, isCurrent: closed.isCurrent, isOpen: false)
-            var warnings: [LocalizedStringResource] = []
-            if let warning = closed.transitWarning { warnings.append(transitText(warning)) }
-            return Entry(
-                id: "\(closed.timeSeconds)-\(index)",
-                position: .closed,
-                headline: closed.isCurrent ? "Closed" : "Closed at \(time)",
-                supporting: closed.isCurrent
-                    ? .copy("Since \(time) · \(String(localized: duration))")
-                    : .copy(duration),
-                warnings: warnings
-            )
-        case .anomaly(let anomaly):
-            return Entry(
-                id: "\(anomaly.timeSeconds)-\(index)",
-                position: anomaly.doorPosition,
-                headline: anomalyTitle(anomaly.kind),
-                supporting: .data(clockText(anomaly.timeSeconds)),
-                warnings: []
-            )
+        case .opened(let e): return e.timeSeconds
+        case .closed(let e): return e.timeSeconds
+        case .anomaly(let e): return e.timeSeconds
         }
     }
 
@@ -247,12 +258,7 @@ final class HistoryViewModelWrapper: ObservableObject {
     /// this supplies the words. Both were previously reimplemented here against
     /// Android's `stateDurationDisplay`, on the highest-traffic surface in the
     /// app — every row of the history list.
-    private static func stateDuration(_ seconds: Int64, isCurrent: Bool, isOpen: Bool) -> LocalizedStringResource {
-        let display = HistoryDurationMapper.shared.stateSpan(
-            seconds: seconds,
-            isCurrent: isCurrent,
-            isOpen: isOpen
-        )
+    private static func stateSpanText(_ display: StateSpanDisplay) -> LocalizedStringResource {
         let text = stateDurationText(display.duration)
         switch display.framing {
         case .andCounting: return "\(text) and counting"

--- a/MobileGarage/iosApp/Features/Settings/SettingsScreen.swift
+++ b/MobileGarage/iosApp/Features/Settings/SettingsScreen.swift
@@ -218,8 +218,8 @@ struct SettingsContentView: View {
                         SettingsRowLabel(
                             icon: "person.crop.circle.fill",
                             // The person's own name when known, our copy when not.
-                            title: displayName.map(SettingsRowText.data) ?? .copy("Signed in"),
-                            subtitle: email.map(SettingsRowText.data),
+                            title: displayName.map(DisplayText.data) ?? .copy("Signed in"),
+                            subtitle: email.map(DisplayText.data),
                             showChevron: true
                         )
                     }
@@ -345,41 +345,10 @@ struct SettingsContentView: View {
 /// state text, optional chevron / in-flight spinner. The SwiftUI analog of
 /// Android's `SettingsRow` ListItem (icon, headline, supporting text, trailing
 /// chevron, in-flight indicator). `internal` for previews.
-/// Text in a settings row: either translatable copy, or data that must be shown
-/// exactly as-is.
-///
-/// The distinction is load-bearing. The account row's title is the signed-in
-/// person's name when there is one and the literal "Signed in" when there is
-/// not, and its subtitle is their email address. A single `String` parameter
-/// erases which is which — and a `String` parameter also silently swallows the
-/// literals, since SwiftUI only extracts what it can see as a
-/// `LocalizedStringResource` (see MobileGarage/docs/IOS_LOCALIZATION.md).
-///
-/// Deliberately NOT `ExpressibleByStringLiteral`. That would let call sites keep
-/// writing bare literals, but the literal would arrive as a plain `String`
-/// through `init(stringLiteral:)` and never be extracted — reintroducing exactly
-/// the silent failure this type exists to prevent, while looking tidier.
-enum SettingsRowText {
-    /// Translatable copy. Write the literal inline so the compiler extracts it.
-    case copy(LocalizedStringResource)
-    /// User or system data — a name, an email address, a version. Rendered
-    /// verbatim; translating it would be meaningless or actively wrong.
-    case data(String)
-
-    /// No `@ViewBuilder`: it would wrap the switch in `_ConditionalContent`,
-    /// and the callers apply `Text`-only modifiers (`.font`) to the result.
-    var view: Text {
-        switch self {
-        case .copy(let resource): return Text(resource)
-        case .data(let string): return Text(verbatim: string)
-        }
-    }
-}
-
 struct SettingsRowLabel: View {
     let icon: String
-    let title: SettingsRowText
-    var subtitle: SettingsRowText?
+    let title: DisplayText
+    var subtitle: DisplayText?
     var showChevron: Bool = false
     var inFlight: Bool = false
 

--- a/MobileGarage/iosApp/GarageControl/Localizable.xcstrings
+++ b/MobileGarage/iosApp/GarageControl/Localizable.xcstrings
@@ -85,7 +85,25 @@
     "Closed": {
       "extractionState": "manual"
     },
+    "Closed at %@": {
+      "extractionState": "manual"
+    },
+    "Closed at 7:18 AM": {
+      "extractionState": "manual"
+    },
+    "Closed at 8:30 PM": {
+      "extractionState": "manual"
+    },
+    "Closed at 9:53 AM": {
+      "extractionState": "manual"
+    },
     "Closed for %@": {
+      "extractionState": "manual"
+    },
+    "Closed for 10 hr 12 min": {
+      "extractionState": "manual"
+    },
+    "Closed for 22 min": {
       "extractionState": "manual"
     },
     "Closing": {
@@ -142,6 +160,9 @@
     "Door status": {
       "extractionState": "manual"
     },
+    "Door was misaligned": {
+      "extractionState": "manual"
+    },
     "Double tap to copy": {
       "extractionState": "manual"
     },
@@ -196,13 +217,37 @@
     "Open": {
       "extractionState": "manual"
     },
+    "Open (misaligned)": {
+      "extractionState": "manual"
+    },
     "Open / close door": {
       "extractionState": "manual"
     },
     "Open for %@": {
       "extractionState": "manual"
     },
+    "Open for 10 min": {
+      "extractionState": "manual"
+    },
+    "Open for 2 hr": {
+      "extractionState": "manual"
+    },
+    "Open for 6 min": {
+      "extractionState": "manual"
+    },
     "Open or close the garage and check back here.": {
+      "extractionState": "manual"
+    },
+    "Opened at %@": {
+      "extractionState": "manual"
+    },
+    "Opened at 11:20 AM": {
+      "extractionState": "manual"
+    },
+    "Opened at 6:30 PM": {
+      "extractionState": "manual"
+    },
+    "Opened at 9:47 AM": {
       "extractionState": "manual"
     },
     "Opening": {
@@ -274,6 +319,15 @@
     "Silences the open-door warning for the selected time. Currently: %@.": {
       "extractionState": "manual"
     },
+    "Since %@ · %@": {
+      "extractionState": "manual"
+    },
+    "Since 10:15 AM · 12 min and counting": {
+      "extractionState": "manual"
+    },
+    "Since 11:30 AM · 47 min and counting": {
+      "extractionState": "manual"
+    },
     "Snooze 1 hour": {
       "extractionState": "manual"
     },
@@ -295,6 +349,12 @@
     "Status": {
       "extractionState": "manual"
     },
+    "Stuck closing": {
+      "extractionState": "manual"
+    },
+    "Stuck opening": {
+      "extractionState": "manual"
+    },
     "Subscribe test notifications": {
       "extractionState": "manual"
     },
@@ -307,10 +367,19 @@
     "This developer panel is gated to allowlisted accounts.": {
       "extractionState": "manual"
     },
+    "Today": {
+      "extractionState": "manual"
+    },
     "Took %@ to close, longer than expected": {
       "extractionState": "manual"
     },
     "Took %@ to open, longer than expected": {
+      "extractionState": "manual"
+    },
+    "Took 3 min to close, longer than expected": {
+      "extractionState": "manual"
+    },
+    "Took 4 min to open, longer than expected": {
       "extractionState": "manual"
     },
     "Topic": {
@@ -320,6 +389,9 @@
       "extractionState": "manual"
     },
     "Unknown": {
+      "extractionState": "manual"
+    },
+    "Unknown state": {
       "extractionState": "manual"
     },
     "Unlocks the remote button and snooze": {
@@ -335,6 +407,9 @@
       "extractionState": "manual"
     },
     "Waiting for the latest door status": {
+      "extractionState": "manual"
+    },
+    "Yesterday": {
       "extractionState": "manual"
     },
     "You can manage permissions in the iOS Settings app.": {

--- a/MobileGarage/presentation-model/src/commonMain/kotlin/com/chriscartland/garage/presentation/HistoryRow.kt
+++ b/MobileGarage/presentation-model/src/commonMain/kotlin/com/chriscartland/garage/presentation/HistoryRow.kt
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.presentation
+
+import com.chriscartland.garage.domain.model.DoorPosition
+
+/**
+ * Which headline a history row shows.
+ *
+ * Six variants across three entry kinds. The arms carry the instant rather than
+ * a formatted time, because clock formatting is locale work each platform
+ * already does its own way.
+ */
+sealed interface HistoryHeadline {
+    /** The door is open right now. */
+    data object OpenNow : HistoryHeadline
+
+    /** Open right now, and reported misaligned. The one headline that mentions
+     *  the anomaly itself — which is why the tag is suppressed for it. */
+    data object OpenNowMisaligned : HistoryHeadline
+
+    /** A past open, named by when it happened. */
+    data class OpenedAt(
+        val timeSeconds: Long,
+    ) : HistoryHeadline
+
+    /** The door is closed right now. */
+    data object ClosedNow : HistoryHeadline
+
+    /** A past close, named by when it happened. */
+    data class ClosedAt(
+        val timeSeconds: Long,
+    ) : HistoryHeadline
+
+    /** An anomaly row, named by its kind. */
+    data class Anomaly(
+        val kind: AnomalyKind,
+    ) : HistoryHeadline
+}
+
+/** The row's second line. */
+sealed interface HistorySupporting {
+    /**
+     * An ongoing span: "Since 9:47 AM · 2 hr 14 min and counting".
+     *
+     * Carries both the start instant and the span, because the line names both.
+     */
+    data class SinceWithSpan(
+        val timeSeconds: Long,
+        val span: StateSpanDisplay,
+    ) : HistorySupporting
+
+    /** A completed span: "Open for 6 min". */
+    data class Span(
+        val span: StateSpanDisplay,
+    ) : HistorySupporting
+
+    /** Just a clock time. Anomaly rows have no span to report. */
+    data class ClockTime(
+        val timeSeconds: Long,
+    ) : HistorySupporting
+}
+
+/** A caution tag rendered under the row's supporting line. */
+sealed interface HistoryTag {
+    /** The transit took longer than expected. */
+    data class Transit(
+        val warning: TransitWarning,
+    ) : HistoryTag
+
+    /** The open state was reported misaligned. */
+    data object Misaligned : HistoryTag
+}
+
+/**
+ * One history row, as decisions rather than text.
+ *
+ * @param doorPosition drives the leading door art.
+ * @param headline which of the six headlines applies.
+ * @param supporting the second line.
+ * @param tags caution tags, in display order. May be empty.
+ */
+data class HistoryRowDisplay(
+    val doorPosition: DoorPosition,
+    val headline: HistoryHeadline,
+    val supporting: HistorySupporting,
+    val tags: List<HistoryTag>,
+)
+
+/**
+ * Resolves a [HistoryEntry] into the four decisions a row makes.
+ *
+ * All four were being made twice — once in Android's `HistoryEntryRow` `when`,
+ * once in iOS's `HistoryViewModelWrapper.resolve`:
+ *
+ *  1. **Door art.** A misaligned open renders the `OPEN_MISALIGNED` art, so the
+ *     misalignment is visible on a row that is otherwise just "Opened".
+ *  2. **Headline variant.** Three ways for an open, two for a close, one for an
+ *     anomaly.
+ *  3. **Supporting variant.** An ongoing span names its start; a completed one
+ *     does not.
+ *  4. **Tag composition, including the suppression rule** — see below.
+ *
+ * The suppression rule is the subtle one and the reason this is worth sharing:
+ * a misaligned tag is emitted only when the headline does *not* already say
+ * "(misaligned)". Written out on each platform, it reads as an incidental
+ * `&& !isCurrent` that looks like it could be simplified away. Stated once, with
+ * a test, it is a rule: **never say the same thing twice in one row.**
+ */
+object HistoryRowMapper {
+    fun forEntry(entry: HistoryEntry): HistoryRowDisplay =
+        when (entry) {
+            is HistoryEntry.Opened -> openedRow(entry)
+            is HistoryEntry.Closed -> closedRow(entry)
+            is HistoryEntry.Anomaly -> HistoryRowDisplay(
+                doorPosition = entry.doorPosition,
+                headline = HistoryHeadline.Anomaly(entry.kind),
+                supporting = HistorySupporting.ClockTime(entry.timeSeconds),
+                tags = emptyList(),
+            )
+        }
+
+    private fun openedRow(entry: HistoryEntry.Opened): HistoryRowDisplay {
+        val headline = when {
+            entry.isCurrent && entry.misaligned -> HistoryHeadline.OpenNowMisaligned
+            entry.isCurrent -> HistoryHeadline.OpenNow
+            else -> HistoryHeadline.OpenedAt(entry.timeSeconds)
+        }
+        return HistoryRowDisplay(
+            // Show the misaligned art even on a plain "Opened" row, so the
+            // anomaly is visible without reading the tags.
+            doorPosition = if (entry.misaligned) DoorPosition.OPEN_MISALIGNED else DoorPosition.OPEN,
+            headline = headline,
+            supporting = supportingFor(
+                entry.timeSeconds,
+                entry.durationSeconds,
+                entry.isCurrent,
+                isOpen = true,
+            ),
+            tags = buildList {
+                entry.transitWarning?.let { add(HistoryTag.Transit(it)) }
+                // Suppressed when the headline already says "(misaligned)".
+                // Two statements of the same fact in one row is noise, and the
+                // headline is the more prominent of the two.
+                if (entry.misaligned && headline != HistoryHeadline.OpenNowMisaligned) {
+                    add(HistoryTag.Misaligned)
+                }
+            },
+        )
+    }
+
+    private fun closedRow(entry: HistoryEntry.Closed): HistoryRowDisplay =
+        HistoryRowDisplay(
+            doorPosition = DoorPosition.CLOSED,
+            headline = if (entry.isCurrent) {
+                HistoryHeadline.ClosedNow
+            } else {
+                HistoryHeadline.ClosedAt(entry.timeSeconds)
+            },
+            supporting = supportingFor(
+                entry.timeSeconds,
+                entry.durationSeconds,
+                entry.isCurrent,
+                isOpen = false,
+            ),
+            tags = buildList {
+                entry.transitWarning?.let { add(HistoryTag.Transit(it)) }
+            },
+        )
+
+    private fun supportingFor(
+        timeSeconds: Long,
+        durationSeconds: Long,
+        isCurrent: Boolean,
+        isOpen: Boolean,
+    ): HistorySupporting {
+        val span = HistoryDurationMapper.stateSpan(
+            seconds = durationSeconds,
+            isCurrent = isCurrent,
+            isOpen = isOpen,
+        )
+        // An ongoing span names when it started; a finished one is identified by
+        // its headline's timestamp already, so repeating it would be redundant.
+        return if (isCurrent) {
+            HistorySupporting.SinceWithSpan(timeSeconds, span)
+        } else {
+            HistorySupporting.Span(span)
+        }
+    }
+}

--- a/MobileGarage/presentation-model/src/commonTest/kotlin/com/chriscartland/garage/presentation/HistoryRowMapperTest.kt
+++ b/MobileGarage/presentation-model/src/commonTest/kotlin/com/chriscartland/garage/presentation/HistoryRowMapperTest.kt
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2026 Chris Cartland. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.chriscartland.garage.presentation
+
+import com.chriscartland.garage.domain.model.DoorPosition
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HistoryRowMapperTest {
+    private val t = 1_700_000_000L
+    private val hour = 3_600L
+
+    private fun opened(
+        isCurrent: Boolean = false,
+        misaligned: Boolean = false,
+        transit: TransitWarning? = null,
+        duration: Long = 2 * hour,
+    ) = HistoryEntry.Opened(
+        timeSeconds = t,
+        durationSeconds = duration,
+        isCurrent = isCurrent,
+        transitWarning = transit,
+        misaligned = misaligned,
+    )
+
+    private fun closed(
+        isCurrent: Boolean = false,
+        transit: TransitWarning? = null,
+    ) = HistoryEntry.Closed(
+        timeSeconds = t,
+        durationSeconds = 2 * hour,
+        isCurrent = isCurrent,
+        transitWarning = transit,
+    )
+
+    // ---- the suppression rule (the reason this mapper exists) ----
+
+    @Test
+    fun aMisalignedTagIsSuppressedWhenTheHeadlineAlreadySaysIt() {
+        val row = HistoryRowMapper.forEntry(opened(isCurrent = true, misaligned = true))
+        assertEquals(HistoryHeadline.OpenNowMisaligned, row.headline)
+        assertFalse(
+            row.tags.contains(HistoryTag.Misaligned),
+            "the headline already says (misaligned); the tag would repeat it",
+        )
+    }
+
+    @Test
+    fun aMisalignedTagAppearsWhenTheHeadlineDoesNot() {
+        val row = HistoryRowMapper.forEntry(opened(isCurrent = false, misaligned = true))
+        assertTrue(row.headline is HistoryHeadline.OpenedAt)
+        assertTrue(
+            row.tags.contains(HistoryTag.Misaligned),
+            "a past misaligned open has nowhere else to report it",
+        )
+    }
+
+    @Test
+    fun noRowEverStatesMisalignmentTwice() {
+        // The rule as a property over every combination, rather than the two
+        // examples above: the misaligned tag and the misaligned headline are
+        // mutually exclusive, always.
+        listOf(true, false).forEach { isCurrent ->
+            listOf(true, false).forEach { misaligned ->
+                val row = HistoryRowMapper.forEntry(opened(isCurrent = isCurrent, misaligned = misaligned))
+                val headlineSaysIt = row.headline == HistoryHeadline.OpenNowMisaligned
+                val tagSaysIt = row.tags.contains(HistoryTag.Misaligned)
+                assertFalse(
+                    headlineSaysIt && tagSaysIt,
+                    "isCurrent=$isCurrent misaligned=$misaligned said it twice",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun misalignmentIsReportedExactlyOnceWhenPresent() {
+        // The complement: suppression must not lose the information entirely.
+        listOf(true, false).forEach { isCurrent ->
+            val row = HistoryRowMapper.forEntry(opened(isCurrent = isCurrent, misaligned = true))
+            val places = listOf(
+                row.headline == HistoryHeadline.OpenNowMisaligned,
+                row.tags.contains(HistoryTag.Misaligned),
+            ).count { it }
+            assertEquals(1, places, "isCurrent=$isCurrent should report misalignment exactly once")
+        }
+        // ...and never when absent.
+        listOf(true, false).forEach { isCurrent ->
+            val row = HistoryRowMapper.forEntry(opened(isCurrent = isCurrent, misaligned = false))
+            assertFalse(row.headline == HistoryHeadline.OpenNowMisaligned)
+            assertFalse(row.tags.contains(HistoryTag.Misaligned))
+        }
+    }
+
+    // ---- door art ----
+
+    @Test
+    fun aMisalignedOpenShowsTheMisalignedArt() {
+        assertEquals(
+            DoorPosition.OPEN_MISALIGNED,
+            HistoryRowMapper.forEntry(opened(misaligned = true)).doorPosition,
+        )
+        assertEquals(
+            DoorPosition.OPEN,
+            HistoryRowMapper.forEntry(opened(misaligned = false)).doorPosition,
+        )
+    }
+
+    @Test
+    fun theArtDoesNotDependOnWhetherTheSpanIsOngoing() {
+        // Art tracks the door's state, not the row's tense.
+        listOf(true, false).forEach { isCurrent ->
+            assertEquals(
+                DoorPosition.OPEN_MISALIGNED,
+                HistoryRowMapper.forEntry(opened(isCurrent = isCurrent, misaligned = true)).doorPosition,
+            )
+        }
+    }
+
+    @Test
+    fun closedRowsAlwaysShowClosedArt() {
+        listOf(true, false).forEach { isCurrent ->
+            assertEquals(DoorPosition.CLOSED, HistoryRowMapper.forEntry(closed(isCurrent = isCurrent)).doorPosition)
+        }
+    }
+
+    @Test
+    fun anomalyRowsCarryTheirOwnArt() {
+        val row = HistoryRowMapper.forEntry(
+            HistoryEntry.Anomaly(
+                doorPosition = DoorPosition.ERROR_SENSOR_CONFLICT,
+                kind = AnomalyKind.SensorConflict,
+                timeSeconds = t,
+            ),
+        )
+        assertEquals(DoorPosition.ERROR_SENSOR_CONFLICT, row.doorPosition)
+        assertEquals(HistoryHeadline.Anomaly(AnomalyKind.SensorConflict), row.headline)
+    }
+
+    // ---- headline / supporting pairing ----
+
+    @Test
+    fun ongoingSpansNameTheirStartAndPastOnesDoNot() {
+        // An ongoing row's headline has no timestamp ("Open"), so the supporting
+        // line supplies it. A past row's headline already carries it ("Opened at
+        // 9:47"), so repeating it below would be redundant.
+        val current = HistoryRowMapper.forEntry(opened(isCurrent = true))
+        assertEquals(HistoryHeadline.OpenNow, current.headline)
+        assertTrue(current.supporting is HistorySupporting.SinceWithSpan)
+
+        val past = HistoryRowMapper.forEntry(opened(isCurrent = false))
+        assertEquals(HistoryHeadline.OpenedAt(t), past.headline)
+        assertTrue(past.supporting is HistorySupporting.Span)
+    }
+
+    @Test
+    fun exactlyOneOfHeadlineAndSupportingCarriesTheTimestamp() {
+        // Stated as a property across both entry kinds and both tenses.
+        listOf(opened(isCurrent = true), opened(isCurrent = false), closed(isCurrent = true), closed(isCurrent = false))
+            .forEach { entry ->
+                val row = HistoryRowMapper.forEntry(entry)
+                val headlineHasTime = row.headline is HistoryHeadline.OpenedAt ||
+                    row.headline is HistoryHeadline.ClosedAt
+                val supportingHasTime = row.supporting is HistorySupporting.SinceWithSpan
+                assertTrue(
+                    headlineHasTime != supportingHasTime,
+                    "$entry put the timestamp in both places or neither",
+                )
+            }
+    }
+
+    @Test
+    fun closedHeadlinesFollowTheSameTensePattern() {
+        assertEquals(HistoryHeadline.ClosedNow, HistoryRowMapper.forEntry(closed(isCurrent = true)).headline)
+        assertEquals(HistoryHeadline.ClosedAt(t), HistoryRowMapper.forEntry(closed(isCurrent = false)).headline)
+    }
+
+    @Test
+    fun anomalyRowsReportOnlyAClockTime() {
+        val row = HistoryRowMapper.forEntry(
+            HistoryEntry.Anomaly(DoorPosition.UNKNOWN, AnomalyKind.UnknownState, t),
+        )
+        assertEquals(HistorySupporting.ClockTime(t), row.supporting)
+        assertTrue(row.tags.isEmpty(), "anomaly rows carry no tags")
+    }
+
+    // ---- the span embedded in the supporting line ----
+
+    @Test
+    fun theSupportingSpanUsesTheStateLadderAndTheOngoingFraming() {
+        val row = HistoryRowMapper.forEntry(opened(isCurrent = true, duration = 2 * hour + 14 * 60))
+        val supporting = row.supporting as HistorySupporting.SinceWithSpan
+        assertEquals(StateSpanFraming.AND_COUNTING, supporting.span.framing)
+        assertEquals(StateSpanDuration.HoursMinutes(2, 14), supporting.span.duration)
+    }
+
+    @Test
+    fun completedOpenAndCloseSpansAreFramedDifferently() {
+        val open = HistoryRowMapper.forEntry(opened(isCurrent = false)).supporting as HistorySupporting.Span
+        val close = HistoryRowMapper.forEntry(closed(isCurrent = false)).supporting as HistorySupporting.Span
+        assertEquals(StateSpanFraming.OPEN_FOR, open.span.framing)
+        assertEquals(StateSpanFraming.CLOSED_FOR, close.span.framing)
+    }
+
+    // ---- tags ----
+
+    @Test
+    fun aTransitWarningBecomesTheFirstTag() {
+        val warning = TransitWarning.ToOpen(transitSeconds = 240)
+        val row = HistoryRowMapper.forEntry(opened(misaligned = true, transit = warning))
+        assertEquals(HistoryTag.Transit(warning), row.tags.first())
+        // Order matters: the transit is about this event, the misalignment about
+        // the resulting state.
+        assertEquals(listOf(HistoryTag.Transit(warning), HistoryTag.Misaligned), row.tags)
+    }
+
+    @Test
+    fun closedRowsCanCarryATransitTag() {
+        val warning = TransitWarning.ToClose(transitSeconds = 300)
+        assertEquals(
+            listOf(HistoryTag.Transit(warning)),
+            HistoryRowMapper.forEntry(closed(transit = warning)).tags,
+        )
+    }
+
+    @Test
+    fun aCleanRowHasNoTags() {
+        assertTrue(HistoryRowMapper.forEntry(opened()).tags.isEmpty())
+        assertTrue(HistoryRowMapper.forEntry(closed()).tags.isEmpty())
+    }
+}


### PR DESCRIPTION
The last item from the duplicate-decision survey.

Every history row makes four decisions, and every one of them was made twice — once in Android's `HistoryEntryRow` `when`, once in iOS's `HistoryViewModelWrapper.resolve`:

1. **Door art** — a misaligned open shows the `OPEN_MISALIGNED` art, so the anomaly is visible on a row that otherwise just says "Opened".
2. **Which of six headlines** (three for an open, two for a close, one for an anomaly).
3. **Which supporting line** — an ongoing span names its start; a finished one doesn't.
4. **Tag composition, including the suppression rule.**

## The suppression rule is why this one was worth doing

A misaligned tag is emitted only when the headline doesn't *already* say `"(misaligned)"`. Written out per platform, it reads as an incidental `&& !isCurrent` that looks like it could be simplified away. Stated once with a test, it's a rule: **never say the same thing twice in one row.**

## Tests

17, written as properties rather than examples. The two that carry weight:

- **Misalignment is reported *exactly* once when present** — never twice, never zero times — across every `isCurrent × misaligned` combination. Both halves matter: suppression that loses the information is as wrong as repeating it, and a test that only checked "not twice" would pass if the tag were dropped entirely.
- **Exactly one of headline and supporting carries the timestamp**, over both entry kinds and both tenses. That's the invariant behind "Open" + "Since 9:47 · …" versus "Opened at 9:47" + "Open for 6 min".

Plus: door art tracks the door's *state*, not the row's tense.

## Also closes a gap from #1166

#1166 merged incomplete. Two things were meant to be in it and weren't: the 25 History catalog keys, and collapsing #1165's `SettingsRowText` into `DisplayText`.

Cause worth recording: `git-guardrails.sh` is a **`PreToolUse`** hook, so when it blocked a compound `git add && git commit --amend && git push`, the `add` and `amend` never ran either — the whole Bash call was rejected before anything executed. The follow-up push then sent the un-amended commit.

Not user-visible — a `LocalizedStringResource` falls back to its key, so rendering was identical — but the catalog was 25 keys short of what the code needs, which would have surfaced as untranslatable strings the moment anyone added a locale. Now 141, verified key by key. My earlier report of "103 → 141" was wrong; main was at 116.

**Lesson: never chain a mutation with a push in one call.**

## Verification

- `validate.sh` — all checks passed
- `validate-ios.sh` — 6/6 green, including cold + warm launch smoke
- `presentation-model` — 429 tests across 4 targets, 0 failures
- **iOS snapshot regen produced zero changed PNGs** — the check that matters most here, since History is the most snapshot-covered screen and this rewrote how every row is assembled on both platforms

Survey complete: #1160, #1161, #1162, #1163, and this. Home localization is the remaining piece of the iOS sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)