### PR TITLE
feat(ios): make the Home tab's text translatable

### DIFF
--- a/MobileGarage/docs/IOS_LOCALIZATION.md
+++ b/MobileGarage/docs/IOS_LOCALIZATION.md
@@ -8,13 +8,12 @@ last_verified: 2026-07-29
 
 Android localizes through `strings.xml` (209 entries).
 
-**Status.** iOS now has the mechanism: `Localizable.xcstrings` +
-`SWIFT_EMIT_LOC_STRINGS: YES` + `scripts/sync-ios-string-catalog.sh` (step 1 below,
-shipped in #1159), and the fence lint from step 3 (shipped 2026-07-29). Step 2 — the
-`String` → `LocalizedStringResource` type sweep — is **in progress**: the catalog holds
-~103 keys, against roughly 189 user-visible strings, because the rest are still flattened
-to `String` before they reach a `Text`. Re-check the real number with
-`./scripts/sync-ios-string-catalog.sh` rather than trusting this paragraph.
+**Status.** iOS has the mechanism (`Localizable.xcstrings` +
+`SWIFT_EMIT_LOC_STRINGS: YES` + `scripts/sync-ios-string-catalog.sh`, #1159) and the
+fence lint (step 3, #1164). The step-2 type sweep has covered **Settings** (#1165),
+**History** (#1166) and **Home**; **Function list** and **Diagnostics** remain. The
+catalog holds ~189 keys. Re-measure with `./scripts/sync-ios-string-catalog.sh` rather
+than trusting this paragraph.
 
 ADR-035 governs *where* a string is decided (platform, not shared). This document covers
 the separate question of *how* iOS stores its words once it has them.
@@ -90,6 +89,47 @@ gitignored and the whole workflow is `validate-ios.sh` → `xcodebuild`, adoptin
 needs either opening Xcode once per string-adding PR, or a
 `scripts/sync-ios-string-catalog.sh` that merges keys from `$STRINGSDATA_DIR/*.stringsdata`
 (plain plists, `plutil -p` readable).
+
+## Three things the sweep surfaced
+
+**1. `#Preview` fixture text lands in the catalog — ~20 keys today, unfixed.**
+Once a field is typed `LocalizedStringResource`, the literals `#Preview` bodies pass into
+it are literals *in resource position*, so the compiler extracts them. The catalog now
+carries `"Since 11:22 AM · 38 min"`, `"Closed for 22 min"`, `"23 min ago"` and similar —
+sample data, never shipped, and meaningless to translate. Harmless while the catalog is
+English-only (nothing is translated yet), but it should be cleaned before any locale is
+added. The fix, when someone does it:
+
+```swift
+/// Sample text for `#Preview` fixtures. Takes a runtime `String`, so the
+/// compiler never sees a literal in `LocalizedStringResource` position and the
+/// sample never reaches the catalog.
+func previewText(_ value: String) -> LocalizedStringResource {
+    LocalizedStringResource(stringLiteral: value)
+}
+```
+
+Must be `internal` (a `#Preview` body is embedded verbatim into the generated snapshot
+test, which cannot see `private` symbols).
+
+**2. Interpolate the bridged `Int32` directly; do not wrap it in `Int(...)`.**
+A Kotlin `Int` bridges to Swift `Int32`, which interpolates into a catalog key as `%d`.
+Wrapping it (`Int(d.days)`) widens to `Int` and yields `%lld` — so the same phrase gets
+two keys (`"%d min"` *and* `"%lld min"`) and a translator is asked for both. History
+originally used the wrapped form and Home the bare one; unified on `%d`. The stale `%lld`
+keys had to be pruned by hand, because the sync script only ever adds.
+
+**3. A lone number must be formatted, not localized.**
+`Text("\(counter.value)")` produced a catalog key of literally `"%lld"` — meaningless to
+a translator, and it collides with every other bare-integer interpolation in the app. A
+number wants locale *formatting*, not translation:
+`Text(verbatim: counter.value.formatted())`.
+
+**Do not try to fix (1) by extracting in Release configuration.** `#Preview` bodies are
+excluded from a Release build, so it looks like the obvious answer. Measured: a Release
+build with `SWIFT_EMIT_LOC_STRINGS=YES` yields **zero** usable keys — production strings
+like `"Retry"` and `"Connecting…"` vanish too, not just the fixtures. Switching the sync
+script to Release would silently stop it finding anything.
 
 ## `Localizable.xcstrings` conflicts on every parallel PR — regenerate, don't merge
 

--- a/MobileGarage/iosApp/Features/Diagnostics/DiagnosticsScreen.swift
+++ b/MobileGarage/iosApp/Features/Diagnostics/DiagnosticsScreen.swift
@@ -84,7 +84,12 @@ struct DiagnosticsContentView: View {
                     HStack {
                         Text(counter.label)
                         Spacer()
-                        Text("\(counter.value)")
+                        // verbatim + .formatted(): a counter is a NUMBER, so it wants
+                        // locale digit grouping, not a catalog lookup. Written as
+                        // Text("\(value)") it produced a literal "%lld" catalog key —
+                        // meaningless to a translator, and it would collide with every
+                        // other bare-integer interpolation in the app.
+                        Text(verbatim: counter.value.formatted())
                             .monospacedDigit()
                             .foregroundStyle(.secondary)
                     }

--- a/MobileGarage/iosApp/Features/History/HistoryViewModelWrapper.swift
+++ b/MobileGarage/iosApp/Features/History/HistoryViewModelWrapper.swift
@@ -259,7 +259,9 @@ final class HistoryViewModelWrapper: ObservableObject {
     /// Android's `stateDurationDisplay`, on the highest-traffic surface in the
     /// app — every row of the history list.
     private static func stateSpanText(_ display: StateSpanDisplay) -> LocalizedStringResource {
-        let text = stateDurationText(display.duration)
+        // Resolved here so it can be interpolated into the framing's own
+        // catalog entry ("Open for %@").
+        let text = String(localized: stateDurationText(display.duration))
         switch display.framing {
         case .andCounting: return "\(text) and counting"
         case .openFor: return "Open for \(text)"
@@ -268,22 +270,22 @@ final class HistoryViewModelWrapper: ObservableObject {
     }
 
     /// iOS wording for one shared `StateSpanDuration` arm.
-    private static func stateDurationText(_ duration: StateSpanDuration) -> String {
+    private static func stateDurationText(_ duration: StateSpanDuration) -> LocalizedStringResource {
         switch onEnum(of: duration) {
         case .days(let d):
             return d.days == 1
-                ? String(localized: "1 day")
-                : String(localized: "\(Int(d.days)) days")
+                ? "1 day"
+                : "\(d.days) days"
         case .daysHours(let d):
-            return String(localized: "\(Int(d.days)) day \(Int(d.hours)) hr")
+            return "\(d.days) day \(d.hours) hr"
         case .hours(let d):
-            return String(localized: "\(Int(d.hours)) hr")
+            return "\(d.hours) hr"
         case .hoursMinutes(let d):
-            return String(localized: "\(Int(d.hours)) hr \(Int(d.minutes)) min")
+            return "\(d.hours) hr \(d.minutes) min"
         case .minutes(let d):
-            return String(localized: "\(Int(d.minutes)) min")
+            return "\(d.minutes) min"
         case .seconds(let d):
-            return String(localized: "\(Int(d.seconds)) sec")
+            return "\(d.seconds) sec"
         }
     }
 
@@ -299,25 +301,25 @@ final class HistoryViewModelWrapper: ObservableObject {
         case .toOpen(let w): seconds = w.transitSeconds; opening = true
         case .toClose(let w): seconds = w.transitSeconds; opening = false
         }
-        let text = transitDurationText(HistoryDurationMapper.shared.transitSpan(seconds: seconds))
+        let text = String(localized: transitDurationText(HistoryDurationMapper.shared.transitSpan(seconds: seconds)))
         return opening
             ? "Took \(text) to open, longer than expected"
             : "Took \(text) to close, longer than expected"
     }
 
     /// iOS wording for one shared `TransitSpanDuration` arm.
-    private static func transitDurationText(_ duration: TransitSpanDuration) -> String {
+    private static func transitDurationText(_ duration: TransitSpanDuration) -> LocalizedStringResource {
         switch onEnum(of: duration) {
         case .hours(let d):
-            return String(localized: "\(Int(d.hours)) hr")
+            return "\(d.hours) hr"
         case .hoursMinutes(let d):
-            return String(localized: "\(Int(d.hours)) hr \(Int(d.minutes)) min")
+            return "\(d.hours) hr \(d.minutes) min"
         case .minutes(let d):
-            return String(localized: "\(Int(d.minutes)) min")
+            return "\(d.minutes) min"
         case .minutesSeconds(let d):
-            return String(localized: "\(Int(d.minutes)) min \(Int(d.seconds)) sec")
+            return "\(d.minutes) min \(d.seconds) sec"
         case .seconds(let d):
-            return String(localized: "\(Int(d.seconds)) sec")
+            return "\(d.seconds) sec"
         }
     }
 

--- a/MobileGarage/iosApp/Features/Home/GarageDoorCanvas.swift
+++ b/MobileGarage/iosApp/Features/Home/GarageDoorCanvas.swift
@@ -426,14 +426,14 @@ extension DoorPosition {
     /// `DoorHeadlineMapper`, so the two apps cannot end up naming the same door
     /// differently; this picks only the words. Anomalous variants say what makes
     /// them anomalous in the warning chip, not here.
-    var statusLabel: String {
+    var statusLabel: LocalizedStringResource {
         switch DoorHeadlineMapper.shared.forPosition(position: self) {
-        case .open: return String(localized: "Open")
-        case .closed: return String(localized: "Closed")
-        case .opening: return String(localized: "Opening")
-        case .closing: return String(localized: "Closing")
-        case .unknown: return String(localized: "Unknown")
-        case .sensorConflict: return String(localized: "Sensor conflict")
+        case .open: return "Open"
+        case .closed: return "Closed"
+        case .opening: return "Opening"
+        case .closing: return "Closing"
+        case .unknown: return "Unknown"
+        case .sensorConflict: return "Sensor conflict"
         }
     }
 }

--- a/MobileGarage/iosApp/Features/Home/HomeScreen.swift
+++ b/MobileGarage/iosApp/Features/Home/HomeScreen.swift
@@ -63,10 +63,10 @@ struct HomeContentView: View {
     /// Pre-formatted "Since 9:47 AM · 2 hr 14 min" line (resolved from the shared
     /// typed `SinceStatus` in the wrapper); `nil` when the last-change time is
     /// unknown. Mirrors Android's status line; replaces the old raw door message.
-    let sinceLine: String?
+    let sinceLine: LocalizedStringResource?
     /// Already-localized warning text (resolved from the shared typed
     /// `DoorWarning` in the wrapper). Non-nil only for stuck/anomalous states.
-    let warningText: String?
+    let warningText: DisplayText?
     let isCheckInStale: Bool
     /// View-ready remote-button state — styling kind + copy + the shared diagram.
     /// All logic lives in the shared `ButtonStateMachine`; this is display data
@@ -114,8 +114,8 @@ struct HomeContentView: View {
     init(
         doorPosition: DoorPosition,
         lastChangeTimeSeconds: Int64?,
-        sinceLine: String?,
-        warningText: String?,
+        sinceLine: LocalizedStringResource?,
+        warningText: DisplayText?,
         isCheckInStale: Bool,
         buttonItem: RemoteButtonItem,
         buttonHealth: ButtonHealthItem?,
@@ -291,7 +291,7 @@ private struct HomeAlertBanner: View {
         HStack(alignment: .top, spacing: GarageSpacing.card) {
             Image(systemName: icon)
                 .foregroundStyle(GarageColors.statusWarning)
-            Text(alert.message)
+            alert.message.view
                 .font(.footnote)
                 .frame(maxWidth: .infinity, alignment: .leading)
             Button(alert.actionLabel, action: onAction)
@@ -436,7 +436,9 @@ struct RemoteProgressDiagram: View {
 
     /// Spoken summary, derived from the shared statuses rather than a second
     /// phase enum — so it cannot describe a state the diagram is not drawing.
-    private var accessibilityText: String {
+    /// `LocalizedStringResource` so the announcement is translatable — a
+    /// screen-reader label is user-visible text like any other.
+    private var accessibilityText: LocalizedStringResource {
         guard let diagram else { return "Remote button idle" }
         if diagram.toDoor == .failed { return "Door did not respond" }
         if diagram.toServer == .failed { return "Server did not accept the request" }
@@ -576,10 +578,12 @@ private struct RemoteButtonHealthPill: View {
 /// Android's errorContainer warning Surface in `HomeContent`. Renders the
 /// already-localized `text` (resolved from the shared typed `DoorWarning`).
 private struct DoorWarningChip: View {
-    let text: String
+    /// `DisplayText`: one arm of the shared `DoorWarning` is a server-supplied
+    /// message, which must render verbatim rather than through the catalog.
+    let text: DisplayText
 
     var body: some View {
-        Label(text, systemImage: "exclamationmark.triangle.fill")
+        Label { text.view } icon: { Image(systemName: "exclamationmark.triangle.fill") }
             .font(.footnote)
             .multilineTextAlignment(.leading)
             .padding(.horizontal, 12)
@@ -601,14 +605,14 @@ enum HomeInfoSheet: String, Identifiable {
 
     var id: String { rawValue }
 
-    var title: String {
+    var title: LocalizedStringResource {
         switch self {
         case .doorStatus: return "Door status"
         case .remoteControl: return "Remote control"
         }
     }
 
-    var paragraphs: [String] {
+    var paragraphs: [LocalizedStringResource] {
         switch self {
         case .doorStatus:
             return [
@@ -630,8 +634,8 @@ enum HomeInfoSheet: String, Identifiable {
 /// of its own; tall content on a short viewport would otherwise clip). Pure
 /// values so it renders in the snapshot gallery without a live component.
 struct HomeInfoSheetContentView: View {
-    let title: String
-    let paragraphs: [String]
+    let title: LocalizedStringResource
+    let paragraphs: [LocalizedStringResource]
 
     var body: some View {
         ScrollView {
@@ -715,7 +719,7 @@ private struct HomeInfoSheetView: View {
             doorPosition: .openingTooLong,
             lastChangeTimeSeconds: nil,
             sinceLine: "Since 12:01 PM · 4 min",
-            warningText: "Opening, taking longer than expected",
+            warningText: .copy("Opening, taking longer than expected"),
             isCheckInStale: false,
             buttonItem: RemoteButtonItem(kind: .ready, title: "Tap to open or close", subtitle: nil),
             buttonHealth: ButtonHealthItem(label: "Available", kind: .online),
@@ -747,13 +751,13 @@ private struct HomeInfoSheetView: View {
                 HomeAlertItem(
                     id: "stale",
                     kind: .stale,
-                    message: "Not receiving updates from server",
+                    message: .copy("Not receiving updates from server"),
                     actionLabel: "Retry"
                 ),
                 HomeAlertItem(
                     id: "permission",
                     kind: .permission,
-                    message: "Turn on notifications to get alerted when the door is left open.",
+                    message: .copy("Turn on notifications to get alerted when the door is left open."),
                     actionLabel: "Allow"
                 ),
             ],

--- a/MobileGarage/iosApp/Features/Home/HomeViewModelWrapper.swift
+++ b/MobileGarage/iosApp/Features/Home/HomeViewModelWrapper.swift
@@ -38,13 +38,16 @@ final class HomeViewModelWrapper: ObservableObject {
     /// time is unknown. The elapsed-bucket *logic* is shared; the clock-time +
     /// localized-unit formatting happen here (mirrors Android's
     /// `rememberSinceLine`).
-    @Published private(set) var sinceLine: String?
+    @Published private(set) var sinceLine: LocalizedStringResource?
     /// Localized text for the typed `DoorWarning` exposed by the shared VM
     /// (ADR-031), or `nil` when the current state warrants no warning. The
     /// shared layer emits a *typed* warning; this wrapper resolves it to a
     /// string here (iOS's localization boundary) — mirrors Android's
     /// `doorWarningText` Composable + `strings.xml`.
-    @Published private(set) var warningText: String?
+    /// `DisplayText` because one arm is a SERVER-SUPPLIED message. Routing that
+    /// through the catalog would look the server's sentence up as a key — a
+    /// collision would silently replace it. The fallbacks are our own copy.
+    @Published private(set) var warningText: DisplayText?
     @Published private(set) var lastChangeTimeSeconds: Int64?
     @Published private(set) var isCheckInStale: Bool = false
     /// Resolved device check-in pill (ADR-031 Phase 5). The shared
@@ -233,21 +236,22 @@ final class HomeViewModelWrapper: ObservableObject {
             return HomeAlertItem(
                 id: "stale",
                 kind: .stale,
-                message: "Not receiving updates from server",
+                message: .copy("Not receiving updates from server"),
                 actionLabel: "Retry"
             )
         case .permissionMissing(let permission):
             return HomeAlertItem(
                 id: "permission",
                 kind: .permission,
-                message: justificationText(attemptCount: permission.attemptCount),
+                // Already-localized multi-line block; see HomeAlertItem.message.
+                message: .data(justificationText(attemptCount: permission.attemptCount)),
                 actionLabel: "Allow"
             )
         case .fetchError(let fetchError):
             return HomeAlertItem(
                 id: "fetchError",
                 kind: .fetchError,
-                message: "Error fetching current door event: \(fetchError.truncatedException)",
+                message: .copy("Error fetching current door event: \(fetchError.truncatedException)"),
                 actionLabel: "Retry"
             )
         }
@@ -293,14 +297,15 @@ final class HomeViewModelWrapper: ObservableObject {
             return
         }
         let date = Date(timeIntervalSince1970: TimeInterval(status.sinceEpochSeconds))
-        sinceLine = "Since \(Self.clockText(for: date)) · \(Self.durationText(for: status.elapsed))"
+        let elapsed = String(localized: Self.durationText(for: status.elapsed))
+        sinceLine = "Since \(Self.clockText(for: date)) · \(elapsed)"
     }
 
     /// Words for the shared typed offline age. Mirrors Android's
     /// `RemoteOfflineText`; each platform owns its own phrasing so it can be
     /// translated independently.
-    private static func offlineAgeText(_ offline: UsecaseButtonHealthDisplayOffline) -> String {
-        let age: String
+    private static func offlineAgeText(_ offline: UsecaseButtonHealthDisplayOffline) -> LocalizedStringResource {
+        let age: LocalizedStringResource
         switch onEnum(of: offline.age) {
         case .unknown:
             age = "unknown"
@@ -316,7 +321,9 @@ final class HomeViewModelWrapper: ObservableObject {
             age = v.days == 1 ? "1 day ago" : "\(v.days) days ago"
         }
         switch offline.source {
-        case .lastSeen: return "Last seen \(age)"
+        // Resolved to characters only here, so the age can be interpolated into
+        // the wrapper's own catalog entry ("Last seen %@").
+        case .lastSeen: return "Last seen \(String(localized: age))"
         case .stateChanged: return age
         default: return age
         }
@@ -343,7 +350,7 @@ final class HomeViewModelWrapper: ObservableObject {
         return formatter.string(from: date)
     }
 
-    private static func durationText(for elapsed: ElapsedDuration) -> String {
+    private static func durationText(for elapsed: ElapsedDuration) -> LocalizedStringResource {
         switch onEnum(of: elapsed) {
         case .days(let days):
             return days.days == 1 ? "1 day" : "\(days.days) days"
@@ -366,15 +373,16 @@ final class HomeViewModelWrapper: ObservableObject {
         }
         switch onEnum(of: warning) {
         case .serverMessage(let message):
-            warningText = message.text
+            // Server text: render exactly as received.
+            warningText = .data(message.text)
         case .openingTooLong:
-            warningText = "Opening, taking longer than expected"
+            warningText = .copy("Opening, taking longer than expected")
         case .closingTooLong:
-            warningText = "Closing, taking longer than expected"
+            warningText = .copy("Closing, taking longer than expected")
         case .openMisaligned:
-            warningText = "Door is open and misaligned"
+            warningText = .copy("Door is open and misaligned")
         case .sensorConflict:
-            warningText = "Sensor conflict. Check the door."
+            warningText = .copy("Sensor conflict. Check the door.")
         }
     }
 
@@ -431,7 +439,7 @@ final class HomeViewModelWrapper: ObservableObject {
 
     /// Formats a typed `CheckInAge` bucket as "… ago". Mirrors Android's
     /// `DeviceCheckIn.label` verbatim so both platforms read identically.
-    private static func agoText(_ age: CheckInAge) -> String {
+    private static func agoText(_ age: CheckInAge) -> LocalizedStringResource {
         switch onEnum(of: age) {
         case .justNow:
             return "Just now"
@@ -551,8 +559,11 @@ struct HomeAlertItem: Identifiable {
 
     let id: String
     let kind: Kind
-    let message: String
-    let actionLabel: String
+    /// Copy for the single-sentence alerts. The permission banner is `.data`
+    /// because it is a multi-line block already assembled from several catalog
+    /// entries — re-looking it up would search for the whole paragraph as a key.
+    let message: DisplayText
+    let actionLabel: LocalizedStringResource
 }
 
 /// View-ready device check-in pill data (ADR-031 Phase 5). The shared
@@ -562,7 +573,7 @@ struct HomeAlertItem: Identifiable {
 /// `internal` so `#Preview` fixtures can build it (the generated snapshot test
 /// embeds preview bodies verbatim and can't see `private` symbols).
 struct DeviceCheckInItem {
-    let label: String?
+    let label: LocalizedStringResource?
     let isStale: Bool
 }
 
@@ -575,7 +586,7 @@ struct DeviceCheckInItem {
 struct ButtonHealthItem {
     enum Kind { case unauthorized, unknown, online, offline }
 
-    let label: String
+    let label: LocalizedStringResource
     let kind: Kind
 }
 
@@ -592,13 +603,18 @@ struct RemoteButtonItem {
     /// Preparing / AwaitingConfirmation diagram state.
 
     let kind: Kind
-    let title: String
-    let subtitle: String?
+    let title: LocalizedStringResource
+    let subtitle: LocalizedStringResource?
     /// The shared diagram table's answer for this state, or nil while idle.
     /// Previously a local `Phase` enum that could not express every shared state.
     var diagram: RemoteButtonDiagram?
 
-    init(kind: Kind, title: String, subtitle: String?, diagram: RemoteButtonDiagram? = nil) {
+    init(
+        kind: Kind,
+        title: LocalizedStringResource,
+        subtitle: LocalizedStringResource?,
+        diagram: RemoteButtonDiagram? = nil
+    ) {
         self.kind = kind
         self.title = title
         self.subtitle = subtitle

--- a/MobileGarage/iosApp/GarageControl/Localizable.xcstrings
+++ b/MobileGarage/iosApp/GarageControl/Localizable.xcstrings
@@ -4,37 +4,67 @@
     "%@ and counting": {
       "extractionState": "manual"
     },
-    "%lld": {
+    "%d day %d hr": {
       "extractionState": "manual"
     },
-    "%lld day %lld hr": {
+    "%d days": {
       "extractionState": "manual"
     },
-    "%lld days": {
+    "%d days ago": {
       "extractionState": "manual"
     },
-    "%lld hr": {
+    "%d hr": {
       "extractionState": "manual"
     },
-    "%lld hr %lld min": {
+    "%d hr %d min": {
       "extractionState": "manual"
     },
-    "%lld min": {
+    "%d hr %d min ago": {
       "extractionState": "manual"
     },
-    "%lld min %lld sec": {
+    "%d hr ago": {
       "extractionState": "manual"
     },
-    "%lld sec": {
+    "%d min": {
+      "extractionState": "manual"
+    },
+    "%d min %d sec": {
+      "extractionState": "manual"
+    },
+    "%d min %d sec ago": {
+      "extractionState": "manual"
+    },
+    "%d min ago": {
+      "extractionState": "manual"
+    },
+    "%d sec": {
+      "extractionState": "manual"
+    },
+    "%d sec ago": {
       "extractionState": "manual"
     },
     "1 day": {
       "extractionState": "manual"
     },
+    "1 day ago": {
+      "extractionState": "manual"
+    },
     "1 hour": {
       "extractionState": "manual"
     },
+    "1 min": {
+      "extractionState": "manual"
+    },
+    "1 min ago": {
+      "extractionState": "manual"
+    },
+    "1 sec": {
+      "extractionState": "manual"
+    },
     "12 hours": {
+      "extractionState": "manual"
+    },
+    "23 min ago": {
       "extractionState": "manual"
     },
     "4 hours": {
@@ -49,7 +79,13 @@
     "Account": {
       "extractionState": "manual"
     },
+    "Allow": {
+      "extractionState": "manual"
+    },
     "Auth": {
+      "extractionState": "manual"
+    },
+    "Available": {
       "extractionState": "manual"
     },
     "Build": {
@@ -62,6 +98,9 @@
       "extractionState": "manual"
     },
     "Cancel": {
+      "extractionState": "manual"
+    },
+    "Cancelled": {
       "extractionState": "manual"
     },
     "Change test topic": {
@@ -109,6 +148,9 @@
     "Closing": {
       "extractionState": "manual"
     },
+    "Closing, taking longer than expected": {
+      "extractionState": "manual"
+    },
     "Confirm": {
       "extractionState": "manual"
     },
@@ -145,13 +187,25 @@
     "Door": {
       "extractionState": "manual"
     },
+    "Door did not move": {
+      "extractionState": "manual"
+    },
+    "Door did not respond": {
+      "extractionState": "manual"
+    },
     "Door failed": {
       "extractionState": "manual"
     },
     "Door history": {
       "extractionState": "manual"
     },
+    "Door is open and misaligned": {
+      "extractionState": "manual"
+    },
     "Door open notifications": {
+      "extractionState": "manual"
+    },
+    "Door responded": {
       "extractionState": "manual"
     },
     "Door state changed before snooze could apply. Try again.": {
@@ -163,7 +217,13 @@
     "Door was misaligned": {
       "extractionState": "manual"
     },
+    "Door will move.": {
+      "extractionState": "manual"
+    },
     "Double tap to copy": {
+      "extractionState": "manual"
+    },
+    "Error fetching current door event: %@": {
       "extractionState": "manual"
     },
     "Export CSV": {
@@ -188,6 +248,18 @@
       "extractionState": "manual"
     },
     "Home": {
+      "extractionState": "manual"
+    },
+    "If contact stops, this shows when we last heard from it. Tapping the button may not work until it reconnects.": {
+      "extractionState": "manual"
+    },
+    "If we don't hear from it on schedule, this shows \"no signal\" so you know the sensor may be offline.": {
+      "extractionState": "manual"
+    },
+    "Just now": {
+      "extractionState": "manual"
+    },
+    "Last seen %@": {
       "extractionState": "manual"
     },
     "Loading…": {
@@ -253,7 +325,13 @@
     "Opening": {
       "extractionState": "manual"
     },
+    "Opening, taking longer than expected": {
+      "extractionState": "manual"
+    },
     "Package": {
+      "extractionState": "manual"
+    },
+    "Preparing…": {
       "extractionState": "manual"
     },
     "Privacy policy": {
@@ -265,6 +343,9 @@
     "Ready": {
       "extractionState": "manual"
     },
+    "Ready to send": {
+      "extractionState": "manual"
+    },
     "Refresh": {
       "extractionState": "manual"
     },
@@ -272,6 +353,9 @@
       "extractionState": "manual"
     },
     "Remote button %@": {
+      "extractionState": "manual"
+    },
+    "Remote button idle": {
       "extractionState": "manual"
     },
     "Remote control": {
@@ -289,7 +373,22 @@
     "Sending": {
       "extractionState": "manual"
     },
+    "Sending to server": {
+      "extractionState": "manual"
+    },
+    "Sending…": {
+      "extractionState": "manual"
+    },
     "Sensor conflict": {
+      "extractionState": "manual"
+    },
+    "Sensor conflict. Check the door.": {
+      "extractionState": "manual"
+    },
+    "Server did not accept the request": {
+      "extractionState": "manual"
+    },
+    "Server error": {
       "extractionState": "manual"
     },
     "Settings": {
@@ -325,7 +424,19 @@
     "Since 10:15 AM · 12 min and counting": {
       "extractionState": "manual"
     },
+    "Since 11:22 AM · 38 min": {
+      "extractionState": "manual"
+    },
     "Since 11:30 AM · 47 min and counting": {
+      "extractionState": "manual"
+    },
+    "Since 12:01 PM · 4 min": {
+      "extractionState": "manual"
+    },
+    "Since 8:15 AM · 1 hr 5 min": {
+      "extractionState": "manual"
+    },
+    "Since 9:47 AM · 2 hr 14 min": {
       "extractionState": "manual"
     },
     "Snooze 1 hour": {
@@ -361,7 +472,19 @@
     "Succeeded": {
       "extractionState": "manual"
     },
+    "Tap again to confirm": {
+      "extractionState": "manual"
+    },
+    "Tap to open or close": {
+      "extractionState": "manual"
+    },
     "Test notifications": {
+      "extractionState": "manual"
+    },
+    "The door sensor checks in every 10 minutes, or whenever the door moves.": {
+      "extractionState": "manual"
+    },
+    "The remote button checks in frequently. \"Available\" means it just told us it's ready to open or close the door.": {
       "extractionState": "manual"
     },
     "This developer panel is gated to allowlisted accounts.": {
@@ -388,6 +511,15 @@
     "Turn on notifications to get alerted when the door is left open.": {
       "extractionState": "manual"
     },
+    "Unauthorized": {
+      "extractionState": "manual"
+    },
+    "Unavailable · %@": {
+      "extractionState": "manual"
+    },
+    "Unavailable · 11 min ago": {
+      "extractionState": "manual"
+    },
     "Unknown": {
       "extractionState": "manual"
     },
@@ -406,6 +538,12 @@
     "Waiting for door": {
       "extractionState": "manual"
     },
+    "Waiting for door…": {
+      "extractionState": "manual"
+    },
+    "Waiting for the door to respond": {
+      "extractionState": "manual"
+    },
     "Waiting for the latest door status": {
       "extractionState": "manual"
     },
@@ -422,6 +560,12 @@
       "extractionState": "manual"
     },
     "iOS may be blocking requests because the permission was denied multiple times.": {
+      "extractionState": "manual"
+    },
+    "just now": {
+      "extractionState": "manual"
+    },
+    "unknown": {
       "extractionState": "manual"
     }
   },


### PR DESCRIPTION
The largest feature area, and the last big one. Every user-visible string on Home now carries a type the compiler can extract: the door headline, the "Since … · …" line, all three alert banners with their action labels, both device-availability pills, the remote button's title and subtitle, the warning chip, both info sheets, and the send-progress diagram's **screen-reader announcement** — an accessibility label is user-visible text like any other.

## Two things on Home are data, not copy

- **The server-supplied door warning.** `DoorWarning.ServerMessage` carries text the *server* wrote. Looking that sentence up as a catalog key means a collision silently replaces it with something else. `warningText` is a `DisplayText`; only the four local fallbacks are `.copy`.
- **The permission banner**, which is a multi-line block already assembled from several catalog entries. Re-looking it up would search for the whole paragraph as one key.

## Three defects found by reading the resulting catalog, not the diff

**1. `%d` vs `%lld`.** A Kotlin `Int` bridges to Swift `Int32` and interpolates as `%d`; History wrapped it in `Int(...)`, widening to `%lld`. So identical phrases had *two* keys each — `"%d min"` **and** `"%lld min"` — and a translator would be asked for both. Unified on the bare form. The eight orphaned `%lld` keys are pruned by hand, since the sync script only ever adds.

**2. A lone number was being translated.** `Text("\(counter.value)")` in Diagnostics produced a catalog key of literally `"%lld"` — meaningless to a translator, and it collides with every other bare-integer interpolation in the app. A number wants locale *formatting*: `Text(verbatim: counter.value.formatted())`.

**3. `#Preview` fixture text now reaches the catalog** (~20 keys like `"Since 11:22 AM · 38 min"`), because a literal passed into a `LocalizedStringResource` field is a literal in resource position. Harmless while nothing is translated, and **deliberately not fixed here** — the remedy touches preview fixtures on every screen, so it's documented with the exact helper to add rather than bundled in and making this PR unreviewable.

## A dead end worth not repeating

`#Preview` bodies are excluded from Release builds, so extracting in Release looks like the obvious fix for (3). Measured: a Release build with `SWIFT_EMIT_LOC_STRINGS=YES` yields **zero** usable keys — `"Retry"` and `"Connecting…"` disappear right along with the fixtures. Making that change would have quietly stopped the sync from finding anything, while looking like an improvement.

## Verification

- Catalog: **189 keys**, verified against a *from-scratch* extraction (derived data deleted first), so no stale entry is being counted — which is how the bare `"%lld"` was finally traced to its source after two earlier searches missed it.
- `validate.sh` — all checks passed
- `validate-ios.sh` — 6/6 green, including cold + warm launch smoke
- **iOS snapshot regen produced zero changed PNGs**

Remaining for the sweep: Function list and Diagnostics. The fence lint keeps the pattern from spreading meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)