### PR TITLE
feat(ios): localize the last two areas — Function list and Diagnostics

### DIFF
--- a/MobileGarage/docs/IOS_LOCALIZATION.md
+++ b/MobileGarage/docs/IOS_LOCALIZATION.md
@@ -8,12 +8,15 @@ last_verified: 2026-07-29
 
 Android localizes through `strings.xml` (209 entries).
 
-**Status.** iOS has the mechanism (`Localizable.xcstrings` +
-`SWIFT_EMIT_LOC_STRINGS: YES` + `scripts/sync-ios-string-catalog.sh`, #1159) and the
-fence lint (step 3, #1164). The step-2 type sweep has covered **Settings** (#1165),
-**History** (#1166) and **Home**; **Function list** and **Diagnostics** remain. The
-catalog holds ~189 keys. Re-measure with `./scripts/sync-ios-string-catalog.sh` rather
-than trusting this paragraph.
+**Status.** All three steps are done. iOS has the mechanism (`Localizable.xcstrings` +
+`SWIFT_EMIT_LOC_STRINGS: YES` + `scripts/sync-ios-string-catalog.sh`, #1159), the fence
+lint (#1164), and the step-2 type sweep now covers **every** feature area — Settings
+(#1165), History (#1166), Home (#1169), Function list and Diagnostics. The catalog holds
+~198 keys. Re-measure with `./scripts/sync-ios-string-catalog.sh` rather than trusting
+this paragraph.
+
+One known wart remains: ~20 of those keys are `#Preview` fixture text, not shipped copy —
+see "Three things the sweep surfaced" below. Fixing that is the only outstanding item.
 
 ADR-035 governs *where* a string is decided (platform, not shared). This document covers
 the separate question of *how* iOS stores its words once it has them.

--- a/MobileGarage/ios-localizable-text-exemptions.txt
+++ b/MobileGarage/ios-localizable-text-exemptions.txt
@@ -25,7 +25,6 @@
 # and the three shapes this takes: MobileGarage/docs/IOS_LOCALIZATION.md.
 MobileGarage/iosApp/Features/Diagnostics/DiagnosticsScreen.swift
 MobileGarage/iosApp/Features/FunctionList/AuthTokenCopier.swift
-MobileGarage/iosApp/Features/FunctionList/FunctionListScreen.swift
 MobileGarage/iosApp/Features/History/HistoryScreen.swift
 MobileGarage/iosApp/Features/Home/GarageDoorCanvas.swift
 MobileGarage/iosApp/Features/Home/HomeScreen.swift

--- a/MobileGarage/iosApp/Features/Diagnostics/DiagnosticsViewModelWrapper.swift
+++ b/MobileGarage/iosApp/Features/Diagnostics/DiagnosticsViewModelWrapper.swift
@@ -28,7 +28,12 @@ import SwiftUI
 final class DiagnosticsViewModelWrapper: ObservableObject {
     struct Counter: Identifiable {
         let id: String
-        let label: String
+        /// `LocalizedStringResource`: a `String` reaching `Text` is invisible to
+        /// the compiler's string extractor, so these row names could never be
+        /// translated. See MobileGarage/docs/IOS_LOCALIZATION.md.
+        let label: LocalizedStringResource
+        /// Rendered with `Text(verbatim:)` + `.formatted()` — a count wants
+        /// locale digit grouping, not a catalog lookup.
         let value: Int64
     }
 

--- a/MobileGarage/iosApp/Features/FunctionList/AuthTokenCopier.swift
+++ b/MobileGarage/iosApp/Features/FunctionList/AuthTokenCopier.swift
@@ -59,7 +59,10 @@ struct CopyAuthTokenButton: View {
     @State private var flash: Flash?
 
     private struct Flash {
-        let text: String
+        /// `LocalizedStringResource`: as a `String` this confirmation was
+        /// invisible to the compiler's string extractor and could never be
+        /// translated. See MobileGarage/docs/IOS_LOCALIZATION.md.
+        let text: LocalizedStringResource
         let systemImage: String
     }
 

--- a/MobileGarage/iosApp/Features/FunctionList/FunctionListScreen.swift
+++ b/MobileGarage/iosApp/Features/FunctionList/FunctionListScreen.swift
@@ -175,7 +175,11 @@ struct TestNotificationSectionView: View {
     var body: some View {
         Section("Test notifications") {
             LabeledContent("Topic") {
-                Text(topic)
+                // verbatim: an FCM topic name is a WIRE IDENTIFIER, not copy.
+                // Translating it would break the subscription, and CLAUDE.md
+                // lists topic names among the things that must never become
+                // shared/localized strings. The monospaced font says the same.
+                Text(verbatim: topic)
                     .font(.footnote.monospaced())
                     .foregroundStyle(.secondary)
                     .lineLimit(1)

--- a/MobileGarage/iosApp/GarageControl/Localizable.xcstrings
+++ b/MobileGarage/iosApp/GarageControl/Localizable.xcstrings
@@ -226,6 +226,9 @@
     "Error fetching current door event: %@": {
       "extractionState": "manual"
     },
+    "Exceeded expected time without FCM": {
+      "extractionState": "manual"
+    },
     "Export CSV": {
       "extractionState": "manual"
     },
@@ -233,6 +236,12 @@
       "extractionState": "manual"
     },
     "FCM": {
+      "extractionState": "manual"
+    },
+    "FCM door events received": {
+      "extractionState": "manual"
+    },
+    "FCM topic subscribes": {
       "extractionState": "manual"
     },
     "Function list": {
@@ -254,6 +263,12 @@
       "extractionState": "manual"
     },
     "If we don't hear from it on schedule, this shows \"no signal\" so you know the sensor may be offline.": {
+      "extractionState": "manual"
+    },
+    "Init current door": {
+      "extractionState": "manual"
+    },
+    "Init recent door": {
       "extractionState": "manual"
     },
     "Just now": {
@@ -403,6 +418,9 @@
     "Sign in": {
       "extractionState": "manual"
     },
+    "Sign in to copy auth token": {
+      "extractionState": "manual"
+    },
     "Sign in to snooze notifications.": {
       "extractionState": "manual"
     },
@@ -490,6 +508,9 @@
     "This developer panel is gated to allowlisted accounts.": {
       "extractionState": "manual"
     },
+    "Time without FCM in range": {
+      "extractionState": "manual"
+    },
     "Today": {
       "extractionState": "manual"
     },
@@ -530,6 +551,12 @@
       "extractionState": "manual"
     },
     "Unsubscribe test notifications": {
+      "extractionState": "manual"
+    },
+    "User fetch current": {
+      "extractionState": "manual"
+    },
+    "User fetch recent": {
       "extractionState": "manual"
     },
     "Version": {


### PR DESCRIPTION
Completes the step-2 type sweep. Every feature area now types its display text as something the compiler can extract; the catalog holds **198 keys**.

Small in code, but two of the three sites turned out not to be copy at all:

- **The FCM topic name** in the test-notification panel is a **wire identifier**. Rendering it through the catalog invites a collision that would silently change the string the app subscribes with. CLAUDE.md already lists topic names among the things that must never become shared or localized strings; it now renders `Text(verbatim:)`, which says so at the call site. The monospaced font was the only hint before.
- **The Diagnostics counter values** were handled in #1169 for the same reason — a number wants locale *formatting*, not translation.

That leaves the genuinely-copy ones: the eight counter row labels, and the auth-token button's two flash confirmations (`"Copied"` / `"Sign in to copy auth token"`), which as `String`s were invisible to the extractor.

## The stale-entry check earned its keep

`FunctionListScreen.swift` leaves the fence list — with the topic now `verbatim:` it has no value-typed `Text()` at all. The check **failed the build** on the leftover entry rather than letting the list carry dead weight, which is exactly what it was added for.

Note the asymmetry, which is the fence's documented limitation working as described: `DiagnosticsScreen` and `AuthTokenCopier` are now *fully converted* and **stay** on the list, because `Text(counter.label)` still matches textually even though `label` is a `LocalizedStringResource`. Leaving the list means "passes no value to `Text()`", not "is localized." Two files moving in opposite directions in one PR is a good illustration of why the list isn't a scorecard.

## Verification

- `validate-ios.sh` — 6/6 green, including cold + warm launch smoke
- New keys confirmed present in `Localizable.xcstrings` **by measurement**, not inspection
- **iOS snapshot regen produced zero changed PNGs**

## Remaining

~20 catalog keys are `#Preview` fixture text (`"Since 11:22 AM · 38 min"` and friends) rather than shipped copy. Documented in `IOS_LOCALIZATION.md` with the exact helper to add; not bundled here, since the fix touches preview fixtures on every screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)