### PR TITLE
chore: 2.23.5 (Android) and 0.1.3 (iOS) — release the localization work

### DIFF
--- a/MobileGarage/CHANGELOG.md
+++ b/MobileGarage/CHANGELOG.md
@@ -15,6 +15,18 @@ Internal release history. For Play Store "What's New" text, see `distribution/wh
 
 Every version gets an entry in this file (internal history). Play Store `distribution/whatsnew/` gets a line per minor/major — patches roll up into the next minor's line, or get a combined line if promoted to production on their own.
 
+## 2.23.5
+
+- **The snooze time now reads correctly outside the US.** It was formatted with
+  a hardcoded 12-hour AM/PM pattern, so a device set to a 24-hour locale still
+  saw "5:30 PM". Whether a clock is 12- or 24-hour is a property of the
+  language, not of this app.
+- Under the hood, several decisions the app makes about what to show you moved
+  into one place shared with the iOS app: how door states are grouped into a
+  headline, what the snooze row says, how history durations are rounded, and how
+  a history row is assembled. Both apps previously worked these out separately
+  and could drift apart without anyone noticing. Nothing on screen changes.
+
 ## 2.23.4
 
 - **The remote button says what it does, and names the two ways it can fail.**

--- a/MobileGarage/iosApp/CHANGELOG.md
+++ b/MobileGarage/iosApp/CHANGELOG.md
@@ -19,6 +19,23 @@ Versioning mirrors Android (see `MobileGarage/CHANGELOG.md` § versioning):
 major = rewrite or core-experience shift; minor = a user-facing feature added or
 removed; patch = fixes, polish, refactors. iOS uses independent `ios/N` tags.
 
+## 0.1.3
+
+- **The app can now be translated.** Every screen's text was built as plain
+  Swift strings, which the compiler cannot collect — so there was nothing for a
+  translator to translate, and no warning that this was the case. All five tabs
+  now carry text in a form that reaches the app's string catalog: 175 entries,
+  covering everything you can read. English is unchanged; adding a language is
+  now a matter of supplying translations rather than changing code.
+- **Two things that should never be translated no longer can be.** Your own name
+  and email address on the account row, and the notification topic identifier in
+  the developer panel, were being routed through the same machinery as ordinary
+  copy. Version numbers and diagnostic counters are now formatted as numbers
+  rather than looked up as text.
+- Several decisions about what to display moved into code shared with the
+  Android app — door-state headlines, the snooze row, history durations and row
+  layout — so the two apps cannot quietly disagree. Nothing on screen changes.
+
 ## 0.1.2
 
 - **The app stops forgetting what it knew.** On every launch while signed in, it

--- a/MobileGarage/iosApp/project.yml
+++ b/MobileGarage/iosApp/project.yml
@@ -34,7 +34,7 @@ settings:
     SWIFT_STRICT_CONCURRENCY: minimal
     # KMP gradle Run Script writes outside the Xcode sandbox.
     ENABLE_USER_SCRIPT_SANDBOXING: NO
-    MARKETING_VERSION: "0.1.2"
+    MARKETING_VERSION: "0.1.3"
     CURRENT_PROJECT_VERSION: "1"
     # Required for Localizable.xcstrings to ever receive anything. Xcode's own
     # project template sets this; XcodeGen does not, and it defaults to NO —

--- a/MobileGarage/version.properties
+++ b/MobileGarage/version.properties
@@ -1,1 +1,1 @@
-versionName=2.23.4
+versionName=2.23.5


### PR DESCRIPTION
Version bumps + changelog entries so the release gates pass. Both **patch** releases.

## Why patch, not minor

The shared-decision refactors render identically on every screen — each of #1160, #1161, #1162, #1163 and #1168 shipped with **zero snapshot diffs on both platforms**, which was the point. And iOS's localization changes nothing visible in English.

Translation-readiness becomes user-facing when a locale ships, not before.

## Android 2.23.5

One real user-facing fix: the snooze time was formatted with a hardcoded 12-hour AM/PM pattern, so a device set to a 24-hour locale still saw "5:30 PM". Plus the shared-decision moves, which are invisible.

## iOS 0.1.3

Makes the app translatable at all. Every screen's text was plain Swift strings the compiler cannot collect, so there was nothing for a translator to work with and no warning to that effect. The catalog now holds 175 entries covering all five tabs.

Also stops two things being translated that never should be: the signed-in person's own name and email, and the FCM topic identifier.

## Not released

- **Wear** — `wearApp/` is untouched since `wear/16` and references none of the changed shared symbols, so a release would ship a functionally identical app.
- **Firebase** — only dependency bumps since `server/34`, no source changes.

Both confirmed with the maintainer rather than assumed.

No `distribution/whatsnew/` change — patches roll up into the next minor's line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)